### PR TITLE
Action execution benchmark

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,11 +6,12 @@ on:
   pull_request:
     branches: []
 
+env:
+  BENCHMARKS_SNAPSHOT: https://9c-test.s3.amazonaws.com/snapshots/4582250d0da33b06779a8475d283d5dd210c683b9b999d74d03fac4f58fa6bce-snapshot-c017f9bbe7729feee19aa5ca1e4b3ee53b53c7b5406b8392dbce1f613e5f8406.zip
+
 jobs:
   build-and-test:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
       with:
@@ -25,3 +26,30 @@ jobs:
       run: dotnet build --configuration Release
     - name: Test
       run: dotnet test --no-restore --verbosity normal
+
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.403
+    - run: |
+        tmpfile="$(mktemp --suffix=.zip)"
+        curl -o "$tmpfile" "$BENCHMARKS_SNAPSHOT"
+        mkdir _benchmarks_snapshot
+        pushd _benchmarks_snapshot
+        7z x "$tmpfile"
+        popd
+    - id: run-benchmarks
+      run: |
+        dotnet build Lib9c.Benchmarks
+        dotnet run \
+          --project Lib9c.Benchmarks \
+          --no-build \
+          --verbosity quiet \
+          -- \
+          _benchmarks_snapshot 50000

--- a/Lib9c.Benchmarks/Lib9c.Benchmarks.csproj
+++ b/Lib9c.Benchmarks/Lib9c.Benchmarks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\.Libplanet\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
+      <ProjectReference Include="..\.Libplanet\Libplanet\Libplanet.csproj" />
+      <ProjectReference Include="..\Lib9c\Lib9c.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Serilog" Version="2.9.0" />
+    </ItemGroup>
+
+</Project>

--- a/Lib9c.Benchmarks/Program.cs
+++ b/Lib9c.Benchmarks/Program.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Linq;
+using System.Security.Cryptography;
+using Libplanet;
+using Libplanet.Assets;
+using Libplanet.Blockchain;
+using Libplanet.Blockchain.Policies;
+using Libplanet.Blocks;
+using Libplanet.RocksDBStore;
+using Nekoyume.BlockChain;
+using Serilog;
+using Serilog.Events;
+using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
+
+namespace Lib9c.Benchmarks
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length < 2)
+            {
+                Console.Error.WriteLine("Too few arguments.");
+                Environment.Exit(1);
+                return;
+            }
+
+            string storePath = args[0];
+            int limit = int.Parse(args[1]);
+            ILogger logger = new LoggerConfiguration().CreateLogger();
+            Libplanet.Crypto.CryptoConfig.CryptoBackend = new Secp256K1CryptoBackend<SHA256>();
+            var policySource = new BlockPolicySource(logger, LogEventLevel.Verbose);
+            IBlockPolicy<NCAction> policy =
+                policySource.GetPolicy(BlockPolicySource.DifficultyBoundDivisor + 1, 0);
+            var store = new RocksDBStore(storePath);
+            if (!(store.GetCanonicalChainId() is Guid chainId))
+            {
+                Console.Error.WriteLine("There is no canonical chain: {0}", storePath);
+                Environment.Exit(1);
+                return;
+            }
+
+            if (!(store.IndexBlockHash(chainId, 0) is HashDigest<SHA256> gHash))
+            {
+                Console.Error.WriteLine("There is no genesis block: {0}", storePath);
+                Environment.Exit(1);
+                return;
+            }
+
+            DateTimeOffset started = DateTimeOffset.UtcNow;
+            Block<NCAction> genesis = store.GetBlock<NCAction>(gHash);
+            var chain = new BlockChain<NCAction>(policy, store, store, genesis);
+            long height = chain.Tip.Index;
+            var blockHashes = limit < 0
+                ? chain.BlockHashes.SkipWhile((_, i) => i < height + limit).ToArray()
+                : chain.BlockHashes.Take(limit).ToArray();
+            Console.Error.WriteLine(
+                "Executing {0} blocks: {1}-{2} (inclusive).",
+                blockHashes.Length,
+                blockHashes[0],
+                blockHashes.Last()
+            );
+            DateTimeOffset blocksLoaded = DateTimeOffset.UtcNow;
+            long txs = 0;
+            long actions = 0;
+            foreach (HashDigest<SHA256> blockHash in blockHashes)
+            {
+                Block<NCAction> block = chain[blockHash];
+                Console.Error.WriteLine(
+                    "Block #{0} {1}; {2} txs",
+                    block.Index,
+                    blockHash,
+                    block.Transactions.Count()
+                );
+                if (block.Index > 0)
+                {
+                    block.Evaluate(
+                        DateTimeOffset.UtcNow,
+                        address => chain.GetState(address, blockHash),
+                        (address, currency) => chain.GetBalance(address, currency, blockHash)
+                    );
+                }
+                else
+                {
+                    block.Evaluate(
+                        DateTimeOffset.UtcNow,
+                        _ => null,
+                        ((_, currency) => new FungibleAssetValue(currency))
+                    );
+                }
+                txs += block.Transactions.LongCount();
+                actions += block.Transactions.Sum(tx => tx.Actions.LongCount()) + 1;
+            }
+
+            DateTimeOffset ended = DateTimeOffset.UtcNow;
+            Console.WriteLine("Loading blocks\t{0}", blocksLoaded - started);
+            TimeSpan execActions = ended - blocksLoaded;
+            Console.WriteLine("Executing actions\t{0}", execActions);
+            Console.WriteLine("Average per block\t{0}", execActions / blockHashes.Length);
+            Console.WriteLine("Average per tx\t{0}", execActions / txs);
+            Console.WriteLine("Average per action\t{0}", execActions / actions);
+            Console.WriteLine("Total elapsed\t{0}", ended - started);
+        }
+    }
+}

--- a/Lib9c.sln
+++ b/Lib9c.sln
@@ -17,6 +17,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet", ".Libplanet\Lib
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Analyzers", ".Libplanet\Libplanet.Analyzers\Libplanet.Analyzers.csproj", "{659722A9-132F-4B41-87BC-1B56A97A98FA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib9c.Benchmarks", "Lib9c.Benchmarks\Lib9c.Benchmarks.csproj", "{9EB7458F-FD90-4719-A3B6-FBC678BC43D8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.RocksDBStore", ".Libplanet\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj", "{17AAB5B1-695B-4597-8B36-1DF5012EE686}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,10 +59,19 @@ Global
 		{659722A9-132F-4B41-87BC-1B56A97A98FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{659722A9-132F-4B41-87BC-1B56A97A98FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{659722A9-132F-4B41-87BC-1B56A97A98FA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9EB7458F-FD90-4719-A3B6-FBC678BC43D8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9EB7458F-FD90-4719-A3B6-FBC678BC43D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9EB7458F-FD90-4719-A3B6-FBC678BC43D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9EB7458F-FD90-4719-A3B6-FBC678BC43D8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{17AAB5B1-695B-4597-8B36-1DF5012EE686}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{17AAB5B1-695B-4597-8B36-1DF5012EE686}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{17AAB5B1-695B-4597-8B36-1DF5012EE686}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{17AAB5B1-695B-4597-8B36-1DF5012EE686}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{6126D57A-F079-4B07-B1E4-531630DCCDBF} = {AFA609F0-8CAE-4494-A4E2-EABD9E95D678}
 		{5C9F5F97-367E-4F8B-A123-D9AADE786CA1} = {AFA609F0-8CAE-4494-A4E2-EABD9E95D678}
 		{659722A9-132F-4B41-87BC-1B56A97A98FA} = {AFA609F0-8CAE-4494-A4E2-EABD9E95D678}
+		{17AAB5B1-695B-4597-8B36-1DF5012EE686} = {AFA609F0-8CAE-4494-A4E2-EABD9E95D678}
 	EndGlobalSection
 EndGlobal

--- a/Lib9c/BlockPolicySource.cs
+++ b/Lib9c/BlockPolicySource.cs
@@ -26,6 +26,8 @@ namespace Nekoyume.BlockChain
 {
     public class BlockPolicySource
     {
+        public const int DifficultyBoundDivisor = 2048;
+
         private readonly TimeSpan _blockInterval = TimeSpan.FromSeconds(8);
 
         public readonly ActionRenderer ActionRenderer = new ActionRenderer();
@@ -55,7 +57,7 @@ namespace Nekoyume.BlockChain
                 new RewardGold(),
                 _blockInterval,
                 minimumDifficulty,
-                2048,
+                DifficultyBoundDivisor,
                 maximumTransactions,
                 DoesTransactionFollowPolicy
             );


### PR DESCRIPTION
Here's usage; the following command executes all actions in the first 50,000 blocks in the SNAPSHOT_PATH (assuming it uses RocksDB):

```bash
dotnet run -p Lib9c.Benchmarks -- SNAPSHOT_PATH 50000
```

The following executs the last 50,000 blocks (there's `-` sign):

```bash
dotnet run -p Lib9c.Benchmarks -- SNAPSHOT_PATH -50000
```