### PR TITLE
Fix bug in `Progress` property in `ItemEnhancementQuest`.

### DIFF
--- a/Lib9c/Model/Quest/ItemEnhancementQuest.cs
+++ b/Lib9c/Model/Quest/ItemEnhancementQuest.cs
@@ -14,6 +14,7 @@ namespace Nekoyume.Model.Quest
         public readonly int Grade;
         private readonly int _count;
         public int Count => _count;
+        public override float Progress => (float) _current / _count;
 
         public ItemEnhancementQuest(ItemEnhancementQuestSheet.Row data, QuestReward reward) 
             : base(data, reward)

--- a/Lib9c/Model/Quest/Quest.cs
+++ b/Lib9c/Model/Quest/Quest.cs
@@ -59,7 +59,7 @@ namespace Nekoyume.Model.Quest
         /// </summary>
         public bool IsPaidInAction { get; set; }
 
-        public float Progress => (float) _current / Goal;
+        public virtual float Progress => (float) _current / Goal;
 
         public const string GoalFormat = "({0}/{1})";
 


### PR DESCRIPTION
The usage of property `Goal` in `ItemEnhancementQuest` class is different from super class `Quest`, so the derived `Progress` property was not working as intended.
So, I've made `Progress` property `virtual`, and implemented properly in `ItemEnhancementQuest`.