### PR TITLE
Validate action render in `ValidatingActionRenderer<T>`

### DIFF
--- a/.Lib9c.Tests/Lib9c.Tests.csproj
+++ b/.Lib9c.Tests/Lib9c.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />
     
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/.Lib9c.Tests/Renderer/RendererTest.cs
+++ b/.Lib9c.Tests/Renderer/RendererTest.cs
@@ -1,17 +1,35 @@
 ﻿namespace Lib9c.Tests.Renderer
 {
     using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Linq;
     using Lib9c.Renderer;
+    using Lib9c.Tests.Action;
     using Libplanet;
     using Libplanet.Blocks;
+    using Libplanet.Crypto;
     using Libplanet.Tx;
+    using Nekoyume.Action;
+    using Serilog;
     using Xunit;
+    using Xunit.Abstractions;
     using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
     using NCBlock = Libplanet.Blocks.Block<Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>>;
 
     public class RendererTest
     {
+        public RendererTest(ITestOutputHelper output)
+        {
+            const string outputTemplate =
+                "{Timestamp:HH:mm:ss:ffffffZ} - {Message}";
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.TestOutput(output, outputTemplate: outputTemplate)
+                .CreateLogger()
+                .ForContext<RendererTest>();
+        }
+
         [Fact]
         public void BlockRendererTest()
         {
@@ -40,7 +58,7 @@
                 totalDifficulty: 100000,
                 nonce: new Nonce(new byte[] { 0x00, 0x00, 0x00, 0x03 }),
                 miner: default,
-                previousHash: oldBlock.Hash,
+                previousHash: branchPointBlock.Hash,
                 timestamp: DateTimeOffset.MinValue.AddSeconds(2),
                 transactions: Enumerable.Empty<Transaction<NCAction>>());
 
@@ -64,6 +82,177 @@
             Assert.Equal(oldBlock, everyReorgEndResult.OldTip);
             Assert.Equal(newBlock, everyReorgEndResult.NewTip);
             Assert.Equal(branchPointBlock, everyReorgEndResult.BranchPoint);
+        }
+
+        [Fact]
+        public void ValidatingActionRendererTest()
+        {
+            var renderer = new ValidatingActionRenderer<NCAction>(new DebugPolicy());
+            var branchPointBlock = new Block<NCAction>(
+                index: 9,
+                difficulty: 10000,
+                totalDifficulty: 90000,
+                nonce: new Nonce(new byte[] { 0x00, 0x00, 0x00, 0x01 }),
+                miner: default,
+                previousHash: null,
+                timestamp: DateTimeOffset.MinValue,
+                transactions: Enumerable.Empty<Transaction<NCAction>>());
+            var differentBlock = new Block<NCAction>(
+                index: 9,
+                difficulty: 10000,
+                totalDifficulty: 90000,
+                nonce: new Nonce(new byte[] { 0x00, 0x00, 0x01, 0x01 }),
+                miner: default,
+                previousHash: null,
+                timestamp: DateTimeOffset.MinValue,
+                transactions: Enumerable.Empty<Transaction<NCAction>>());
+            var oldBlock = new Block<NCAction>(
+                index: 10,
+                difficulty: 10000,
+                totalDifficulty: 100000,
+                nonce: new Nonce(new byte[] { 0x00, 0x00, 0x00, 0x02 }),
+                miner: default,
+                previousHash: branchPointBlock.Hash,
+                timestamp: DateTimeOffset.MinValue.AddSeconds(1),
+                transactions: Enumerable.Empty<Transaction<NCAction>>());
+            var newBlock = new Block<NCAction>(
+                index: 10,
+                difficulty: 10000,
+                totalDifficulty: 100000,
+                nonce: new Nonce(new byte[] { 0x00, 0x00, 0x00, 0x03 }),
+                miner: default,
+                previousHash: oldBlock.Hash,
+                timestamp: DateTimeOffset.MinValue.AddSeconds(2),
+                transactions: Enumerable.Empty<Transaction<NCAction>>());
+            var privateKey = new PrivateKey();
+            NCAction action1 = new HackAndSlash
+            {
+                costumes = new List<int>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = 0,
+                stageId = 1,
+            };
+            NCAction action2 = new HackAndSlash
+            {
+                costumes = new List<int>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = 0,
+                stageId = 2,
+            };
+            NCAction action3 = new HackAndSlash
+            {
+                costumes = new List<int>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = 0,
+                stageId = 3,
+            };
+            var tx1 = Transaction<NCAction>.Create(
+                0,
+                privateKey,
+                null,
+                new[] { action1 },
+                ImmutableHashSet<Address>.Empty,
+                DateTimeOffset.MinValue);
+            var tx2 = Transaction<NCAction>.Create(
+                1,
+                privateKey,
+                null,
+                new[] { action2, action3 },
+                ImmutableHashSet<Address>.Empty,
+                DateTimeOffset.MinValue);
+            var blockWithTxs = new Block<NCAction>(
+                index: 11,
+                difficulty: 10000,
+                totalDifficulty: 100000,
+                nonce: new Nonce(new byte[] { 0x00, 0x00, 0x00, 0x04 }),
+                miner: default,
+                previousHash: oldBlock.Hash,
+                timestamp: DateTimeOffset.MinValue.AddSeconds(3),
+                transactions: new[] { tx1, tx2 });
+
+            renderer.RenderBlock(branchPointBlock, oldBlock);
+            Assert.Throws<ValidatingActionRenderer<NCAction>.InvalidRenderException>(() =>
+                renderer.RenderBlockEnd(differentBlock, oldBlock));
+
+            renderer.ResetRecords();
+
+            renderer.RenderBlock(branchPointBlock, oldBlock);
+            Assert.Throws<ValidatingActionRenderer<NCAction>.InvalidRenderException>(() =>
+                renderer.RenderBlockEnd(branchPointBlock, newBlock));
+
+            renderer.ResetRecords();
+
+            // Different action render count
+            renderer.RenderBlock(oldBlock, blockWithTxs);
+            Assert.Throws<ValidatingActionRenderer<NCAction>.InvalidRenderException>(() => renderer.RenderBlockEnd(oldBlock, blockWithTxs));
+
+            renderer.ResetRecords();
+
+            // Different action render
+            renderer.RenderBlock(oldBlock, blockWithTxs);
+            renderer.RenderAction(
+                new RewardGold(),
+                new ActionContext { BlockIndex = blockWithTxs.Index },
+                new State());
+            renderer.RenderAction(
+                new RewardGold(),
+                new ActionContext { BlockIndex = blockWithTxs.Index },
+                new State());
+            renderer.RenderAction(
+                new RewardGold(),
+                new ActionContext { BlockIndex = blockWithTxs.Index },
+                new State());
+            renderer.RenderAction(
+                new RewardGold(),
+                new ActionContext { BlockIndex = blockWithTxs.Index },
+                new State());
+            Assert.Throws<ValidatingActionRenderer<NCAction>.InvalidRenderException>(() => renderer.RenderBlockEnd(oldBlock, blockWithTxs));
+
+            renderer.ResetRecords();
+
+            // Different action order
+            renderer.RenderBlock(oldBlock, blockWithTxs);
+            renderer.RenderAction(
+                action1,
+                new ActionContext { BlockIndex = blockWithTxs.Index },
+                new State());
+            renderer.RenderAction(
+                action3,
+                new ActionContext { BlockIndex = blockWithTxs.Index },
+                new State());
+            renderer.RenderAction(
+                action2,
+                new ActionContext { BlockIndex = blockWithTxs.Index },
+                new State());
+            renderer.RenderAction(
+                new RewardGold(),
+                new ActionContext { BlockIndex = blockWithTxs.Index },
+                new State());
+            Assert.Throws<ValidatingActionRenderer<NCAction>.InvalidRenderException>(() => renderer.RenderBlockEnd(oldBlock, blockWithTxs));
+
+            renderer.ResetRecords();
+
+            renderer.RenderBlock(oldBlock, blockWithTxs);
+            renderer.RenderAction(
+                action1,
+                new ActionContext { BlockIndex = blockWithTxs.Index },
+                new State());
+            renderer.RenderAction(
+                action2,
+                new ActionContext { BlockIndex = blockWithTxs.Index },
+                new State());
+            renderer.RenderAction(
+                action3,
+                new ActionContext { BlockIndex = blockWithTxs.Index },
+                new State());
+            renderer.RenderAction(
+                new RewardGold(),
+                new ActionContext { BlockIndex = blockWithTxs.Index },
+                new State());
+            renderer.RenderBlockEnd(oldBlock, blockWithTxs);
         }
     }
 }

--- a/Lib9c/Renderer/ActionRenderer.cs
+++ b/Lib9c/Renderer/ActionRenderer.cs
@@ -67,7 +67,7 @@ namespace Lib9c.Renderer
             Exception exception
         )
         {
-            Log.Error(exception, "{action} exeuction failed.", action);
+            Log.Error(exception, "{action} execution failed.", action);
             ActionRenderSubject.OnNext(new ActionEvaluation<ActionBase>()
             {
                 Action = GetActionBase(action),

--- a/Lib9c/Renderer/ValidatingActionRenderer.cs
+++ b/Lib9c/Renderer/ValidatingActionRenderer.cs
@@ -95,9 +95,9 @@ namespace Lib9c.Renderer
 
             List<IAction> expectedActions = new List<IAction>();
             
-            foreach(var tx in newTip.Transactions)
+            foreach (var tx in newTip.Transactions)
             {
-                expectedActions.AddRange(tx.Actions.Select(a => (IAction) a));
+                expectedActions.AddRange(tx.Actions.Cast<IAction>());
             }
             
             if (_policy.BlockAction != null)


### PR DESCRIPTION
Now compares actions rendered in renderer with actions in actual block that rendered at `ValidatingActionRenderer<T>.RenderBlockEnd()`. It became to take `IBlockPolicy` in its constructor.