### PR TITLE
Support decimal for GoldDistribution.AmountPerBlock

### DIFF
--- a/.Lib9c.Tests/Action/GoldDistributionTest.cs
+++ b/.Lib9c.Tests/Action/GoldDistributionTest.cs
@@ -12,28 +12,28 @@ namespace Lib9c.Tests.Action
             new GoldDistribution
             {
                 Address = new Address("F9A15F870701268Bd7bBeA6502eB15F4997f32f9"),
-                AmountPerBlock = 100,
+                AmountPerBlock = 100m,
                 StartBlock = 1,
                 EndBlock = 100000,
             },
             new GoldDistribution
             {
                 Address = new Address("Fb90278C67f9b266eA309E6AE8463042f5461449"),
-                AmountPerBlock = 3000,
+                AmountPerBlock = 3000m,
                 StartBlock = 3600,
                 EndBlock = 13600,
             },
             new GoldDistribution
             {
                 Address = new Address("Fb90278C67f9b266eA309E6AE8463042f5461449"),
-                AmountPerBlock = 100000000000,
+                AmountPerBlock = 100000000000m,
                 StartBlock = 2,
                 EndBlock = 2,
             },
             new GoldDistribution
             {
                 Address = new Address("F9A15F870701268Bd7bBeA6502eB15F4997f32f9"),
-                AmountPerBlock = 1000000,
+                AmountPerBlock = 1000000m,
                 StartBlock = 0,
                 EndBlock = 0,
             },

--- a/Lib9c/Action/GoldDistribution.cs
+++ b/Lib9c/Action/GoldDistribution.cs
@@ -26,7 +26,7 @@ namespace Nekoyume.Action
         }
 
         [Index(1)]
-        public BigInteger AmountPerBlock { get; set; }
+        public decimal AmountPerBlock { get; set; }
 
         [Index(2)]
         public long StartBlock { get; set; }
@@ -59,7 +59,7 @@ namespace Nekoyume.Action
         public GoldDistribution(Bencodex.Types.Dictionary serialized)
         {
             Address = serialized["addr"].ToAddress();
-            AmountPerBlock = serialized["amnt"].ToBigInteger();
+            AmountPerBlock = serialized["amnt"].ToDecimal();
             StartBlock = serialized["strt"].ToLong();
             EndBlock = serialized["end"].ToLong();
         }
@@ -70,14 +70,14 @@ namespace Nekoyume.Action
             .Add("strt", StartBlock.Serialize())
             .Add("end", EndBlock.Serialize());
 
-        public BigInteger GetAmount(long blockIndex)
+        public decimal GetAmount(long blockIndex)
         {
             if (StartBlock <= blockIndex && blockIndex <= EndBlock)
             {
                 return AmountPerBlock;
             }
 
-            return 0;
+            return 0m;
         }
 
         public bool Equals(GoldDistribution other) =>

--- a/Lib9c/Action/RewardGold.cs
+++ b/Lib9c/Action/RewardGold.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Numerics;
 using Bencodex.Types;
 using Libplanet;
@@ -38,12 +39,15 @@ namespace Nekoyume.Action
             Address fund = GoldCurrencyState.Address;
             foreach(GoldDistribution distribution in goldDistributions)
             {
-                BigInteger amount = distribution.GetAmount(index);
+                decimal amount = distribution.GetAmount(index);
                 if (amount <= 0) continue;
                 states = states.TransferAsset(
                     fund,
                     distribution.Address,
-                    goldCurrency * amount
+                    FungibleAssetValue.Parse(
+                        goldCurrency, 
+                        amount.ToString(CultureInfo.InvariantCulture)
+                    )
                 );
             }
             return states;


### PR DESCRIPTION
This PR changes the type of `GoldDistribution.AmountPerBlock` from `BigInteger` to `decimal` to support decimal number.