### PR TITLE
Introduce dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR introduces [Dependabot](https://dependabot.com/) to update dependencies in this project automatically.

I'll also apply it to https://github.com/planetarium/nineChronicles.standalone too.