### PR TITLE
Add tests to prove actions are idempotent

### DIFF
--- a/.Lib9c.Tests/Action/ActionExecutionUtils.cs
+++ b/.Lib9c.Tests/Action/ActionExecutionUtils.cs
@@ -1,0 +1,46 @@
+namespace Lib9c.Tests.Action
+{
+    using System.Collections.Immutable;
+    using System.Security.Cryptography;
+    using Bencodex.Types;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Assets;
+    using Libplanet.Blockchain;
+    using Libplanet.Store;
+    using Libplanet.Store.Trie;
+
+    public static class ActionExecutionUtils
+    {
+        public static HashDigest<SHA256> CalculateStateRootHash<T>(
+            T action, IAccountStateDelta previousStates = null, Address? signer = null, int? randomSeed = null)
+            where T : IAction, new()
+        {
+            var address = default(Address);
+            var nextState = action.Execute(new ActionContext()
+            {
+                PreviousStates = previousStates ?? new State(ImmutableDictionary<Address, IValue>.Empty),
+                Signer = signer ?? address,
+                Miner = address,
+                Random = new Random(randomSeed ?? 0),
+                BlockIndex = 1,
+            });
+            var stateStore = new TrieStateStore(new DefaultKeyValueStore(null), new DefaultKeyValueStore(null));
+            IImmutableDictionary<string, IValue> delta = nextState.GetTotalDelta(ToStateKey, ToFungibleAssetKey);
+
+            var genesis = BlockChain<T>.MakeGenesisBlock();
+            stateStore.SetStates(genesis, delta);
+            HashDigest<SHA256> stateRootHash = stateStore.GetRootHash(genesis.Hash);
+            return stateRootHash;
+        }
+
+        internal static string ToStateKey(Address address) => address.ToHex().ToLowerInvariant();
+
+        internal static string ToFungibleAssetKey(Address address, Currency currency) =>
+            "_" + address.ToHex().ToLowerInvariant() +
+            "_" + ByteUtil.Hex(currency.Hash.ByteArray).ToLowerInvariant();
+
+        internal static string ToFungibleAssetKey((Address, Currency) pair) =>
+            ToFungibleAssetKey(pair.Item1, pair.Item2);
+    }
+}

--- a/.Lib9c.Tests/Action/AddActivatedAccountTest.cs
+++ b/.Lib9c.Tests/Action/AddActivatedAccountTest.cs
@@ -1,6 +1,7 @@
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Immutable;
+    using System.Security.Cryptography;
     using Bencodex.Types;
     using Libplanet;
     using Libplanet.Action;
@@ -124,6 +125,24 @@ namespace Lib9c.Tests.Action
                     Signer = admin,
                 });
             });
+        }
+
+        [Fact]
+        public void Determinism()
+        {
+            var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
+            var state = new State(
+                ImmutableDictionary<Address, IValue>.Empty
+                    .Add(AdminState.Address, new AdminState(admin, 100).Serialize())
+                    .Add(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize())
+            );
+            var newComer = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
+            var action = new AddActivatedAccount(newComer);
+
+            HashDigest<SHA256> stateRootHashA = ActionExecutionUtils.CalculateStateRootHash(action, previousStates: state, signer: admin);
+            HashDigest<SHA256> stateRootHashB = ActionExecutionUtils.CalculateStateRootHash(action, previousStates: state, signer: admin);
+
+            Assert.Equal(stateRootHashA, stateRootHashB);
         }
     }
 }

--- a/.Lib9c.Tests/Action/IAccountStateDeltaExtensions.cs
+++ b/.Lib9c.Tests/Action/IAccountStateDeltaExtensions.cs
@@ -1,0 +1,42 @@
+namespace Lib9c.Tests.Action
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using Bencodex.Types;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Assets;
+
+    public static class IAccountStateDeltaExtensions
+    {
+        public static ImmutableDictionary<string, IValue> GetTotalDelta(
+            this IAccountStateDelta accountStateDelta,
+            Func<Address, string> toStateKey,
+            Func<(Address, Currency), string> toFungibleAssetKey)
+        {
+            IImmutableSet<Address> stateUpdatedAddresses = accountStateDelta.UpdatedAddresses;
+            IImmutableSet<(Address, Currency)> updatedFungibleAssets = accountStateDelta.UpdatedFungibleAssets
+                .SelectMany(kv => kv.Value.Select(c => (kv.Key, c)))
+                .ToImmutableHashSet();
+
+            ImmutableDictionary<string, IValue> totalDelta =
+                stateUpdatedAddresses.ToImmutableDictionary(
+                    toStateKey,
+                    a => accountStateDelta?.GetState(a)
+                ).SetItems(
+                    updatedFungibleAssets.Select(pair =>
+                        new KeyValuePair<string, IValue>(
+                            toFungibleAssetKey(pair),
+                            new Bencodex.Types.Integer(
+                                accountStateDelta?.GetBalance(pair.Item1, pair.Item2).RawValue ?? 0
+                            )
+                        )
+                    )
+                );
+
+            return totalDelta;
+        }
+    }
+}

--- a/.Lib9c.Tests/Action/InitializeStatesTest.cs
+++ b/.Lib9c.Tests/Action/InitializeStatesTest.cs
@@ -3,6 +3,7 @@ namespace Lib9c.Tests.Action
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
+    using System.Security.Cryptography;
     using Bencodex.Types;
     using Libplanet;
     using Libplanet.Assets;
@@ -176,6 +177,44 @@ namespace Lib9c.Tests.Action
                 (Dictionary)genesisState.GetState(Addresses.ActivatedAccount));
 
             Assert.Contains(adminAddress, fetchedState.Accounts);
+        }
+
+        [Fact]
+        public void Determinism()
+        {
+            var gameConfigState = new GameConfigState(_sheets[nameof(GameConfigSheet)]);
+            var redeemCodeListSheet = new RedeemCodeListSheet();
+            redeemCodeListSheet.Set(_sheets[nameof(RedeemCodeListSheet)]);
+            var goldDistributionCsvPath = GoldDistributionTest.CreateFixtureCsvFile();
+            var goldDistributions = GoldDistribution.LoadInDescendingEndBlockOrder(goldDistributionCsvPath);
+            var minterKey = new PrivateKey();
+            var ncg = new Currency("NCG", 2, minterKey.ToAddress());
+            var nonce = new byte[] { 0x00, 0x01, 0x02, 0x03 };
+            var privateKey = new PrivateKey();
+            (ActivationKey activationKey, PendingActivationState pendingActivation) =
+                ActivationKey.Create(privateKey, nonce);
+
+            var action = new InitializeStates
+            {
+                RankingState = new RankingState(),
+                ShopState = new ShopState(),
+                TableSheets = _sheets,
+                GameConfigState = gameConfigState,
+                RedeemCodeState = new RedeemCodeState(redeemCodeListSheet),
+                AdminAddressState = new AdminState(
+                    new Address("F9A15F870701268Bd7bBeA6502eB15F4997f32f9"),
+                    1500000
+                ),
+                ActivatedAccountsState = new ActivatedAccountsState(),
+                GoldCurrencyState = new GoldCurrencyState(ncg),
+                GoldDistributions = goldDistributions,
+                PendingActivationStates = new[] { pendingActivation },
+            };
+
+            HashDigest<SHA256> stateRootHashA = ActionExecutionUtils.CalculateStateRootHash(action, previousStates: new State());
+            HashDigest<SHA256> stateRootHashB = ActionExecutionUtils.CalculateStateRootHash(action, previousStates: new State());
+
+            Assert.Equal(stateRootHashA, stateRootHashB);
         }
     }
 }

--- a/.Lib9c.Tests/Action/Random.cs
+++ b/.Lib9c.Tests/Action/Random.cs
@@ -1,0 +1,12 @@
+namespace Lib9c.Tests.Action
+{
+    using Libplanet.Action;
+
+    internal class Random : System.Random, IRandom
+    {
+        internal Random(int seed)
+            : base(seed)
+        {
+        }
+    }
+}

--- a/.Lib9c.Tests/Action/RapidCombinationTest.cs
+++ b/.Lib9c.Tests/Action/RapidCombinationTest.cs
@@ -3,8 +3,10 @@ namespace Lib9c.Tests.Action
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
+    using System.Security.Cryptography;
     using Bencodex.Types;
     using Libplanet;
+    using Libplanet.Action;
     using Nekoyume;
     using Nekoyume.Action;
     using Nekoyume.Model.Item;
@@ -17,30 +19,30 @@ namespace Lib9c.Tests.Action
     {
         private readonly Dictionary<string, string> _sheets;
         private readonly TableSheets _tableSheets;
+        private readonly IAccountStateDelta _initialState;
+        private readonly Address _agentAddress;
+        private readonly Address _avatarAddress;
+        private readonly Equipment _equipment;
 
         public RapidCombinationTest()
         {
             _sheets = TableSheetsImporter.ImportSheets();
             _tableSheets = new TableSheets(_sheets);
-        }
 
-        [Fact]
-        public void Execute()
-        {
-            var agentAddress = default(Address);
-            var agentState = new AgentState(agentAddress);
+            _agentAddress = default(Address);
+            var agentState = new AgentState(_agentAddress);
 
-            var avatarAddress = agentAddress.Derive("avatar");
+            _avatarAddress = _agentAddress.Derive("avatar");
             var avatarState = new AvatarState(
-                avatarAddress,
-                agentAddress,
+                _avatarAddress,
+                _agentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
                 new GameConfigState(),
                 default
             );
 
-            agentState.avatarAddresses.Add(0, avatarAddress);
+            agentState.avatarAddresses.Add(0, _avatarAddress);
 
             var material =
                 ItemFactory.CreateMaterial(_tableSheets.MaterialItemSheet.Values.First(r => r.ItemSubType == ItemSubType.Hourglass));
@@ -50,15 +52,15 @@ namespace Lib9c.Tests.Action
 
             var gameConfigState = new GameConfigState(_sheets[nameof(GameConfigSheet)]);
             var row = _tableSheets.EquipmentItemSheet.Values.First();
-            var equipment = (Equipment)ItemFactory.CreateItemUsable(row, default, gameConfigState.HourglassPerBlock, 0);
-            avatarState.inventory.AddItem(equipment);
+            _equipment = (Equipment)ItemFactory.CreateItemUsable(row, default, gameConfigState.HourglassPerBlock, 0);
+            avatarState.inventory.AddItem(_equipment);
 
             var result = new CombinationConsumable.ResultModel
             {
                 actionPoint = 0,
                 gold = 0,
                 materials = new Dictionary<Material, int>(),
-                itemUsable = equipment,
+                itemUsable = _equipment,
                 recipeId = 0,
                 itemType = ItemType.Equipment,
             };
@@ -69,44 +71,63 @@ namespace Lib9c.Tests.Action
             avatarState.Update(mail);
 
             var slotAddress =
-                avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));
+                _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));
             var slotState = new CombinationSlotState(slotAddress, 1);
 
             slotState.Update(result, 0, requiredBlockIndex);
 
-            var state = new State()
-                .SetState(agentAddress, agentState.Serialize())
-                .SetState(avatarAddress, avatarState.Serialize())
+            _initialState = new State()
+                .SetState(_agentAddress, agentState.Serialize())
+                .SetState(_avatarAddress, avatarState.Serialize())
                 .SetState(slotAddress, slotState.Serialize())
                 .SetState(Addresses.GameConfig, gameConfigState.Serialize());
 
             foreach (var (key, value) in _sheets)
             {
-                state = state.SetState(
+                _initialState = _initialState.SetState(
                     Addresses.TableSheet.Derive(key),
                     value.Serialize()
                 );
             }
+        }
 
+        [Fact]
+        public void Execute()
+        {
             var action = new RapidCombination()
             {
-                avatarAddress = avatarAddress,
+                avatarAddress = _avatarAddress,
                 slotIndex = 0,
             };
 
             var nextState = action.Execute(new ActionContext()
             {
-                PreviousStates = state,
-                Signer = agentAddress,
+                PreviousStates = _initialState,
+                Signer = _agentAddress,
                 BlockIndex = 1,
             });
 
-            var nextAvatarState = nextState.GetAvatarState(avatarAddress);
+            var nextAvatarState = nextState.GetAvatarState(_avatarAddress);
             var item = nextAvatarState.inventory.Equipments.First();
 
             Assert.Empty(nextAvatarState.inventory.Materials.Select(r => r.ItemSubType == ItemSubType.Hourglass));
-            Assert.Equal(equipment.ItemId, item.ItemId);
+            Assert.Equal(_equipment.ItemId, item.ItemId);
             Assert.Equal(1, item.RequiredBlockIndex);
+        }
+
+        [Fact]
+        public void Determinism()
+        {
+            var action = new RapidCombination()
+            {
+                avatarAddress = _avatarAddress,
+                slotIndex = 0,
+            };
+
+            HashDigest<SHA256> stateRootHashA = ActionExecutionUtils.CalculateStateRootHash(action, previousStates: _initialState, signer: _agentAddress);
+            HashDigest<SHA256> stateRootHashB = ActionExecutionUtils.CalculateStateRootHash(action, previousStates: _initialState, signer: _agentAddress);
+
+            Assert.Equal(stateRootHashA, stateRootHashB);
         }
     }
 }

--- a/.Lib9c.Tests/Action/RedeemCodeTest.cs
+++ b/.Lib9c.Tests/Action/RedeemCodeTest.cs
@@ -3,6 +3,7 @@ namespace Lib9c.Tests.Action
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
+    using System.Security.Cryptography;
     using Bencodex.Types;
     using Libplanet;
     using Libplanet.Action;
@@ -36,18 +37,17 @@ namespace Lib9c.Tests.Action
 
         private readonly Dictionary<string, string> _sheets;
         private readonly TableSheets _tableSheets;
+        private readonly PrivateKey _privateKey;
+        private readonly GoldCurrencyState _goldState;
+        private readonly IAccountStateDelta _initialState;
 
         public RedeemCodeTest()
         {
             _sheets = TableSheetsImporter.ImportSheets();
             _tableSheets = new TableSheets(_sheets);
-        }
 
-        [Fact]
-        public void Execute()
-        {
-            var privateKey = new PrivateKey();
-            PublicKey publicKey = privateKey.PublicKey;
+            _privateKey = new PrivateKey();
+            PublicKey publicKey = _privateKey.PublicKey;
             var prevRedeemCodesState = new RedeemCodeState(new Dictionary<PublicKey, Reward>()
             {
                 [publicKey] = new Reward(1),
@@ -64,25 +64,29 @@ namespace Lib9c.Tests.Action
                 default
             );
 
-            var goldState = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+            _goldState = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
 
-            var initialState = new State()
+            _initialState = new State()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
                 .SetState(RedeemCodeState.Address, prevRedeemCodesState.Serialize())
-                .SetState(GoldCurrencyState.Address, goldState.Serialize())
-                .MintAsset(GoldCurrencyState.Address, goldState.Currency * 100000000);
+                .SetState(GoldCurrencyState.Address, _goldState.Serialize())
+                .MintAsset(GoldCurrencyState.Address, _goldState.Currency * 100000000);
 
             foreach (var (key, value) in _sheets)
             {
-                initialState = initialState.SetState(
+                _initialState = _initialState.SetState(
                     Addresses.TableSheet.Derive(key),
                     value.Serialize()
                 );
             }
+        }
 
+        [Fact]
+        public void Execute()
+        {
             var redeemCode = new RedeemCode(
-                ByteUtil.Hex(privateKey.ByteArray),
+                ByteUtil.Hex(_privateKey.ByteArray),
                 _avatarAddress
             );
 
@@ -90,7 +94,7 @@ namespace Lib9c.Tests.Action
             {
                 BlockIndex = 1,
                 Miner = default,
-                PreviousStates = initialState,
+                PreviousStates = _initialState,
                 Rehearsal = false,
                 Signer = _agentAddress,
             });
@@ -98,10 +102,10 @@ namespace Lib9c.Tests.Action
             // Check target avatar & agent
             AvatarState nextAvatarState = nextState.GetAvatarState(_avatarAddress);
             // See also Data/TableCSV/RedeemRewardSheet.csv
-            ItemSheet itemSheet = initialState.GetItemSheet();
+            ItemSheet itemSheet = _initialState.GetItemSheet();
             HashSet<int> expectedItems = new[] { 100000, 40100000 }.ToHashSet();
             Assert.Subset(nextAvatarState.inventory.Items.Select(i => i.item.Id).ToHashSet(), expectedItems);
-            Assert.Equal(goldState.Currency * 100, nextState.GetBalance(_agentAddress, goldState.Currency));
+            Assert.Equal(_goldState.Currency * 100, nextState.GetBalance(_agentAddress, _goldState.Currency));
 
             // Check the code redeemed properly
             RedeemCodeState nextRedeemCodeState = nextState.GetRedeemCodeState();
@@ -132,6 +136,20 @@ namespace Lib9c.Tests.Action
                 nextState.UpdatedAddresses,
                 new[] { _avatarAddress, _agentAddress, RedeemCodeState.Address, GoldCurrencyState.Address }.ToImmutableHashSet()
             );
+        }
+
+        [Fact]
+        public void Determinism()
+        {
+            var action = new RedeemCode(
+                ByteUtil.Hex(_privateKey.ByteArray),
+                _avatarAddress
+            );
+
+            HashDigest<SHA256> stateRootHashA = ActionExecutionUtils.CalculateStateRootHash(action, previousStates: _initialState, signer: _agentAddress);
+            HashDigest<SHA256> stateRootHashB = ActionExecutionUtils.CalculateStateRootHash(action, previousStates: _initialState, signer: _agentAddress);
+
+            Assert.Equal(stateRootHashA, stateRootHashB);
         }
     }
 }


### PR DESCRIPTION
I tried to prove actions' idempotency by executing every action twice and comparing two. If you thought it is not enough, then please leave your opinion. 🙏 

### Actions

- ActivateAccount
- AddActivatedAccount
- ChargeActionPoint
- CombinationConsumable
- CombinationEquipment
- CreateAvatar
- CreatePendingActivation
- HackAndSlash
- InitializeStates
- ItemEnhancement
- RankingBattle
- RapidCombination
- RedeemCode
- TransferAsset