### PR TITLE
Make BlockPolicy.GetRenderer() to return a concrete type

### DIFF
--- a/Lib9c/BlockPolicy.cs
+++ b/Lib9c/BlockPolicy.cs
@@ -10,7 +10,6 @@ using Libplanet.Tx;
 using Nekoyume.Action;
 using Nekoyume.Model.State;
 using Libplanet;
-using Libplanet.Blockchain.Renderers;
 #if UNITY_EDITOR || UNITY_STANDALONE
 using UniRx;
 #else
@@ -61,8 +60,7 @@ namespace Nekoyume.BlockChain
 #endif
         }
 
-        public static IRenderer<PolymorphicAction<ActionBase>> GetRenderer() =>
-            ActionRenderer;
+        public static ActionRenderer GetRenderer() => ActionRenderer;
 
         private static bool IsSignerAuthorized(Transaction<PolymorphicAction<ActionBase>> transaction)
         {


### PR DESCRIPTION
Make` BlockPolicy.GetRenderer()` to return a concrete type (i.e., `ActionRenderer`) instead of an abstract type (`IRenderer<PolymorphicAction<ActionBase>>`), so that client code can subscribe its observables without downcasting to `ActionRenderer`.