### PR TITLE
Avoid needless PublicKey instantiation (which is time expensive)

### DIFF
--- a/Lib9c/TableData/RedeemCodeListSheet.cs
+++ b/Lib9c/TableData/RedeemCodeListSheet.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using Bencodex.Types;
 using Libplanet;
 using Libplanet.Crypto;
+using Nekoyume.Model.State;
 using static Nekoyume.TableData.TableExtensions;
 
 namespace Nekoyume.TableData
@@ -15,12 +17,14 @@ namespace Nekoyume.TableData
             public override int Key => Id;
             public int Id { get; private set; }
             public int RewardId { get; private set; }
-            public PublicKey PublicKey { get; private set; }
+            public PublicKey PublicKey => PublicKeyBinary.ToPublicKey();
+            public Binary PublicKeyBinary { get; private set; }
+
             public override void Set(IReadOnlyList<string> fields)
             {
                 Id = ParseInt(fields[0]);
                 RewardId = ParseInt(fields[1]);
-                PublicKey = new PublicKey(ByteUtil.ParseHex(fields[2]));
+                PublicKeyBinary = ByteUtil.ParseHex(fields[2]);
             }
         }
 


### PR DESCRIPTION
Made `RedeemCodeState` to avoid needless `PublicKey` instantiation, which is time expensive.

I am going to try to find the similar pattern in other areas like activation code.