### PR TITLE
Reject blocks with too many transactions in BlockPolicy

### DIFF
--- a/.Lib9c.Tests/BlockPolicyTest.cs
+++ b/.Lib9c.Tests/BlockPolicyTest.cs
@@ -28,7 +28,7 @@ namespace Lib9c.Tests
             var adminPrivateKey = new PrivateKey();
             var adminAddress = new Address(adminPrivateKey.PublicKey);
             var blockPolicySource = new BlockPolicySource(Logger.None);
-            IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(10000);
+            IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(10000, 100);
             Block<PolymorphicAction<ActionBase>> genesis = MakeGenesisBlock(adminAddress, ImmutableHashSet<Address>.Empty);
 
             using var store = new DefaultStore(null);
@@ -57,7 +57,7 @@ namespace Lib9c.Tests
             var activatedAddress = activatedPrivateKey.ToAddress();
 
             var blockPolicySource = new BlockPolicySource(Logger.None);
-            IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(10000);
+            IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(10000, 100);
             Block<PolymorphicAction<ActionBase>> genesis = MakeGenesisBlock(
                 adminAddress,
                 ImmutableHashSet.Create(activatedAddress).Add(adminAddress)
@@ -141,7 +141,7 @@ namespace Lib9c.Tests
             );
 
             var blockPolicySource = new BlockPolicySource(Logger.None);
-            IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(10000);
+            IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(10000, 100);
             Block<PolymorphicAction<ActionBase>> genesis = MakeGenesisBlock(
                 adminAddress,
                 ImmutableHashSet<Address>.Empty,
@@ -196,7 +196,7 @@ namespace Lib9c.Tests
             var miners = new[] { miner };
 
             var blockPolicySource = new BlockPolicySource(Logger.None);
-            IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(4096);
+            IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(4096, 100);
             Block<PolymorphicAction<ActionBase>> genesis = MakeGenesisBlock(
                 adminAddress,
                 ImmutableHashSet<Address>.Empty,

--- a/Lib9c/BlockHelper.cs
+++ b/Lib9c/BlockHelper.cs
@@ -26,7 +26,8 @@ namespace Nekoyume
             AuthorizedMinersState authorizedMinersState = null,
             IImmutableSet<Address> activatedAccounts = null,
             bool isActivateAdminAddress = false,
-            IEnumerable<string> credits = null
+            IEnumerable<string> credits = null,
+            int maximumTransactions = 100
         )
         {
             if (!tableSheets.TryGetValue(nameof(GameConfigSheet), out var csv))
@@ -63,7 +64,7 @@ namespace Nekoyume
             {
                 initialStatesAction,
             };
-            var blockAction = new BlockPolicySource(Log.Logger).GetPolicy(5000000).BlockAction;
+            var blockAction = new BlockPolicySource(Log.Logger).GetPolicy(5000000, maximumTransactions).BlockAction;
             return
                 BlockChain<PolymorphicAction<ActionBase>>.MakeGenesisBlock(
                     actions,

--- a/Lib9c/BlockPolicySource.cs
+++ b/Lib9c/BlockPolicySource.cs
@@ -46,7 +46,7 @@ namespace Nekoyume.BlockChain
         }
 
         // FIXME 남은 설정들도 설정화 해야 할지도?
-        public IBlockPolicy<NCAction> GetPolicy(int minimumDifficulty)
+        public IBlockPolicy<NCAction> GetPolicy(int minimumDifficulty, int maximumTransactions)
         {
 #if UNITY_EDITOR
             return new DebugPolicy();
@@ -56,6 +56,7 @@ namespace Nekoyume.BlockChain
                 _blockInterval,
                 minimumDifficulty,
                 2048,
+                maximumTransactions,
                 IsSignerAuthorized
             );
 #endif

--- a/Lib9c/InvalidTxCountException.cs
+++ b/Lib9c/InvalidTxCountException.cs
@@ -1,0 +1,35 @@
+﻿using Libplanet;
+using Libplanet.Blocks;
+using System;
+using System.Runtime.Serialization;
+
+namespace Lib9c
+{
+    [Serializable]
+    public class InvalidTxCountException : InvalidBlockException
+    {
+        public int Maximum { get; }
+        public int Actual { get; }
+        public InvalidTxCountException(string message, int maximum, int actual)
+            : base(message)
+        {
+            Maximum = maximum;
+            Actual = actual;
+        }
+
+        public InvalidTxCountException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            Maximum = (int) info.GetValue(nameof(Maximum), typeof(int));
+            Actual = (int) info.GetValue(nameof(Actual), typeof(int));
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue(nameof(Maximum), Maximum);
+            info.AddValue(nameof(Actual), Actual);
+            
+            base.GetObjectData(info, context);
+        }
+    }
+}


### PR DESCRIPTION
It checks number of transactions in blocks to append, reject if its count exceeds the maximum.