### PR TITLE
Use raw Dictionary instead of ShopState

### DIFF
--- a/Lib9c/Action/Buy.cs
+++ b/Lib9c/Action/Buy.cs
@@ -146,22 +146,32 @@ namespace Nekoyume.Action
                 throw new NotEnoughClearedStageLevelException(GameConfig.RequireClearedStageLevel.ActionsInShop, current);
             }
 
-            if (!states.TryGetState(ShopState.Address, out Bencodex.Types.Dictionary d))
+            if (!states.TryGetState(ShopState.Address, out Bencodex.Types.Dictionary shopStateDict))
             {
                 throw new FailedLoadStateException("Aborted as the shop state was failed to load.");
             }
 
-            var shopState = new ShopState(d);
             sw.Stop();
             Log.Debug("Buy Get ShopState: {Elapsed}", sw.Elapsed);
             sw.Restart();
 
             Log.Debug("Execute Buy; buyer: {Buyer} seller: {Seller}", buyerAvatarAddress, sellerAvatarAddress);
             // 상점에서 구매할 아이템을 찾는다.
-            if (!shopState.TryGet(sellerAgentAddress, productId, out var shopItem))
+            Dictionary products = (Dictionary)shopStateDict["products"];
+
+            IKey productIdSerialized = (IKey)productId.Serialize();
+            if (!products.ContainsKey(productIdSerialized))
             {
                 throw new ItemDoesNotExistException(
-                    $"Aborted as the shop item ({productId}) was failed to get from the seller agent ({sellerAgentAddress})."
+                    $"Aborted as the shop item ({productId}) was failed to get from the shop."
+                );
+            }
+
+            ShopItem shopItem = new ShopItem((Dictionary)products[productIdSerialized]);
+            if (!shopItem.SellerAgentAddress.Equals(sellerAgentAddress))
+            {
+                throw new ItemDoesNotExistException(
+                    $"Aborted as the shop item ({productId}) of seller ({shopItem.SellerAgentAddress}) is different from ({sellerAgentAddress})."
                 );
             }
             sw.Stop();
@@ -205,7 +215,8 @@ namespace Nekoyume.Action
                 taxedPrice
             );
 
-            shopState.Unregister(shopItem);
+            products = (Dictionary)products.Remove(productIdSerialized);
+            shopStateDict = shopStateDict.SetItem("products", products);
 
             // 구매자, 판매자에게 결과 메일 전송
             buyerResult = new BuyerResult
@@ -253,7 +264,7 @@ namespace Nekoyume.Action
             Log.Debug("Buy Set Buyer AvatarState: {Elapsed}", sw.Elapsed);
             sw.Restart();
 
-            states = states.SetState(ShopState.Address, shopState.Serialize());
+            states = states.SetState(ShopState.Address, shopStateDict);
             sw.Stop();
             var ended = DateTimeOffset.UtcNow;
             Log.Debug("Buy Set ShopState: {Elapsed}", sw.Elapsed);

--- a/Lib9c/Action/Buy3.cs
+++ b/Lib9c/Action/Buy3.cs
@@ -7,6 +7,7 @@ using Libplanet;
 using Libplanet.Action;
 using Libplanet.Assets;
 using Nekoyume.Model.EnumType;
+using Nekoyume.Model.Item;
 using Nekoyume.Model.Mail;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
@@ -83,22 +84,32 @@ namespace Nekoyume.Action
                 throw new NotEnoughClearedStageLevelException(GameConfig.RequireClearedStageLevel.ActionsInShop, current);
             }
 
-            if (!states.TryGetState(ShopState.Address, out Bencodex.Types.Dictionary d))
+            if (!states.TryGetState(ShopState.Address, out Bencodex.Types.Dictionary shopStateDict))
             {
                 throw new FailedLoadStateException("Aborted as the shop state was failed to load.");
             }
 
-            var shopState = new ShopState(d);
             sw.Stop();
             Log.Debug("Buy Get ShopState: {Elapsed}", sw.Elapsed);
             sw.Restart();
 
             Log.Debug("Execute Buy; buyer: {Buyer} seller: {Seller}", buyerAvatarAddress, sellerAvatarAddress);
             // 상점에서 구매할 아이템을 찾는다.
-            if (!shopState.TryGet(sellerAgentAddress, productId, out var shopItem))
+            Dictionary products = (Dictionary)shopStateDict["products"];
+
+            IKey productIdSerialized = (IKey)productId.Serialize();
+            if (!products.ContainsKey(productIdSerialized))
             {
                 throw new ItemDoesNotExistException(
-                    $"Aborted as the shop item ({productId}) was failed to get from the seller agent ({sellerAgentAddress})."
+                    $"Aborted as the shop item ({productId}) was failed to get from the shop."
+                );
+            }
+
+            ShopItem shopItem = new ShopItem((Dictionary)products[productIdSerialized]);
+            if (!shopItem.SellerAgentAddress.Equals(sellerAgentAddress))
+            {
+                throw new ItemDoesNotExistException(
+                    $"Aborted as the shop item ({productId}) of seller ({shopItem.SellerAgentAddress}) is different from ({sellerAgentAddress})."
                 );
             }
             sw.Stop();
@@ -142,7 +153,8 @@ namespace Nekoyume.Action
                 taxedPrice
             );
 
-            shopState.Unregister(shopItem);
+            products = (Dictionary)products.Remove(productIdSerialized);
+            shopStateDict = shopStateDict.SetItem("products", products);
 
             // 구매자, 판매자에게 결과 메일 전송
             buyerResult = new Buy.BuyerResult
@@ -200,7 +212,7 @@ namespace Nekoyume.Action
             Log.Debug("Buy Set Buyer AvatarState: {Elapsed}", sw.Elapsed);
             sw.Restart();
 
-            states = states.SetState(ShopState.Address, shopState.Serialize());
+            states = states.SetState(ShopState.Address, shopStateDict);
             sw.Stop();
             var ended = DateTimeOffset.UtcNow;
             Log.Debug("Buy Set ShopState: {Elapsed}", sw.Elapsed);

--- a/Lib9c/Action/SellCancellation.cs
+++ b/Lib9c/Action/SellCancellation.cs
@@ -93,20 +93,27 @@ namespace Nekoyume.Action
                 return states;
             }
 
-            if (!states.TryGetState(ShopState.Address, out Bencodex.Types.Dictionary d))
+            if (!states.TryGetState(ShopState.Address, out Bencodex.Types.Dictionary shopStateDict))
             {
                 return states;
             }
-            var shopState = new ShopState(d);
             sw.Stop();
             Log.Debug($"Sell Cancel Get ShopState: {sw.Elapsed}");
             sw.Restart();
 
             // 상점에서 아이템을 빼온다.
-            if (!shopState.TryUnregister(productId, out var outUnregisteredItem))
+            Dictionary products = (Dictionary)shopStateDict["products"];
+
+            IKey productIdSerialized = (IKey)productId.Serialize();
+            if (!products.ContainsKey(productIdSerialized))
             {
                 return states;
             }
+
+            ShopItem outUnregisteredItem = new ShopItem((Dictionary)products[productIdSerialized]);
+
+            products = (Dictionary)products.Remove(productIdSerialized);
+            shopStateDict = shopStateDict.SetItem("products", products);
 
             sw.Stop();
             Log.Debug($"Sell Cancel Get Unregister Item: {sw.Elapsed}");
@@ -141,7 +148,7 @@ namespace Nekoyume.Action
             Log.Debug($"Sell Cancel Set AvatarState: {sw.Elapsed}");
             sw.Restart();
 
-            states = states.SetState(ShopState.Address, shopState.Serialize());
+            states = states.SetState(ShopState.Address, shopStateDict);
             sw.Stop();
             var ended = DateTimeOffset.UtcNow;
             Log.Debug($"Sell Cancel Set ShopState: {sw.Elapsed}");

--- a/Lib9c/Action/SellCancellation3.cs
+++ b/Lib9c/Action/SellCancellation3.cs
@@ -65,20 +65,27 @@ namespace Nekoyume.Action
                 return states;
             }
 
-            if (!states.TryGetState(ShopState.Address, out Bencodex.Types.Dictionary d))
+            if (!states.TryGetState(ShopState.Address, out Bencodex.Types.Dictionary shopStateDict))
             {
                 return states;
             }
-            var shopState = new ShopState(d);
             sw.Stop();
             Log.Debug($"Sell Cancel Get ShopState: {sw.Elapsed}");
             sw.Restart();
 
             // 상점에서 아이템을 빼온다.
-            if (!shopState.TryUnregister(productId, out var outUnregisteredItem))
+            Dictionary products = (Dictionary)shopStateDict["products"];
+
+            IKey productIdSerialized = (IKey)productId.Serialize();
+            if (!products.ContainsKey(productIdSerialized))
             {
                 return states;
             }
+
+            ShopItem outUnregisteredItem = new ShopItem((Dictionary)products[productIdSerialized]);
+
+            products = (Dictionary)products.Remove(productIdSerialized);
+            shopStateDict = shopStateDict.SetItem("products", products);
 
             sw.Stop();
             Log.Debug($"Sell Cancel Get Unregister Item: {sw.Elapsed}");
@@ -102,7 +109,7 @@ namespace Nekoyume.Action
             result.id = mail.id;
 
             avatarState.Update(mail);
-            
+
             if (result.itemUsable != null)
             {
                 avatarState.UpdateFromAddItem(result.itemUsable, true);
@@ -112,10 +119,10 @@ namespace Nekoyume.Action
             {
                 avatarState.UpdateFromAddCostume(result.costume, true);
             }
-            
+
             avatarState.updatedAt = ctx.BlockIndex;
             avatarState.blockIndex = ctx.BlockIndex;
-            
+
             sw.Stop();
             Log.Debug($"Sell Cancel Update AvatarState: {sw.Elapsed}");
             sw.Restart();
@@ -125,7 +132,7 @@ namespace Nekoyume.Action
             Log.Debug($"Sell Cancel Set AvatarState: {sw.Elapsed}");
             sw.Restart();
 
-            states = states.SetState(ShopState.Address, shopState.Serialize());
+            states = states.SetState(ShopState.Address, shopStateDict);
             sw.Stop();
             var ended = DateTimeOffset.UtcNow;
             Log.Debug($"Sell Cancel Set ShopState: {sw.Elapsed}");


### PR DESCRIPTION
This PR changes `Buy`, `Sell`, `SellCancellation` actions to use raw `Dictionary` instead of `ShopState` to reduce the serialization and deserialization time.

--- 

Before:
```
[22:45:28 DBG] Buy Total Executed Time: 00:00:00.3772240
[22:45:42 DBG] Sell Total Executed Time: 00:00:00.3090630
[22:46:38 DBG] Sell Cancel Total Executed Time: 00:00:00.2639720
```

After:
```
[22:50:03 DBG] Buy Total Executed Time: 00:00:00.1555280
[22:50:15 DBG] Sell Total Executed Time: 00:00:00.1101030
[22:51:02 DBG] Sell Cancel Total Executed Time: 00:00:00.0872910
```