### PR TITLE
fix: replace zio abstraction with another.

### DIFF
--- a/.Lib9c.Tests/JsonStatesLoader.cs
+++ b/.Lib9c.Tests/JsonStatesLoader.cs
@@ -3,12 +3,10 @@ namespace Lib9c.Tests
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.IO.Abstractions;
     using System.Linq;
     using Bencodex;
     using Bencodex.Types;
-    using Libplanet;
-    using Zio;
-    using Zio.FileSystems;
     using JsonSerializer = System.Text.Json.JsonSerializer;
 
     public class JsonStatesLoader
@@ -20,7 +18,7 @@ namespace Lib9c.Tests
             _fileSystem = fileSystem;
         }
 
-        public static JsonStatesLoader Default => new JsonStatesLoader(new PhysicalFileSystem());
+        public static JsonStatesLoader Default => new JsonStatesLoader(new FileSystem());
 
         public Dictionary<string, IValue> Load(string jsonFilePath)
         {
@@ -29,15 +27,15 @@ namespace Lib9c.Tests
                 throw new ArgumentNullException(nameof(jsonFilePath));
             }
 
-            if (!_fileSystem.FileExists(jsonFilePath))
+            if (!_fileSystem.File.Exists(jsonFilePath))
             {
                 throw new FileNotFoundException();
             }
 
-            string rawJsonString = _fileSystem.ReadAllText(jsonFilePath);
-            Dictionary<string, string> json = JsonSerializer.Deserialize<Dictionary<string, string>>(rawJsonString);
+            string rawJsonString = _fileSystem.File.ReadAllText(jsonFilePath);
+            Dictionary<string, byte[]> json = JsonSerializer.Deserialize<Dictionary<string, byte[]>>(rawJsonString);
             var codec = new Codec();
-            return json.ToDictionary(pair => pair.Key, pair => codec.Decode(ByteUtil.ParseHex(pair.Value)));
+            return json.ToDictionary(pair => pair.Key, pair => codec.Decode(pair.Value));
         }
     }
 }

--- a/.Lib9c.Tests/JsonStatesLoaderTest.cs
+++ b/.Lib9c.Tests/JsonStatesLoaderTest.cs
@@ -5,9 +5,11 @@ namespace Lib9c.Tests
     using System.IO;
     using System.IO.Abstractions;
     using System.IO.Abstractions.TestingHelpers;
+    using System.Text;
     using Bencodex;
     using Bencodex.Types;
     using Libplanet;
+    using Org.BouncyCastle.Utilities.Encoders;
     using Xunit;
 
     public class JsonStatesLoaderTest
@@ -17,9 +19,21 @@ namespace Lib9c.Tests
         {
             var codec = new Codec();
             Text barValue = (Text)"bar";
+
+            byte[] Base64Encode(byte[] data)
+            {
+                var encoder = new Base64Encoder();
+                using var stream = new MemoryStream();
+                encoder.Encode(data, 0, data.Length, stream);
+                return stream.ToArray();
+            }
+
+            string Base64EncodeString(byte[] data)
+                => Encoding.UTF8.GetString(Base64Encode(data));
+
             IFileSystem fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                { "/foo", new MockFileData($"{{\"foo\": \"{ByteUtil.Hex(codec.Encode(barValue))}\"}}") },
+                { "/foo", new MockFileData($"{{\"foo\": \"{Base64EncodeString(codec.Encode(barValue))}\"}}") },
             });
             var loader = new JsonStatesLoader(fileSystem);
             var states = loader.Load("/foo");

--- a/.Lib9c.Tests/JsonStatesLoaderTest.cs
+++ b/.Lib9c.Tests/JsonStatesLoaderTest.cs
@@ -9,7 +9,6 @@ namespace Lib9c.Tests
     using Bencodex;
     using Bencodex.Types;
     using Libplanet;
-    using Org.BouncyCastle.Utilities.Encoders;
     using Xunit;
 
     public class JsonStatesLoaderTest
@@ -19,21 +18,9 @@ namespace Lib9c.Tests
         {
             var codec = new Codec();
             Text barValue = (Text)"bar";
-
-            byte[] Base64Encode(byte[] data)
-            {
-                var encoder = new Base64Encoder();
-                using var stream = new MemoryStream();
-                encoder.Encode(data, 0, data.Length, stream);
-                return stream.ToArray();
-            }
-
-            string Base64EncodeString(byte[] data)
-                => Encoding.UTF8.GetString(Base64Encode(data));
-
             IFileSystem fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                { "/foo", new MockFileData($"{{\"foo\": \"{Base64EncodeString(codec.Encode(barValue))}\"}}") },
+                { "/foo", new MockFileData($"{{\"foo\": \"{Convert.ToBase64String(codec.Encode(barValue))}\"}}") },
             });
             var loader = new JsonStatesLoader(fileSystem);
             var states = loader.Load("/foo");

--- a/.Lib9c.Tests/JsonStatesLoaderTest.cs
+++ b/.Lib9c.Tests/JsonStatesLoaderTest.cs
@@ -1,23 +1,26 @@
 namespace Lib9c.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
+    using System.IO.Abstractions;
+    using System.IO.Abstractions.TestingHelpers;
     using Bencodex;
     using Bencodex.Types;
     using Libplanet;
     using Xunit;
-    using Zio;
-    using Zio.FileSystems;
 
     public class JsonStatesLoaderTest
     {
         [Fact]
         public void Load()
         {
-            IFileSystem fileSystem = new MemoryFileSystem();
             var codec = new Codec();
             Text barValue = (Text)"bar";
-            fileSystem.WriteAllText("/foo", $"{{\"foo\": \"{ByteUtil.Hex(codec.Encode(barValue))}\"}}");
+            IFileSystem fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { "/foo", new MockFileData($"{{\"foo\": \"{ByteUtil.Hex(codec.Encode(barValue))}\"}}") },
+            });
             var loader = new JsonStatesLoader(fileSystem);
             var states = loader.Load("/foo");
             Assert.Single(states);
@@ -27,7 +30,7 @@ namespace Lib9c.Tests
         [Fact]
         public void ThrowsWhenFileNotFound()
         {
-            IFileSystem fileSystem = new MemoryFileSystem();
+            IFileSystem fileSystem = new MockFileSystem();
             var loader = new JsonStatesLoader(fileSystem);
             Assert.Throws<FileNotFoundException>(() => loader.Load("/foo"));
         }
@@ -35,7 +38,7 @@ namespace Lib9c.Tests
         [Fact]
         public void ThrowsWhenPassedNull()
         {
-            IFileSystem fileSystem = new MemoryFileSystem();
+            IFileSystem fileSystem = new MockFileSystem();
             var loader = new JsonStatesLoader(fileSystem);
             Assert.Throws<ArgumentNullException>(() => loader.Load(null));
         }

--- a/.Lib9c.Tests/Lib9c.Tests.csproj
+++ b/.Lib9c.Tests/Lib9c.Tests.csproj
@@ -16,6 +16,8 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />
+    <PackageReference Include="System.IO.Abstractions" Version="12.2.6" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="12.2.6" />
     
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
There was an issue to resolve the path of the JSON file because of the Zio's file system abstraction policy. So I replaced it with `System.IO.Abstractions`. And I also fixed the problem that can't load states from JSON successfully.