### PR TITLE
Fix serialization in ActionBase.ActionEvaluation

### DIFF
--- a/.Lib9c.Tests/Action/ActionEvaluationTest.cs
+++ b/.Lib9c.Tests/Action/ActionEvaluationTest.cs
@@ -1,0 +1,52 @@
+namespace Lib9c.Tests.Action
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using Bencodex.Types;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Assets;
+    using Nekoyume.Action;
+    using Xunit;
+
+    public class ActionEvaluationTest
+    {
+        [Fact]
+        public void SerializeWithDotnetAPI()
+        {
+            var currency = new Currency("NCG", 2, minters: null);
+            var signer = default(Address);
+            var blockIndex = 1234;
+            var states = new State()
+                .SetState(signer, (Text)"ANYTHING")
+                .MintAsset(signer, currency * 10000);
+            var action = new TransferAsset(
+                sender: default,
+                recipient: default,
+                amount: 100,
+                currency
+            );
+
+            var evaluation = new ActionBase.ActionEvaluation<ActionBase>()
+            {
+                Action = action,
+                Signer = signer,
+                BlockIndex = blockIndex,
+                PreviousStates = states,
+                OutputStates = states,
+            };
+
+            var formatter = new BinaryFormatter();
+            using var ms = new MemoryStream();
+            formatter.Serialize(ms, evaluation);
+
+            ms.Seek(0, SeekOrigin.Begin);
+            var deserialized = (ActionBase.ActionEvaluation<ActionBase>)formatter.Deserialize(ms);
+
+            // FIXME We should equality check more precisely.
+            Assert.Equal(evaluation.Signer, deserialized.Signer);
+            Assert.Equal(evaluation.BlockIndex, deserialized.BlockIndex);
+        }
+    }
+}

--- a/Lib9c/Action/ActionBase.cs
+++ b/Lib9c/Action/ActionBase.cs
@@ -245,8 +245,7 @@ namespace Nekoyume.Action
                                 {
                                     new KeyValuePair<IKey, IValue>((Text) "address", (Binary) ua.Key.ToByteArray()),
                                     new KeyValuePair<IKey, IValue>((Text) "currency", c.Serialize()),
-                                    // FIXME: It seems that b.Sign is missing. Now we can serialize FungibleAssetValue at once with b.Serialize().
-                                    new KeyValuePair<IKey, IValue>((Text) "amount", new Bencodex.Types.List(new IValue[]{ (Integer)b.MajorUnit, (Integer)b.MinorUnit})),
+                                    new KeyValuePair<IKey, IValue>((Text) "amount", (Integer) b.RawValue),
                                 });
                             }
                         )


### PR DESCRIPTION
The title says it all. 

I haven't finished writing the unittest becuase `ActionBase.ActionEvaluation<T>` doesn't implement `IEquatable<T>`, so I left `FIXME` ther. 