### PR TITLE
Apply Libplanet.Analyzers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,6 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Release
     - name: Test
       run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: 3.1.403
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/Lib9c.sln
+++ b/Lib9c.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Stun", ".Libplane
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet", ".Libplanet\Libplanet\Libplanet.csproj", "{5C9F5F97-367E-4F8B-A123-D9AADE786CA1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Analyzers", ".Libplanet\Libplanet.Analyzers\Libplanet.Analyzers.csproj", "{659722A9-132F-4B41-87BC-1B56A97A98FA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -49,9 +51,14 @@ Global
 		{5C9F5F97-367E-4F8B-A123-D9AADE786CA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5C9F5F97-367E-4F8B-A123-D9AADE786CA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5C9F5F97-367E-4F8B-A123-D9AADE786CA1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{659722A9-132F-4B41-87BC-1B56A97A98FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{659722A9-132F-4B41-87BC-1B56A97A98FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{659722A9-132F-4B41-87BC-1B56A97A98FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{659722A9-132F-4B41-87BC-1B56A97A98FA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{6126D57A-F079-4B07-B1E4-531630DCCDBF} = {AFA609F0-8CAE-4494-A4E2-EABD9E95D678}
 		{5C9F5F97-367E-4F8B-A123-D9AADE786CA1} = {AFA609F0-8CAE-4494-A4E2-EABD9E95D678}
+		{659722A9-132F-4B41-87BC-1B56A97A98FA} = {AFA609F0-8CAE-4494-A4E2-EABD9E95D678}
 	EndGlobalSection
 EndGlobal

--- a/Lib9c/Lib9c.csproj
+++ b/Lib9c/Lib9c.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CS0162</NoWarn>
+    <NoWarn>$(NoWarn);CS0162;CS8032</NoWarn>
     <CodeAnalysisRuleSet>Lib9c.ruleset</CodeAnalysisRuleSet>
     <OutputPath>.bin</OutputPath>
     <IntermediateOutputPath>.obj</IntermediateOutputPath>
@@ -29,5 +29,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\.Libplanet\Libplanet\Libplanet.csproj" />
+    <ProjectReference Include="..\.Libplanet\Libplanet.Analyzers\Libplanet.Analyzers.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Analyzer</OutputItemType>
+      <!-- https://github.com/dotnet/roslyn/issues/18093#issuecomment-405702631 -->
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/Lib9c/Lib9c.ruleset
+++ b/Lib9c/Lib9c.ruleset
@@ -4,8 +4,9 @@
   Description="Code analysis rules for Lib9c.csproj."
   ToolsVersion="10.0">
   <Rules AnalyzerId="Libplanet.Analyzers" RuleNamespace="Libplanet.Analyzers">
-    <Rule Id="LAA9999" Action="Warning" />
-    <Rule Id="LAA1001" Action="Warning" />
+    <Rule Id="LAA9999" Action="Error" />
+    <Rule Id="LAA1001" Action="Error" />
+    <Rule Id="LAA1002" Action="Info" />  <!----> FIXME: should be Action="Error" -->
   </Rules>
 
   <Rules AnalyzerId="SonarAnalyzer" RuleNamespace="SonarAnalyzer">

--- a/Lib9c/Lib9c.ruleset
+++ b/Lib9c/Lib9c.ruleset
@@ -3,6 +3,11 @@
   Name="Rules for Lib9c"
   Description="Code analysis rules for Lib9c.csproj."
   ToolsVersion="10.0">
+  <Rules AnalyzerId="Libplanet.Analyzers" RuleNamespace="Libplanet.Analyzers">
+    <Rule Id="LAA9999" Action="Warning" />
+    <Rule Id="LAA1001" Action="Warning" />
+  </Rules>
+
   <Rules AnalyzerId="SonarAnalyzer" RuleNamespace="SonarAnalyzer">
     <!-- These warn about leaving parameters taking ICultureInfo default,
     which implicitly follows the system's locale settings so that code is

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "3.1.400",
+    "rollForward": "patch"
+  }
+}


### PR DESCRIPTION
*(This should be merged after <https://github.com/planetarium/libplanet/pull/1034> is merged.)*

This applies *Libplanet.Analyzer.CSharp* to *Lib9c*.  With this analyzer, if we make a change like below:

```diff
diff --git a/Lib9c/Action/CreateAvatar.cs b/Lib9c/Action/CreateAvatar.cs
index 8931d6e..63dc575 100644
--- a/Lib9c/Action/CreateAvatar.cs
+++ b/Lib9c/Action/CreateAvatar.cs
@@ -81,10 +81,11 @@ namespace Nekoyume.Action
                     $"Aborted as the input name {name} does not follow the allowed name pattern.");
             }
 
+            var r = new Random();
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("CreateAvatar exec started.");
+            Log.Debug($"CreateAvatar exec started. {r.Next()}");
             AgentState existingAgentState = states.GetAgentState(ctx.Signer);
             var agentState = existingAgentState ?? new AgentState(ctx.Signer);
             var avatarState = states.GetAvatarState(avatarAddress);
```

The compiler warns like the following:

```
Action/CreateAvatar.cs(84,21): error LAC1001: The System.Random makes an IAction.Execute() method indeterministic; use IActionContext.Random property instead.
```