### PR TITLE
Make AvatarState deterministic

### DIFF
--- a/.Lib9c.Tests/Model/State/AvatarStateTest.cs
+++ b/.Lib9c.Tests/Model/State/AvatarStateTest.cs
@@ -1,0 +1,49 @@
+namespace Lib9c.Tests.Model.State
+{
+    using System.Collections.Generic;
+    using System.Security.Cryptography;
+    using System.Threading.Tasks;
+    using Bencodex;
+    using Libplanet;
+    using Libplanet.Crypto;
+    using Nekoyume.Model.State;
+    using Xunit;
+
+    public class AvatarStateTest
+    {
+        private Dictionary<string, string> _sheets;
+        private TableSheets _tableSheets;
+
+        public AvatarStateTest()
+        {
+            _sheets = TableSheetsImporter.ImportSheets();
+            _tableSheets = new TableSheets(_sheets);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(4)]
+        public async Task ConstructDeterministic(int waitMilliseconds)
+        {
+            var rankingState = new RankingState();
+            Address avatarAddress = new PrivateKey().ToAddress();
+            Address agentAddress = new PrivateKey().ToAddress();
+            AvatarState AvatarStateConstructor() =>
+                new AvatarState(
+                    avatarAddress,
+                    agentAddress,
+                    0,
+                    _tableSheets.GetAvatarSheets(),
+                    new GameConfigState(),
+                    rankingState.UpdateRankingMap(avatarAddress));
+
+            AvatarState avatarStateA = AvatarStateConstructor();
+            await Task.Delay(waitMilliseconds);
+            AvatarState avatarStateB = AvatarStateConstructor();
+
+            HashDigest<SHA256> Hash(AvatarState avatarState) => Hashcash.Hash(new Codec().Encode(avatarState.Serialize()));
+            Assert.Equal(Hash(avatarStateA), Hash(avatarStateB));
+        }
+    }
+}

--- a/Lib9c/Action/Buy.cs
+++ b/Lib9c/Action/Buy.cs
@@ -260,10 +260,9 @@ namespace Nekoyume.Action
             buyerAvatarState.questList.UpdateTradeQuest(TradeType.Buy, shopItem.Price);
             sellerAvatarState.questList.UpdateTradeQuest(TradeType.Sell, shopItem.Price);
 
-            var timestamp = DateTimeOffset.UtcNow;
-            buyerAvatarState.updatedAt = timestamp;
+            buyerAvatarState.updatedAt = ctx.BlockIndex;
             buyerAvatarState.blockIndex = ctx.BlockIndex;
-            sellerAvatarState.updatedAt = timestamp;
+            sellerAvatarState.updatedAt = ctx.BlockIndex;
             sellerAvatarState.blockIndex = ctx.BlockIndex;
 
             var materialSheet = states.GetSheet<MaterialItemSheet>();

--- a/Lib9c/Action/CombinationConsumable.cs
+++ b/Lib9c/Action/CombinationConsumable.cs
@@ -255,7 +255,7 @@ namespace Nekoyume.Action
             var materialSheet = states.GetSheet<MaterialItemSheet>();
             avatarState.UpdateQuestRewards(materialSheet);
 
-            avatarState.updatedAt = DateTimeOffset.UtcNow;
+            avatarState.updatedAt = ctx.BlockIndex;
             avatarState.blockIndex = ctx.BlockIndex;
             states = states.SetState(AvatarAddress, avatarState.Serialize());
             slotState.Update(result, ctx.BlockIndex, requiredBlockIndex);

--- a/Lib9c/Action/HackAndSlash.cs
+++ b/Lib9c/Action/HackAndSlash.cs
@@ -218,7 +218,7 @@ namespace Nekoyume.Action
             var materialSheet = states.GetSheet<MaterialItemSheet>();
             avatarState.UpdateQuestRewards(materialSheet);
 
-            avatarState.updatedAt = DateTimeOffset.UtcNow;
+            avatarState.updatedAt = ctx.BlockIndex;
             states = states.SetState(avatarAddress, avatarState.Serialize());
 
             sw.Stop();

--- a/Lib9c/Action/Sell.cs
+++ b/Lib9c/Action/Sell.cs
@@ -142,7 +142,7 @@ namespace Nekoyume.Action
             Log.Debug("Sell Get Register Item: {Elapsed}", sw.Elapsed);
             sw.Restart();
 
-            avatarState.updatedAt = DateTimeOffset.UtcNow;
+            avatarState.updatedAt = ctx.BlockIndex;
             avatarState.blockIndex = ctx.BlockIndex;
 
             states = states.SetState(sellerAvatarAddress, avatarState.Serialize());

--- a/Lib9c/Action/SellCancellation.cs
+++ b/Lib9c/Action/SellCancellation.cs
@@ -128,7 +128,7 @@ namespace Nekoyume.Action
 
             avatarState.Update(mail);
             avatarState.UpdateFromAddItem(result.itemUsable, true);
-            avatarState.updatedAt = DateTimeOffset.UtcNow;
+            avatarState.updatedAt = ctx.BlockIndex;
             avatarState.blockIndex = ctx.BlockIndex;
             sw.Stop();
             Log.Debug($"Sell Cancel Update AvatarState: {sw.Elapsed}");

--- a/Lib9c/Model/State/AvatarState.cs
+++ b/Lib9c/Model/State/AvatarState.cs
@@ -27,7 +27,8 @@ namespace Nekoyume.Model.State
         public long exp;
         public Inventory inventory;
         public WorldInformation worldInformation;
-        public DateTimeOffset updatedAt;
+        // FIXME: it seems duplicated with blockIndex.
+        public long updatedAt;
         public Address agentAddress;
         public QuestList questList;
         public MailBox mailBox;
@@ -73,7 +74,7 @@ namespace Nekoyume.Model.State
             exp = 0;
             inventory = new Inventory();
             worldInformation = new WorldInformation(blockIndex, avatarSheets.WorldSheet, GameConfig.IsEditor);
-            updatedAt = DateTimeOffset.UtcNow;
+            updatedAt = blockIndex;
             this.agentAddress = agentAddress;
             questList = new QuestList(
                 avatarSheets.QuestSheet,
@@ -156,7 +157,7 @@ namespace Nekoyume.Model.State
             exp = (long)((Integer)serialized["exp"]).Value;
             inventory = new Inventory((List)serialized["inventory"]);
             worldInformation = new WorldInformation((Dictionary)serialized["worldInformation"]);
-            updatedAt = serialized["updatedAt"].ToDateTimeOffset();
+            updatedAt = serialized["updatedAt"].ToLong();
             agentAddress = new Address(((Binary)serialized["agentAddress"]).Value);
             questList = new QuestList((Dictionary) serialized["questList"]);
             mailBox = new MailBox((List)serialized["mailBox"]);

--- a/Lib9c/Model/State/RankingMapState.cs
+++ b/Lib9c/Model/State/RankingMapState.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Bencodex.Types;
@@ -41,15 +40,15 @@ namespace Nekoyume.Model.State
             }
         }
 
-        public List<RankingInfo> GetRankingInfos(DateTimeOffset? dt)
+        public List<RankingInfo> GetRankingInfos(long? blockOffset)
         {
             var list = _map.Values
                 .OrderByDescending(c => c.Exp)
                 .ThenBy(c => c.StageClearedBlockIndex)
                 .ToList();
-            return dt != null
+            return blockOffset != null
                 ? list
-                    .Where(context => ((TimeSpan)(dt - context.UpdatedAt)).Days <= 1)
+                    .Where(context => blockOffset <= context.UpdatedAt)
                     .ToList()
                 : list;
         }
@@ -109,7 +108,7 @@ namespace Nekoyume.Model.State
         public readonly string AvatarName;
         public readonly long Exp;
         public readonly long StageClearedBlockIndex;
-        public readonly DateTimeOffset UpdatedAt;
+        public readonly long UpdatedAt;
 
         public RankingInfo(AvatarState avatarState)
         {
@@ -133,7 +132,7 @@ namespace Nekoyume.Model.State
             AvatarName = serialized.GetString("avatarName");
             Exp = serialized.GetLong("exp");
             StageClearedBlockIndex = serialized.GetLong("stageClearedBlockIndex");
-            UpdatedAt = serialized.GetDateTimeOffset("updatedAt");
+            UpdatedAt = serialized.GetLong("updatedAt");
         }
         public IValue Serialize() =>
             new Dictionary(new Dictionary<IKey, IValue>


### PR DESCRIPTION
Before this pull request, `AvatarState`'s constructor constructs a different state with different `updatedAt` for each call. This pull request fixes the problem by presenting it as an index of the block the state created and the state updated.