### PR TITLE
Use the minimum difficulty in blocks for authorized miners

### DIFF
--- a/Lib9c/BlockPolicy.cs
+++ b/Lib9c/BlockPolicy.cs
@@ -1,38 +1,132 @@
-using Lib9c;
-using Libplanet;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Tx;
-using Nekoyume.Action;
 using System;
+using Lib9c;
+using Libplanet;
+using Nekoyume.Model.State;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
 namespace Nekoyume.BlockChain
 {
     public class BlockPolicy : BlockPolicy<NCAction>
     {
-        private readonly Func<Block<NCAction>, InvalidBlockException> _blockValidator;
+        private readonly long _minimumDifficulty;
+        private readonly long _difficultyBoundDivisor;
 
         public BlockPolicy(
             IAction blockAction,
             TimeSpan blockInterval,
             long minimumDifficulty,
             int difficultyBoundDivisor,
-            Func<Transaction<NCAction>, BlockChain<NCAction>, bool> doesTransactionFollowPolicy = null,
-            Func<Block<NCAction>, InvalidBlockException> blockValidator)
-            : base(
+            Func<Transaction<NCAction>, BlockChain<NCAction>, bool> doesTransactionFollowPolicy = null
+        ) : base(
                 blockAction,
                 blockInterval,
                 minimumDifficulty,
                 difficultyBoundDivisor,
                 doesTransactionFollowPolicy)
         {
-            _blockValidator = blockValidator;
+            _minimumDifficulty = minimumDifficulty;
+            _difficultyBoundDivisor = difficultyBoundDivisor;
         }
 
+        public AuthorizedMinersState AuthorizedMinersState { get; set; }
+
         public override InvalidBlockException ValidateNextBlock(BlockChain<NCAction> blocks, Block<NCAction> nextBlock)
-            => _blockValidator(nextBlock);
+        {
+            InvalidBlockException e = ValidateMinerAuthority(nextBlock);
+            return e ?? base.ValidateNextBlock(blocks, nextBlock);
+        }
+
+        public override long GetNextBlockDifficulty(BlockChain<NCAction> blocks)
+        {
+            if (AuthorizedMinersState is null)
+            {
+                return base.GetNextBlockDifficulty(blocks);
+            }
+
+            long index = blocks.Count;
+
+            if (index < 0)
+            {
+                throw new InvalidBlockIndexException(
+                    $"index must be 0 or more, but its index is {index}.");
+            }
+
+            if (index <= 1)
+            {
+                return index == 0 ? 0 : _minimumDifficulty;
+            }
+
+            var prevIndex = IsTargetBlock(index - 1) ? index - 2 : index - 1;
+            var beforePrevIndex = IsTargetBlock(prevIndex - 1) ? prevIndex - 2 : prevIndex - 1;
+
+            if (beforePrevIndex > AuthorizedMinersState.ValidUntil)
+            {
+                return base.GetNextBlockDifficulty(blocks);
+            }
+
+            if (IsTargetBlock(index) || prevIndex <= 1 || beforePrevIndex <= 1)
+            {
+                return _minimumDifficulty;
+            }
+
+            var prevBlock = blocks[prevIndex];
+            var beforePrevBlock = blocks[beforePrevIndex];
+
+            DateTimeOffset beforePrevTimestamp = beforePrevBlock.Timestamp;
+            DateTimeOffset prevTimestamp = prevBlock.Timestamp;
+            TimeSpan timeDiff = prevTimestamp - beforePrevTimestamp;
+            long timeDiffMilliseconds = (long)timeDiff.TotalMilliseconds;
+            const long minimumMultiplier = -99;
+            long multiplier = 1 - timeDiffMilliseconds / (long)BlockInterval.TotalMilliseconds;
+            multiplier = Math.Max(multiplier, minimumMultiplier);
+
+            var prevDifficulty = prevBlock.Difficulty;
+            var offset = prevDifficulty / _difficultyBoundDivisor;
+            long nextDifficulty = prevDifficulty + (offset * multiplier);
+
+            return Math.Max(nextDifficulty, _minimumDifficulty);
+        }
+
+        private InvalidBlockException ValidateMinerAuthority(Block<NCAction> block)
+        {
+            if (AuthorizedMinersState is null)
+            {
+                return null;
+            }
+
+            if (!(block.Miner is Address miner))
+            {
+                return null;
+            }
+
+            if (!IsTargetBlock(block.Index))
+            {
+                return null;
+            }
+
+            bool minedByAuthorities = AuthorizedMinersState.Miners.Contains(miner);
+
+            if (minedByAuthorities)
+            {
+                return null;
+            }
+
+            return new InvalidMinerException(
+                $"The given block[{block}] isn't mined by authorities.",
+                miner
+            );
+        }
+
+        private bool IsTargetBlock(long blockIndex)
+        {
+            return blockIndex > 0
+                   && blockIndex <= AuthorizedMinersState.ValidUntil
+                   && blockIndex % AuthorizedMinersState.Interval == 0;
+        }
     }
 }

--- a/Lib9c/BlockPolicy.cs
+++ b/Lib9c/BlockPolicy.cs
@@ -11,40 +11,28 @@ using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
 namespace Nekoyume.BlockChain
 {
-    public class BlockPolicy : IBlockPolicy<NCAction>
+    public class BlockPolicy : BlockPolicy<NCAction>
     {
-        private readonly IBlockPolicy<NCAction> _impl;
-        
         private readonly Func<Block<NCAction>, InvalidBlockException> _blockValidator;
 
         public BlockPolicy(
-            IBlockPolicy<NCAction> impl, 
-            Func<Block<NCAction>, InvalidBlockException> blockValidator
-        )
+            IAction blockAction,
+            TimeSpan blockInterval,
+            long minimumDifficulty,
+            int difficultyBoundDivisor,
+            Func<Transaction<NCAction>, BlockChain<NCAction>, bool> doesTransactionFollowPolicy = null,
+            Func<Block<NCAction>, InvalidBlockException> blockValidator)
+            : base(
+                blockAction,
+                blockInterval,
+                minimumDifficulty,
+                difficultyBoundDivisor,
+                doesTransactionFollowPolicy)
         {
-            _impl = impl;
             _blockValidator = blockValidator;
         }
 
-        public IAction BlockAction => _impl.BlockAction;
-
-        public bool DoesTransactionFollowsPolicy(
-            Transaction<NCAction> transaction, 
-            BlockChain<NCAction> blockChain
-        ) => _impl.DoesTransactionFollowsPolicy(transaction, blockChain);
-
-        public long GetNextBlockDifficulty(BlockChain<NCAction> blocks)
-            => _impl.GetNextBlockDifficulty(blocks);
-
-        public InvalidBlockException ValidateNextBlock(BlockChain<NCAction> blocks, Block<NCAction> nextBlock)
-        {
-            InvalidBlockException excFromValidator = _blockValidator(nextBlock);
-            if (!(excFromValidator is null))
-            {
-                return excFromValidator;
-            }
-
-            return _impl.ValidateNextBlock(blocks, nextBlock);
-        }
+        public override InvalidBlockException ValidateNextBlock(BlockChain<NCAction> blocks, Block<NCAction> nextBlock)
+            => _blockValidator(nextBlock);
     }
 }

--- a/Lib9c/BlockPolicySource.cs
+++ b/Lib9c/BlockPolicySource.cs
@@ -46,8 +46,6 @@ namespace Nekoyume.BlockChain
                 new LoggedRenderer<NCAction>(BlockRenderer, logger, logEventLevel);
         }
 
-        public AuthorizedMinersState AuthorizedMinersState { get; set; }
-
         // FIXME 남은 설정들도 설정화 해야 할지도?
         public IBlockPolicy<NCAction> GetPolicy(int minimumDifficulty)
         {
@@ -59,8 +57,7 @@ namespace Nekoyume.BlockChain
                 _blockInterval,
                 minimumDifficulty,
                 2048,
-                IsSignerAuthorized,
-                ValidateMinerAuthority
+                IsSignerAuthorized
             );
 #endif
         }
@@ -73,57 +70,23 @@ namespace Nekoyume.BlockChain
             BlockChain<NCAction> blockChain
         )
         {
-            if (transaction.Actions.Count == 1 && 
+            if (transaction.Actions.Count == 1 &&
                 transaction.Actions.First().InnerAction is ActivateAccount)
             {
                 return true;
             }
-            
+
             if (blockChain.GetState(ActivatedAccountsState.Address) is Dictionary asDict)
             {
-                IImmutableSet<Address> activatedAccounts = 
+                IImmutableSet<Address> activatedAccounts =
                     new ActivatedAccountsState(asDict).Accounts;
-                return !activatedAccounts.Any() || 
+                return !activatedAccounts.Any() ||
                     activatedAccounts.Contains(transaction.Signer);
             }
             else
             {
                 return true;
             }
-        }
-
-        private InvalidBlockException ValidateMinerAuthority(Block<NCAction> block)
-        {
-            if (AuthorizedMinersState is null)
-            {
-                return null;
-            }
-
-            if (!(block.Miner is Address miner))
-            {
-                return null;
-            }
-
-            bool targetBlock = 0 < block.Index
-                               && block.Index <= AuthorizedMinersState.ValidUntil
-                               && block.Index % AuthorizedMinersState.Interval == 0;
-
-            bool minedByAuthorities = AuthorizedMinersState.Miners.Contains(miner);
-
-            if (!targetBlock)
-            {
-                return null;
-            }
-
-            if (minedByAuthorities)
-            {
-                return null;
-            }
-
-            return new InvalidMinerException(
-                $"The given block[{block}] isn't mined by authorities.",
-                miner
-            );
         }
     }
 }


### PR DESCRIPTION
This change `GetNextBlockDifficulty` to use the minimum difficulty in blocks for authorized miners.