### PR TITLE
Add private-key option for 9c-tools genesis

### DIFF
--- a/.Lib9c.Tools/SubCommand/Genesis.cs
+++ b/.Lib9c.Tools/SubCommand/Genesis.cs
@@ -2,6 +2,7 @@ using Cocona;
 using Libplanet;
 using Libplanet.Action;
 using Libplanet.Blocks;
+using Libplanet.Crypto;
 using Nekoyume;
 using Nekoyume.Action;
 using Nekoyume.Model;
@@ -30,7 +31,9 @@ namespace Lib9c.Tools.SubCommand
             [Option('m', Description = "Config path to create AuthorizedMinersState")]
             string authorizedMinerConfigPath = null,
             [Option('c', Description = "Path of a plain text file containing names for credits.")]
-            string creditsPath = null
+            string creditsPath = null,
+            [Option("private-key", new[]{ 'p' }, Description = "Hex encoded private key for gensis block")]
+            string privateKeyHex = null
         )
         {
             Dictionary<string, string> tableSheets = Utils.ImportSheets(gameConfigDir);
@@ -61,7 +64,8 @@ namespace Lib9c.Tools.SubCommand
                 authorizedMinersState: authorizedMinersState,
                 activatedAccounts: activatedAccounts,
                 isActivateAdminAddress: activationKeyCount != 0,
-                credits: creditsPath is null ? null : File.ReadLines(creditsPath)
+                credits: creditsPath is null ? null : File.ReadLines(creditsPath),
+                privateKey: privateKeyHex is null ? null : new PrivateKey(ByteUtil.ParseHex(privateKeyHex))
             );
 
             ExportBlock(block, "genesis-block");

--- a/.Lib9c.Tools/SubCommand/Genesis.cs
+++ b/.Lib9c.Tools/SubCommand/Genesis.cs
@@ -18,6 +18,8 @@ namespace Lib9c.Tools.SubCommand
     {
         [Command(Description = "Create a new genesis block.")]
         public void Create(
+            [Option("private-key", new[]{ 'p' }, Description = "Hex encoded private key for gensis block")]
+            string privateKeyHex,
             [Option('g', Description = "/path/to/nekoyume-unity/nekoyume/Assets/AddressableAssets/TableCSV")]
             string gameConfigDir,
             [Option('d', Description = "/path/to/nekoyume-unity/nekoyume/Assets/StreamingAssets/GoldDistribution.csv")]
@@ -31,9 +33,7 @@ namespace Lib9c.Tools.SubCommand
             [Option('m', Description = "Config path to create AuthorizedMinersState")]
             string authorizedMinerConfigPath = null,
             [Option('c', Description = "Path of a plain text file containing names for credits.")]
-            string creditsPath = null,
-            [Option("private-key", new[]{ 'p' }, Description = "Hex encoded private key for gensis block")]
-            string privateKeyHex = null
+            string creditsPath = null
         )
         {
             Dictionary<string, string> tableSheets = Utils.ImportSheets(gameConfigDir);
@@ -65,7 +65,7 @@ namespace Lib9c.Tools.SubCommand
                 activatedAccounts: activatedAccounts,
                 isActivateAdminAddress: activationKeyCount != 0,
                 credits: creditsPath is null ? null : File.ReadLines(creditsPath),
-                privateKey: privateKeyHex is null ? null : new PrivateKey(ByteUtil.ParseHex(privateKeyHex))
+                privateKey: new PrivateKey(ByteUtil.ParseHex(privateKeyHex))
             );
 
             ExportBlock(block, "genesis-block");

--- a/Lib9c/BlockHelper.cs
+++ b/Lib9c/BlockHelper.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using Bencodex.Types;
 using Libplanet;
 using Libplanet.Action;
 using Libplanet.Assets;
@@ -27,7 +25,8 @@ namespace Nekoyume
             IImmutableSet<Address> activatedAccounts = null,
             bool isActivateAdminAddress = false,
             IEnumerable<string> credits = null,
-            int maximumTransactions = 100
+            int maximumTransactions = 100,
+            PrivateKey privateKey = null
         )
         {
             if (!tableSheets.TryGetValue(nameof(GameConfigSheet), out var csv))
@@ -38,9 +37,12 @@ namespace Nekoyume
             var redeemCodeListSheet = new RedeemCodeListSheet();
             redeemCodeListSheet.Set(tableSheets[nameof(RedeemCodeListSheet)]);
 
-            // FIXME Must use a separate key for the mainnet.
-            var minterKey = new PrivateKey();
-            var ncg = new Currency("NCG", 2, minterKey.ToAddress());
+            if (privateKey is null)
+            {
+                privateKey = new PrivateKey();
+            }
+
+            var ncg = new Currency("NCG", 2, privateKey.ToAddress());
             activatedAccounts = activatedAccounts ?? ImmutableHashSet<Address>.Empty;
             var initialStatesAction = new InitializeStates
             (
@@ -68,7 +70,7 @@ namespace Nekoyume
             return
                 BlockChain<PolymorphicAction<ActionBase>>.MakeGenesisBlock(
                     actions,
-                    privateKey: minterKey,
+                    privateKey: privateKey,
                     blockAction: blockAction);
         }
     }


### PR DESCRIPTION
This PR adds `--private-key` option to `9c-tools genesis` to provide signer key for genesis block.