### PR TITLE
Add tx sub-command to Lib9c.Tools.exe

### DIFF
--- a/.Lib9c.Tools/Program.cs
+++ b/.Lib9c.Tools/Program.cs
@@ -4,6 +4,7 @@ using Lib9c.Tools.SubCommand;
 namespace Lib9c.Tools
 {
     [HasSubCommands(typeof(Genesis), Description = "Manage genesis block.")]
+    [HasSubCommands(typeof(Tx), Description = "Manage transactions.")]
     class Program
     {
         static void Main(string[] args) => CoconaLiteApp.Run<Program>(args);

--- a/.Lib9c.Tools/Program.cs
+++ b/.Lib9c.Tools/Program.cs
@@ -1,11 +1,9 @@
-﻿using System;
 using Cocona;
-using Lib9c.Tools.SubCommend;
+using Lib9c.Tools.SubCommand;
 
 namespace Lib9c.Tools
 {
-    // FIXME more detailed description need
-    [HasSubCommands(typeof(Create), Description = "Create Genesis Block")]
+    [HasSubCommands(typeof(Genesis), Description = "Manage genesis block.")]
     class Program
     {
         static void Main(string[] args) => CoconaLiteApp.Run<Program>(args);

--- a/.Lib9c.Tools/SubCommand/Genesis.cs
+++ b/.Lib9c.Tools/SubCommand/Genesis.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.ComponentModel;
-using System.IO;
-using System.Linq;
 using Cocona;
 using Libplanet;
 using Libplanet.Action;
@@ -12,12 +6,17 @@ using Nekoyume;
 using Nekoyume.Action;
 using Nekoyume.Model;
 using Nekoyume.Model.State;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
 
-namespace Lib9c.Tools.SubCommend
+namespace Lib9c.Tools.SubCommand
 {
-    public class Create
+    public class Genesis
     {
-        public void Genesis(
+        [Command(Description = "Create a new genesis block.")]
+        public void Create(
             [Option('g', Description = "/path/to/nekoyume-unity/nekoyume/Assets/AddressableAssets/TableCSV")]
             string gameConfigDir,
             [Option('d', Description = "/path/to/nekoyume-unity/nekoyume/Assets/StreamingAssets/GoldDistribution.csv")]

--- a/.Lib9c.Tools/SubCommand/Tx.cs
+++ b/.Lib9c.Tools/SubCommand/Tx.cs
@@ -1,0 +1,104 @@
+using Bencodex;
+using Bencodex.Types;
+using Cocona;
+using Libplanet;
+using Libplanet.Assets;
+using Libplanet.Blocks;
+using Libplanet.Crypto;
+using Libplanet.Tx;
+using Nekoyume.Action;
+using Nekoyume.Model.State;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
+
+namespace Lib9c.Tools.SubCommand
+{
+    public class Tx
+    {
+        private static Codec _codec = new Codec();
+
+        [Command(Description = "Create TransferAsset action and dump it.")]
+        public void TransferAsset(
+            [Argument("SENDER", Description = "An address of sender.")] string sender,
+            [Argument("RECIPIENT", Description = "An address of recipient.")] string recipient,
+            [Argument("AMOUNT", Description = "An amount of gold to transfer.")] int goldAmount,
+            [Argument("GENESIS-BLOCK", Description = "A genesis block containing InitializeStates.")] string genesisBlock
+        )
+        {
+            Block<NCAction> genesis = Block<NCAction>.Deserialize(File.ReadAllBytes(genesisBlock));
+            var initStates = (InitializeStates)genesis.Transactions.Single().Actions.Single().InnerAction;
+            Currency currency = new GoldCurrencyState(initStates.GoldCurrency).Currency;
+
+            var action = new TransferAsset(
+                new Address(sender),
+                new Address(recipient),
+                currency * goldAmount
+            );
+
+            var bencoded = new List(
+                new IValue[]
+                {
+                    (Text) nameof(TransferAsset),
+                    action.PlainValue
+                }
+            );
+            
+            byte[] raw = _codec.Encode(bencoded);
+            Console.Write(ByteUtil.Hex(raw));
+        }
+
+        [Command(Description = "Create new transaction with given actions and dump it.")]
+        public void Sign(
+            [Argument("PRIVATE-KEY", Description = "A hex-encoded private key for signing.")] string privateKey,
+            [Argument("NONCE", Description = "A nonce for new transaction.")] long nonce,
+            [Argument("TIMESTAMP", Description = "A datetime for new transaction.")] string timestamp = null,
+            [Argument("GENESIS-HASH", Description = "A hex-encoded genesis block hash.")] string genesisHash = null,
+            [Option("action", new[] { 'a' }, Description = "Hex-encoded actions")] string[] actions = null,
+            [Option("bytes", new[] { 'b' }, Description = "Print raw bytes instead of hexadecimal.  No trailing LF appended.")] bool bytes = false
+        )
+        {
+            List<NCAction> parsedActions = null;
+            if (!(actions is null))
+            {
+                parsedActions = actions.Select(a =>
+                {
+                    var bencoded = (List)_codec.Decode(ByteUtil.ParseHex(a));
+                    string type = (Text) bencoded[0];
+                    Dictionary plainValue = (Dictionary)bencoded[1];
+                    
+                    ActionBase action = null;
+                    action = type switch
+                    {
+                        nameof(TransferAsset) => new TransferAsset(),
+                        _ => throw new CommandExitedException($"Can't determine given action type: {type}", 128),
+                    };
+                    action.LoadPlainValue(plainValue);
+
+                    return (NCAction)action;
+                }).ToList();
+            }
+            Transaction<NCAction> tx = Transaction<NCAction>.Create(
+                nonce: nonce,
+                privateKey: new PrivateKey(ByteUtil.ParseHex(privateKey)),
+                genesisHash: (genesisHash is null) ? default : new HashDigest<SHA256>(ByteUtil.ParseHex(genesisHash)),
+                timestamp: (timestamp is null) ? default : DateTimeOffset.Parse(timestamp),
+                actions: parsedActions
+            );
+            byte[] raw = tx.Serialize(true);
+
+            if (bytes)
+            {
+                using Stream stdout = Console.OpenStandardOutput();
+                stdout.Write(raw);
+            }
+            else
+            {
+                Console.WriteLine(ByteUtil.Hex(raw));
+            }
+        }
+    }
+}

--- a/.Lib9c.Tools/SubCommand/Tx.cs
+++ b/.Lib9c.Tools/SubCommand/Tx.cs
@@ -57,7 +57,7 @@ namespace Lib9c.Tools.SubCommand
             [Argument("NONCE", Description = "A nonce for new transaction.")] long nonce,
             [Argument("TIMESTAMP", Description = "A datetime for new transaction.")] string timestamp = null,
             [Argument("GENESIS-HASH", Description = "A hex-encoded genesis block hash.")] string genesisHash = null,
-            [Option("action", new[] { 'a' }, Description = "Hex-encoded actions")] string[] actions = null,
+            [Option("action", new[] { 'a' }, Description = "Hex-encoded actions.")] string[] actions = null,
             [Option("bytes", new[] { 'b' }, Description = "Print raw bytes instead of hexadecimal.  No trailing LF appended.")] bool bytes = false
         )
         {


### PR DESCRIPTION
This PR adds `tx` sub-command to `Lib9c.Tools.exe` to enable users to create directly `TransferAsset` action and tx containing it.

```pwsh
PS C:\Users\X1E\electron-launcher\NineChronicles.Standalone\Lib9c\.Lib9c.Tools> dotnet run -- tx transfer-asset 9686661FDcf33Ce01aFF59a371bcdB7f748f7155 9686661FDcf33Ce01aFF59a371bcdB7f748f7155 1000 .\genesis-block-9c-beta-8-rc2
6c7531333a5472616e7366657241737365746475363a616d6f756e746c647531333a646563696d616c506c61636573313a0275373a6d696e746572736c32303a2de26698a6245f477dff4cfc0d172f9c070ea18d6575363a7469636b657275333a4e43476569313030303030656575393a726563697069656e7432303a9686661fdcf33ce01aff59a371bcdb7f748f715575363a73656e64657232303a9686661fdcf33ce01aff59a371bcdb7f748f71556565

PS C:\Users\X1E\electron-launcher\NineChronicles.Standalone\Lib9c\.Lib9c.Tools> dotnet run -- tx sign 7de7384057a13164883e8e25170b7eb7b34e316ef8412b6097bfe87e28a29155 0 -a 6c7531333a5472616e7366657241737365746475363a616d6f756e746c647531333a646563696d616c506c61636573313a0275373a6d696e746572736c32303a2de26698a6245f477dff4cfc0d172f9c070ea18d6575363a7469636b657275333a4e43476569313030303030656575393a726563697069656e7432303a9686661fdcf33ce01aff59a371bcdb7f748f715575363a73656e64657232303a9686661fdcf33ce01aff59a371bcdb7f748f71556565
64313a5337313a3045022100bfa98fbf345d6de54e66f259b9f7686051bc7071517feb382945c9e2c8b53f2e02204c55a1e5b285d196e95dc84f4886b816c65fb12dd072eb390c467ebb161b1b3c313a616c6475373a747970655f69647531343a7472616e736665725f617373657475363a76616c7565736475363a616d6f756e746c647531333a646563696d616c506c61636573313a0275373a6d696e746572736c32303a2de26698a6245f477dff4cfc0d172f9c070ea18d6575363a7469636b657275333a4e43476569313030303030656575393a726563697069656e7432303a9686661fdcf33ce01aff59a371bcdb7f748f715575363a73656e64657232303a9686661fdcf33ce01aff59a371bcdb7f748f7155656565313a6733323a0000000000000000000000000000000000000000000000000000000000000000313a6e693065313a7036353a0469cf2503acc91f62e85bd8483039118fe18ee8fd0d435d87c3b90ef81df2f7020eeab55c10088d212e04da1261c732383214e225af63a472aa5efaaf2ed49634313a7332303aee12703bc0e05085c70741851a2dc48946d16766313a747532373a303030312d30312d30315430303a30303a30302e3030303030305a313a756c32303a9686661fdcf33ce01aff59a371bcdb7f748f71556565
```

Also, this PR renames `create` sub-command to `genesis` to more specify its purpose.