### PR TITLE
Make get fixture dir on TableSheetsImporter.ImportSheet

### DIFF
--- a/.Lib9c.Tests/TableSheetsImporter.cs
+++ b/.Lib9c.Tests/TableSheetsImporter.cs
@@ -5,10 +5,11 @@ namespace Lib9c.Tests
 
     public static class TableSheetsImporter
     {
-        public static Dictionary<string, string> ImportSheets()
+        public static Dictionary<string, string> ImportSheets(
+            string dir = null)
         {
             var sheets = new Dictionary<string, string>();
-            var dir = Path.Combine("Data", "TableCSV");
+            dir ??= Path.Combine("Data", "TableCSV");
             var files = Directory.GetFiles(dir, "*.csv", SearchOption.AllDirectories);
             foreach (var filePath in files)
             {


### PR DESCRIPTION
- To make a fixture available in another repository using Lib9c as a submodule.