### PR TITLE
Fix bug/Not equal updated addresses in buy action

### DIFF
--- a/Lib9c/Action/Buy.cs
+++ b/Lib9c/Action/Buy.cs
@@ -108,7 +108,11 @@ namespace Nekoyume.Action
                     .SetState(buyerAvatarAddress, MarkChanged)
                     .SetState(ctx.Signer, MarkChanged)
                     .SetState(sellerAvatarAddress, MarkChanged)
-                    .MarkBalanceChanged(GoldCurrencyMock, ctx.Signer, sellerAgentAddress);
+                    .MarkBalanceChanged(
+                        GoldCurrencyMock,
+                        ctx.Signer,
+                        sellerAgentAddress,
+                        GoldCurrencyState.Address);
                 return states.SetState(ShopState.Address, MarkChanged);
             }
 


### PR DESCRIPTION
### Problem

1. In the Buy action, the updated addresses between the rehearsal and the main run are different, so the TX is invalidated.
