### PR TITLE
Bug fix/failed to `HackAndSlash3` when `AvatarState` already max level and max exp

### DIFF
--- a/.Lib9c.Tests/Action/HackAndSlash4Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash4Test.cs
@@ -1,0 +1,171 @@
+namespace Lib9c.Tests.Action
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.IO;
+    using System.Linq;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using Bencodex.Types;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Crypto;
+    using Nekoyume;
+    using Nekoyume.Action;
+    using Nekoyume.Battle;
+    using Nekoyume.Model;
+    using Nekoyume.Model.BattleStatus;
+    using Nekoyume.Model.Item;
+    using Nekoyume.Model.Mail;
+    using Nekoyume.Model.State;
+    using Nekoyume.TableData;
+    using Xunit;
+
+    public class HackAndSlash4Test
+    {
+        private readonly TableSheets _tableSheets;
+
+        private readonly Address _agentAddress;
+
+        private readonly Address _avatarAddress;
+        private readonly AvatarState _avatarState;
+
+        private readonly Address _rankingMapAddress;
+
+        private readonly WeeklyArenaState _weeklyArenaState;
+        private readonly IAccountStateDelta _initialState;
+
+        public HackAndSlash4Test()
+        {
+            var sheets = TableSheetsImporter.ImportSheets();
+            _tableSheets = new TableSheets(sheets);
+
+            var privateKey = new PrivateKey();
+            _agentAddress = privateKey.PublicKey.ToAddress();
+            var agentState = new AgentState(_agentAddress);
+
+            _avatarAddress = _agentAddress.Derive("avatar");
+            _rankingMapAddress = _avatarAddress.Derive("ranking_map");
+            _avatarState = new AvatarState(
+                _avatarAddress,
+                _agentAddress,
+                0,
+                _tableSheets.GetAvatarSheets(),
+                new GameConfigState(sheets[nameof(GameConfigSheet)]),
+                _rankingMapAddress
+            )
+            {
+                level = 100,
+            };
+            agentState.avatarAddresses.Add(0, _avatarAddress);
+
+            _weeklyArenaState = new WeeklyArenaState(0);
+
+            _initialState = new State()
+                .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
+                .SetState(_agentAddress, agentState.Serialize())
+                .SetState(_avatarAddress, _avatarState.Serialize())
+                .SetState(_rankingMapAddress, new RankingMapState(_rankingMapAddress).Serialize());
+
+            foreach (var (key, value) in sheets)
+            {
+                _initialState = _initialState
+                    .SetState(Addresses.TableSheet.Derive(key), value.Serialize());
+            }
+        }
+
+        [Theory]
+        [InlineData(GameConfig.RequireCharacterLevel.CharacterFullCostumeSlot, 1, 1, false)]
+        [InlineData(100, 1, GameConfig.RequireClearedStageLevel.ActionsInRankingBoard, true)]
+        public void Execute(int avatarLevel, int worldId, int stageId, bool contains)
+        {
+            Assert.True(_tableSheets.WorldSheet.TryGetValue(worldId, out var worldRow));
+            Assert.True(stageId >= worldRow.StageBegin);
+            Assert.True(stageId <= worldRow.StageEnd);
+            Assert.True(_tableSheets.StageSheet.TryGetValue(stageId, out _));
+
+            var previousAvatarState = _initialState.GetAvatarState(_avatarAddress);
+            previousAvatarState.level = avatarLevel;
+            previousAvatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                Math.Max(_tableSheets.StageSheet.First?.Id ?? 1, stageId - 1));
+
+            var costumeId = _tableSheets
+                .CostumeItemSheet
+                .Values
+                .First(r => r.ItemSubType == ItemSubType.FullCostume)
+                .Id;
+            var costume =
+                ItemFactory.CreateItem(_tableSheets.ItemSheet[costumeId], new ItemEnhancementTest.TestRandom());
+            previousAvatarState.inventory.AddItem(costume);
+
+            var equipmentRow = _tableSheets.EquipmentItemSheet.Values.First();
+            var equipment = ItemFactory.CreateItemUsable(equipmentRow, default, 0);
+            var result = new CombinationConsumable.ResultModel
+            {
+                id = default,
+                gold = 0,
+                actionPoint = 0,
+                recipeId = 1,
+                materials = new Dictionary<Material, int>(),
+                itemUsable = equipment,
+            };
+            for (var i = 0; i < 100; i++)
+            {
+                var mail = new CombinationMail(result, i, default, 0);
+                previousAvatarState.Update(mail);
+            }
+
+            var state = _initialState.SetState(_avatarAddress, previousAvatarState.Serialize());
+
+            var action = new HackAndSlash4
+            {
+                costumes = new List<int> { costumeId },
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = worldId,
+                stageId = stageId,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Null(action.Result);
+
+            var nextState = action.Execute(new ActionContext
+            {
+                PreviousStates = state,
+                Signer = _agentAddress,
+                Random = new ItemEnhancementTest.TestRandom(),
+                Rehearsal = false,
+            });
+
+            var nextAvatarState = nextState.GetAvatarState(_avatarAddress);
+            var newWeeklyState = nextState.GetWeeklyArenaState(0);
+
+            Assert.NotNull(action.Result);
+
+            Assert.NotEmpty(action.Result.OfType<GetReward>());
+            Assert.Equal(BattleLog.Result.Win, action.Result.result);
+            Assert.Equal(contains, newWeeklyState.ContainsKey(_avatarAddress));
+            Assert.True(nextAvatarState.worldInformation.IsStageCleared(stageId));
+            Assert.Equal(30, nextAvatarState.mailBox.Count);
+            if (contains)
+            {
+                Assert.True(
+                    newWeeklyState[_avatarAddress].CombatPoint >
+                    CPHelper.GetCP(nextAvatarState, _tableSheets.CharacterSheet)
+                );
+            }
+
+            var value = nextState.GetState(_rankingMapAddress);
+
+            var rankingMapState = new RankingMapState((Dictionary)value);
+            var info = rankingMapState.GetRankingInfos(null).First();
+
+            Assert.Equal(info.AgentAddress, _agentAddress);
+            Assert.Equal(info.AvatarAddress, _avatarAddress);
+        }
+    }
+}

--- a/.Lib9c.Tests/Action/HackAndSlash4Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash4Test.cs
@@ -91,7 +91,7 @@ namespace Lib9c.Tests.Action
                 _tableSheets.WorldSheet,
                 Math.Max(_tableSheets.StageSheet.First?.Id ?? 1, stageId - 1));
 
-            List<int> costumes = new List<int>();
+            List<Guid> costumes = new List<Guid>();
             if (avatarLevel >= GameConfig.RequireCharacterLevel.CharacterFullCostumeSlot)
             {
                 var costumeId = _tableSheets
@@ -99,10 +99,11 @@ namespace Lib9c.Tests.Action
                 .Values
                 .First(r => r.ItemSubType == ItemSubType.FullCostume)
                 .Id;
-                costumes.Add(costumeId);
 
-                var costume = ItemFactory.CreateItem(_tableSheets.ItemSheet[costumeId], new ItemEnhancementTest.TestRandom());
+                var costume = (Costume)ItemFactory.CreateItem(
+                    _tableSheets.ItemSheet[costumeId], new ItemEnhancementTest.TestRandom());
                 previousAvatarState.inventory.AddItem(costume);
+                costumes.Add(costume.ItemId);
             }
 
             List<Guid> equipments = new List<Guid>();
@@ -242,7 +243,7 @@ namespace Lib9c.Tests.Action
 
             var action = new HackAndSlash4
             {
-                costumes = new List<int>(),
+                costumes = new List<Guid>(),
                 equipments = new List<Guid>(),
                 foods = new List<Guid>(),
                 worldId = worldId,

--- a/.Lib9c.Tests/Action/HackAndSlash4Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash4Test.cs
@@ -2,7 +2,6 @@ namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.Immutable;
     using System.IO;
     using System.Linq;
     using System.Runtime.Serialization.Formatters.Binary;

--- a/.Lib9c.Tests/Action/HackAndSlash4Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash4Test.cs
@@ -101,7 +101,7 @@ namespace Lib9c.Tests.Action
                 .Id;
 
                 var costume = (Costume)ItemFactory.CreateItem(
-                    _tableSheets.ItemSheet[costumeId], new ItemEnhancementTest.TestRandom());
+                    _tableSheets.ItemSheet[costumeId], new TestRandom());
                 previousAvatarState.inventory.AddItem(costume);
                 costumes.Add(costume.ItemId);
             }
@@ -120,7 +120,7 @@ namespace Lib9c.Tests.Action
 
                 var weapon = ItemFactory.CreateItem(
                     _tableSheets.EquipmentItemSheet[weaponId],
-                    new ItemEnhancementTest.TestRandom())
+                    new TestRandom())
                     as Equipment;
                 equipments.Add(weapon.ItemId);
                 previousAvatarState.inventory.AddItem(weapon);
@@ -138,7 +138,7 @@ namespace Lib9c.Tests.Action
 
                 var armor = ItemFactory.CreateItem(
                     _tableSheets.EquipmentItemSheet[armorId],
-                    new ItemEnhancementTest.TestRandom())
+                    new TestRandom())
                     as Equipment;
                 equipments.Add(armor.ItemId);
                 previousAvatarState.inventory.AddItem(armor);
@@ -181,7 +181,7 @@ namespace Lib9c.Tests.Action
             {
                 PreviousStates = state,
                 Signer = _agentAddress,
-                Random = new ItemEnhancementTest.TestRandom(),
+                Random = new TestRandom(),
                 Rehearsal = false,
             });
 
@@ -259,7 +259,7 @@ namespace Lib9c.Tests.Action
             {
                 PreviousStates = state,
                 Signer = _agentAddress,
-                Random = new ItemEnhancementTest.TestRandom(),
+                Random = new TestRandom(),
                 Rehearsal = false,
             });
 

--- a/.Lib9c.Tests/Action/HackAndSlash4Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash4Test.cs
@@ -325,6 +325,433 @@ namespace Lib9c.Tests.Action
             SerializeException<DuplicateEquipmentException>(exec);
         }
 
+        [Fact]
+        public void ExecuteThrowInvalidRankingMapAddress()
+        {
+            var action = new HackAndSlash4()
+            {
+                costumes = new List<Guid>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = 1,
+                stageId = 1,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = default,
+            };
+
+            Assert.Null(action.Result);
+
+            var exec = Assert.Throws<InvalidAddressException>(() =>
+                action.Execute(new ActionContext()
+                {
+                    PreviousStates = _initialState,
+                    Signer = _agentAddress,
+                    Random = new TestRandom(),
+                    Rehearsal = false,
+                })
+            );
+
+            SerializeException<InvalidAddressException>(exec);
+        }
+
+        [Fact]
+        public void ExecuteThrowFailedLoadStateException()
+        {
+            var action = new HackAndSlash4()
+            {
+                costumes = new List<Guid>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = 1,
+                stageId = 1,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+            };
+
+            Assert.Null(action.Result);
+
+            var exec = Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
+            {
+                PreviousStates = new State(),
+                Signer = _agentAddress,
+                Random = new TestRandom(),
+            }));
+
+            Assert.Null(action.Result);
+
+            SerializeException<FailedLoadStateException>(exec);
+        }
+
+        [Fact]
+        public void ExecuteThrowSheetRowNotFoundExceptionByWorld()
+        {
+            var action = new HackAndSlash4()
+            {
+                costumes = new List<Guid>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = 100,
+                stageId = 1,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Null(action.Result);
+
+            var exec = Assert.Throws<SheetRowNotFoundException>(() => action.Execute(new ActionContext()
+            {
+                PreviousStates = _initialState,
+                Signer = _agentAddress,
+                Random = new TestRandom(),
+            }));
+
+            Assert.Null(action.Result);
+
+            SerializeException<SheetRowNotFoundException>(exec);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(51)]
+        public void ExecuteThrowSheetRowColumnException(int stageId)
+        {
+            var action = new HackAndSlash4()
+            {
+                costumes = new List<Guid>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = 1,
+                stageId = stageId,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Null(action.Result);
+
+            var exec = Assert.Throws<SheetRowColumnException>(() => action.Execute(new ActionContext()
+            {
+                PreviousStates = _initialState,
+                Signer = _agentAddress,
+                Random = new TestRandom(),
+            }));
+
+            Assert.Null(action.Result);
+
+            SerializeException<SheetRowColumnException>(exec);
+        }
+
+        [Fact]
+        public void ExecuteThrowSheetRowNotFoundExceptionByStage()
+        {
+            var action = new HackAndSlash4()
+            {
+                costumes = new List<Guid>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = 1,
+                stageId = 1,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Null(action.Result);
+
+            var state = _initialState;
+            state = state.SetState(Addresses.TableSheet.Derive(nameof(StageSheet)), "test".Serialize());
+
+            var exec = Assert.Throws<SheetRowNotFoundException>(() => action.Execute(new ActionContext()
+            {
+                PreviousStates = state,
+                Signer = _agentAddress,
+                Random = new TestRandom(),
+            }));
+
+            Assert.Null(action.Result);
+
+            SerializeException<SheetRowNotFoundException>(exec);
+        }
+
+        [Fact]
+        public void ExecuteThrowFailedAddWorldException()
+        {
+            var action = new HackAndSlash4()
+            {
+                costumes = new List<Guid>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = 1,
+                stageId = 1,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Null(action.Result);
+
+            var state = _initialState;
+            var worldSheet = new WorldSheet();
+            worldSheet.Set("test");
+            var avatarState = new AvatarState(_avatarState)
+            {
+                worldInformation = new WorldInformation(0, worldSheet, false),
+            };
+            state = state.SetState(_avatarAddress, avatarState.Serialize());
+
+            Assert.False(avatarState.worldInformation.IsStageCleared(0));
+
+            var exec = Assert.Throws<FailedAddWorldException>(() => action.Execute(new ActionContext()
+            {
+                PreviousStates = state,
+                Signer = _agentAddress,
+                Random = new TestRandom(),
+            }));
+
+            Assert.Null(action.Result);
+
+            SerializeException<FailedAddWorldException>(exec);
+        }
+
+        [Fact]
+        public void ExecuteThrowInvalidWorldException()
+        {
+            var action = new HackAndSlash4()
+            {
+                costumes = new List<Guid>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = 2,
+                stageId = 51,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Null(action.Result);
+
+            Assert.False(_avatarState.worldInformation.IsStageCleared(51));
+
+            var exec = Assert.Throws<InvalidWorldException>(() => action.Execute(new ActionContext()
+            {
+                PreviousStates = _initialState,
+                Signer = _agentAddress,
+                Random = new TestRandom(),
+            }));
+
+            Assert.Null(action.Result);
+
+            SerializeException<InvalidWorldException>(exec);
+        }
+
+        [Fact]
+        public void ExecuteThrowInvalidStageException()
+        {
+            var action = new HackAndSlash4()
+            {
+                costumes = new List<Guid>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = 1,
+                stageId = 3,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Null(action.Result);
+
+            var avatarState = new AvatarState(_avatarState);
+            avatarState.worldInformation.ClearStage(
+                1,
+                1,
+                0,
+                _tableSheets.WorldSheet,
+                _tableSheets.WorldUnlockSheet
+            );
+
+            avatarState.worldInformation.TryGetWorld(1, out var world);
+
+            Assert.True(world.IsStageCleared);
+            Assert.True(avatarState.worldInformation.IsWorldUnlocked(1));
+
+            var state = _initialState;
+            state = state.SetState(_avatarAddress, avatarState.Serialize());
+
+            var exec = Assert.Throws<InvalidStageException>(() => action.Execute(new ActionContext()
+            {
+                PreviousStates = state,
+                Signer = _agentAddress,
+                Random = new TestRandom(),
+            }));
+
+            Assert.Null(action.Result);
+
+            SerializeException<InvalidStageException>(exec);
+        }
+
+        [Fact]
+        public void ExecuteThrowInvalidStageExceptionUnlockedWorld()
+        {
+            var action = new HackAndSlash4()
+            {
+                costumes = new List<Guid>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = 1,
+                stageId = 2,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Null(action.Result);
+
+            _avatarState.worldInformation.TryGetWorld(1, out var world);
+            Assert.False(world.IsStageCleared);
+
+            var exec = Assert.Throws<InvalidStageException>(() => action.Execute(new ActionContext()
+            {
+                PreviousStates = _initialState,
+                Signer = _agentAddress,
+                Random = new TestRandom(),
+            }));
+
+            Assert.Null(action.Result);
+
+            SerializeException<InvalidStageException>(exec);
+        }
+
+        [Theory]
+        [InlineData(ItemSubType.Weapon)]
+        [InlineData(ItemSubType.Armor)]
+        [InlineData(ItemSubType.Belt)]
+        [InlineData(ItemSubType.Necklace)]
+        [InlineData(ItemSubType.Ring)]
+        public void ExecuteThrowInvalidEquipmentException(ItemSubType itemSubType)
+        {
+            var avatarState = new AvatarState(_avatarState);
+            var equipRow = _tableSheets.EquipmentItemSheet.Values.First(r => r.ItemSubType == itemSubType);
+            var equipment = ItemFactory.CreateItemUsable(equipRow, Guid.NewGuid(), 100);
+            avatarState.inventory.AddItem(equipment);
+
+            var action = new HackAndSlash4()
+            {
+                costumes = new List<Guid>(),
+                equipments = new List<Guid>()
+                {
+                    equipment.ItemId,
+                },
+                foods = new List<Guid>(),
+                worldId = 1,
+                stageId = 1,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Null(action.Result);
+
+            var state = _initialState;
+            state = state.SetState(_avatarAddress, avatarState.Serialize());
+
+            var exec = Assert.Throws<RequiredBlockIndexException>(() => action.Execute(new ActionContext()
+            {
+                PreviousStates = state,
+                Signer = _agentAddress,
+                Random = new TestRandom(),
+            }));
+
+            Assert.Null(action.Result);
+
+            SerializeException<RequiredBlockIndexException>(exec);
+        }
+
+        [Theory]
+        [InlineData(ItemSubType.Weapon)]
+        [InlineData(ItemSubType.Armor)]
+        [InlineData(ItemSubType.Belt)]
+        [InlineData(ItemSubType.Necklace)]
+        [InlineData(ItemSubType.Ring)]
+        public void ExecuteThrowEquipmentSlotUnlockException(ItemSubType itemSubType)
+        {
+            var avatarState = new AvatarState(_avatarState);
+            var equipRow = _tableSheets.EquipmentItemSheet.Values.First(r => r.ItemSubType == itemSubType);
+            var equipment = ItemFactory.CreateItemUsable(equipRow, Guid.NewGuid(), 0);
+            avatarState.inventory.AddItem(equipment);
+            avatarState.level = 0;
+
+            var action = new HackAndSlash4()
+            {
+                costumes = new List<Guid>(),
+                equipments = new List<Guid>()
+                {
+                    equipment.ItemId,
+                },
+                foods = new List<Guid>(),
+                worldId = 1,
+                stageId = 1,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Null(action.Result);
+
+            var state = _initialState;
+            state = state.SetState(_avatarAddress, avatarState.Serialize());
+
+            var exec = Assert.Throws<EquipmentSlotUnlockException>(() => action.Execute(new ActionContext()
+            {
+                PreviousStates = state,
+                Signer = _agentAddress,
+                Random = new TestRandom(),
+            }));
+
+            Assert.Null(action.Result);
+
+            SerializeException<EquipmentSlotUnlockException>(exec);
+        }
+
+        [Fact]
+        public void ExecuteThrowNotEnoughActionPointException()
+        {
+            var avatarState = new AvatarState(_avatarState)
+            {
+                actionPoint = 0,
+            };
+
+            var action = new HackAndSlash4()
+            {
+                costumes = new List<Guid>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = 1,
+                stageId = 1,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Null(action.Result);
+
+            var state = _initialState;
+            state = state.SetState(_avatarAddress, avatarState.Serialize());
+
+            var exec = Assert.Throws<NotEnoughActionPointException>(() => action.Execute(new ActionContext()
+            {
+                PreviousStates = state,
+                Signer = _agentAddress,
+                Random = new TestRandom(),
+            }));
+
+            Assert.Null(action.Result);
+
+            SerializeException<NotEnoughActionPointException>(exec);
+        }
+
         private static void SerializeException<T>(Exception exec)
             where T : Exception
         {

--- a/.Lib9c.Tests/Action/HackAndSlash4Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash4Test.cs
@@ -270,6 +270,10 @@ namespace Lib9c.Tests.Action
 
         [Theory]
         [InlineData(ItemSubType.Weapon, GameConfig.MaxEquipmentSlotCount.Weapon)]
+        [InlineData(ItemSubType.Armor, GameConfig.MaxEquipmentSlotCount.Armor)]
+        [InlineData(ItemSubType.Belt, GameConfig.MaxEquipmentSlotCount.Belt)]
+        [InlineData(ItemSubType.Necklace, GameConfig.MaxEquipmentSlotCount.Necklace)]
+        [InlineData(ItemSubType.Ring, GameConfig.MaxEquipmentSlotCount.Ring)]
         public void MultipleEquipmentTest(ItemSubType type, int maxCount)
         {
             var previousAvatarState = _initialState.GetAvatarState(_avatarAddress);

--- a/.Lib9c.Tests/Action/HackAndSlash4Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash4Test.cs
@@ -91,39 +91,57 @@ namespace Lib9c.Tests.Action
                 _tableSheets.WorldSheet,
                 Math.Max(_tableSheets.StageSheet.First?.Id ?? 1, stageId - 1));
 
-            var costumeId = _tableSheets
+            List<int> costumes = new List<int>();
+            if (avatarLevel >= GameConfig.RequireCharacterLevel.CharacterFullCostumeSlot)
+            {
+                var costumeId = _tableSheets
                 .CostumeItemSheet
                 .Values
                 .First(r => r.ItemSubType == ItemSubType.FullCostume)
                 .Id;
-            var costume =
-                ItemFactory.CreateItem(_tableSheets.ItemSheet[costumeId], new ItemEnhancementTest.TestRandom());
+                costumes.Add(costumeId);
 
-            var weaponId = _tableSheets
+                var costume = ItemFactory.CreateItem(_tableSheets.ItemSheet[costumeId], new ItemEnhancementTest.TestRandom());
+                previousAvatarState.inventory.AddItem(costume);
+            }
+
+            List<Guid> equipments = new List<Guid>();
+
+            if (avatarLevel >= GameConfig.RequireCharacterLevel.CharacterEquipmentSlotWeapon)
+            {
+                var weaponId = _tableSheets
                 .EquipmentItemSheet
                 .Values
                 .Where(r => r.ItemSubType == ItemSubType.Weapon)
                 .OrderBy(r => r.Stat.ValueAsInt)
                 .Last()
                 .Id;
-            var weapon =
-                ItemFactory.CreateItem(_tableSheets.EquipmentItemSheet[weaponId], new ItemEnhancementTest.TestRandom())
-                as Equipment;
 
-            var armorId = _tableSheets
+                var weapon = ItemFactory.CreateItem(
+                    _tableSheets.EquipmentItemSheet[weaponId],
+                    new ItemEnhancementTest.TestRandom())
+                    as Equipment;
+                equipments.Add(weapon.ItemId);
+                previousAvatarState.inventory.AddItem(weapon);
+            }
+
+            if (avatarLevel >= GameConfig.RequireCharacterLevel.CharacterEquipmentSlotArmor)
+            {
+                var armorId = _tableSheets
                 .EquipmentItemSheet
                 .Values
                 .Where(r => r.ItemSubType == ItemSubType.Armor)
                 .OrderBy(r => r.Stat.ValueAsInt)
                 .Last()
                 .Id;
-            var armor =
-                ItemFactory.CreateItem(_tableSheets.EquipmentItemSheet[armorId], new ItemEnhancementTest.TestRandom())
-                as Equipment;
 
-            previousAvatarState.inventory.AddItem(costume);
-            previousAvatarState.inventory.AddItem(armor);
-            previousAvatarState.inventory.AddItem(weapon);
+                var armor = ItemFactory.CreateItem(
+                    _tableSheets.EquipmentItemSheet[armorId],
+                    new ItemEnhancementTest.TestRandom())
+                    as Equipment;
+                equipments.Add(armor.ItemId);
+                previousAvatarState.inventory.AddItem(armor);
+            }
 
             var mailEquipmentRow = _tableSheets.EquipmentItemSheet.Values.First();
             var mailEquipment = ItemFactory.CreateItemUsable(mailEquipmentRow, default, 0);
@@ -146,8 +164,8 @@ namespace Lib9c.Tests.Action
 
             var action = new HackAndSlash4
             {
-                costumes = new List<int> { costumeId },
-                equipments = new List<Guid> { weapon.ItemId, armor.ItemId },
+                costumes = costumes,
+                equipments = equipments,
                 foods = new List<Guid>(),
                 worldId = worldId,
                 stageId = stageId,

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle2Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle2Test.cs
@@ -18,7 +18,7 @@
     using Nekoyume.TableData;
     using Xunit;
 
-    public class MimisbrunnrBttleTest
+    public class MimisbrunnrBattle2Test
     {
         private readonly TableSheets _tableSheets;
 
@@ -31,7 +31,7 @@
         private readonly WeeklyArenaState _weeklyArenaState;
         private readonly IAccountStateDelta _initialState;
 
-        public MimisbrunnrBttleTest()
+        public MimisbrunnrBattle2Test()
         {
             var sheets = TableSheetsImporter.ImportSheets();
             _tableSheets = new TableSheets(sheets);
@@ -133,7 +133,7 @@
 
             var state = _initialState.SetState(_avatarAddress, previousAvatarState.Serialize());
 
-            var action = new MimisbrunnrBattle()
+            var action = new MimisbrunnrBattle2()
             {
                 costumes = new List<Guid> { ((Costume)costume).ItemId },
                 equipments = new List<Guid>() { equipment.ItemId },
@@ -223,7 +223,7 @@
                 }
             }
 
-            var action = new MimisbrunnrBattle()
+            var action = new MimisbrunnrBattle2()
             {
                 costumes = new List<Guid> { costume.ItemId },
                 equipments = new List<Guid>() { equipment.ItemId },
@@ -250,7 +250,7 @@
         [Fact]
         public void ExecuteThrowFailedLoadStateException()
         {
-            var action = new MimisbrunnrBattle()
+            var action = new MimisbrunnrBattle2()
             {
                 costumes = new List<Guid>(),
                 equipments = new List<Guid>(),
@@ -275,7 +275,7 @@
         [Fact]
         public void ExecuteThrowInvalidRankingMapAddress()
         {
-            var action = new MimisbrunnrBattle()
+            var action = new MimisbrunnrBattle2()
             {
                 costumes = new List<Guid>(),
                 equipments = new List<Guid>(),
@@ -302,7 +302,7 @@
         [Fact]
         public void ExecuteThrowSheetRowNotFound()
         {
-            var action = new MimisbrunnrBattle()
+            var action = new MimisbrunnrBattle2()
             {
                 costumes = new List<Guid>(),
                 equipments = new List<Guid>(),
@@ -329,7 +329,7 @@
         [Fact]
         public void ExecuteThrowSheetRowColumn()
         {
-            var action = new MimisbrunnrBattle()
+            var action = new MimisbrunnrBattle2()
             {
                 costumes = new List<Guid>(),
                 equipments = new List<Guid>(),
@@ -371,7 +371,7 @@
                 _tableSheets.WorldSheet,
                 _tableSheets.WorldUnlockSheet);
 
-            var action = new MimisbrunnrBattle()
+            var action = new MimisbrunnrBattle2()
             {
                 costumes = new List<Guid>(),
                 equipments = new List<Guid>(),
@@ -459,7 +459,7 @@
 
             var state = _initialState.SetState(_avatarAddress, previousAvatarState.Serialize());
 
-            var action = new MimisbrunnrBattle()
+            var action = new MimisbrunnrBattle2()
             {
                 costumes = new List<Guid> { ((Costume)costume).ItemId },
                 equipments = new List<Guid>() { equipment.ItemId },
@@ -501,7 +501,7 @@
             avatarState.worldInformation = new WorldInformation(0, worldSheet, alreadyClearedStageId);
             var nextState = _initialState.SetState(_avatarAddress, avatarState.Serialize());
 
-            var action = new MimisbrunnrBattle
+            var action = new MimisbrunnrBattle2
             {
                 costumes = new List<Guid>(),
                 equipments = new List<Guid>(),
@@ -549,7 +549,7 @@
             avatarState.inventory.AddItem(equipment);
             var nextState = _initialState.SetState(_avatarAddress, avatarState.Serialize());
 
-            var action = new MimisbrunnrBattle()
+            var action = new MimisbrunnrBattle2()
             {
                 costumes = new List<Guid> { ((Costume)costume).ItemId },
                 equipments = new List<Guid>() { equipment.ItemId },

--- a/.Lib9c.Tests/Action/MimisbrunnrBattleTest.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattleTest.cs
@@ -1,0 +1,582 @@
+﻿namespace Lib9c.Tests.Action
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Bencodex.Types;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Crypto;
+    using Nekoyume;
+    using Nekoyume.Action;
+    using Nekoyume.Model;
+    using Nekoyume.Model.BattleStatus;
+    using Nekoyume.Model.Elemental;
+    using Nekoyume.Model.Item;
+    using Nekoyume.Model.Mail;
+    using Nekoyume.Model.State;
+    using Nekoyume.TableData;
+    using Xunit;
+
+    public class MimisbrunnrBattleTest
+    {
+        private readonly TableSheets _tableSheets;
+
+        private readonly Address _agentAddress;
+
+        private readonly Address _avatarAddress;
+
+        private readonly Address _rankingMapAddress;
+
+        private readonly WeeklyArenaState _weeklyArenaState;
+        private readonly IAccountStateDelta _initialState;
+
+        public MimisbrunnrBattleTest()
+        {
+            var sheets = TableSheetsImporter.ImportSheets();
+            _tableSheets = new TableSheets(sheets);
+
+            var privateKey = new PrivateKey();
+            _agentAddress = privateKey.PublicKey.ToAddress();
+            var agentState = new AgentState(_agentAddress);
+
+            _avatarAddress = _agentAddress.Derive("avatar");
+            _rankingMapAddress = _avatarAddress.Derive("ranking_map");
+            var avatarState = new AvatarState(
+                _avatarAddress,
+                _agentAddress,
+                0,
+                _tableSheets.GetAvatarSheets(),
+                new GameConfigState(sheets[nameof(GameConfigSheet)]),
+                _rankingMapAddress
+            )
+            {
+                level = 400,
+            };
+            agentState.avatarAddresses.Add(0, _avatarAddress);
+
+            _weeklyArenaState = new WeeklyArenaState(0);
+
+            _initialState = new State()
+                .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
+                .SetState(_agentAddress, agentState.Serialize())
+                .SetState(_avatarAddress, avatarState.Serialize())
+                .SetState(_rankingMapAddress, new RankingMapState(_rankingMapAddress).Serialize());
+
+            foreach (var (key, value) in sheets)
+            {
+                _initialState = _initialState
+                    .SetState(Addresses.TableSheet.Derive(key), value.Serialize());
+            }
+        }
+
+        [Theory]
+        [InlineData(200, GameConfig.MimisbrunnrWorldId, GameConfig.MimisbrunnrStartStageId, 140)]
+        [InlineData(400, GameConfig.MimisbrunnrWorldId, GameConfig.MimisbrunnrStartStageId, 100)]
+        public void Execute(int avatarLevel, int worldId, int stageId, int clearStageId)
+        {
+            Assert.True(_tableSheets.WorldSheet.TryGetValue(worldId, out var worldRow));
+            Assert.True(stageId >= worldRow.StageBegin);
+            Assert.True(stageId <= worldRow.StageEnd);
+            Assert.True(_tableSheets.StageSheet.TryGetValue(stageId, out _));
+
+            var previousAvatarState = _initialState.GetAvatarState(_avatarAddress);
+            previousAvatarState.level = avatarLevel;
+            previousAvatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                clearStageId);
+
+            var costumeId = _tableSheets
+                .CostumeItemSheet
+                .Values
+                .First(r => r.ItemSubType == ItemSubType.FullCostume)
+                .Id;
+            var costume =
+                ItemFactory.CreateItem(_tableSheets.ItemSheet[costumeId], new TestRandom());
+            previousAvatarState.inventory.AddItem(costume);
+
+            var mimisbrunnrSheet = _tableSheets.MimisbrunnrSheet;
+            if (!mimisbrunnrSheet.TryGetValue(stageId, out var mimisbrunnrSheetRow))
+            {
+                throw new SheetRowNotFoundException("MimisbrunnrSheet", stageId);
+            }
+
+            var equipmentRow =
+                _tableSheets.EquipmentItemSheet.Values.First(x => x.ElementalType == ElementalType.Fire);
+            var equipment = ItemFactory.CreateItemUsable(equipmentRow, default, 0);
+            previousAvatarState.inventory.AddItem(equipment);
+
+            foreach (var equipmentId in previousAvatarState.inventory.Equipments)
+            {
+                if (previousAvatarState.inventory.TryGetNonFungibleItem(equipmentId, out ItemUsable itemUsable))
+                {
+                    var elementalType = ((Equipment)itemUsable).ElementalType;
+                    Assert.True(mimisbrunnrSheetRow.ElementalTypes.Exists(x => x == elementalType));
+                }
+            }
+
+            var result = new CombinationConsumable.ResultModel()
+            {
+                id = default,
+                gold = 0,
+                actionPoint = 0,
+                recipeId = 1,
+                materials = new Dictionary<Material, int>(),
+                itemUsable = equipment,
+            };
+            for (var i = 0; i < 100; i++)
+            {
+                var mail = new CombinationMail(result, i, default, 0);
+                previousAvatarState.Update(mail);
+            }
+
+            var state = _initialState.SetState(_avatarAddress, previousAvatarState.Serialize());
+
+            var action = new MimisbrunnrBattle()
+            {
+                costumes = new List<Guid> { ((Costume)costume).ItemId },
+                equipments = new List<Guid>() { equipment.ItemId },
+                foods = new List<Guid>(),
+                worldId = worldId,
+                stageId = stageId,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Null(action.Result);
+
+            var nextState = action.Execute(new ActionContext()
+            {
+                PreviousStates = state,
+                Signer = _agentAddress,
+                Random = new TestRandom(),
+                Rehearsal = false,
+            });
+
+            var nextAvatarState = nextState.GetAvatarState(_avatarAddress);
+            var newWeeklyState = nextState.GetWeeklyArenaState(0);
+            Assert.NotNull(action.Result);
+            var reward = action.Result.OfType<GetReward>();
+            Assert.NotEmpty(reward);
+            Assert.Equal(BattleLog.Result.Win, action.Result.result);
+            Assert.True(nextAvatarState.worldInformation.IsStageCleared(stageId));
+            Assert.Equal(30, nextAvatarState.mailBox.Count);
+
+            var value = nextState.GetState(_rankingMapAddress);
+            if (value != null)
+            {
+                var rankingMapState = new RankingMapState((Dictionary)value);
+                var info = rankingMapState.GetRankingInfos(null).First();
+
+                Assert.Equal(info.AgentAddress, _agentAddress);
+                Assert.Equal(info.AvatarAddress, _avatarAddress);
+            }
+        }
+
+        [Fact]
+        public void ExecuteThrowInvalidStageException()
+        {
+            var stageId = 10000002;
+            var worldId = 10001;
+            var previousAvatarState = _initialState.GetAvatarState(_avatarAddress);
+
+            previousAvatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                100
+            );
+
+            previousAvatarState.worldInformation.ClearStage(
+                2,
+                100,
+                0,
+                _tableSheets.WorldSheet,
+                _tableSheets.WorldUnlockSheet);
+
+            var previousState = _initialState.SetState(
+                _avatarAddress,
+                previousAvatarState.Serialize());
+
+            var costumeRow =
+                _tableSheets.CostumeItemSheet.Values.First(x => x.ItemSubType == ItemSubType.FullCostume);
+            var costume = ItemFactory.CreateCostume(costumeRow, default);
+
+            var equipmentRow =
+                _tableSheets.EquipmentItemSheet.Values.First(x => x.ElementalType == ElementalType.Fire);
+            var equipment = ItemFactory.CreateItemUsable(equipmentRow, default, 0);
+            previousAvatarState.inventory.AddItem(equipment);
+
+            var mimisbrunnrSheet = _tableSheets.MimisbrunnrSheet;
+            if (!mimisbrunnrSheet.TryGetValue(stageId, out var mimisbrunnrSheetRow))
+            {
+                throw new SheetRowNotFoundException("MimisbrunnrSheet", stageId);
+            }
+
+            foreach (var equipmentId in previousAvatarState.inventory.Equipments)
+            {
+                if (previousAvatarState.inventory.TryGetNonFungibleItem(equipmentId, out ItemUsable itemUsable))
+                {
+                    var elementalType = ((Equipment)itemUsable).ElementalType;
+                    Assert.True(mimisbrunnrSheetRow.ElementalTypes.Exists(x => x == elementalType));
+                }
+            }
+
+            var action = new MimisbrunnrBattle()
+            {
+                costumes = new List<Guid> { costume.ItemId },
+                equipments = new List<Guid>() { equipment.ItemId },
+                foods = new List<Guid>(),
+                worldId = worldId,
+                stageId = stageId,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Throws<InvalidStageException>(() =>
+            {
+                action.Execute(new ActionContext()
+                {
+                    PreviousStates = previousState,
+                    Signer = _agentAddress,
+                    Random = new TestRandom(),
+                    Rehearsal = false,
+                });
+            });
+        }
+
+        [Fact]
+        public void ExecuteThrowFailedLoadStateException()
+        {
+            var action = new MimisbrunnrBattle()
+            {
+                costumes = new List<Guid>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = 10001,
+                stageId = 10000002,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Throws<FailedLoadStateException>(() =>
+            {
+                action.Execute(new ActionContext()
+                {
+                    PreviousStates = new State(),
+                    Signer = _agentAddress,
+                });
+            });
+        }
+
+        [Fact]
+        public void ExecuteThrowInvalidRankingMapAddress()
+        {
+            var action = new MimisbrunnrBattle()
+            {
+                costumes = new List<Guid>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = 10001,
+                stageId = 10000002,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = default,
+            };
+
+            Assert.Null(action.Result);
+
+            Assert.Throws<InvalidAddressException>(() =>
+            {
+                action.Execute(new ActionContext()
+                {
+                    PreviousStates = _initialState,
+                    Signer = _agentAddress,
+                });
+            });
+        }
+
+        [Fact]
+        public void ExecuteThrowSheetRowNotFound()
+        {
+            var action = new MimisbrunnrBattle()
+            {
+                costumes = new List<Guid>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = 10011,
+                stageId = 10000002,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Null(action.Result);
+
+            Assert.Throws<SheetRowNotFoundException>(() =>
+            {
+                action.Execute(new ActionContext()
+                {
+                    PreviousStates = _initialState,
+                    Signer = _agentAddress,
+                });
+            });
+        }
+
+        [Fact]
+        public void ExecuteThrowSheetRowColumn()
+        {
+            var action = new MimisbrunnrBattle()
+            {
+                costumes = new List<Guid>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = 10001,
+                stageId = 10000022,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Null(action.Result);
+
+            Assert.Throws<SheetRowColumnException>(() =>
+            {
+                action.Execute(new ActionContext()
+                {
+                    PreviousStates = _initialState,
+                    Signer = _agentAddress,
+                });
+            });
+        }
+
+        [Fact]
+        public void ExecuteThrowNotEnoughActionPoint()
+        {
+            var previousAvatarState = _initialState.GetAvatarState(_avatarAddress);
+            previousAvatarState.actionPoint = 0;
+
+            previousAvatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                100);
+
+            previousAvatarState.worldInformation.ClearStage(
+                2,
+                100,
+                0,
+                _tableSheets.WorldSheet,
+                _tableSheets.WorldUnlockSheet);
+
+            var action = new MimisbrunnrBattle()
+            {
+                costumes = new List<Guid>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = 10001,
+                stageId = 10000001,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Null(action.Result);
+            var state = _initialState;
+            state = state.SetState(_avatarAddress, previousAvatarState.Serialize());
+            Assert.Throws<NotEnoughActionPointException>(() =>
+            {
+                action.Execute(new ActionContext()
+                {
+                    PreviousStates = state,
+                    Signer = _agentAddress,
+                    Random = new TestRandom(),
+                });
+            });
+        }
+
+        [Theory]
+        [InlineData(400, 10001, 10000001, 99)]
+        public void ExecuteThrowInvalidWorld(int avatarLevel, int worldId, int stageId, int clearStageId)
+        {
+            Assert.True(_tableSheets.WorldSheet.TryGetValue(worldId, out var worldRow));
+            Assert.True(stageId >= worldRow.StageBegin);
+            Assert.True(stageId <= worldRow.StageEnd);
+            Assert.True(_tableSheets.StageSheet.TryGetValue(stageId, out _));
+
+            var previousAvatarState = _initialState.GetAvatarState(_avatarAddress);
+            previousAvatarState.level = avatarLevel;
+            previousAvatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                clearStageId);
+
+            var costumeId = _tableSheets
+                .CostumeItemSheet
+                .Values
+                .First(r => r.ItemSubType == ItemSubType.FullCostume)
+                .Id;
+            var costume =
+                ItemFactory.CreateItem(_tableSheets.ItemSheet[costumeId], new TestRandom());
+            previousAvatarState.inventory.AddItem(costume);
+
+            var mimisbrunnrSheet = _tableSheets.MimisbrunnrSheet;
+            if (!mimisbrunnrSheet.TryGetValue(stageId, out var mimisbrunnrSheetRow))
+            {
+                throw new SheetRowNotFoundException("MimisbrunnrSheet", stageId);
+            }
+
+            var equipmentRow =
+                _tableSheets.EquipmentItemSheet.Values.First(x => x.ElementalType == ElementalType.Fire);
+            var equipment = ItemFactory.CreateItemUsable(equipmentRow, default, 0);
+            previousAvatarState.inventory.AddItem(equipment);
+
+            foreach (var equipmentId in previousAvatarState.inventory.Equipments)
+            {
+                if (previousAvatarState.inventory.TryGetNonFungibleItem(equipmentId, out ItemUsable itemUsable))
+                {
+                    var elementalType = ((Equipment)itemUsable).ElementalType;
+                    Assert.True(mimisbrunnrSheetRow.ElementalTypes.Exists(x => x == elementalType));
+                }
+            }
+
+            var result = new CombinationConsumable.ResultModel()
+            {
+                id = default,
+                gold = 0,
+                actionPoint = 0,
+                recipeId = 1,
+                materials = new Dictionary<Material, int>(),
+                itemUsable = equipment,
+            };
+            for (var i = 0; i < 100; i++)
+            {
+                var mail = new CombinationMail(result, i, default, 0);
+                previousAvatarState.Update(mail);
+            }
+
+            var state = _initialState.SetState(_avatarAddress, previousAvatarState.Serialize());
+
+            var action = new MimisbrunnrBattle()
+            {
+                costumes = new List<Guid> { ((Costume)costume).ItemId },
+                equipments = new List<Guid>() { equipment.ItemId },
+                foods = new List<Guid>(),
+                worldId = worldId,
+                stageId = stageId,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Null(action.Result);
+
+            Assert.Throws<InvalidWorldException>(() =>
+            {
+                action.Execute(new ActionContext()
+                {
+                    PreviousStates = state, Signer = _agentAddress, Random = new TestRandom(), Rehearsal = false,
+                });
+            });
+        }
+
+        /// <summary>
+        /// void ExecuteThrowFailedAddWorldExceptionWhenDoesNotMimisbrunnr(int).
+        /// </summary>
+        /// <param name="alreadyClearedStageId">Less than stageId condition to unlock the mimisbrunnr world in `WorldUnlockSheet`.</param>
+        [Theory]
+        [InlineData(1)]
+        [InlineData(99)]
+        public void ExecuteThrowFailedAddWorldExceptionWhenDoesNotMimisbrunnr(int alreadyClearedStageId)
+        {
+            const int worldId = GameConfig.MimisbrunnrWorldId;
+            const int stageId = GameConfig.MimisbrunnrStartStageId;
+            var worldSheetCsv = _initialState.GetSheetCsv<WorldSheet>();
+            worldSheetCsv = worldSheetCsv.Replace($"{worldId},", $"_{worldId},");
+            var worldSheet = new WorldSheet();
+            worldSheet.Set(worldSheetCsv);
+            var avatarState = _initialState.GetAvatarState(_avatarAddress);
+            avatarState.worldInformation = new WorldInformation(0, worldSheet, alreadyClearedStageId);
+            var nextState = _initialState.SetState(_avatarAddress, avatarState.Serialize());
+
+            var action = new MimisbrunnrBattle
+            {
+                costumes = new List<Guid>(),
+                equipments = new List<Guid>(),
+                foods = new List<Guid>(),
+                worldId = worldId,
+                stageId = stageId,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Null(action.Result);
+
+            Assert.Throws<FailedAddWorldException>(() =>
+            {
+                action.Execute(new ActionContext
+                {
+                    PreviousStates = nextState,
+                    Signer = _agentAddress,
+                });
+            });
+        }
+
+        [Fact]
+        public void ExecuteEquippableItemValidation()
+        {
+            var avatarState = _initialState.GetAvatarState(_avatarAddress);
+            avatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                140);
+
+            var costumeId = _tableSheets
+                .CostumeItemSheet
+                .OrderedList
+                .First(r => r.ItemSubType == ItemSubType.FullCostume)
+                .Id;
+            var costume =
+                ItemFactory.CreateItem(_tableSheets.ItemSheet[costumeId], new TestRandom());
+            avatarState.inventory.AddItem(costume);
+
+            var equipmentRow =
+                _tableSheets.EquipmentItemSheet.OrderedList.First(x => x.ElementalType == ElementalType.Fire);
+            var equipment = ItemFactory.CreateItemUsable(equipmentRow, default, 0);
+            avatarState.inventory.AddItem(equipment);
+            var nextState = _initialState.SetState(_avatarAddress, avatarState.Serialize());
+
+            var action = new MimisbrunnrBattle()
+            {
+                costumes = new List<Guid> { ((Costume)costume).ItemId },
+                equipments = new List<Guid>() { equipment.ItemId },
+                foods = new List<Guid>(),
+                worldId = GameConfig.MimisbrunnrWorldId,
+                stageId = GameConfig.MimisbrunnrStartStageId,
+                avatarAddress = _avatarAddress,
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
+            };
+
+            Assert.Null(action.Result);
+
+            action.Execute(new ActionContext
+            {
+                PreviousStates = nextState,
+                Signer = _agentAddress,
+                Rehearsal = false,
+                Random = new TestRandom(),
+            });
+
+            var spawnPlayer = action.Result.FirstOrDefault(e => e is SpawnPlayer);
+            Assert.NotNull(spawnPlayer);
+            Assert.True(spawnPlayer.Character is Player p);
+            var player = (Player)spawnPlayer.Character;
+            Assert.Equal(player.Costumes.First().ItemId, ((Costume)costume).ItemId);
+            Assert.Equal(player.Equipments.First().ItemId, equipment.ItemId);
+        }
+    }
+}

--- a/.Lib9c.Tests/Action/RankingBattle3Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle3Test.cs
@@ -114,7 +114,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatar1Address,
                 EnemyAddress = _avatar2Address,
                 WeeklyArenaAddress = _weeklyArenaAddress,
-                equipments = new List<Guid> { costume.ItemId },
+                costumeIds = new List<Guid> { costume.ItemId },
                 equipmentIds = new List<Guid>(),
                 consumableIds = new List<Guid>(),
             };
@@ -148,7 +148,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatar1Address,
                 EnemyAddress = _avatar1Address,
                 WeeklyArenaAddress = _weeklyArenaAddress,
-                equipments = new List<Guid>(),
+                costumeIds = new List<Guid>(),
                 equipmentIds = new List<Guid>(),
                 consumableIds = new List<Guid>(),
             };
@@ -193,7 +193,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = avatarAddress,
                 EnemyAddress = enemyAddress,
                 WeeklyArenaAddress = _weeklyArenaAddress,
-                equipments = new List<Guid>(),
+                costumeIds = new List<Guid>(),
                 equipmentIds = new List<Guid>(),
                 consumableIds = new List<Guid>(),
             };
@@ -228,7 +228,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatar1Address,
                 EnemyAddress = _avatar2Address,
                 WeeklyArenaAddress = _weeklyArenaAddress,
-                equipments = new List<Guid>(),
+                costumeIds = new List<Guid>(),
                 equipmentIds = new List<Guid>(),
                 consumableIds = new List<Guid>(),
             };
@@ -260,7 +260,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatar1Address,
                 EnemyAddress = _avatar2Address,
                 WeeklyArenaAddress = _weeklyArenaAddress,
-                equipments = new List<Guid>(),
+                costumeIds = new List<Guid>(),
                 equipmentIds = new List<Guid>(),
                 consumableIds = new List<Guid>(),
             };
@@ -306,7 +306,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatar1Address,
                 EnemyAddress = _avatar2Address,
                 WeeklyArenaAddress = _weeklyArenaAddress,
-                equipments = new List<Guid>(),
+                costumeIds = new List<Guid>(),
                 equipmentIds = new List<Guid>(),
                 consumableIds = new List<Guid>(),
             };
@@ -347,7 +347,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatar1Address,
                 EnemyAddress = _avatar2Address,
                 WeeklyArenaAddress = _weeklyArenaAddress,
-                equipments = new List<Guid>(),
+                costumeIds = new List<Guid>(),
                 equipmentIds = new List<Guid>(),
                 consumableIds = new List<Guid>(),
             };
@@ -372,7 +372,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatar1Address,
                 EnemyAddress = _avatar2Address,
                 WeeklyArenaAddress = _weeklyArenaAddress,
-                equipments = new List<Guid>(),
+                costumeIds = new List<Guid>(),
                 equipmentIds = new List<Guid>(),
                 consumableIds = new List<Guid>(),
             };
@@ -430,7 +430,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatar1Address,
                 EnemyAddress = _avatar2Address,
                 WeeklyArenaAddress = _weeklyArenaAddress,
-                equipments = new List<Guid>(),
+                costumeIds = new List<Guid>(),
                 equipmentIds = equipments,
                 consumableIds = new List<Guid>(),
             };

--- a/.Lib9c.Tests/Action/RankingBattle3Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle3Test.cs
@@ -395,6 +395,10 @@ namespace Lib9c.Tests.Action
 
         [Theory]
         [InlineData(ItemSubType.Weapon, GameConfig.MaxEquipmentSlotCount.Weapon)]
+        [InlineData(ItemSubType.Armor, GameConfig.MaxEquipmentSlotCount.Armor)]
+        [InlineData(ItemSubType.Belt, GameConfig.MaxEquipmentSlotCount.Belt)]
+        [InlineData(ItemSubType.Necklace, GameConfig.MaxEquipmentSlotCount.Necklace)]
+        [InlineData(ItemSubType.Ring, GameConfig.MaxEquipmentSlotCount.Ring)]
         public void MultipleEquipmentTest(ItemSubType type, int maxCount)
         {
             var previousAvatarState = _initialState.GetAvatarState(_avatar1Address);

--- a/.Lib9c.Tests/Action/RankingBattle3Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle3Test.cs
@@ -18,7 +18,9 @@ namespace Lib9c.Tests.Action
     using Nekoyume.Model.Stat;
     using Nekoyume.Model.State;
     using Nekoyume.TableData;
+    using Serilog;
     using Xunit;
+    using Xunit.Abstractions;
 
     public class RankingBattle3Test
     {
@@ -29,7 +31,7 @@ namespace Lib9c.Tests.Action
         private readonly Address _weeklyArenaAddress;
         private IAccountStateDelta _initialState;
 
-        public RankingBattle3Test()
+        public RankingBattle3Test(ITestOutputHelper outputHelper)
         {
             _initialState = new State();
 
@@ -72,6 +74,11 @@ namespace Lib9c.Tests.Action
                 .SetState(agent2Address, agent2State.Serialize())
                 .SetState(_avatar2Address, avatar2State.Serialize())
                 .SetState(_weeklyArenaAddress, weeklyArenaState.Serialize());
+
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.TestOutput(outputHelper)
+                .CreateLogger();
         }
 
         [Fact]
@@ -95,8 +102,7 @@ namespace Lib9c.Tests.Action
             var costume = (Costume)ItemFactory.CreateItem(
                 _tableSheets.ItemSheet[row.CostumeId], new TestRandom());
             costume.equipped = true;
-            var avatarState = _initialState.GetAvatarState(_avatar1Address);
-            avatarState.inventory.AddItem(costume);
+            previousAvatar1State.inventory.AddItem(costume);
 
             var row2 = _tableSheets.CostumeStatSheet.Values.First(r => r.StatType == StatType.DEF);
             var enemyCostume = (Costume)ItemFactory.CreateItem(
@@ -105,8 +111,8 @@ namespace Lib9c.Tests.Action
             var enemyAvatarState = _initialState.GetAvatarState(_avatar2Address);
             enemyAvatarState.inventory.AddItem(enemyCostume);
 
-            _initialState = _initialState
-                .SetState(_avatar1Address, avatarState.Serialize())
+            previousState = previousState
+                .SetState(_avatar1Address, previousAvatar1State.Serialize())
                 .SetState(_avatar2Address, enemyAvatarState.Serialize());
 
             var action = new RankingBattle3

--- a/.Lib9c.Tests/Action/RankingBattle3Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle3Test.cs
@@ -114,7 +114,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatar1Address,
                 EnemyAddress = _avatar2Address,
                 WeeklyArenaAddress = _weeklyArenaAddress,
-                costumeIds = new List<int> { costume.Id },
+                equipments = new List<Guid> { costume.ItemId },
                 equipmentIds = new List<Guid>(),
                 consumableIds = new List<Guid>(),
             };
@@ -148,7 +148,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatar1Address,
                 EnemyAddress = _avatar1Address,
                 WeeklyArenaAddress = _weeklyArenaAddress,
-                costumeIds = new List<int>(),
+                equipments = new List<Guid>(),
                 equipmentIds = new List<Guid>(),
                 consumableIds = new List<Guid>(),
             };
@@ -193,7 +193,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = avatarAddress,
                 EnemyAddress = enemyAddress,
                 WeeklyArenaAddress = _weeklyArenaAddress,
-                costumeIds = new List<int>(),
+                equipments = new List<Guid>(),
                 equipmentIds = new List<Guid>(),
                 consumableIds = new List<Guid>(),
             };
@@ -228,7 +228,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatar1Address,
                 EnemyAddress = _avatar2Address,
                 WeeklyArenaAddress = _weeklyArenaAddress,
-                costumeIds = new List<int>(),
+                equipments = new List<Guid>(),
                 equipmentIds = new List<Guid>(),
                 consumableIds = new List<Guid>(),
             };
@@ -260,7 +260,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatar1Address,
                 EnemyAddress = _avatar2Address,
                 WeeklyArenaAddress = _weeklyArenaAddress,
-                costumeIds = new List<int>(),
+                equipments = new List<Guid>(),
                 equipmentIds = new List<Guid>(),
                 consumableIds = new List<Guid>(),
             };
@@ -306,7 +306,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatar1Address,
                 EnemyAddress = _avatar2Address,
                 WeeklyArenaAddress = _weeklyArenaAddress,
-                costumeIds = new List<int>(),
+                equipments = new List<Guid>(),
                 equipmentIds = new List<Guid>(),
                 consumableIds = new List<Guid>(),
             };
@@ -347,7 +347,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatar1Address,
                 EnemyAddress = _avatar2Address,
                 WeeklyArenaAddress = _weeklyArenaAddress,
-                costumeIds = new List<int>(),
+                equipments = new List<Guid>(),
                 equipmentIds = new List<Guid>(),
                 consumableIds = new List<Guid>(),
             };
@@ -372,7 +372,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatar1Address,
                 EnemyAddress = _avatar2Address,
                 WeeklyArenaAddress = _weeklyArenaAddress,
-                costumeIds = new List<int>(),
+                equipments = new List<Guid>(),
                 equipmentIds = new List<Guid>(),
                 consumableIds = new List<Guid>(),
             };
@@ -430,7 +430,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatar1Address,
                 EnemyAddress = _avatar2Address,
                 WeeklyArenaAddress = _weeklyArenaAddress,
-                costumeIds = new List<int>(),
+                equipments = new List<Guid>(),
                 equipmentIds = equipments,
                 consumableIds = new List<Guid>(),
             };

--- a/.Lib9c.Tests/Action/RankingBattle3Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle3Test.cs
@@ -1,0 +1,449 @@
+namespace Lib9c.Tests.Action
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Assets;
+    using Libplanet.Crypto;
+    using Nekoyume;
+    using Nekoyume.Action;
+    using Nekoyume.Battle;
+    using Nekoyume.Model;
+    using Nekoyume.Model.BattleStatus;
+    using Nekoyume.Model.Item;
+    using Nekoyume.Model.Stat;
+    using Nekoyume.Model.State;
+    using Nekoyume.TableData;
+    using Xunit;
+
+    public class RankingBattle3Test
+    {
+        private readonly TableSheets _tableSheets;
+        private readonly Address _agent1Address;
+        private readonly Address _avatar1Address;
+        private readonly Address _avatar2Address;
+        private readonly Address _weeklyArenaAddress;
+        private IAccountStateDelta _initialState;
+
+        public RankingBattle3Test()
+        {
+            _initialState = new State();
+
+            var sheets = TableSheetsImporter.ImportSheets();
+            foreach (var (key, value) in sheets)
+            {
+                _initialState = _initialState.SetState(
+                    Addresses.TableSheet.Derive(key),
+                    value.Serialize());
+            }
+
+            _tableSheets = new TableSheets(sheets);
+
+            var rankingMapAddress = new PrivateKey().ToAddress();
+
+            var (agent1State, avatar1State) = RankingBattleTest.GetAgentStateWithAvatarState(
+                sheets,
+                _tableSheets,
+                rankingMapAddress);
+            _agent1Address = agent1State.address;
+            _avatar1Address = avatar1State.address;
+
+            var (agent2State, avatar2State) = RankingBattleTest.GetAgentStateWithAvatarState(
+                sheets,
+                _tableSheets,
+                rankingMapAddress);
+            var agent2Address = agent2State.address;
+            _avatar2Address = avatar2State.address;
+
+            var weeklyArenaState = new WeeklyArenaState(0);
+            weeklyArenaState.SetV2(avatar1State, _tableSheets.CharacterSheet, _tableSheets.CostumeStatSheet);
+            weeklyArenaState[_avatar1Address].Activate();
+            weeklyArenaState.SetV2(avatar2State, _tableSheets.CharacterSheet, _tableSheets.CostumeStatSheet);
+            weeklyArenaState[_avatar2Address].Activate();
+            _weeklyArenaAddress = weeklyArenaState.address;
+
+            _initialState = _initialState
+                .SetState(_agent1Address, agent1State.Serialize())
+                .SetState(_avatar1Address, avatar1State.Serialize())
+                .SetState(agent2Address, agent2State.Serialize())
+                .SetState(_avatar2Address, avatar2State.Serialize())
+                .SetState(_weeklyArenaAddress, weeklyArenaState.Serialize());
+        }
+
+        [Fact]
+        public void Execute()
+        {
+            var previousWeeklyState = _initialState.GetWeeklyArenaState(0);
+            var previousAvatar1State = _initialState.GetAvatarState(_avatar1Address);
+            previousAvatar1State.level = 10;
+
+            var previousState = _initialState.SetState(
+                _avatar1Address,
+                previousAvatar1State.Serialize());
+
+            var itemIds = _tableSheets.WeeklyArenaRewardSheet.Values
+                .Select(r => r.Reward.ItemId)
+                .ToList();
+
+            Assert.All(itemIds, id => Assert.False(previousAvatar1State.inventory.HasItem(id)));
+
+            var row = _tableSheets.CostumeStatSheet.Values.First(r => r.StatType == StatType.ATK);
+            var costume = (Costume)ItemFactory.CreateItem(
+                _tableSheets.ItemSheet[row.CostumeId], new TestRandom());
+            costume.equipped = true;
+            var avatarState = _initialState.GetAvatarState(_avatar1Address);
+            avatarState.inventory.AddItem(costume);
+
+            var row2 = _tableSheets.CostumeStatSheet.Values.First(r => r.StatType == StatType.DEF);
+            var enemyCostume = (Costume)ItemFactory.CreateItem(
+                _tableSheets.ItemSheet[row2.CostumeId], new TestRandom());
+            enemyCostume.equipped = true;
+            var enemyAvatarState = _initialState.GetAvatarState(_avatar2Address);
+            enemyAvatarState.inventory.AddItem(enemyCostume);
+
+            _initialState = _initialState
+                .SetState(_avatar1Address, avatarState.Serialize())
+                .SetState(_avatar2Address, enemyAvatarState.Serialize());
+
+            var action = new RankingBattle3
+            {
+                AvatarAddress = _avatar1Address,
+                EnemyAddress = _avatar2Address,
+                WeeklyArenaAddress = _weeklyArenaAddress,
+                costumeIds = new List<int> { costume.Id },
+                equipmentIds = new List<Guid>(),
+                consumableIds = new List<Guid>(),
+            };
+
+            Assert.Null(action.Result);
+
+            var nextState = action.Execute(new ActionContext()
+            {
+                PreviousStates = previousState,
+                Signer = _agent1Address,
+                Random = new TestRandom(),
+                Rehearsal = false,
+            });
+
+            var nextAvatar1State = nextState.GetAvatarState(_avatar1Address);
+            var nextWeeklyState = nextState.GetWeeklyArenaState(0);
+
+            Assert.Contains(nextAvatar1State.inventory.Materials, i => itemIds.Contains(i.Id));
+            Assert.NotNull(action.Result);
+            Assert.Contains(typeof(GetReward), action.Result.Select(e => e.GetType()));
+            Assert.Equal(BattleLog.Result.Win, action.Result.result);
+            Assert.True(nextWeeklyState[_avatar1Address].Score >
+                        previousWeeklyState[_avatar1Address].Score);
+        }
+
+        [Fact]
+        public void ExecuteThrowInvalidAddressException()
+        {
+            var action = new RankingBattle3
+            {
+                AvatarAddress = _avatar1Address,
+                EnemyAddress = _avatar1Address,
+                WeeklyArenaAddress = _weeklyArenaAddress,
+                costumeIds = new List<int>(),
+                equipmentIds = new List<Guid>(),
+                consumableIds = new List<Guid>(),
+            };
+
+            Assert.Throws<InvalidAddressException>(() =>
+            {
+                action.Execute(new ActionContext()
+                {
+                    PreviousStates = _initialState,
+                    Signer = _agent1Address,
+                    Random = new TestRandom(),
+                    Rehearsal = false,
+                });
+            });
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void ExecuteThrowFailedLoadStateException(int caseIndex)
+        {
+            Address signer;
+            Address avatarAddress;
+            Address enemyAddress;
+
+            switch (caseIndex)
+            {
+                case 0:
+                    signer = new PrivateKey().ToAddress();
+                    avatarAddress = _avatar1Address;
+                    enemyAddress = _avatar2Address;
+                    break;
+                case 1:
+                    signer = _agent1Address;
+                    avatarAddress = _avatar1Address;
+                    enemyAddress = new PrivateKey().ToAddress();
+                    break;
+            }
+
+            var action = new RankingBattle3
+            {
+                AvatarAddress = avatarAddress,
+                EnemyAddress = enemyAddress,
+                WeeklyArenaAddress = _weeklyArenaAddress,
+                costumeIds = new List<int>(),
+                equipmentIds = new List<Guid>(),
+                consumableIds = new List<Guid>(),
+            };
+
+            Assert.Throws<FailedLoadStateException>(() =>
+            {
+                action.Execute(new ActionContext()
+                {
+                    PreviousStates = _initialState,
+                    Signer = signer,
+                    Random = new TestRandom(),
+                    Rehearsal = false,
+                });
+            });
+        }
+
+        [Fact]
+        public void ExecuteThrowNotEnoughClearedStageLevelException()
+        {
+            var previousAvatar1State = _initialState.GetAvatarState(_avatar1Address);
+            previousAvatar1State.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                false
+            );
+            var previousState = _initialState.SetState(
+                _avatar1Address,
+                previousAvatar1State.Serialize());
+
+            var action = new RankingBattle3
+            {
+                AvatarAddress = _avatar1Address,
+                EnemyAddress = _avatar2Address,
+                WeeklyArenaAddress = _weeklyArenaAddress,
+                costumeIds = new List<int>(),
+                equipmentIds = new List<Guid>(),
+                consumableIds = new List<Guid>(),
+            };
+
+            Assert.Throws<NotEnoughClearedStageLevelException>(() =>
+            {
+                action.Execute(new ActionContext()
+                {
+                    PreviousStates = previousState,
+                    Signer = _agent1Address,
+                    Random = new TestRandom(),
+                    Rehearsal = false,
+                });
+            });
+        }
+
+        [Fact]
+        public void ExecuteThrowWeeklyArenaStateAlreadyEndedException()
+        {
+            var previousWeeklyArenaState = _initialState.GetWeeklyArenaState(_weeklyArenaAddress);
+            previousWeeklyArenaState.Ended = true;
+
+            var previousState = _initialState.SetState(
+                _weeklyArenaAddress,
+                previousWeeklyArenaState.Serialize());
+
+            var action = new RankingBattle3
+            {
+                AvatarAddress = _avatar1Address,
+                EnemyAddress = _avatar2Address,
+                WeeklyArenaAddress = _weeklyArenaAddress,
+                costumeIds = new List<int>(),
+                equipmentIds = new List<Guid>(),
+                consumableIds = new List<Guid>(),
+            };
+
+            Assert.Throws<WeeklyArenaStateAlreadyEndedException>(() =>
+            {
+                action.Execute(new ActionContext()
+                {
+                    PreviousStates = previousState,
+                    Signer = _agent1Address,
+                    Random = new TestRandom(),
+                    Rehearsal = false,
+                });
+            });
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void ExecuteThrowWeeklyArenaStateNotContainsAvatarAddressException(
+            int caseIndex)
+        {
+            Address targetAddress;
+            switch (caseIndex)
+            {
+                case 0:
+                    targetAddress = _avatar1Address;
+                    break;
+                case 1:
+                    targetAddress = _avatar2Address;
+                    break;
+            }
+
+            var previousWeeklyArenaState = _initialState.GetWeeklyArenaState(_weeklyArenaAddress);
+            previousWeeklyArenaState.Remove(targetAddress);
+
+            var previousState = _initialState.SetState(
+                _weeklyArenaAddress,
+                previousWeeklyArenaState.Serialize());
+
+            var action = new RankingBattle3
+            {
+                AvatarAddress = _avatar1Address,
+                EnemyAddress = _avatar2Address,
+                WeeklyArenaAddress = _weeklyArenaAddress,
+                costumeIds = new List<int>(),
+                equipmentIds = new List<Guid>(),
+                consumableIds = new List<Guid>(),
+            };
+
+            Assert.Throws<WeeklyArenaStateNotContainsAvatarAddressException>(() =>
+            {
+                action.Execute(new ActionContext()
+                {
+                    PreviousStates = previousState,
+                    Signer = _agent1Address,
+                    Random = new TestRandom(),
+                    Rehearsal = false,
+                });
+            });
+        }
+
+        [Fact]
+        public void ExecuteThrowNotEnoughWeeklyArenaChallengeCountException()
+        {
+            var previousAvatarState = _initialState.GetAvatarState(_avatar1Address);
+            var previousWeeklyArenaState = _initialState.GetWeeklyArenaState(_weeklyArenaAddress);
+            while (true)
+            {
+                var arenaInfo = previousWeeklyArenaState.GetArenaInfo(_avatar1Address);
+                arenaInfo.Update(previousAvatarState, arenaInfo, BattleLog.Result.Lose);
+                if (arenaInfo.DailyChallengeCount == 0)
+                {
+                    break;
+                }
+            }
+
+            var previousState = _initialState.SetState(
+                _weeklyArenaAddress,
+                previousWeeklyArenaState.Serialize());
+
+            var action = new RankingBattle3
+            {
+                AvatarAddress = _avatar1Address,
+                EnemyAddress = _avatar2Address,
+                WeeklyArenaAddress = _weeklyArenaAddress,
+                costumeIds = new List<int>(),
+                equipmentIds = new List<Guid>(),
+                consumableIds = new List<Guid>(),
+            };
+
+            Assert.Throws<NotEnoughWeeklyArenaChallengeCountException>(() =>
+            {
+                action.Execute(new ActionContext()
+                {
+                    PreviousStates = previousState,
+                    Signer = _agent1Address,
+                    Random = new TestRandom(),
+                    Rehearsal = false,
+                });
+            });
+        }
+
+        [Fact]
+        public void SerializeWithDotnetAPI()
+        {
+            var action = new RankingBattle3
+            {
+                AvatarAddress = _avatar1Address,
+                EnemyAddress = _avatar2Address,
+                WeeklyArenaAddress = _weeklyArenaAddress,
+                costumeIds = new List<int>(),
+                equipmentIds = new List<Guid>(),
+                consumableIds = new List<Guid>(),
+            };
+            action.Execute(new ActionContext()
+            {
+                PreviousStates = _initialState,
+                Signer = _agent1Address,
+                Random = new TestRandom(),
+                Rehearsal = false,
+            });
+
+            var formatter = new BinaryFormatter();
+            using var ms = new MemoryStream();
+            formatter.Serialize(ms, action);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            var deserialized = (RankingBattle3)formatter.Deserialize(ms);
+            Assert.Equal(action.PlainValue, deserialized.PlainValue);
+        }
+
+        [Theory]
+        [InlineData(ItemSubType.Weapon, GameConfig.MaxEquipmentSlotCount.Weapon)]
+        public void MultipleEquipmentTest(ItemSubType type, int maxCount)
+        {
+            var previousAvatarState = _initialState.GetAvatarState(_avatar1Address);
+            var maxLevel = _tableSheets.CharacterLevelSheet.Max(row => row.Value.Level);
+            var expRow = _tableSheets.CharacterLevelSheet[maxLevel];
+            var maxLevelExp = expRow.Exp;
+
+            previousAvatarState.level = maxLevel;
+            previousAvatarState.exp = maxLevelExp;
+
+            var weaponRows = _tableSheets
+                .EquipmentItemSheet
+                .Values
+                .Where(r => r.ItemSubType == type)
+                .Take(maxCount + 1);
+
+            var equipments = new List<Guid>();
+            foreach (var row in weaponRows)
+            {
+                var equipment = ItemFactory.CreateItem(
+                    _tableSheets.EquipmentItemSheet[row.Id],
+                    new TestRandom())
+                    as Equipment;
+
+                equipments.Add(equipment.ItemId);
+                previousAvatarState.inventory.AddItem(equipment);
+            }
+
+            var state = _initialState.SetState(_avatar1Address, previousAvatarState.Serialize());
+
+            var action = new RankingBattle3
+            {
+                AvatarAddress = _avatar1Address,
+                EnemyAddress = _avatar2Address,
+                WeeklyArenaAddress = _weeklyArenaAddress,
+                costumeIds = new List<int>(),
+                equipmentIds = equipments,
+                consumableIds = new List<Guid>(),
+            };
+
+            Assert.Null(action.Result);
+
+            Assert.Throws<DuplicateEquipmentException>(() => action.Execute(new ActionContext
+            {
+                PreviousStates = state,
+                Signer = _agent1Address,
+                Random = new TestRandom(),
+                Rehearsal = false,
+            }));
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/PlayerTest.cs
+++ b/.Lib9c.Tests/Model/PlayerTest.cs
@@ -141,7 +141,7 @@ namespace Lib9c.Tests.Model
         }
 
         [Fact]
-        public void LevelUp()
+        public void GetExp()
         {
             var row = _tableSheets.CostumeStatSheet.Values.First(r => r.StatType == StatType.HP);
             var costume = (Costume)ItemFactory.CreateItem(_tableSheets.ItemSheet[row.CostumeId], _random);
@@ -171,6 +171,47 @@ namespace Lib9c.Tests.Model
             Assert.Equal(2, player.Level);
             Assert.Equal(612, player.HP);
             Assert.Equal(590, player.CurrentHP);
+        }
+
+        [Theory]
+        [InlineData(1, 1)]
+        [InlineData(2, 3)]
+        [InlineData(5, 5)]
+        public void GetExpV2(int level, int count = 1)
+        {
+            var player = new Player(
+                level,
+                _tableSheets.CharacterSheet,
+                _tableSheets.CharacterLevelSheet,
+                _tableSheets.EquipmentItemSetEffectSheet);
+
+            for (int i = 0; i < count; ++i)
+            {
+                var requiredExp = _tableSheets.CharacterLevelSheet[level].ExpNeed;
+                player.GetExpV2(requiredExp);
+
+                Assert.Equal(level + 1, player.Level);
+                ++level;
+            }
+        }
+
+        [Fact]
+        public void MaxLevelTest()
+        {
+            var maxLevel = _tableSheets.CharacterLevelSheet.Max(row => row.Value.Level);
+            var player = new Player(
+                maxLevel,
+                _tableSheets.CharacterSheet,
+                _tableSheets.CharacterLevelSheet,
+                _tableSheets.EquipmentItemSetEffectSheet);
+
+            var expRow = _tableSheets.CharacterLevelSheet[maxLevel];
+            var maxLevelExp = expRow.Exp;
+            var requiredExp = expRow.ExpNeed;
+            player.GetExpV2(requiredExp);
+
+            Assert.Equal(maxLevel, player.Level);
+            Assert.Equal(requiredExp - 1, player.Exp.Current - expRow.Exp);
         }
     }
 }

--- a/.Lib9c.Tests/Model/State/AvatarStateTest.cs
+++ b/.Lib9c.Tests/Model/State/AvatarStateTest.cs
@@ -415,7 +415,7 @@ namespace Lib9c.Tests.Model.State
                 }
                 else if (count > maxCount)
                 {
-                    Assert.True(e is DuplicateCostumeException);
+                    Assert.True(e is DuplicateEquipmentException);
                 }
             }
         }

--- a/Lib9c/Action/DuplicateEquipmentException.cs
+++ b/Lib9c/Action/DuplicateEquipmentException.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Nekoyume.Action
+{
+    [Serializable]
+    public class DuplicateEquipmentException: InvalidOperationException
+    {
+        public DuplicateEquipmentException(string s) : base(s)
+        {
+        }
+
+        protected DuplicateEquipmentException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Lib9c/Action/HackAndSlash3.cs
+++ b/Lib9c/Action/HackAndSlash3.cs
@@ -175,14 +175,7 @@ namespace Nekoyume.Action
             Log.Debug("HAS Initialize Simulator: {Elapsed}", sw.Elapsed);
 
             sw.Restart();
-            if (ctx.BlockIndex >= StageSimulator.StartBlockIndexToUseSimulatorV2)
-            {
-                simulator.SimulateV2();
-            }
-            else
-            {
-                simulator.Simulate();
-            }
+            simulator.Simulate();
             sw.Stop();
             Log.Debug("HAS Simulator.Simulate(): {Elapsed}", sw.Elapsed);
 

--- a/Lib9c/Action/HackAndSlash3.cs
+++ b/Lib9c/Action/HackAndSlash3.cs
@@ -175,7 +175,14 @@ namespace Nekoyume.Action
             Log.Debug("HAS Initialize Simulator: {Elapsed}", sw.Elapsed);
 
             sw.Restart();
-            simulator.Simulate();
+            if (ctx.BlockIndex >= StageSimulator.StartBlockIndexToUseSimulatorV2)
+            {
+                simulator.SimulateV2();
+            }
+            else
+            {
+                simulator.Simulate();
+            }
             sw.Stop();
             Log.Debug("HAS Simulator.Simulate(): {Elapsed}", sw.Elapsed);
 

--- a/Lib9c/Action/HackAndSlash4.cs
+++ b/Lib9c/Action/HackAndSlash4.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Action;
+using Nekoyume.Battle;
+using Nekoyume.Model.BattleStatus;
+using Nekoyume.Model.State;
+using Nekoyume.TableData;
+using Serilog;
+
+namespace Nekoyume.Action
+{
+    [Serializable]
+    [ActionType("hack_and_slash4")]
+    public class HackAndSlash4 : GameAction
+    {
+        public List<int> costumes;
+        public List<Guid> equipments;
+        public List<Guid> foods;
+        public int worldId;
+        public int stageId;
+        public Address avatarAddress;
+        public Address WeeklyArenaAddress;
+        public Address RankingMapAddress;
+        public BattleLog Result { get; private set; }
+
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            new Dictionary<string, IValue>
+            {
+                ["costumes"] = new List(costumes.OrderBy(i => i).Select(e => e.Serialize())),
+                ["equipments"] = new List(equipments.OrderBy(i => i).Select(e => e.Serialize())),
+                ["foods"] = new List(foods.OrderBy(i => i).Select(e => e.Serialize())),
+                ["worldId"] = worldId.Serialize(),
+                ["stageId"] = stageId.Serialize(),
+                ["avatarAddress"] = avatarAddress.Serialize(),
+                ["weeklyArenaAddress"] = WeeklyArenaAddress.Serialize(),
+                ["rankingMapAddress"] = RankingMapAddress.Serialize(),
+            }.ToImmutableDictionary();
+
+
+        protected override void LoadPlainValueInternal(
+            IImmutableDictionary<string, IValue> plainValue)
+        {
+            costumes =  ((List) plainValue["costumes"]).Select(e => e.ToInteger()).ToList();
+            equipments = ((List) plainValue["equipments"]).Select(e => e.ToGuid()).ToList();
+            foods = ((List) plainValue["foods"]).Select(e => e.ToGuid()).ToList();
+            worldId = plainValue["worldId"].ToInteger();
+            stageId = plainValue["stageId"].ToInteger();
+            avatarAddress = plainValue["avatarAddress"].ToAddress();
+            WeeklyArenaAddress = plainValue["weeklyArenaAddress"].ToAddress();
+            RankingMapAddress = plainValue["rankingMapAddress"].ToAddress();
+        }
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            IActionContext ctx = context;
+            var states = ctx.PreviousStates;
+            if (ctx.Rehearsal)
+            {
+                states = states.SetState(RankingMapAddress, MarkChanged);
+                states = states.SetState(avatarAddress, MarkChanged);
+                states = states.SetState(WeeklyArenaAddress, MarkChanged);
+                return states.SetState(ctx.Signer, MarkChanged);
+            }
+
+            var sw = new Stopwatch();
+            sw.Start();
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("HAS exec started.");
+
+            if (!states.TryGetAvatarState(ctx.Signer, avatarAddress, out AvatarState avatarState))
+            {
+                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+            }
+
+            sw.Stop();
+            Log.Debug("HAS Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+
+            sw.Restart();
+
+            if (avatarState.RankingMapAddress != RankingMapAddress)
+            {
+                throw new InvalidAddressException("Invalid ranking map address");
+            }
+
+            // worldId와 stageId가 유효한지 확인합니다.
+            var worldSheet = states.GetSheet<WorldSheet>();
+
+            if (!worldSheet.TryGetValue(worldId, out var worldRow, false))
+            {
+                throw new SheetRowNotFoundException(nameof(WorldSheet), worldId);
+            }
+
+            if (stageId < worldRow.StageBegin ||
+                stageId > worldRow.StageEnd)
+            {
+                throw new SheetRowColumnException(
+                    $"{worldId} world is not contains {worldRow.Id} stage: " +
+                    $"{worldRow.StageBegin}-{worldRow.StageEnd}");
+            }
+
+            var stageSheet = states.GetSheet<StageSheet>();
+            if (!stageSheet.TryGetValue(stageId, out var stageRow))
+            {
+                throw new SheetRowNotFoundException(nameof(StageSheet), stageId);
+            }
+
+            var worldInformation = avatarState.worldInformation;
+            if (!worldInformation.TryGetWorld(worldId, out var world))
+            {
+                // NOTE: Add new World from WorldSheet
+                worldInformation.AddAndUnlockNewWorld(worldRow, ctx.BlockIndex, worldSheet);
+            }
+
+            if (!world.IsUnlocked)
+            {
+                throw new InvalidWorldException($"{worldId} is locked.");
+            }
+
+            if (world.StageBegin != worldRow.StageBegin ||
+                world.StageEnd != worldRow.StageEnd)
+            {
+                worldInformation.UpdateWorld(worldRow);
+            }
+
+            if (world.IsStageCleared && stageId > world.StageClearedId + 1 ||
+                !world.IsStageCleared && stageId != world.StageBegin)
+            {
+                throw new InvalidStageException(
+                    $"Aborted as the stage ({worldId}/{stageId}) is not cleared; " +
+                    $"cleared stage: {world.StageClearedId}"
+                );
+            }
+
+            avatarState.ValidateEquipments(equipments, context.BlockIndex);
+            avatarState.ValidateConsumable(foods, context.BlockIndex);
+            avatarState.ValidateCostume(new HashSet<int>(costumes));
+
+            var costumeStatSheet = states.GetSheet<CostumeStatSheet>();
+
+            sw.Restart();
+            if (avatarState.actionPoint < stageRow.CostAP)
+            {
+                throw new NotEnoughActionPointException(
+                    $"Aborted due to insufficient action point: " +
+                    $"{avatarState.actionPoint} < {stageRow.CostAP}"
+                );
+            }
+
+            avatarState.actionPoint -= stageRow.CostAP;
+
+            avatarState.EquipCostumes(new HashSet<int>(costumes));
+
+            avatarState.EquipEquipments(equipments);
+            sw.Stop();
+            Log.Debug("HAS Unequip items: {Elapsed}", sw.Elapsed);
+
+            sw.Restart();
+            var characterSheet = states.GetSheet<CharacterSheet>();
+            var simulator = new StageSimulator(
+                ctx.Random,
+                avatarState,
+                foods,
+                worldId,
+                stageId,
+                states.GetStageSimulatorSheets(),
+                costumeStatSheet
+            );
+
+            sw.Stop();
+            Log.Debug("HAS Initialize Simulator: {Elapsed}", sw.Elapsed);
+
+            sw.Restart();
+            simulator.SimulateV2();
+            sw.Stop();
+            Log.Debug("HAS Simulator.SimulateV2(): {Elapsed}", sw.Elapsed);
+
+            Log.Debug(
+                "Execute HackAndSlash({AvatarAddress}); worldId: {WorldId}, stageId: {StageId}, result: {Result}, " +
+                "clearWave: {ClearWave}, totalWave: {TotalWave}",
+                avatarAddress,
+                worldId,
+                stageId,
+                simulator.Log.result,
+                simulator.Log.clearedWaveNumber,
+                simulator.Log.waveCount
+            );
+
+            sw.Restart();
+            if (simulator.Log.IsClear)
+            {
+                var worldUnlockSheet = states.GetSheet<WorldUnlockSheet>();
+                simulator.Player.worldInformation.ClearStage(
+                    worldId,
+                    stageId,
+                    ctx.BlockIndex,
+                    worldSheet,
+                    worldUnlockSheet
+                );
+            }
+
+            sw.Stop();
+            Log.Debug("HAS ClearStage: {Elapsed}", sw.Elapsed);
+
+            sw.Restart();
+            avatarState.Update(simulator);
+
+            var materialSheet = states.GetSheet<MaterialItemSheet>();
+            avatarState.UpdateQuestRewards(materialSheet);
+
+            avatarState.updatedAt = ctx.BlockIndex;
+            avatarState.mailBox.CleanUp();
+            states = states.SetState(avatarAddress, avatarState.Serialize());
+
+            sw.Stop();
+            Log.Debug("HAS Set AvatarState: {Elapsed}", sw.Elapsed);
+
+            sw.Restart();
+            if (states.TryGetState(RankingMapAddress, out Dictionary d) && simulator.Log.IsClear)
+            {
+                var ranking = new RankingMapState(d);
+                ranking.Update(avatarState);
+
+                sw.Stop();
+                Log.Debug("HAS Update RankingState: {Elapsed}", sw.Elapsed);
+                sw.Restart();
+
+                var serialized = ranking.Serialize();
+
+                sw.Stop();
+                Log.Debug("HAS Serialize RankingState: {Elapsed}", sw.Elapsed);
+                sw.Restart();
+                states = states.SetState(RankingMapAddress, serialized);
+            }
+
+            sw.Stop();
+            Log.Debug("HAS Set RankingState: {Elapsed}", sw.Elapsed);
+
+            sw.Restart();
+            if (simulator.Log.stageId >= GameConfig.RequireClearedStageLevel.ActionsInRankingBoard &&
+                simulator.Log.IsClear &&
+                states.TryGetState(WeeklyArenaAddress, out Dictionary weeklyDict))
+            {
+                var weekly = new WeeklyArenaState(weeklyDict);
+                if (!weekly.Ended)
+                {
+                    if (weekly.ContainsKey(avatarAddress))
+                    {
+                        var info = weekly[avatarAddress];
+                        info.Update(avatarState, characterSheet, costumeStatSheet);
+                        weekly.Update(info);
+                    }
+                    else
+                    {
+                        weekly.SetV2(avatarState, characterSheet, costumeStatSheet);
+                    }
+
+                    sw.Stop();
+                    Log.Debug("HAS Update WeeklyArenaState: {Elapsed}", sw.Elapsed);
+
+                    sw.Restart();
+                    var weeklySerialized = weekly.Serialize();
+                    sw.Stop();
+                    Log.Debug("HAS Serialize RankingState: {Elapsed}", sw.Elapsed);
+
+                    states = states.SetState(weekly.address, weeklySerialized);
+                }
+            }
+
+            Result = simulator.Log;
+
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("HAS Total Executed Time: {Elapsed}", ended - started);
+            return states;
+        }
+    }
+}

--- a/Lib9c/Action/HackAndSlash4.cs
+++ b/Lib9c/Action/HackAndSlash4.cs
@@ -136,7 +136,7 @@ namespace Nekoyume.Action
                 );
             }
 
-            avatarState.ValidateEquipments(equipments, context.BlockIndex);
+            avatarState.ValidateEquipmentsV2(equipments, context.BlockIndex);
             avatarState.ValidateConsumable(foods, context.BlockIndex);
             avatarState.ValidateCostume(costumes);
 

--- a/Lib9c/Action/HackAndSlash4.cs
+++ b/Lib9c/Action/HackAndSlash4.cs
@@ -18,7 +18,7 @@ namespace Nekoyume.Action
     [ActionType("hack_and_slash4")]
     public class HackAndSlash4 : GameAction
     {
-        public List<int> costumes;
+        public List<Guid> costumes;
         public List<Guid> equipments;
         public List<Guid> foods;
         public int worldId;
@@ -45,7 +45,7 @@ namespace Nekoyume.Action
         protected override void LoadPlainValueInternal(
             IImmutableDictionary<string, IValue> plainValue)
         {
-            costumes =  ((List) plainValue["costumes"]).Select(e => e.ToInteger()).ToList();
+            costumes =  ((List) plainValue["costumes"]).Select(e => e.ToGuid()).ToList();
             equipments = ((List) plainValue["equipments"]).Select(e => e.ToGuid()).ToList();
             foods = ((List) plainValue["foods"]).Select(e => e.ToGuid()).ToList();
             worldId = plainValue["worldId"].ToInteger();
@@ -138,7 +138,7 @@ namespace Nekoyume.Action
 
             avatarState.ValidateEquipments(equipments, context.BlockIndex);
             avatarState.ValidateConsumable(foods, context.BlockIndex);
-            avatarState.ValidateCostume(new HashSet<int>(costumes));
+            avatarState.ValidateCostume(costumes);
 
             var costumeStatSheet = states.GetSheet<CostumeStatSheet>();
 
@@ -153,9 +153,8 @@ namespace Nekoyume.Action
 
             avatarState.actionPoint -= stageRow.CostAP;
 
-            avatarState.EquipCostumes(new HashSet<int>(costumes));
-
-            avatarState.EquipEquipments(equipments);
+            var items = equipments.Concat(costumes);
+            avatarState.EquipItems(items);
             sw.Stop();
             Log.Debug("HAS Unequip items: {Elapsed}", sw.Elapsed);
 

--- a/Lib9c/Action/MimisbrunnrBattle2.cs
+++ b/Lib9c/Action/MimisbrunnrBattle2.cs
@@ -1,0 +1,316 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Action;
+using Nekoyume.Battle;
+using Nekoyume.Model.BattleStatus;
+using Nekoyume.Model.Item;
+using Nekoyume.Model.State;
+using Nekoyume.TableData;
+using Serilog;
+
+namespace Nekoyume.Action
+{
+    [Serializable]
+    [ActionType("mimisbrunnr_battle2")]
+    public class MimisbrunnrBattle2 : GameAction
+    {
+        public List<Guid> costumes;
+        public List<Guid> equipments;
+        public List<Guid> foods;
+        public int worldId;
+        public int stageId;
+        public Address avatarAddress;
+        public Address WeeklyArenaAddress;
+        public Address RankingMapAddress;
+        
+        private const int AlfheimId = 2;
+        public BattleLog Result { get; private set; }
+        
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            new Dictionary<string, IValue>
+            {
+                ["costumes"] = new List(costumes.OrderBy(i => i).Select(e => e.Serialize())),
+                ["equipments"] = new List(equipments.OrderBy(i => i).Select(e => e.Serialize())),
+                ["foods"] = new List(foods.OrderBy(i => i).Select(e => e.Serialize())),
+                ["worldId"] = worldId.Serialize(),
+                ["stageId"] = stageId.Serialize(),
+                ["avatarAddress"] = avatarAddress.Serialize(),
+                ["weeklyArenaAddress"] = WeeklyArenaAddress.Serialize(),
+                ["rankingMapAddress"] = RankingMapAddress.Serialize(),
+            }.ToImmutableDictionary();
+
+        protected override void LoadPlainValueInternal(IImmutableDictionary<string, IValue> plainValue)
+        {
+            costumes =  ((List) plainValue["costumes"]).Select(e => e.ToGuid()).ToList();
+            equipments = ((List) plainValue["equipments"]).Select(e => e.ToGuid()).ToList();
+            foods = ((List) plainValue["foods"]).Select(e => e.ToGuid()).ToList();
+            worldId = plainValue["worldId"].ToInteger();
+            stageId = plainValue["stageId"].ToInteger();
+            avatarAddress = plainValue["avatarAddress"].ToAddress();
+            WeeklyArenaAddress = plainValue["weeklyArenaAddress"].ToAddress();
+            RankingMapAddress = plainValue["rankingMapAddress"].ToAddress();
+        }
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            IActionContext ctx = context;
+            var states = ctx.PreviousStates;
+            if (ctx.Rehearsal)
+            {
+                states = states.SetState(RankingMapAddress, MarkChanged);
+                states = states.SetState(avatarAddress, MarkChanged);
+                return states.SetState(WeeklyArenaAddress, MarkChanged);
+            }
+            
+            var sw = new Stopwatch();
+            sw.Start();
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("Mimisbrunnr exec started.");
+
+            if (!states.TryGetAvatarState(ctx.Signer, avatarAddress, out AvatarState avatarState))
+            {
+                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+            }
+            
+            sw.Stop();
+            Log.Debug("Mimisbrunnr Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            
+            sw.Restart();
+
+            if (avatarState.RankingMapAddress != RankingMapAddress)
+            {
+                throw new InvalidAddressException("Invalid ranking map address");
+            }
+            
+            var worldSheet = states.GetSheet<WorldSheet>();
+            var worldUnlockSheet = states.GetSheet<WorldUnlockSheet>();
+            if (!worldSheet.TryGetValue(worldId, out var worldRow, false))
+            {
+                throw new SheetRowNotFoundException(nameof(WorldSheet), worldId);
+            }
+
+            if (stageId < worldRow.StageBegin ||
+                stageId > worldRow.StageEnd)
+            {
+                throw new SheetRowColumnException(
+                    $"{worldId} world is not contains {worldRow.Id} stage: " +
+                    $"{worldRow.StageBegin}-{worldRow.StageEnd}");
+            }
+            
+            var stageSheet = states.GetSheet<StageSheet>();
+            if (!stageSheet.TryGetValue(stageId, out var stageRow))
+            {
+                throw new SheetRowNotFoundException(nameof(StageSheet), stageId);
+            }
+            
+            var worldInformation = avatarState.worldInformation;
+            if (!worldInformation.TryGetWorld(worldId, out var world))
+            {
+                // NOTE: Add new World from WorldSheet
+                worldInformation.AddAndUnlockMimisbrunnrWorld(worldRow, ctx.BlockIndex, worldSheet, worldUnlockSheet);
+                if (!worldInformation.TryGetWorld(worldId, out world))
+                {
+                    // Do nothing.
+                }
+            }
+            
+            if (!world.IsUnlocked)
+            {
+                var worldUnlockSheetRow = worldUnlockSheet.OrderedList.FirstOrDefault(row => row.WorldIdToUnlock == worldId);
+                if (!(worldUnlockSheetRow is null) &&
+                    worldInformation.IsWorldUnlocked(worldUnlockSheetRow.WorldId) &&
+                    worldInformation.IsStageCleared(worldUnlockSheetRow.StageId))
+                {
+                    worldInformation.UnlockWorld(worldId, ctx.BlockIndex, worldSheet);
+                    if (!worldInformation.TryGetWorld(worldId, out world))
+                    {
+                        // Do nothing.
+                    }
+                }
+            }
+            
+            if (!world.IsUnlocked)
+            {
+                throw new InvalidWorldException($"{worldId} is locked.");
+            }
+         
+            if (world.StageBegin != worldRow.StageBegin ||
+                world.StageEnd != worldRow.StageEnd)
+            {
+                worldInformation.UpdateWorld(worldRow);
+            }
+            
+            if (world.IsStageCleared && stageId > world.StageClearedId + 1 ||
+                !world.IsStageCleared && stageId != world.StageBegin)
+            {
+                throw new InvalidStageException(
+                    $"Aborted as the stage ({worldId}/{stageId}) is not cleared; " +
+                    $"cleared stage: {world.StageClearedId}"
+                );
+            }
+            
+            sw.Restart();
+            var mimisbrunnrSheet = states.GetSheet<MimisbrunnrSheet>();
+            if (!mimisbrunnrSheet.TryGetValue(stageId, out var mimisbrunnrSheetRow))
+            {
+                throw new SheetRowNotFoundException("MimisbrunnrSheet", stageId);
+            }
+            
+            foreach (var equipmentId in equipments)
+            {
+                if (avatarState.inventory.TryGetNonFungibleItem(equipmentId, out ItemUsable itemUsable))
+                {
+                    var elementalType = ((Equipment) itemUsable).ElementalType;
+                    if (!mimisbrunnrSheetRow.ElementalTypes.Exists(x => x == elementalType))
+                    {
+                        throw new InvalidElementalException(
+                            $"ElementalType of {equipmentId} does not match.");
+                    }
+                }
+            }
+            sw.Stop();
+            Log.Debug("Mimisbrunnr Check Equipments ElementalType: {Elapsed}", sw.Elapsed);
+
+            avatarState.ValidateEquipmentsV2(equipments, context.BlockIndex);
+            avatarState.ValidateConsumable(foods, context.BlockIndex);
+            avatarState.ValidateCostume(costumes);
+            
+            sw.Restart();
+            if (avatarState.actionPoint < stageRow.CostAP)
+            {
+                throw new NotEnoughActionPointException(
+                    $"Aborted due to insufficient action point: " +
+                    $"{avatarState.actionPoint} < {stageRow.CostAP}"
+                );
+            }
+            avatarState.actionPoint -= stageRow.CostAP;
+            var equippableItem = new List<Guid>();
+            equippableItem.AddRange(costumes);
+            equippableItem.AddRange(equipments);
+            avatarState.EquipItems(equippableItem);
+            sw.Stop();
+            Log.Debug("Mimisbrunnr Unequip items: {Elapsed}", sw.Elapsed);
+            
+            sw.Restart();
+            var costumeStatSheet = states.GetSheet<CostumeStatSheet>();
+            var simulator = new StageSimulator(
+                ctx.Random,
+                avatarState,
+                foods,
+                worldId,
+                stageId,
+                states.GetStageSimulatorSheets(),
+                costumeStatSheet
+            );
+            sw.Stop();
+            Log.Debug("Mimisbrunnr Initialize Simulator: {Elapsed}", sw.Elapsed);
+            
+            sw.Restart();
+            simulator.Simulate();
+            sw.Stop();
+            Log.Debug("Mimisbrunnr Simulator.Simulate(): {Elapsed}", sw.Elapsed);
+            
+            Log.Debug(
+                "Execute Mimisbrunnr({AvatarAddress}); worldId: {WorldId}, stageId: {StageId}, result: {Result}, " +
+                "clearWave: {ClearWave}, totalWave: {TotalWave}",
+                avatarAddress,
+                worldId,
+                stageId,
+                simulator.Log.result,
+                simulator.Log.clearedWaveNumber,
+                simulator.Log.waveCount
+            );
+            
+            sw.Restart();
+            if (simulator.Log.IsClear)
+            {
+                simulator.Player.worldInformation.ClearStage(
+                    worldId,
+                    stageId,
+                    ctx.BlockIndex,
+                    worldSheet,
+                    worldUnlockSheet
+                );
+            }
+            sw.Stop();
+            Log.Debug("Mimisbrunnr ClearStage: {Elapsed}", sw.Elapsed);
+            
+            sw.Restart();
+            avatarState.Update(simulator);
+
+            var materialSheet = states.GetSheet<MaterialItemSheet>();
+            avatarState.UpdateQuestRewards(materialSheet);
+
+            avatarState.updatedAt = ctx.BlockIndex;
+            avatarState.mailBox.CleanUp();
+            states = states.SetState(avatarAddress, avatarState.Serialize());
+
+            sw.Stop();
+            Log.Debug("Mimisbrunnr Set AvatarState: {Elapsed}", sw.Elapsed);
+            
+            sw.Restart();
+            if (states.TryGetState(RankingMapAddress, out Dictionary d) && simulator.Log.IsClear)
+            {
+                var ranking = new RankingMapState(d);
+                ranking.Update(avatarState);
+
+                sw.Stop();
+                Log.Debug("Mimisbrunnr Update RankingState: {Elapsed}", sw.Elapsed);
+                sw.Restart();
+
+                var serialized = ranking.Serialize();
+
+                sw.Stop();
+                Log.Debug("Mimisbrunnr Serialize RankingState: {Elapsed}", sw.Elapsed);
+                sw.Restart();
+                states = states.SetState(RankingMapAddress, serialized);
+            }
+
+            sw.Stop();
+            Log.Debug("Mimisbrunnr Set RankingState: {Elapsed}", sw.Elapsed);
+            
+            sw.Restart();
+            if (simulator.Log.stageId >= GameConfig.RequireClearedStageLevel.ActionsInRankingBoard &&
+                simulator.Log.IsClear &&
+                states.TryGetState(WeeklyArenaAddress, out Dictionary weeklyDict))
+            {
+                var weekly = new WeeklyArenaState(weeklyDict);
+                if (!weekly.Ended)
+                {
+                    var characterSheet = states.GetSheet<CharacterSheet>();
+                    if (weekly.ContainsKey(avatarAddress))
+                    {
+                        var info = weekly[avatarAddress];
+                        info.Update(avatarState, characterSheet, costumeStatSheet);
+                        weekly.Update(info);
+                    }
+                    else
+                    {
+                        weekly.SetV2(avatarState, characterSheet, costumeStatSheet);
+                    }
+
+                    sw.Stop();
+                    Log.Debug("Mimisbrunnr Update WeeklyArenaState: {Elapsed}", sw.Elapsed);
+
+                    sw.Restart();
+                    var weeklySerialized = weekly.Serialize();
+                    sw.Stop();
+                    Log.Debug("Mimisbrunnr Serialize RankingState: {Elapsed}", sw.Elapsed);
+
+                    states = states.SetState(weekly.address, weeklySerialized);
+                }
+            }
+
+            Result = simulator.Log;
+
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("Mimisbrunnr Total Executed Time: {Elapsed}", ended - started);
+            return states;
+        }
+    }
+}

--- a/Lib9c/Action/RankingBattle3.cs
+++ b/Lib9c/Action/RankingBattle3.cs
@@ -25,7 +25,7 @@ namespace Nekoyume.Action
         public Address AvatarAddress;
         public Address EnemyAddress;
         public Address WeeklyArenaAddress;
-        public List<Guid> equipments;
+        public List<Guid> costumeIds;
         public List<Guid> equipmentIds;
         public List<Guid> consumableIds;
         public BattleLog Result { get; private set; }
@@ -53,11 +53,11 @@ namespace Nekoyume.Action
                 throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
             }
 
-            var items = equipmentIds.Concat(equipments);
+            var items = equipmentIds.Concat(costumeIds);
 
             avatarState.ValidateEquipmentsV2(equipmentIds, context.BlockIndex);
             avatarState.ValidateConsumable(consumableIds, context.BlockIndex);
-            avatarState.ValidateCostume(equipments);
+            avatarState.ValidateCostume(costumeIds);
             avatarState.EquipItems(items);
 
             if (!avatarState.worldInformation.TryGetUnlockedWorldByStageClearedBlockIndex(out var world) ||
@@ -137,7 +137,7 @@ namespace Nekoyume.Action
                 ["avatarAddress"] = AvatarAddress.Serialize(),
                 ["enemyAddress"] = EnemyAddress.Serialize(),
                 ["weeklyArenaAddress"] = WeeklyArenaAddress.Serialize(),
-                ["costume_ids"] = new Bencodex.Types.List(equipments
+                ["costume_ids"] = new Bencodex.Types.List(costumeIds
                     .OrderBy(element => element)
                     .Select(e => e.Serialize())),
                 ["equipment_ids"] = new Bencodex.Types.List(equipmentIds
@@ -153,7 +153,7 @@ namespace Nekoyume.Action
             AvatarAddress = plainValue["avatarAddress"].ToAddress();
             EnemyAddress = plainValue["enemyAddress"].ToAddress();
             WeeklyArenaAddress = plainValue["weeklyArenaAddress"].ToAddress();
-            equipments = ((Bencodex.Types.List) plainValue["costume_ids"])
+            costumeIds = ((Bencodex.Types.List) plainValue["costume_ids"])
                 .Select(e => e.ToGuid())
                 .ToList();
             equipmentIds = ((Bencodex.Types.List) plainValue["equipment_ids"])

--- a/Lib9c/Action/RankingBattle3.cs
+++ b/Lib9c/Action/RankingBattle3.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Numerics;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Action;
+using Libplanet.Assets;
+using Nekoyume.Battle;
+using Nekoyume.Model.BattleStatus;
+using Nekoyume.Model.State;
+using Nekoyume.TableData;
+using Serilog;
+
+namespace Nekoyume.Action
+{
+    [Serializable]
+    [ActionType("ranking_battle3")]
+    public class RankingBattle3 : GameAction
+    {
+        public const int StageId = 999999;
+        public static readonly BigInteger EntranceFee = 100;
+
+        public Address AvatarAddress;
+        public Address EnemyAddress;
+        public Address WeeklyArenaAddress;
+        public List<int> costumeIds;
+        public List<Guid> equipmentIds;
+        public List<Guid> consumableIds;
+        public BattleLog Result { get; private set; }
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            IActionContext ctx = context;
+            var states = ctx.PreviousStates;
+            if (ctx.Rehearsal)
+            {
+                return states.SetState(ctx.Signer, MarkChanged)
+                    .SetState(AvatarAddress, MarkChanged)
+                    .SetState(WeeklyArenaAddress, MarkChanged)
+                    .SetState(ctx.Signer, MarkChanged)
+                    .MarkBalanceChanged(GoldCurrencyMock, ctx.Signer, WeeklyArenaAddress);
+            }
+
+            if (AvatarAddress.Equals(EnemyAddress))
+            {
+                throw new InvalidAddressException("Aborted as the signer tried to battle for themselves.");
+            }
+
+            if (!states.TryGetAvatarState(ctx.Signer, AvatarAddress, out var avatarState))
+            {
+                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+            }
+
+            avatarState.ValidateEquipmentsV2(equipmentIds, context.BlockIndex);
+            avatarState.ValidateConsumable(consumableIds, context.BlockIndex);
+
+            if (!avatarState.worldInformation.TryGetUnlockedWorldByStageClearedBlockIndex(out var world) ||
+                world.StageClearedId < GameConfig.RequireClearedStageLevel.ActionsInRankingBoard)
+            {
+                throw new NotEnoughClearedStageLevelException(
+                    GameConfig.RequireClearedStageLevel.ActionsInRankingBoard,
+                    world.StageClearedId);
+            }
+
+            avatarState.EquipCostumes(new HashSet<int>(costumeIds));
+            avatarState.EquipEquipments(equipmentIds);
+            avatarState.ValidateCostume(new HashSet<int>(costumeIds));
+
+            var enemyAvatarState = states.GetAvatarState(EnemyAddress);
+            if (enemyAvatarState is null)
+            {
+                throw new FailedLoadStateException($"Aborted as the avatar state of the opponent ({EnemyAddress}) was failed to load.");
+            }
+
+            var weeklyArenaState = states.GetWeeklyArenaState(WeeklyArenaAddress);
+
+            if (weeklyArenaState.Ended)
+            {
+                throw new WeeklyArenaStateAlreadyEndedException();
+            }
+
+            if (!weeklyArenaState.ContainsKey(AvatarAddress))
+            {
+                throw new WeeklyArenaStateNotContainsAvatarAddressException(AvatarAddress);
+            }
+
+            var arenaInfo = weeklyArenaState[AvatarAddress];
+
+            if (arenaInfo.DailyChallengeCount <= 0)
+            {
+                throw new NotEnoughWeeklyArenaChallengeCountException();
+            }
+
+            if (!arenaInfo.Active)
+            {
+                arenaInfo.Activate();
+            }
+
+            if (!weeklyArenaState.ContainsKey(EnemyAddress))
+            {
+                throw new WeeklyArenaStateNotContainsAvatarAddressException(EnemyAddress);
+            }
+
+            Log.Debug(weeklyArenaState.address.ToHex());
+
+            var costumeStatSheet = states.GetSheet<CostumeStatSheet>();
+            var simulator = new RankingSimulator(
+                ctx.Random,
+                avatarState,
+                enemyAvatarState,
+                consumableIds,
+                states.GetRankingSimulatorSheets(),
+                StageId,
+                arenaInfo,
+                weeklyArenaState[EnemyAddress],
+                costumeStatSheet);
+
+            simulator.Simulate();
+
+            Result = simulator.Log;
+
+            foreach (var itemBase in simulator.Reward.OrderBy(i => i.Id))
+            {
+                avatarState.inventory.AddItem(itemBase);
+            }
+
+            return states
+                .SetState(WeeklyArenaAddress, weeklyArenaState.Serialize())
+                .SetState(AvatarAddress, avatarState.Serialize());
+        }
+
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            new Dictionary<string, IValue>
+            {
+                ["avatarAddress"] = AvatarAddress.Serialize(),
+                ["enemyAddress"] = EnemyAddress.Serialize(),
+                ["weeklyArenaAddress"] = WeeklyArenaAddress.Serialize(),
+                ["costume_ids"] = new Bencodex.Types.List(costumeIds
+                    .OrderBy(element => element)
+                    .Select(e => e.Serialize())),
+                ["equipment_ids"] = new Bencodex.Types.List(equipmentIds
+                    .OrderBy(element => element)
+                    .Select(e => e.Serialize())),
+                ["consumable_ids"] = new Bencodex.Types.List(consumableIds
+                    .OrderBy(element => element)
+                    .Select(e => e.Serialize())),
+            }.ToImmutableDictionary();
+
+        protected override void LoadPlainValueInternal(IImmutableDictionary<string, IValue> plainValue)
+        {
+            AvatarAddress = plainValue["avatarAddress"].ToAddress();
+            EnemyAddress = plainValue["enemyAddress"].ToAddress();
+            WeeklyArenaAddress = plainValue["weeklyArenaAddress"].ToAddress();
+            costumeIds = ((Bencodex.Types.List) plainValue["costume_ids"])
+                .Select(e => e.ToInteger())
+                .ToList();
+            equipmentIds = ((Bencodex.Types.List) plainValue["equipment_ids"])
+                .Select(e => e.ToGuid())
+                .ToList();
+            consumableIds = ((Bencodex.Types.List) plainValue["consumable_ids"])
+                .Select(e => e.ToGuid())
+                .ToList();
+        }
+    }
+}

--- a/Lib9c/Battle/RankingSimulator.cs
+++ b/Lib9c/Battle/RankingSimulator.cs
@@ -76,7 +76,7 @@ namespace Nekoyume.Battle
             _enemyPlayer.SetCostumeStat(costumeStatSheet);
         }
 
-        public override Player Simulate()
+        public Player Simulate()
         {
 #if TEST_LOG
             var sb = new System.Text.StringBuilder();
@@ -113,13 +113,13 @@ namespace Nekoyume.Battle
 #endif
                     break;
                 }
-                
+
                 // 캐릭터 큐가 비어 있는 경우 break.
                 if (!Characters.TryDequeue(out var character))
                     break;
 
                 character.Tick();
-                
+
                 // 플레이어가 죽은 경우 break;
                 if (Player.IsDead)
                 {
@@ -141,7 +141,7 @@ namespace Nekoyume.Battle
                 {
                     Result = BattleLog.Result.Win;
                     Log.clearedWaveNumber = WaveNumber;
-                    
+
                     break;
                 }
 

--- a/Lib9c/Battle/Simulator.cs
+++ b/Lib9c/Battle/Simulator.cs
@@ -53,8 +53,6 @@ namespace Nekoyume.Battle
             Player.Stats.EqualizeCurrentHPWithHP();
         }
 
-        public abstract Player Simulate();
-
         public static List<ItemBase> SetReward(
             WeightedSelector<StageSheet.RewardData> itemSelector,
             int maxCount,
@@ -95,6 +93,5 @@ namespace Nekoyume.Battle
             reward = reward.OrderBy(r => r.Id).ToList();
             return reward;
         }
-
     }
 }

--- a/Lib9c/Battle/StageSimulator.cs
+++ b/Lib9c/Battle/StageSimulator.cs
@@ -16,8 +16,6 @@ namespace Nekoyume.Battle
 {
     public class StageSimulator : Simulator
     {
-        public const long StartBlockIndexToUseSimulatorV2 = 230000;
-
         private readonly List<Wave> _waves;
         private readonly List<ItemBase> _waveRewards;
         public CollectionMap ItemMap = new CollectionMap();

--- a/Lib9c/Battle/StageSimulator.cs
+++ b/Lib9c/Battle/StageSimulator.cs
@@ -16,6 +16,8 @@ namespace Nekoyume.Battle
 {
     public class StageSimulator : Simulator
     {
+        public const long StartBlockIndexToUseSimulatorV2 = 230000;
+
         private readonly List<Wave> _waves;
         private readonly List<ItemBase> _waveRewards;
         public CollectionMap ItemMap = new CollectionMap();
@@ -84,7 +86,7 @@ namespace Nekoyume.Battle
                 random,
                 avatarState,
                 foods,
-                worldId, 
+                worldId,
                 stageId,
                 stageSimulatorSheets
             )
@@ -123,7 +125,7 @@ namespace Nekoyume.Battle
             Player.SetCostumeStat(costumeStatSheet);
         }
 
-        public override Player Simulate()
+        public Player Simulate()
         {
 #if TEST_LOG
             var sb = new System.Text.StringBuilder();
@@ -240,6 +242,167 @@ namespace Nekoyume.Battle
                                 {
                                     Player.GetExp(Exp, true);
                                 }
+                                break;
+                            case 2:
+                            {
+                                ItemMap = Player.GetRewards(_waveRewards);
+                                var dropBox = new DropBox(null, _waveRewards);
+                                Log.Add(dropBox);
+                                var getReward = new GetReward(null, _waveRewards);
+                                Log.Add(getReward);
+                                break;
+                            }
+                            default:
+                                if (WaveNumber == _waves.Count)
+                                {
+                                    if (!IsCleared)
+                                    {
+                                        Log.newlyCleared = true;
+                                    }
+                                }
+                                break;
+                        }
+
+                        break;
+                    }
+
+                    foreach (var other in Characters)
+                    {
+                        var current = Characters.GetPriority(other);
+                        var speed = current * 0.6m;
+                        Characters.UpdatePriority(other, speed);
+                    }
+
+                    Characters.Enqueue(character, TurnPriority / character.SPD);
+                }
+
+                // 제한 턴을 넘거나 플레이어가 죽은 경우 break;
+                if (TurnNumber > TurnLimit ||
+                    Player.IsDead)
+                    break;
+            }
+
+            Log.result = Result;
+#if TEST_LOG
+            sb.Clear();
+            sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+            sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+            sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+            sb.Append($" / {nameof(Simulate)} End");
+            sb.Append($" / {nameof(Result)}: {Result.ToString()}");
+            UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+            return Player;
+        }
+
+        public Player SimulateV2()
+        {
+#if TEST_LOG
+            var sb = new System.Text.StringBuilder();
+#endif
+            Log.worldId = WorldId;
+            Log.stageId = StageId;
+            Log.waveCount = _waves.Count;
+            Log.clearedWaveNumber = 0;
+            Log.newlyCleared = false;
+            Player.Spawn();
+            TurnNumber = 0;
+            for (var i = 0; i < _waves.Count; i++)
+            {
+                Characters = new SimplePriorityQueue<CharacterBase, decimal>();
+                Characters.Enqueue(Player, TurnPriority / Player.SPD);
+
+                WaveNumber = i + 1;
+                WaveTurn = 1;
+                _waves[i].Spawn(this);
+#if TEST_LOG
+                sb.Clear();
+                sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+                sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+                sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+                sb.Append(" / Wave Start");
+                UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+                while (true)
+                {
+                    // 제한 턴을 넘어서는 경우 break.
+                    if (TurnNumber > TurnLimit)
+                    {
+                        if (i == 0)
+                        {
+                            Player.GetExpV2((int) (Exp * 0.3m), true);
+                            Result = BattleLog.Result.Lose;
+                        }
+                        else
+                        {
+                            Result = BattleLog.Result.TimeOver;
+                        }
+#if TEST_LOG
+                        sb.Clear();
+                        sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+                        sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+                        sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+                        sb.Append($" / {nameof(TurnLimit)}: {TurnLimit}");
+                        sb.Append($" / {nameof(Result)}: {Result.ToString()}");
+                        UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+                        break;
+                    }
+
+                    // 캐릭터 큐가 비어 있는 경우 break.
+                    if (!Characters.TryDequeue(out var character))
+                        break;
+#if TEST_LOG
+                    var turnBefore = TurnNumber;
+#endif
+                    character.Tick();
+#if TEST_LOG
+                    var turnAfter = TurnNumber;
+                    if (turnBefore != turnAfter)
+                    {
+                        sb.Clear();
+                        sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+                        sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+                        sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+                        sb.Append(" / Turn End");
+                        UnityEngine.Debug.LogWarning(sb.ToString());
+                    }
+#endif
+
+                    // 플레이어가 죽은 경우 break;
+                    if (Player.IsDead)
+                    {
+                        if (i == 0)
+                        {
+                            Result = BattleLog.Result.Lose;
+                            Player.GetExpV2((int) (Exp * 0.3m), true);
+                        }
+                        else
+                        {
+                            Result = BattleLog.Result.Win;
+                        }
+#if TEST_LOG
+                        sb.Clear();
+                        sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+                        sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+                        sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+                        sb.Append($" / {nameof(Player)} Dead");
+                        sb.Append($" / {nameof(Result)}: {Result.ToString()}");
+                        UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+                        break;
+                    }
+
+                    // 플레이어의 타겟(적)이 없는 경우 break.
+                    if (!Player.Targets.Any())
+                    {
+                        Result = BattleLog.Result.Win;
+                        Log.clearedWaveNumber = WaveNumber;
+
+                        switch (WaveNumber)
+                        {
+                            case 1:
+                                Player.GetExpV2(Exp, true);
                                 break;
                             case 2:
                             {

--- a/Lib9c/Battle/StageSimulator.cs
+++ b/Lib9c/Battle/StageSimulator.cs
@@ -16,6 +16,8 @@ namespace Nekoyume.Battle
 {
     public class StageSimulator : Simulator
     {
+        public const long StartBlockIndexToUseSimulatorV2 = 230000;
+
         private readonly List<Wave> _waves;
         private readonly List<ItemBase> _waveRewards;
         public CollectionMap ItemMap = new CollectionMap();

--- a/Lib9c/GameConfig.cs
+++ b/Lib9c/GameConfig.cs
@@ -1,3 +1,6 @@
+using Nekoyume.Model.Item;
+using System.Collections.Generic;
+
 namespace Nekoyume
 {
     public static class GameConfig
@@ -113,5 +116,14 @@ namespace Nekoyume
         }
 
         #endregion
+
+        public static class MaxEquipmentSlotCount
+        {
+            public const int Weapon = 1;
+            public const int Armor = 1;
+            public const int Belt = 1;
+            public const int Necklace = 1;
+            public const int Ring = 2;
+        }
     }
 }

--- a/Lib9c/Model/Character/Player.cs
+++ b/Lib9c/Model/Character/Player.cs
@@ -140,7 +140,7 @@ namespace Nekoyume.Model
             GameConfig.DefaultAvatarCharacterId,
             level)
         {
-            Exp.Current = 0;
+            Exp.Current = characterLevelSheet[level].Exp;
             Inventory = new Inventory();
             worldInformation = null;
             weapon = null;
@@ -310,6 +310,7 @@ namespace Nekoyume.Model
                 return;
             }
 
+            Level = newLevel;
             if (Level < newLevel)
             {
                 eventMap?.Add(new KeyValuePair<int, int>((int) QuestEventType.Level, newLevel - Level));

--- a/Lib9c/Model/Character/Player.cs
+++ b/Lib9c/Model/Character/Player.cs
@@ -102,8 +102,8 @@ namespace Nekoyume.Model
 
         public Player(
             AvatarState avatarState,
-            CharacterSheet characterSheet, 
-            CharacterLevelSheet characterLevelSheet, 
+            CharacterSheet characterSheet,
+            CharacterLevelSheet characterLevelSheet,
             EquipmentItemSetEffectSheet equipmentItemSetEffectSheet
         ) : base(
             null,
@@ -130,9 +130,9 @@ namespace Nekoyume.Model
         }
 
         public Player(
-            int level, 
-            CharacterSheet characterSheet, 
-            CharacterLevelSheet characterLevelSheet, 
+            int level,
+            CharacterSheet characterSheet,
+            CharacterLevelSheet characterLevelSheet,
             EquipmentItemSetEffectSheet equipmentItemSetEffectSheet
         ) : base(
             null,
@@ -284,6 +284,35 @@ namespace Nekoyume.Model
             if (level < Level)
             {
                 eventMap?.Add(new KeyValuePair<int, int>((int) QuestEventType.Level, Level - level));
+            }
+
+            UpdateExp();
+        }
+
+        public void GetExpV2(long waveExp, bool log = false)
+        {
+            if (!characterLevelSheet.TryGetLevel(Exp.Current + waveExp, out var newLevel))
+            {
+                waveExp = Exp.Max - Exp.Current - 1;
+                newLevel = Level;
+            }
+
+            Exp.Current += waveExp;
+
+            if (log)
+            {
+                var getExp = new GetExp((CharacterBase) Clone(), waveExp);
+                Simulator.Log.Add(getExp);
+            }
+
+            if (Level == newLevel)
+            {
+                return;
+            }
+
+            if (Level < newLevel)
+            {
+                eventMap?.Add(new KeyValuePair<int, int>((int) QuestEventType.Level, newLevel - Level));
             }
 
             UpdateExp();

--- a/Lib9c/Model/State/AvatarState.cs
+++ b/Lib9c/Model/State/AvatarState.cs
@@ -322,7 +322,7 @@ namespace Nekoyume.Model.State
 
             UpdateCompletedQuest();
         }
-        
+
         public void UpdateFromAddCostume(Costume costume, bool canceled)
         {
             var pair = inventory.AddItem(costume);

--- a/Lib9c/Model/State/AvatarState.cs
+++ b/Lib9c/Model/State/AvatarState.cs
@@ -569,55 +569,6 @@ namespace Nekoyume.Model.State
             }
         }
 
-        public void ValidateCostume(IEnumerable<Guid> costumeIds)
-        {
-            var subTypes = new List<ItemSubType>();
-            foreach (var costumeId in costumeIds.OrderBy(i => i))
-            {
-                if (!inventory.TryGetNonFungibleItem(costumeId, out Costume costume))
-                {
-                    continue;
-                }
-
-                if (subTypes.Contains(costume.ItemSubType))
-                {
-                    throw new DuplicateCostumeException($"can't equip duplicate costume type : {costume.ItemSubType}");
-                }
-                subTypes.Add(costume.ItemSubType);
-
-                int requiredLevel;
-                switch (costume.ItemSubType)
-                {
-                    case ItemSubType.FullCostume:
-                        requiredLevel = GameConfig.RequireCharacterLevel.CharacterFullCostumeSlot;
-                        break;
-                    case ItemSubType.HairCostume:
-                        requiredLevel = GameConfig.RequireCharacterLevel.CharacterHairCostumeSlot;
-                        break;
-                    case ItemSubType.EarCostume:
-                        requiredLevel = GameConfig.RequireCharacterLevel.CharacterEarCostumeSlot;
-                        break;
-                    case ItemSubType.EyeCostume:
-                        requiredLevel = GameConfig.RequireCharacterLevel.CharacterEyeCostumeSlot;
-                        break;
-                    case ItemSubType.TailCostume:
-                        requiredLevel = GameConfig.RequireCharacterLevel.CharacterTailCostumeSlot;
-                        break;
-                    case ItemSubType.Title:
-                        requiredLevel = GameConfig.RequireCharacterLevel.CharacterTitleSlot;
-                        break;
-                    default:
-                        throw new InvalidItemTypeException(
-                            $"Costume[id: {costumeId}] isn't expected type. [type: {costume.ItemSubType}]");
-                }
-
-                if (level < requiredLevel)
-                {
-                    throw new CostumeSlotUnlockException($"not enough level. required: {requiredLevel}");
-                }
-            }
-        }
-
         public void EquipItems(IEnumerable<Guid> itemIds)
         {
             // Unequip items already equipped.

--- a/Lib9c/Model/State/AvatarState.cs
+++ b/Lib9c/Model/State/AvatarState.cs
@@ -472,6 +472,7 @@ namespace Nekoyume.Model.State
                             GameConfig.RequireCharacterLevel.CharacterEquipmentSlotNecklace : int.MaxValue;
                         break;
                     case ItemSubType.Ring:
+                        isSlotEnough = countMap[type] <= GameConfig.MaxEquipmentSlotCount.Ring;
                         requiredLevel = countMap[ItemSubType.Ring] == 1
                             ? GameConfig.RequireCharacterLevel.CharacterEquipmentSlotRing1
                             : countMap[ItemSubType.Ring] == 2

--- a/Lib9c/Model/State/AvatarState.cs
+++ b/Lib9c/Model/State/AvatarState.cs
@@ -569,6 +569,55 @@ namespace Nekoyume.Model.State
             }
         }
 
+        public void ValidateCostume(IEnumerable<Guid> costumeIds)
+        {
+            var subTypes = new List<ItemSubType>();
+            foreach (var costumeId in costumeIds.OrderBy(i => i))
+            {
+                if (!inventory.TryGetNonFungibleItem(costumeId, out Costume costume))
+                {
+                    continue;
+                }
+
+                if (subTypes.Contains(costume.ItemSubType))
+                {
+                    throw new DuplicateCostumeException($"can't equip duplicate costume type : {costume.ItemSubType}");
+                }
+                subTypes.Add(costume.ItemSubType);
+
+                int requiredLevel;
+                switch (costume.ItemSubType)
+                {
+                    case ItemSubType.FullCostume:
+                        requiredLevel = GameConfig.RequireCharacterLevel.CharacterFullCostumeSlot;
+                        break;
+                    case ItemSubType.HairCostume:
+                        requiredLevel = GameConfig.RequireCharacterLevel.CharacterHairCostumeSlot;
+                        break;
+                    case ItemSubType.EarCostume:
+                        requiredLevel = GameConfig.RequireCharacterLevel.CharacterEarCostumeSlot;
+                        break;
+                    case ItemSubType.EyeCostume:
+                        requiredLevel = GameConfig.RequireCharacterLevel.CharacterEyeCostumeSlot;
+                        break;
+                    case ItemSubType.TailCostume:
+                        requiredLevel = GameConfig.RequireCharacterLevel.CharacterTailCostumeSlot;
+                        break;
+                    case ItemSubType.Title:
+                        requiredLevel = GameConfig.RequireCharacterLevel.CharacterTitleSlot;
+                        break;
+                    default:
+                        throw new InvalidItemTypeException(
+                            $"Costume[id: {costumeId}] isn't expected type. [type: {costume.ItemSubType}]");
+                }
+
+                if (level < requiredLevel)
+                {
+                    throw new CostumeSlotUnlockException($"not enough level. required: {requiredLevel}");
+                }
+            }
+        }
+
         public void EquipItems(IEnumerable<Guid> itemIds)
         {
             // Unequip items already equipped.

--- a/Lib9c/Model/State/AvatarState.cs
+++ b/Lib9c/Model/State/AvatarState.cs
@@ -452,22 +452,22 @@ namespace Nekoyume.Model.State
                 switch (equipment.ItemSubType)
                 {
                     case ItemSubType.Weapon:
-                        isSlotEnough = countMap[type] > GameConfig.MaxEquipmentSlotCount.Weapon;
+                        isSlotEnough = countMap[type] <= GameConfig.MaxEquipmentSlotCount.Weapon;
                         requiredLevel = isSlotEnough ?
                             GameConfig.RequireCharacterLevel.CharacterEquipmentSlotWeapon : int.MaxValue;
                         break;
                     case ItemSubType.Armor:
-                        isSlotEnough = countMap[type] > GameConfig.MaxEquipmentSlotCount.Armor;
+                        isSlotEnough = countMap[type] <= GameConfig.MaxEquipmentSlotCount.Armor;
                         requiredLevel = isSlotEnough ?
                             GameConfig.RequireCharacterLevel.CharacterEquipmentSlotArmor : int.MaxValue;
                         break;
                     case ItemSubType.Belt:
-                        isSlotEnough = countMap[type] > GameConfig.MaxEquipmentSlotCount.Belt;
+                        isSlotEnough = countMap[type] <= GameConfig.MaxEquipmentSlotCount.Belt;
                         requiredLevel = isSlotEnough ?
                             GameConfig.RequireCharacterLevel.CharacterEquipmentSlotBelt : int.MaxValue;
                         break;
                     case ItemSubType.Necklace:
-                        isSlotEnough = countMap[type] > GameConfig.MaxEquipmentSlotCount.Necklace;
+                        isSlotEnough = countMap[type] <= GameConfig.MaxEquipmentSlotCount.Necklace;
                         requiredLevel = isSlotEnough ?
                             GameConfig.RequireCharacterLevel.CharacterEquipmentSlotNecklace : int.MaxValue;
                         break;

--- a/Lib9c/TableData/Character/CharacterLevelSheet.cs
+++ b/Lib9c/TableData/Character/CharacterLevelSheet.cs
@@ -22,7 +22,7 @@ namespace Nekoyume.TableData
                 ExpNeed = TryParseLong(fields[2], out var expNeed) ? expNeed : 0L;
             }
         }
-        
+
         public CharacterLevelSheet() : base(nameof(CharacterLevelSheet))
         {
         }
@@ -38,6 +38,21 @@ namespace Nekoyume.TableData
             }
 
             return 0;
+        }
+
+        public bool TryGetLevel(long exp, out int level)
+        {
+            foreach (var row in OrderedList)
+            {
+                if (row.Exp + row.ExpNeed > exp)
+                {
+                    level = row.Key;
+                    return true;
+                }
+            }
+
+            level = default;
+            return false;
         }
     }
 }


### PR DESCRIPTION
- Bug fix/failed to `HackAndSlash3` when `AvatarState` already max level and max exp
- Improve equipment validation. (Prevent equipping more equipments than the slot that player has.)