### PR TITLE
GetRenderer to return BlockRenderer instead of LoggedBlockRenderer

### DIFF
--- a/Lib9c/BlockPolicySource.cs
+++ b/Lib9c/BlockPolicySource.cs
@@ -81,7 +81,7 @@ namespace Nekoyume.BlockChain
         }
 
         public IEnumerable<IRenderer<NCAction>> GetRenderers() =>
-            new IRenderer<NCAction>[] { LoggedBlockRenderer, LoggedActionRenderer };
+            new IRenderer<NCAction>[] { BlockRenderer, LoggedActionRenderer };
 
         private bool IsSignerAuthorized(Transaction<PolymorphicAction<ActionBase>> transaction)
         {


### PR DESCRIPTION
Since `LoggedActionRenderer` extends `LoggedRenderer`, duplicated logs were given in block related actions.