### PR TITLE
Filter illegal ActivateAccount on BlockPolicy

### DIFF
--- a/Lib9c/Action/ActivateAccount.cs
+++ b/Lib9c/Action/ActivateAccount.cs
@@ -57,7 +57,7 @@ namespace Nekoyume.Action
             var accounts = new ActivatedAccountsState(accountsAsDict);
             var pending = new PendingActivationState(pendingAsDict);
 
-            if (pending.PublicKey.Verify(pending.Nonce, Signature))
+            if (pending.Verify(this))
             {
                 return state.SetState(
                     ActivatedAccountsState.Address,

--- a/Lib9c/BlockPolicySource.cs
+++ b/Lib9c/BlockPolicySource.cs
@@ -98,6 +98,8 @@ namespace Nekoyume.BlockChain
             {
                 // It can be caused during `Swarm<T>.PreloadAsync()` because it doesn't fill its 
                 // state right away...
+                // FIXME It should be removed after fix that Libplanet fills its state on IBD.
+                // See also: https://github.com/planetarium/lib9c/pull/151#discussion_r506039478
                 return true;
             }
         }

--- a/Lib9c/BlockPolicySource.cs
+++ b/Lib9c/BlockPolicySource.cs
@@ -69,14 +69,15 @@ namespace Nekoyume.BlockChain
             BlockChain<NCAction> blockChain
         )
         {
-            if (transaction.Actions.Count == 1 &&
-                transaction.Actions.First().InnerAction is ActivateAccount)
-            {
-                return true;
-            }
-
             try
             {
+                if (transaction.Actions.Count == 1 &&
+                    transaction.Actions.First().InnerAction is ActivateAccount aa)
+                {
+                    return blockChain.GetState(aa.PendingAddress) is Dictionary rawPending &&
+                        new PendingActivationState(rawPending).Verify(aa);
+                }
+
                 if (blockChain.GetState(ActivatedAccountsState.Address) is Dictionary asDict)
                 {
                     IImmutableSet<Address> activatedAccounts =
@@ -88,6 +89,10 @@ namespace Nekoyume.BlockChain
                 {
                     return true;
                 }
+            }
+            catch (InvalidSignatureException)
+            {
+                return false;
             }
             catch (IncompleteBlockStatesException)
             {

--- a/Lib9c/Model/State/PendingActivationState.cs
+++ b/Lib9c/Model/State/PendingActivationState.cs
@@ -58,5 +58,10 @@ namespace Nekoyume.Model.State
         {
             info.AddValue("serialized", new Codec().Encode(Serialize()));
         }
+
+        public bool Verify(ActivateAccount action)
+        {
+            return PublicKey.Verify(Nonce, action.Signature);
+        }
     }
 }


### PR DESCRIPTION
This PR adds a filter for `BlockPolicy` to block txs containing illegal `ActivateAccount` action.