### PR TITLE
Fix runtime deserialization of `Chest`

### DIFF
--- a/.Lib9c.Tests/Model/Item/ArmorTest.cs
+++ b/.Lib9c.Tests/Model/Item/ArmorTest.cs
@@ -1,0 +1,50 @@
+namespace Lib9c.Tests.Model.Item
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using Nekoyume.Model.Item;
+    using Nekoyume.TableData;
+    using Xunit;
+
+    public class ArmorTest
+    {
+        private readonly EquipmentItemSheet.Row _armorRow;
+
+        public ArmorTest()
+        {
+            var tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
+            _armorRow = tableSheets.EquipmentItemSheet.OrderedList.FirstOrDefault(row =>
+                row.ItemSubType == ItemSubType.Armor);
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            Assert.NotNull(_armorRow);
+
+            var costume = new Armor(_armorRow, Guid.NewGuid(), 0);
+            var serialized = costume.Serialize();
+            var deserialized = new Armor((Bencodex.Types.Dictionary)serialized);
+
+            Assert.Equal(costume, deserialized);
+        }
+
+        [Fact]
+        public void SerializeWithDotNetAPI()
+        {
+            Assert.NotNull(_armorRow);
+
+            var costume = new Armor(_armorRow, Guid.NewGuid(), 0);
+            var formatter = new BinaryFormatter();
+            using var ms = new MemoryStream();
+            formatter.Serialize(ms, costume);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            var deserialized = (Armor)formatter.Deserialize(ms);
+
+            Assert.Equal(costume, deserialized);
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/Item/BeltTest.cs
+++ b/.Lib9c.Tests/Model/Item/BeltTest.cs
@@ -1,0 +1,50 @@
+namespace Lib9c.Tests.Model.Item
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using Nekoyume.Model.Item;
+    using Nekoyume.TableData;
+    using Xunit;
+
+    public class BeltTest
+    {
+        private readonly EquipmentItemSheet.Row _beltRow;
+
+        public BeltTest()
+        {
+            var tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
+            _beltRow = tableSheets.EquipmentItemSheet.OrderedList.FirstOrDefault(row =>
+                row.ItemSubType == ItemSubType.Belt);
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            Assert.NotNull(_beltRow);
+
+            var costume = new Belt(_beltRow, Guid.NewGuid(), 0);
+            var serialized = costume.Serialize();
+            var deserialized = new Belt((Bencodex.Types.Dictionary)serialized);
+
+            Assert.Equal(costume, deserialized);
+        }
+
+        [Fact]
+        public void SerializeWithDotNetAPI()
+        {
+            Assert.NotNull(_beltRow);
+
+            var costume = new Belt(_beltRow, Guid.NewGuid(), 0);
+            var formatter = new BinaryFormatter();
+            using var ms = new MemoryStream();
+            formatter.Serialize(ms, costume);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            var deserialized = (Belt)formatter.Deserialize(ms);
+
+            Assert.Equal(costume, deserialized);
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/Item/ChestTest.cs
+++ b/.Lib9c.Tests/Model/Item/ChestTest.cs
@@ -1,0 +1,33 @@
+namespace Lib9c.Tests.Model.Item
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Nekoyume.Model.Item;
+    using Nekoyume.TableData;
+    using Xunit;
+
+    public class ChestTest
+    {
+        private readonly MaterialItemSheet.Row _chestRow;
+
+        public ChestTest()
+        {
+            var dict = TableSheetsImporter.ImportSheets();
+            var tableSheets = new TableSheets(dict);
+            _chestRow = tableSheets.MaterialItemSheet.OrderedList.FirstOrDefault(row =>
+                row.ItemSubType == ItemSubType.Chest);
+        }
+
+        [Fact]
+        public void Serialization()
+        {
+            Assert.NotNull(_chestRow);
+
+            var chest = new Chest(_chestRow, new List<RedeemRewardSheet.RewardInfo>());
+            var serialized = chest.Serialize();
+            var deserialized = new Chest((Bencodex.Types.Dictionary)serialized);
+
+            Assert.Equal(chest, deserialized);
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/Item/ChestTest.cs
+++ b/.Lib9c.Tests/Model/Item/ChestTest.cs
@@ -1,7 +1,9 @@
 namespace Lib9c.Tests.Model.Item
 {
     using System.Collections.Generic;
+    using System.IO;
     using System.Linq;
+    using System.Runtime.Serialization.Formatters.Binary;
     using Nekoyume.Model.Item;
     using Nekoyume.TableData;
     using Xunit;
@@ -12,20 +14,35 @@ namespace Lib9c.Tests.Model.Item
 
         public ChestTest()
         {
-            var dict = TableSheetsImporter.ImportSheets();
-            var tableSheets = new TableSheets(dict);
+            var tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
             _chestRow = tableSheets.MaterialItemSheet.OrderedList.FirstOrDefault(row =>
                 row.ItemSubType == ItemSubType.Chest);
         }
 
         [Fact]
-        public void Serialization()
+        public void Serialize()
         {
             Assert.NotNull(_chestRow);
 
             var chest = new Chest(_chestRow, new List<RedeemRewardSheet.RewardInfo>());
             var serialized = chest.Serialize();
             var deserialized = new Chest((Bencodex.Types.Dictionary)serialized);
+
+            Assert.Equal(chest, deserialized);
+        }
+
+        [Fact]
+        public void SerializeWithDotNetAPI()
+        {
+            Assert.NotNull(_chestRow);
+
+            var chest = new Chest(_chestRow, new List<RedeemRewardSheet.RewardInfo>());
+            var formatter = new BinaryFormatter();
+            using var ms = new MemoryStream();
+            formatter.Serialize(ms, chest);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            var deserialized = (Chest)formatter.Deserialize(ms);
 
             Assert.Equal(chest, deserialized);
         }

--- a/.Lib9c.Tests/Model/Item/ConsumableTest.cs
+++ b/.Lib9c.Tests/Model/Item/ConsumableTest.cs
@@ -1,0 +1,48 @@
+namespace Lib9c.Tests.Model.Item
+{
+    using System;
+    using System.IO;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using Nekoyume.Model.Item;
+    using Nekoyume.TableData;
+    using Xunit;
+
+    public class ConsumableTest
+    {
+        private readonly ConsumableItemSheet.Row _consumableRow;
+
+        public ConsumableTest()
+        {
+            var tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
+            _consumableRow = tableSheets.ConsumableItemSheet.First;
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            Assert.NotNull(_consumableRow);
+
+            var costume = new Consumable(_consumableRow, Guid.NewGuid(), 0);
+            var serialized = costume.Serialize();
+            var deserialized = new Consumable((Bencodex.Types.Dictionary)serialized);
+
+            Assert.Equal(costume, deserialized);
+        }
+
+        [Fact]
+        public void SerializeWithDotNetAPI()
+        {
+            Assert.NotNull(_consumableRow);
+
+            var costume = new Consumable(_consumableRow, Guid.NewGuid(), 0);
+            var formatter = new BinaryFormatter();
+            using var ms = new MemoryStream();
+            formatter.Serialize(ms, costume);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            var deserialized = (Consumable)formatter.Deserialize(ms);
+
+            Assert.Equal(costume, deserialized);
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/Item/CostumeTest.cs
+++ b/.Lib9c.Tests/Model/Item/CostumeTest.cs
@@ -1,0 +1,48 @@
+namespace Lib9c.Tests.Model.Item
+{
+    using System;
+    using System.IO;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using Nekoyume.Model.Item;
+    using Nekoyume.TableData;
+    using Xunit;
+
+    public class CostumeTest
+    {
+        private readonly CostumeItemSheet.Row _costumeRow;
+
+        public CostumeTest()
+        {
+            var tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
+            _costumeRow = tableSheets.CostumeItemSheet.First;
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            Assert.NotNull(_costumeRow);
+
+            var costume = new Costume(_costumeRow, Guid.NewGuid());
+            var serialized = costume.Serialize();
+            var deserialized = new Costume((Bencodex.Types.Dictionary)serialized);
+
+            Assert.Equal(costume, deserialized);
+        }
+
+        [Fact]
+        public void SerializeWithDotNetAPI()
+        {
+            Assert.NotNull(_costumeRow);
+
+            var costume = new Costume(_costumeRow, Guid.NewGuid());
+            var formatter = new BinaryFormatter();
+            using var ms = new MemoryStream();
+            formatter.Serialize(ms, costume);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            var deserialized = (Costume)formatter.Deserialize(ms);
+
+            Assert.Equal(costume, deserialized);
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/Item/EquipmentTest.cs
+++ b/.Lib9c.Tests/Model/Item/EquipmentTest.cs
@@ -1,0 +1,48 @@
+namespace Lib9c.Tests.Model.Item
+{
+    using System;
+    using System.IO;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using Nekoyume.Model.Item;
+    using Nekoyume.TableData;
+    using Xunit;
+
+    public class EquipmentTest
+    {
+        private readonly EquipmentItemSheet.Row _equipmentRow;
+
+        public EquipmentTest()
+        {
+            var tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
+            _equipmentRow = tableSheets.EquipmentItemSheet.First;
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            Assert.NotNull(_equipmentRow);
+
+            var costume = new Equipment(_equipmentRow, Guid.NewGuid(), 0);
+            var serialized = costume.Serialize();
+            var deserialized = new Equipment((Bencodex.Types.Dictionary)serialized);
+
+            Assert.Equal(costume, deserialized);
+        }
+
+        [Fact]
+        public void SerializeWithDotNetAPI()
+        {
+            Assert.NotNull(_equipmentRow);
+
+            var costume = new Equipment(_equipmentRow, Guid.NewGuid(), 0);
+            var formatter = new BinaryFormatter();
+            using var ms = new MemoryStream();
+            formatter.Serialize(ms, costume);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            var deserialized = (Equipment)formatter.Deserialize(ms);
+
+            Assert.Equal(costume, deserialized);
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/Item/MaterialTest.cs
+++ b/.Lib9c.Tests/Model/Item/MaterialTest.cs
@@ -1,0 +1,48 @@
+namespace Lib9c.Tests.Model.Item
+{
+    using System;
+    using System.IO;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using Nekoyume.Model.Item;
+    using Nekoyume.TableData;
+    using Xunit;
+
+    public class MaterialTest
+    {
+        private readonly MaterialItemSheet.Row _materialRow;
+
+        public MaterialTest()
+        {
+            var tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
+            _materialRow = tableSheets.MaterialItemSheet.First;
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            Assert.NotNull(_materialRow);
+
+            var costume = new Material(_materialRow);
+            var serialized = costume.Serialize();
+            var deserialized = new Material((Bencodex.Types.Dictionary)serialized);
+
+            Assert.Equal(costume, deserialized);
+        }
+
+        [Fact]
+        public void SerializeWithDotNetAPI()
+        {
+            Assert.NotNull(_materialRow);
+
+            var costume = new Material(_materialRow);
+            var formatter = new BinaryFormatter();
+            using var ms = new MemoryStream();
+            formatter.Serialize(ms, costume);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            var deserialized = (Material)formatter.Deserialize(ms);
+
+            Assert.Equal(costume, deserialized);
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/Item/NecklaceTest.cs
+++ b/.Lib9c.Tests/Model/Item/NecklaceTest.cs
@@ -1,0 +1,50 @@
+namespace Lib9c.Tests.Model.Item
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using Nekoyume.Model.Item;
+    using Nekoyume.TableData;
+    using Xunit;
+
+    public class NecklaceTest
+    {
+        private readonly EquipmentItemSheet.Row _necklaceRow;
+
+        public NecklaceTest()
+        {
+            var tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
+            _necklaceRow = tableSheets.EquipmentItemSheet.OrderedList.FirstOrDefault(row =>
+                row.ItemSubType == ItemSubType.Necklace);
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            Assert.NotNull(_necklaceRow);
+
+            var costume = new Necklace(_necklaceRow, Guid.NewGuid(), 0);
+            var serialized = costume.Serialize();
+            var deserialized = new Necklace((Bencodex.Types.Dictionary)serialized);
+
+            Assert.Equal(costume, deserialized);
+        }
+
+        [Fact]
+        public void SerializeWithDotNetAPI()
+        {
+            Assert.NotNull(_necklaceRow);
+
+            var costume = new Necklace(_necklaceRow, Guid.NewGuid(), 0);
+            var formatter = new BinaryFormatter();
+            using var ms = new MemoryStream();
+            formatter.Serialize(ms, costume);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            var deserialized = (Necklace)formatter.Deserialize(ms);
+
+            Assert.Equal(costume, deserialized);
+        }
+    }
+}

--- a/Lib9c/Action/CreateAvatar.cs
+++ b/Lib9c/Action/CreateAvatar.cs
@@ -191,7 +191,7 @@ namespace Nekoyume.Action
                 avatarState.inventory.AddItem(ItemFactory.CreateCostume(row, random.GenerateRandomGuid()));
             }
 
-            foreach (var row in materialItemSheet.OrderedList)
+            foreach (var row in materialItemSheet.OrderedList.Where(row => row.ItemSubType != ItemSubType.Chest))
             {
                 avatarState.inventory.AddItem(ItemFactory.CreateMaterial(row), 10);
             }

--- a/Lib9c/Model/Item/Armor.cs
+++ b/Lib9c/Model/Item/Armor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 using Bencodex.Types;
 using Nekoyume.TableData;
 
@@ -12,6 +13,11 @@ namespace Nekoyume.Model.Item
         }
 
         public Armor(Dictionary serialized) : base(serialized)
+        {
+        }
+        
+        protected Armor(SerializationInfo info, StreamingContext _)
+            : this((Dictionary) Codec.Decode((byte[]) info.GetValue("serialized", typeof(byte[]))))
         {
         }
     }

--- a/Lib9c/Model/Item/Belt.cs
+++ b/Lib9c/Model/Item/Belt.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 using Bencodex.Types;
 using Nekoyume.TableData;
 
@@ -12,6 +13,11 @@ namespace Nekoyume.Model.Item
         }
 
         public Belt(Dictionary serialized) : base(serialized)
+        {
+        }
+        
+        protected Belt(SerializationInfo info, StreamingContext _)
+            : this((Dictionary) Codec.Decode((byte[]) info.GetValue("serialized", typeof(byte[]))))
         {
         }
     }

--- a/Lib9c/Model/Item/Chest.cs
+++ b/Lib9c/Model/Item/Chest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using Bencodex.Types;
 using Libplanet;
 using Nekoyume.Model.State;
@@ -30,6 +31,10 @@ namespace Nekoyume.Model.Item
                 Rewards = new List<RedeemRewardSheet.RewardInfo>();
                 ItemId = Hashcash.Hash(Serialize().EncodeIntoChunks().SelectMany(b => b).ToArray());
             }
+        }
+
+        public Chest(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
         }
 
         public sealed override IValue Serialize() =>

--- a/Lib9c/Model/Item/Chest.cs
+++ b/Lib9c/Model/Item/Chest.cs
@@ -35,6 +35,9 @@ namespace Nekoyume.Model.Item
 
         public Chest(SerializationInfo info, StreamingContext context) : base(info, context)
         {
+            Rewards = (List<RedeemRewardSheet.RewardInfo>) info.GetValue(
+                nameof(Rewards),
+                typeof(List<RedeemRewardSheet.RewardInfo>));
         }
 
         public sealed override IValue Serialize() =>

--- a/Lib9c/Model/Item/Chest.cs
+++ b/Lib9c/Model/Item/Chest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Security.Permissions;
 using Bencodex.Types;
 using Libplanet;
 using Nekoyume.Model.State;
@@ -33,11 +34,9 @@ namespace Nekoyume.Model.Item
             }
         }
 
-        public Chest(SerializationInfo info, StreamingContext context) : base(info, context)
+        public Chest(SerializationInfo info, StreamingContext _)
+            : this((Dictionary) Codec.Decode((byte[]) info.GetValue("serialized", typeof(byte[]))))
         {
-            Rewards = (List<RedeemRewardSheet.RewardInfo>) info.GetValue(
-                nameof(Rewards),
-                typeof(List<RedeemRewardSheet.RewardInfo>));
         }
 
         public sealed override IValue Serialize() =>

--- a/Lib9c/Model/Item/Consumable.cs
+++ b/Lib9c/Model/Item/Consumable.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using Bencodex.Types;
 using Nekoyume.Model.Stat;
 using Nekoyume.Model.State;
@@ -26,6 +27,11 @@ namespace Nekoyume.Model.Item
             {
                 Stats = stats.ToList(i => new StatMap((Dictionary) i));
             }
+        }
+        
+        protected Consumable(SerializationInfo info, StreamingContext _)
+            : this((Dictionary) Codec.Decode((byte[]) info.GetValue("serialized", typeof(byte[]))))
+        {
         }
 
         public override IValue Serialize() =>

--- a/Lib9c/Model/Item/Costume.cs
+++ b/Lib9c/Model/Item/Costume.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using Bencodex.Types;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
@@ -33,6 +34,11 @@ namespace Nekoyume.Model.Item
             }
 
             ItemId = serialized["item_id"].ToGuid();
+        }
+        
+        protected Costume(SerializationInfo info, StreamingContext _)
+            : this((Dictionary) Codec.Decode((byte[]) info.GetValue("serialized", typeof(byte[]))))
+        {
         }
 
         public override IValue Serialize() =>

--- a/Lib9c/Model/Item/Equipment.cs
+++ b/Lib9c/Model/Item/Equipment.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using Bencodex.Types;
 using Nekoyume.Model.Stat;
 using Nekoyume.Model.State;
@@ -61,6 +62,12 @@ namespace Nekoyume.Model.Item
                 SpineResourcePath = (Text) spineResourcePath;
             }
         }
+        
+        protected Equipment(SerializationInfo info, StreamingContext _)
+            : this((Dictionary) Codec.Decode((byte[]) info.GetValue("serialized", typeof(byte[]))))
+        {
+        }
+        
         public override IValue Serialize() =>
 #pragma warning disable LAA1002
             new Dictionary(new Dictionary<IKey, IValue>

--- a/Lib9c/Model/Item/ItemBase.cs
+++ b/Lib9c/Model/Item/ItemBase.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Runtime.Serialization;
+using Bencodex;
 using Bencodex.Types;
 using Nekoyume.Model.Elemental;
 using Nekoyume.Model.State;
@@ -9,6 +11,8 @@ namespace Nekoyume.Model.Item
     [Serializable]
     public abstract class ItemBase : IState
     {
+        protected static readonly Codec Codec = new Codec();
+        
         public int Id { get; }
         public int Grade { get; }
         public ItemType ItemType { get; }
@@ -45,6 +49,21 @@ namespace Nekoyume.Model.Item
             {
                 ElementalType = elementalType.ToEnum<ElementalType>();
             }
+        }
+
+        protected ItemBase(SerializationInfo info, StreamingContext _)
+            : this((Dictionary) Codec.Decode((byte[]) info.GetValue("serialized", typeof(byte[]))))
+        {
+        }
+        
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException(nameof(info));
+            }
+            
+            info.AddValue("serialized", Codec.Encode(Serialize()));
         }
 
         protected bool Equals(ItemBase other)

--- a/Lib9c/Model/Item/ItemUsable.cs
+++ b/Lib9c/Model/Item/ItemUsable.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using Bencodex.Types;
 using Nekoyume.Model.Skill;
 using Nekoyume.Model.Stat;
@@ -78,6 +79,11 @@ namespace Nekoyume.Model.Item
             {
                 RequiredBlockIndex = requiredBlockIndex.ToLong();
             }
+        }
+        
+        protected ItemUsable(SerializationInfo info, StreamingContext _)
+            : this((Dictionary) Codec.Decode((byte[]) info.GetValue("serialized", typeof(byte[]))))
+        {
         }
 
         protected bool Equals(ItemUsable other)

--- a/Lib9c/Model/Item/Material.cs
+++ b/Lib9c/Model/Item/Material.cs
@@ -14,8 +14,6 @@ namespace Nekoyume.Model.Item
     [Serializable]
     public class Material : ItemBase, ISerializable
     {
-        private static Codec _codec = new Codec();
-
         public HashDigest<SHA256> ItemId { get; protected set; }
 
         public Material(MaterialItemSheet.Row data) : base(data)
@@ -32,7 +30,7 @@ namespace Nekoyume.Model.Item
         }
 
         protected Material(SerializationInfo info, StreamingContext _)
-            : this((Dictionary) _codec.Decode((byte[]) info.GetValue("serialized", typeof(byte[]))))
+            : this((Dictionary) Codec.Decode((byte[]) info.GetValue("serialized", typeof(byte[]))))
         {
         }
 
@@ -55,11 +53,6 @@ namespace Nekoyume.Model.Item
             {
                 return (base.GetHashCode() * 397) ^ ItemId.GetHashCode();
             }
-        }
-
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            info.AddValue("serialized", _codec.Encode(Serialize()));
         }
 
         public override IValue Serialize() =>

--- a/Lib9c/Model/Item/Necklace.cs
+++ b/Lib9c/Model/Item/Necklace.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 using Bencodex.Types;
 using Nekoyume.TableData;
 
@@ -12,6 +13,11 @@ namespace Nekoyume.Model.Item
         }
 
         public Necklace(Dictionary serialized) : base(serialized)
+        {
+        }
+        
+        protected Necklace(SerializationInfo info, StreamingContext _)
+            : this((Dictionary) Codec.Decode((byte[]) info.GetValue("serialized", typeof(byte[]))))
         {
         }
     }

--- a/Lib9c/Model/Item/Ring.cs
+++ b/Lib9c/Model/Item/Ring.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 using Bencodex.Types;
 using Nekoyume.TableData;
 
@@ -12,6 +13,11 @@ namespace Nekoyume.Model.Item
         }
 
         public Ring(Dictionary serialized) : base(serialized)
+        {
+        }
+        
+        protected Ring(SerializationInfo info, StreamingContext _)
+            : this((Dictionary) Codec.Decode((byte[]) info.GetValue("serialized", typeof(byte[]))))
         {
         }
     }

--- a/Lib9c/Model/Item/ShopItem.cs
+++ b/Lib9c/Model/Item/ShopItem.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Bencodex;
 using Bencodex.Types;
 using Libplanet;
 using Libplanet.Assets;
@@ -10,6 +12,8 @@ namespace Nekoyume.Model.Item
     [Serializable]
     public class ShopItem
     {
+        protected static readonly Codec Codec = new Codec();
+        
         public readonly Address SellerAgentAddress;
         public readonly Address SellerAvatarAddress;
         public readonly Guid ProductId;
@@ -57,6 +61,21 @@ namespace Nekoyume.Model.Item
             Costume = serialized.ContainsKey("costume")
                 ? (Costume) ItemFactory.Deserialize((Dictionary) serialized["costume"])
                 : null;
+        }
+        
+        protected ShopItem(SerializationInfo info, StreamingContext _)
+            : this((Dictionary) Codec.Decode((byte[]) info.GetValue("serialized", typeof(byte[]))))
+        {
+        }
+        
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException(nameof(info));
+            }
+            
+            info.AddValue("serialized", Codec.Encode(Serialize()));
         }
 
         public IValue Serialize()

--- a/Lib9c/Model/Item/Weapon.cs
+++ b/Lib9c/Model/Item/Weapon.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 using Bencodex.Types;
 using Nekoyume.TableData;
 
@@ -12,6 +13,11 @@ namespace Nekoyume.Model.Item
         }
 
         public Weapon(Dictionary serialized) : base(serialized)
+        {
+        }
+        
+        protected Weapon(SerializationInfo info, StreamingContext _)
+            : this((Dictionary) Codec.Decode((byte[]) info.GetValue("serialized", typeof(byte[]))))
         {
         }
     }


### PR DESCRIPTION
- The title says it all.
- In fact, we don't use the `Chest` object. However, it is cumbersome to remove it, so temporary measures are taken to avoid causing an error.