### PR TITLE
Keep InitailizeStates's fields to serialized

### DIFF
--- a/.Lib9c.Tests/Action/InitializeStatesTest.cs
+++ b/.Lib9c.Tests/Action/InitializeStatesTest.cs
@@ -38,22 +38,21 @@ namespace Lib9c.Tests.Action
             (ActivationKey activationKey, PendingActivationState pendingActivation) =
                 ActivationKey.Create(privateKey, nonce);
 
-            var action = new InitializeStates
-            {
-                RankingState = new RankingState(),
-                ShopState = new ShopState(),
-                TableSheets = _sheets,
-                GameConfigState = gameConfigState,
-                RedeemCodeState = new RedeemCodeState(redeemCodeListSheet),
-                AdminAddressState = new AdminState(
+            var action = new InitializeStates(
+                rankingState: new RankingState(),
+                shopState: new ShopState(),
+                tableSheets: _sheets,
+                gameConfigState: gameConfigState,
+                redeemCodeState: new RedeemCodeState(redeemCodeListSheet),
+                adminAddressState: new AdminState(
                     new Address("F9A15F870701268Bd7bBeA6502eB15F4997f32f9"),
                     1500000
                 ),
-                ActivatedAccountsState = new ActivatedAccountsState(),
-                GoldCurrencyState = new GoldCurrencyState(ncg),
-                GoldDistributions = goldDistributions,
-                PendingActivationStates = new[] { pendingActivation },
-            };
+                activatedAccountsState: new ActivatedAccountsState(),
+                goldCurrencyState: new GoldCurrencyState(ncg),
+                goldDistributions: goldDistributions,
+                pendingActivationStates: new[] { pendingActivation }
+            );
 
             var genesisState = action.Execute(new ActionContext()
             {
@@ -97,27 +96,26 @@ namespace Lib9c.Tests.Action
             (ActivationKey activationKey, PendingActivationState pendingActivation) =
                 ActivationKey.Create(privateKey, nonce);
 
-            var action = new InitializeStates
-            {
-                RankingState = new RankingState(),
-                ShopState = new ShopState(),
-                TableSheets = _sheets,
-                GameConfigState = gameConfigState,
-                RedeemCodeState = new RedeemCodeState(redeemCodeListSheet),
-                AdminAddressState = new AdminState(
+            var action = new InitializeStates(
+                rankingState: new RankingState(),
+                shopState: new ShopState(),
+                tableSheets: _sheets,
+                gameConfigState: gameConfigState,
+                redeemCodeState: new RedeemCodeState(redeemCodeListSheet),
+                adminAddressState: new AdminState(
                     new Address("F9A15F870701268Bd7bBeA6502eB15F4997f32f9"),
                     1500000
                 ),
-                ActivatedAccountsState = new ActivatedAccountsState(),
-                GoldCurrencyState = new GoldCurrencyState(ncg),
-                GoldDistributions = goldDistributions,
-                PendingActivationStates = new[] { pendingActivation },
-                AuthorizedMinersState = new AuthorizedMinersState(
+                activatedAccountsState: new ActivatedAccountsState(),
+                goldCurrencyState: new GoldCurrencyState(ncg),
+                goldDistributions: goldDistributions,
+                pendingActivationStates: new[] { pendingActivation },
+                authorizedMinersState: new AuthorizedMinersState(
                     interval: 50,
                     validUntil: 1000,
                     miners: new[] { default(Address) }
-                ),
-            };
+                )
+            );
 
             var genesisState = action.Execute(new ActionContext()
             {
@@ -151,19 +149,18 @@ namespace Lib9c.Tests.Action
                 ActivationKey.Create(privateKey, nonce);
             var adminAddress = new Address("F9A15F870701268Bd7bBeA6502eB15F4997f32f9");
 
-            var action = new InitializeStates
-            {
-                RankingState = new RankingState(),
-                ShopState = new ShopState(),
-                TableSheets = _sheets,
-                GameConfigState = gameConfigState,
-                RedeemCodeState = new RedeemCodeState(redeemCodeListSheet),
-                AdminAddressState = new AdminState(adminAddress, 1500000),
-                ActivatedAccountsState = new ActivatedAccountsState(ImmutableHashSet<Address>.Empty.Add(adminAddress)),
-                GoldCurrencyState = new GoldCurrencyState(ncg),
-                GoldDistributions = goldDistributions,
-                PendingActivationStates = new[] { pendingActivation },
-            };
+            var action = new InitializeStates(
+                rankingState: new RankingState(),
+                shopState: new ShopState(),
+                tableSheets: _sheets,
+                gameConfigState: gameConfigState,
+                redeemCodeState: new RedeemCodeState(redeemCodeListSheet),
+                adminAddressState: new AdminState(adminAddress, 1500000),
+                activatedAccountsState: new ActivatedAccountsState(ImmutableHashSet<Address>.Empty.Add(adminAddress)),
+                goldCurrencyState: new GoldCurrencyState(ncg),
+                goldDistributions: goldDistributions,
+                pendingActivationStates: new[] { pendingActivation }
+            );
 
             var genesisState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/BlockPolicyTest.cs
+++ b/.Lib9c.Tests/BlockPolicyTest.cs
@@ -305,25 +305,24 @@ namespace Lib9c.Tests
             return BlockChain<PolymorphicAction<ActionBase>>.MakeGenesisBlock(
                     new PolymorphicAction<ActionBase>[]
                     {
-                        new InitializeStates()
-                        {
-                            RankingState = new RankingState(),
-                            ShopState = new ShopState(),
-                            TableSheets = TableSheetsImporter.ImportSheets(),
-                            GameConfigState = new GameConfigState(),
-                            RedeemCodeState = new RedeemCodeState(Dictionary.Empty
+                        new InitializeStates(
+                            rankingState: new RankingState(),
+                            shopState: new ShopState(),
+                            tableSheets: TableSheetsImporter.ImportSheets(),
+                            gameConfigState: new GameConfigState(),
+                            redeemCodeState: new RedeemCodeState(Dictionary.Empty
                                 .Add("address", RedeemCodeState.Address.Serialize())
                                 .Add("map", Dictionary.Empty)
                             ),
-                            AdminAddressState = new AdminState(adminAddress, 1500000),
-                            ActivatedAccountsState = new ActivatedAccountsState(activatedAddresses),
-                            GoldCurrencyState = new GoldCurrencyState(
+                            adminAddressState: new AdminState(adminAddress, 1500000),
+                            activatedAccountsState: new ActivatedAccountsState(activatedAddresses),
+                            goldCurrencyState: new GoldCurrencyState(
                                 new Currency("NCG", 2, minter: null)
                             ),
-                            GoldDistributions = new GoldDistribution[0],
-                            PendingActivationStates = new[] { pendingActivation },
-                            AuthorizedMinersState = authorizedMinersState,
-                        },
+                            goldDistributions: new GoldDistribution[0],
+                            pendingActivationStates: new[] { pendingActivation },
+                            authorizedMinersState: authorizedMinersState
+                        ),
                     },
                     timestamp: timestamp ?? DateTimeOffset.MinValue
                 );

--- a/Lib9c/BlockHelper.cs
+++ b/Lib9c/BlockHelper.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
+using Bencodex.Types;
 using Libplanet;
 using Libplanet.Action;
 using Libplanet.Assets;
@@ -39,22 +41,22 @@ namespace Nekoyume
             var ncg = new Currency("NCG", 2, minterKey.ToAddress());
             activatedAccounts = activatedAccounts ?? ImmutableHashSet<Address>.Empty;
             var initialStatesAction = new InitializeStates
-            {
-                RankingState = new RankingState(),
-                ShopState = new ShopState(),
-                TableSheets = (Dictionary<string, string>) tableSheets,
-                GameConfigState = gameConfigState,
-                RedeemCodeState = new RedeemCodeState(redeemCodeListSheet),
-                AdminAddressState = adminState,
-                ActivatedAccountsState = new ActivatedAccountsState(
+            (
+                rankingState: new RankingState(),
+                shopState: new ShopState(),
+                tableSheets: (Dictionary<string, string>) tableSheets,
+                gameConfigState: gameConfigState,
+                redeemCodeState: new RedeemCodeState(redeemCodeListSheet),
+                adminAddressState: adminState,
+                activatedAccountsState: new ActivatedAccountsState(
                     isActivateAdminAddress
                     ? activatedAccounts.Add(adminState.AdminAddress)
                     : activatedAccounts),
-                GoldCurrencyState = new GoldCurrencyState(ncg),
-                GoldDistributions = goldDistributions,
-                PendingActivationStates = pendingActivationStates,
-                AuthorizedMinersState = authorizedMinersState,
-            };
+                goldCurrencyState: new GoldCurrencyState(ncg),
+                goldDistributions: goldDistributions,
+                pendingActivationStates: pendingActivationStates,
+                authorizedMinersState: authorizedMinersState
+            );
             var actions = new PolymorphicAction<ActionBase>[]
             {
                 initialStatesAction,


### PR DESCRIPTION
This PR forces to keep `InitializeStates`'s fields as serialized to avoid unnecessary serialization.