### PR TITLE
Replace (FAV.MajorUnit, FAV.MinorUnit) with FAV.RawValue

### DIFF
--- a/Lib9c/Lib9c.csproj
+++ b/Lib9c/Lib9c.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="DecimalMath.DecimalEx" Version="1.0.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
-    <PackageReference Include="Libplanet" Version="0.10.0-dev.20200818120248" />
+    <PackageReference Include="Libplanet" Version="0.10.0-dev.20200821052050" />
     <PackageReference Include="OptimizedPriorityQueue" Version="4.2.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.1.0.13383">


### PR DESCRIPTION
This PR is continued from #19 . 

It changes the internal serialization layout from `(FAV.MajorUnit, FAV.MinorUnit)` to `FAV.RawValue`.