### PR TITLE
Pass block action also into MineGenesisBlock

### DIFF
--- a/Lib9c/BlockHelper.cs
+++ b/Lib9c/BlockHelper.cs
@@ -6,8 +6,10 @@ using Libplanet.Blockchain;
 using Libplanet.Blocks;
 using Libplanet.Crypto;
 using Nekoyume.Action;
+using Nekoyume.BlockChain;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
+using Serilog;
 
 namespace Nekoyume
 {
@@ -52,8 +54,12 @@ namespace Nekoyume
             {
                 initialStatesAction,
             };
+            var blockAction = new BlockPolicySource(Log.Logger).GetPolicy(5000000).BlockAction;
             return
-                BlockChain<PolymorphicAction<ActionBase>>.MakeGenesisBlock(actions, privateKey: minterKey);
+                BlockChain<PolymorphicAction<ActionBase>>.MakeGenesisBlock(
+                    actions,
+                    privateKey: minterKey,
+                    blockAction: blockAction);
         }
     }
 }


### PR DESCRIPTION
Since planetarium/libplanet#986, `stateRootHash` became a required field when using `TrieStateStore`. And it should pass block action to get the correct state root hash. If not, it will have an incorrect state root hash and the validation will fail. So this pull request makes it pass block action also.