### PR TITLE
Reduce GetState, SetState call count in IAction.Execute

### DIFF
--- a/.Lib9c.Tests/Action/AccountStateDeltaExtensionsTest.cs
+++ b/.Lib9c.Tests/Action/AccountStateDeltaExtensionsTest.cs
@@ -1,0 +1,86 @@
+namespace Lib9c.Tests.Action
+{
+    using Bencodex.Types;
+    using Libplanet;
+    using Nekoyume;
+    using Nekoyume.Action;
+    using Nekoyume.Model.State;
+    using Xunit;
+
+    public class AccountStateDeltaExtensionsTest
+    {
+        [Fact]
+        public void TryGetAvatarState()
+        {
+            var states = new State();
+            var sheets = new TableSheets(TableSheetsImporter.ImportSheets());
+            var avatarState = new AvatarState(
+                default,
+                default,
+                0,
+                sheets.GetAvatarSheets(),
+                new GameConfigState(),
+                default
+            );
+            states = (State)states.SetState(default, avatarState.Serialize());
+
+            Assert.True(states.TryGetAvatarState(default, default, out var avatarState2));
+            Assert.Equal(avatarState.address, avatarState2.address);
+            Assert.Equal(avatarState.agentAddress, avatarState2.agentAddress);
+        }
+
+        [Fact]
+        public void TryGetAvatarStateEmptyAddress()
+        {
+            var states = new State();
+
+            Assert.False(states.TryGetAvatarState(default, default, out _));
+        }
+
+        [Fact]
+        public void TryGetAvatarStateAddressKeyNotFoundException()
+        {
+            var states = new State().SetState(default, Dictionary.Empty);
+
+            Assert.False(states.TryGetAvatarState(default, default, out _));
+        }
+
+        [Fact]
+        public void TryGetAvatarStateKeyNotFoundException()
+        {
+            var states = new State()
+                .SetState(
+                default,
+                Dictionary.Empty
+                    .Add("agentAddress", default(Address).Serialize())
+            );
+
+            Assert.False(states.TryGetAvatarState(default, default, out _));
+        }
+
+        [Fact]
+        public void TryGetAvatarStateInvalidCastException()
+        {
+            var states = new State().SetState(default, default(Text));
+
+            Assert.False(states.TryGetAvatarState(default, default, out _));
+        }
+
+        [Fact]
+        public void TryGetAvatarStateInvalidAddress()
+        {
+            var sheets = new TableSheets(TableSheetsImporter.ImportSheets());
+            var avatarState = new AvatarState(
+                default,
+                default,
+                0,
+                sheets.GetAvatarSheets(),
+                new GameConfigState(),
+                default
+            );
+            var states = new State().SetState(default, avatarState.Serialize());
+
+            Assert.False(states.TryGetAvatarState(Addresses.GameConfig, default, out _));
+        }
+    }
+}

--- a/Lib9c/Action/AccountStateDeltaExtensions.cs
+++ b/Lib9c/Action/AccountStateDeltaExtensions.cs
@@ -155,8 +155,32 @@ namespace Nekoyume.Action
             out AvatarState avatarState
         )
         {
-            avatarState = states.GetAvatarState(avatarAddress);
-            return !(avatarState is null) && avatarState.agentAddress == agentAddress;
+            avatarState = null;
+            var value = states.GetState(avatarAddress);
+            if (value is null)
+            {
+                return false;
+            }
+
+            try
+            {
+                var serializedAvatar = (Dictionary) value;
+                if (serializedAvatar["agentAddress"].ToAddress() != agentAddress)
+                {
+                    return false;
+                }
+
+                avatarState = new AvatarState(serializedAvatar);
+                return true;
+            }
+            catch (InvalidCastException)
+            {
+                return false;
+            }
+            catch (KeyNotFoundException)
+            {
+                return false;
+            }
         }
 
         public static bool TryGetAgentAvatarStates(

--- a/Lib9c/Action/AccountStateDeltaExtensions.cs
+++ b/Lib9c/Action/AccountStateDeltaExtensions.cs
@@ -148,6 +148,17 @@ namespace Nekoyume.Action
             }
         }
 
+        public static bool TryGetAvatarState(
+            this IAccountStateDelta states,
+            Address agentAddress,
+            Address avatarAddress,
+            out AvatarState avatarState
+        )
+        {
+            avatarState = states.GetAvatarState(avatarAddress);
+            return !(avatarState is null) && avatarState.agentAddress == agentAddress;
+        }
+
         public static bool TryGetAgentAvatarStates(
             this IAccountStateDelta states,
             Address agentAddress,

--- a/Lib9c/Action/Buy.cs
+++ b/Lib9c/Action/Buy.cs
@@ -259,7 +259,7 @@ namespace Nekoyume.Action
             Log.Debug("Buy Set ShopState: {Elapsed}", sw.Elapsed);
             Log.Debug("Buy Total Executed Time: {Elapsed}", ended - started);
 
-            return states.SetState(ctx.Signer, buyerAgentState.Serialize());
+            return states;
         }
     }
 }

--- a/Lib9c/Action/Buy.cs
+++ b/Lib9c/Action/Buy.cs
@@ -132,7 +132,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Debug("Buy exec started.");
 
-            if (!states.TryGetAgentAvatarStates(ctx.Signer, buyerAvatarAddress, out var buyerAgentState, out var buyerAvatarState))
+            if (!states.TryGetAvatarState(ctx.Signer, buyerAvatarAddress, out var buyerAvatarState))
             {
                 throw new FailedLoadStateException("Aborted as the avatar state of the buyer was failed to load.");
             }
@@ -168,7 +168,7 @@ namespace Nekoyume.Action
             Log.Debug($"Buy Get Item: {sw.Elapsed}");
             sw.Restart();
 
-            if (!states.TryGetAgentAvatarStates(sellerAgentAddress, sellerAvatarAddress, out var sellerAgentState, out var sellerAvatarState))
+            if (!states.TryGetAvatarState(sellerAgentAddress, sellerAvatarAddress, out var sellerAvatarState))
             {
                 throw new FailedLoadStateException(
                     $"Aborted as the seller agent/avatar was failed to load from {sellerAgentAddress}/{sellerAvatarAddress}."

--- a/Lib9c/Action/CombinationConsumable.cs
+++ b/Lib9c/Action/CombinationConsumable.cs
@@ -125,8 +125,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Debug("Combination exec started.");
 
-            if (!states.TryGetAgentAvatarStates(ctx.Signer, AvatarAddress, out AgentState agentState,
-                out AvatarState avatarState))
+            if (!states.TryGetAvatarState(ctx.Signer, AvatarAddress, out AvatarState avatarState))
             {
                 throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/CombinationConsumable.cs
+++ b/Lib9c/Action/CombinationConsumable.cs
@@ -245,7 +245,6 @@ namespace Nekoyume.Action
             var ended = DateTimeOffset.UtcNow;
             Log.Debug("Combination Total Executed Time: {Elapsed}", ended - started);
             return states
-                .SetState(ctx.Signer, agentState.Serialize())
                 .SetState(slotAddress, slotState.Serialize());
         }
 

--- a/Lib9c/Action/HackAndSlash2.cs
+++ b/Lib9c/Action/HackAndSlash2.cs
@@ -72,11 +72,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Debug("HAS exec started.");
 
-            if (!states.TryGetAgentAvatarStates(
-                ctx.Signer,
-                avatarAddress,
-                out AgentState agentState,
-                out AvatarState avatarState))
+            if (!states.TryGetAvatarState(ctx.Signer, avatarAddress, out AvatarState avatarState))
             {
                 throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/HackAndSlash2.cs
+++ b/Lib9c/Action/HackAndSlash2.cs
@@ -278,7 +278,7 @@ namespace Nekoyume.Action
 
             var ended = DateTimeOffset.UtcNow;
             Log.Debug("HAS Total Executed Time: {Elapsed}", ended - started);
-            return states.SetState(ctx.Signer, agentState.Serialize());
+            return states;
         }
     }
 }

--- a/Lib9c/Action/RankingBattle2.cs
+++ b/Lib9c/Action/RankingBattle2.cs
@@ -48,11 +48,7 @@ namespace Nekoyume.Action
                 throw new InvalidAddressException("Aborted as the signer tried to battle for themselves.");
             }
 
-            if (!states.TryGetAgentAvatarStates(
-                ctx.Signer,
-                AvatarAddress,
-                out var agentState,
-                out var avatarState))
+            if (!states.TryGetAvatarState(ctx.Signer, AvatarAddress, out var avatarState))
             {
                 throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/RankingBattle2.cs
+++ b/Lib9c/Action/RankingBattle2.cs
@@ -131,7 +131,6 @@ namespace Nekoyume.Action
             }
 
             return states
-                .SetState(ctx.Signer, agentState.Serialize())
                 .SetState(WeeklyArenaAddress, weeklyArenaState.Serialize())
                 .SetState(AvatarAddress, avatarState.Serialize());
         }

--- a/Lib9c/Action/RedeemCode.cs
+++ b/Lib9c/Action/RedeemCode.cs
@@ -90,7 +90,6 @@ namespace Nekoyume.Action
                                 avatarState.inventory.AddItem(item, 1);
                             }
                         }
-                        states = states.SetState(AvatarAddress, avatarState.Serialize());
                         break;
                     case RewardType.Gold:
                         states = states.TransferAsset(
@@ -104,8 +103,8 @@ namespace Nekoyume.Action
                         break;
                 }
             }
+            states = states.SetState(AvatarAddress, avatarState.Serialize());
             states = states.SetState(RedeemCodeState.Address, redeemState.Serialize());
-            states = states.SetState(context.Signer, agentState.Serialize());
             return states;
         }
 

--- a/Lib9c/Action/RedeemCode.cs
+++ b/Lib9c/Action/RedeemCode.cs
@@ -44,8 +44,7 @@ namespace Nekoyume.Action
                 return states;
             }
 
-            if (!states.TryGetAgentAvatarStates(context.Signer, AvatarAddress, out AgentState agentState,
-                out AvatarState avatarState))
+            if (!states.TryGetAvatarState(context.Signer, AvatarAddress, out AvatarState avatarState))
             {
                 return states;
             }


### PR DESCRIPTION
- Delete SetState with no changes.
- Use `TryGetAvatarState` instead of `TryGetAgentAvatarStates`.