### PR TITLE
Add creditsState to BlockHelper

### DIFF
--- a/.Lib9c.Tools/Lib9c.Tools.csproj
+++ b/.Lib9c.Tools/Lib9c.Tools.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp3.1</TargetFramework>
+        <AssemblyName>9c-tools</AssemblyName>
     </PropertyGroup>
 
     <ItemGroup>

--- a/.Lib9c.Tools/SubCommand/Genesis.cs
+++ b/.Lib9c.Tools/SubCommand/Genesis.cs
@@ -28,8 +28,9 @@ namespace Lib9c.Tools.SubCommand
             [Option("activatedAccountsList", Description = "List of accounts to be activated")]
             string activatedAccountsListPath = null,
             [Option('m', Description = "Config path to create AuthorizedMinersState")]
-            string authorizedMinerConfigPath = null
-
+            string authorizedMinerConfigPath = null,
+            [Option('c', Description = "Path of a plain text file containing names for credits.")]
+            string creditsPath = null
         )
         {
             Dictionary<string, string> tableSheets = Utils.ImportSheets(gameConfigDir);
@@ -59,7 +60,9 @@ namespace Lib9c.Tools.SubCommand
                 adminState,
                 authorizedMinersState: authorizedMinersState,
                 activatedAccounts: activatedAccounts,
-                isActivateAdminAddress: activationKeyCount != 0);
+                isActivateAdminAddress: activationKeyCount != 0,
+                credits: creditsPath is null ? null : File.ReadLines(creditsPath)
+            );
 
             ExportBlock(block, "genesis-block");
             ExportKeys(activationKeys, "keys.txt");

--- a/Lib9c/BlockHelper.cs
+++ b/Lib9c/BlockHelper.cs
@@ -25,7 +25,8 @@ namespace Nekoyume
             AdminState adminState,
             AuthorizedMinersState authorizedMinersState = null,
             IImmutableSet<Address> activatedAccounts = null,
-            bool isActivateAdminAddress = false
+            bool isActivateAdminAddress = false,
+            IEnumerable<string> credits = null
         )
         {
             if (!tableSheets.TryGetValue(nameof(GameConfigSheet), out var csv))
@@ -55,7 +56,8 @@ namespace Nekoyume
                 goldCurrencyState: new GoldCurrencyState(ncg),
                 goldDistributions: goldDistributions,
                 pendingActivationStates: pendingActivationStates,
-                authorizedMinersState: authorizedMinersState
+                authorizedMinersState: authorizedMinersState,
+                creditsState: credits is null ? null : new CreditsState(credits) 
             );
             var actions = new PolymorphicAction<ActionBase>[]
             {


### PR DESCRIPTION
This PR is a follow-up of #128 . it introduces `CreditsState` to `BlockHelper.MineGenesisBlock()`