### PR TITLE
Update Libplanet to 0.10.0-dev.20200904141108

### DIFF
--- a/.Lib9c.Tests/Action/ActionContext.cs
+++ b/.Lib9c.Tests/Action/ActionContext.cs
@@ -16,5 +16,19 @@ namespace Lib9c.Tests.Action
         public IAccountStateDelta PreviousStates { get; set; }
 
         public IRandom Random { get; set; }
+
+        public IActionContext GetUnconsumedContext()
+        {
+            // Unable to determine if Random has ever been consumed...
+            return new ActionContext
+            {
+                Signer = Signer,
+                Miner = Miner,
+                BlockIndex = BlockIndex,
+                Rehearsal = Rehearsal,
+                PreviousStates = PreviousStates,
+                Random = Random,
+            };
+        }
     }
 }

--- a/Lib9c/Lib9c.csproj
+++ b/Lib9c/Lib9c.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="DecimalMath.DecimalEx" Version="1.0.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
-    <PackageReference Include="Libplanet" Version="0.10.0-nightly.20200831" />
+    <PackageReference Include="Libplanet" Version="0.10.0-dev.20200904141108" />
     <PackageReference Include="OptimizedPriorityQueue" Version="4.2.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.1.0.13383">


### PR DESCRIPTION
To use Libplanet's [delayed renderers][1], upgrades it to 0.10.0-dev.20200904141108.

[1]: https://github.com/planetarium/libplanet/pull/980