### PR TITLE
Add signer and other addresses hex to all of logs in game actions

### DIFF
--- a/Lib9c/Action/ActionBase.cs
+++ b/Lib9c/Action/ActionBase.cs
@@ -6,6 +6,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using System.Text;
 using Bencodex;
 using Bencodex.Types;
 using Libplanet;
@@ -273,6 +274,19 @@ namespace Nekoyume.Action
                     return (T)formatter.Deserialize(stream);
                 }
             }
+        }
+
+        protected string GetSignerAndStateAddressesHex(IActionContext ctx, params State[] states)
+        {
+            StringBuilder sb = new StringBuilder($"[{ctx.Signer.ToHex()}");
+
+            foreach (State state in states)
+            {
+                sb.Append($", {state.address}");
+            }
+
+            sb.Append("]");
+            return sb.ToString();
         }
 
         protected IAccountStateDelta LogError(IActionContext context, string message, params object[] values)

--- a/Lib9c/Action/ActionBase.cs
+++ b/Lib9c/Action/ActionBase.cs
@@ -276,13 +276,19 @@ namespace Nekoyume.Action
             }
         }
 
-        protected string GetSignerAndStateAddressesHex(IActionContext ctx, params State[] states)
+        /// <summary>
+        /// returns "[Signer Address, AvatarState Address, ...]"
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <param name="addresses"></param>
+        /// <returns></returns>
+        protected string GetSignerAndOtherAddressesHex(IActionContext ctx, params Address[] addresses)
         {
             StringBuilder sb = new StringBuilder($"[{ctx.Signer.ToHex()}");
 
-            foreach (State state in states)
+            foreach (Address address in addresses)
             {
-                sb.Append($", {state.address}");
+                sb.Append($", {address.ToHex()}");
             }
 
             sb.Append("]");

--- a/Lib9c/Action/Buy.cs
+++ b/Lib9c/Action/Buy.cs
@@ -121,41 +121,50 @@ namespace Nekoyume.Action
                         GoldCurrencyState.Address);
                 return states.SetState(ShopState.Address, MarkChanged);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(ctx);
 
             if (ctx.Signer.Equals(sellerAgentAddress))
             {
-                throw new InvalidAddressException("Aborted as the signer is the seller.");
+                throw new InvalidAddressException($"{addressesHex}Aborted as the signer is the seller.");
             }
 
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("Buy exec started.");
+            Log.Debug("{Addresses}Buy exec started", addressesHex);
 
             if (!states.TryGetAvatarState(ctx.Signer, buyerAvatarAddress, out var buyerAvatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the buyer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the buyer was failed to load.");
             }
             sw.Stop();
-            Log.Debug("Buy Get Buyer AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Get Buyer AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!buyerAvatarState.worldInformation.IsStageCleared(GameConfig.RequireClearedStageLevel.ActionsInShop))
             {
                 buyerAvatarState.worldInformation.TryGetLastClearedStageId(out var current);
-                throw new NotEnoughClearedStageLevelException(GameConfig.RequireClearedStageLevel.ActionsInShop, current);
+                throw new NotEnoughClearedStageLevelException(
+                    addressesHex,
+                    GameConfig.RequireClearedStageLevel.ActionsInShop,
+                    current);
             }
 
             if (!states.TryGetState(ShopState.Address, out Bencodex.Types.Dictionary shopStateDict))
             {
-                throw new FailedLoadStateException("Aborted as the shop state was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the shop state was failed to load.");
             }
 
             sw.Stop();
-            Log.Debug("Buy Get ShopState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Get ShopState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
-            Log.Debug("Execute Buy; buyer: {Buyer} seller: {Seller}", buyerAvatarAddress, sellerAvatarAddress);
+            Log.Debug(
+                "{AddressesHex}Execute Buy; buyer: {Buyer} seller: {Seller}",
+                addressesHex,
+                buyerAvatarAddress,
+                sellerAvatarAddress);
             // 상점에서 구매할 아이템을 찾는다.
             Dictionary products = (Dictionary)shopStateDict["products"];
 
@@ -163,7 +172,7 @@ namespace Nekoyume.Action
             if (!products.ContainsKey(productIdSerialized))
             {
                 throw new ItemDoesNotExistException(
-                    $"Aborted as the shop item ({productId}) was failed to get from the shop."
+                    $"{addressesHex}Aborted as the shop item ({productId}) was failed to get from the shop."
                 );
             }
 
@@ -171,21 +180,21 @@ namespace Nekoyume.Action
             if (!shopItem.SellerAgentAddress.Equals(sellerAgentAddress))
             {
                 throw new ItemDoesNotExistException(
-                    $"Aborted as the shop item ({productId}) of seller ({shopItem.SellerAgentAddress}) is different from ({sellerAgentAddress})."
+                    $"{addressesHex}Aborted as the shop item ({productId}) of seller ({shopItem.SellerAgentAddress}) is different from ({sellerAgentAddress})."
                 );
             }
             sw.Stop();
-            Log.Debug($"Buy Get Item: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Buy Get Item: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!states.TryGetAvatarState(sellerAgentAddress, sellerAvatarAddress, out var sellerAvatarState))
             {
                 throw new FailedLoadStateException(
-                    $"Aborted as the seller agent/avatar was failed to load from {sellerAgentAddress}/{sellerAvatarAddress}."
+                    $"{addressesHex}Aborted as the seller agent/avatar was failed to load from {sellerAgentAddress}/{sellerAvatarAddress}."
                 );
             }
             sw.Stop();
-            Log.Debug($"Buy Get Seller AgentAvatarStates: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Buy Get Seller AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             // 돈은 있냐?
@@ -195,7 +204,7 @@ namespace Nekoyume.Action
                 throw new InsufficientBalanceException(
                     ctx.Signer,
                     buyerBalance,
-                    $"Aborted as the buyer ({ctx.Signer}) has no sufficient gold: {buyerBalance} < {shopItem.Price}"
+                    $"{addressesHex}Aborted as the buyer ({ctx.Signer}) has no sufficient gold: {buyerBalance} < {shopItem.Price}"
                 );
             }
 
@@ -256,19 +265,19 @@ namespace Nekoyume.Action
 
             states = states.SetState(sellerAvatarAddress, sellerAvatarState.Serialize());
             sw.Stop();
-            Log.Debug("Buy Set Seller AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Set Seller AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(buyerAvatarAddress, buyerAvatarState.Serialize());
             sw.Stop();
-            Log.Debug("Buy Set Buyer AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Set Buyer AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(ShopState.Address, shopStateDict);
             sw.Stop();
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("Buy Set ShopState: {Elapsed}", sw.Elapsed);
-            Log.Debug("Buy Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}Buy Set ShopState: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Total Executed Time: {Elapsed}", addressesHex, ended - started);
 
             return states;
         }

--- a/Lib9c/Action/Buy.cs
+++ b/Lib9c/Action/Buy.cs
@@ -122,7 +122,7 @@ namespace Nekoyume.Action
                 return states.SetState(ShopState.Address, MarkChanged);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(ctx);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, buyerAvatarAddress, sellerAvatarAddress);
 
             if (ctx.Signer.Equals(sellerAgentAddress))
             {

--- a/Lib9c/Action/Buy2.cs
+++ b/Lib9c/Action/Buy2.cs
@@ -63,7 +63,7 @@ namespace Nekoyume.Action
                 return states.SetState(ShopState.Address, MarkChanged);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(ctx);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, buyerAvatarAddress, sellerAvatarAddress);
 
             if (ctx.Signer.Equals(sellerAgentAddress))
             {

--- a/Lib9c/Action/Buy2.cs
+++ b/Lib9c/Action/Buy2.cs
@@ -62,41 +62,50 @@ namespace Nekoyume.Action
                         GoldCurrencyState.Address);
                 return states.SetState(ShopState.Address, MarkChanged);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(ctx);
 
             if (ctx.Signer.Equals(sellerAgentAddress))
             {
-                throw new InvalidAddressException("Aborted as the signer is the seller.");
+                throw new InvalidAddressException($"{addressesHex}Aborted as the signer is the seller.");
             }
 
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("Buy exec started.");
+            Log.Debug("{AddressesHex}Buy exec started", addressesHex);
 
             if (!states.TryGetAvatarState(ctx.Signer, buyerAvatarAddress, out var buyerAvatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the buyer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the buyer was failed to load.");
             }
             sw.Stop();
-            Log.Debug("Buy Get Buyer AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Get Buyer AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!buyerAvatarState.worldInformation.IsStageCleared(GameConfig.RequireClearedStageLevel.ActionsInShop))
             {
                 buyerAvatarState.worldInformation.TryGetLastClearedStageId(out var current);
-                throw new NotEnoughClearedStageLevelException(GameConfig.RequireClearedStageLevel.ActionsInShop, current);
+                throw new NotEnoughClearedStageLevelException(
+                    addressesHex,
+                    GameConfig.RequireClearedStageLevel.ActionsInShop,
+                    current);
             }
 
             if (!states.TryGetState(ShopState.Address, out Bencodex.Types.Dictionary shopStateDict))
             {
-                throw new FailedLoadStateException("Aborted as the shop state was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the shop state was failed to load.");
             }
 
             sw.Stop();
-            Log.Debug("Buy Get ShopState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Get ShopState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
-            Log.Debug("Execute Buy; buyer: {Buyer} seller: {Seller}", buyerAvatarAddress, sellerAvatarAddress);
+            Log.Debug(
+                "{AddressesHex}Execute Buy; buyer: {Buyer} seller: {Seller}",
+                addressesHex,
+                buyerAvatarAddress,
+                sellerAvatarAddress);
             // 상점에서 구매할 아이템을 찾는다.
             Dictionary products = (Dictionary)shopStateDict["products"];
 
@@ -104,7 +113,7 @@ namespace Nekoyume.Action
             if (!products.ContainsKey(productIdSerialized))
             {
                 throw new ItemDoesNotExistException(
-                    $"Aborted as the shop item ({productId}) was failed to get from the shop."
+                    $"{addressesHex}Aborted as the shop item ({productId}) was failed to get from the shop."
                 );
             }
 
@@ -112,21 +121,21 @@ namespace Nekoyume.Action
             if (!shopItem.SellerAgentAddress.Equals(sellerAgentAddress))
             {
                 throw new ItemDoesNotExistException(
-                    $"Aborted as the shop item ({productId}) of seller ({shopItem.SellerAgentAddress}) is different from ({sellerAgentAddress})."
+                    $"{addressesHex}Aborted as the shop item ({productId}) of seller ({shopItem.SellerAgentAddress}) is different from ({sellerAgentAddress})."
                 );
             }
             sw.Stop();
-            Log.Debug($"Buy Get Item: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Buy Get Item: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!states.TryGetAvatarState(sellerAgentAddress, sellerAvatarAddress, out var sellerAvatarState))
             {
                 throw new FailedLoadStateException(
-                    $"Aborted as the seller agent/avatar was failed to load from {sellerAgentAddress}/{sellerAvatarAddress}."
+                    $"{addressesHex}Aborted as the seller agent/avatar was failed to load from {sellerAgentAddress}/{sellerAvatarAddress}."
                 );
             }
             sw.Stop();
-            Log.Debug($"Buy Get Seller AgentAvatarStates: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Buy Get Seller AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             // 돈은 있냐?
@@ -136,7 +145,7 @@ namespace Nekoyume.Action
                 throw new InsufficientBalanceException(
                     ctx.Signer,
                     buyerBalance,
-                    $"Aborted as the buyer ({ctx.Signer}) has no sufficient gold: {buyerBalance} < {shopItem.Price}"
+                    $"{addressesHex}Aborted as the buyer ({ctx.Signer}) has no sufficient gold: {buyerBalance} < {shopItem.Price}"
                 );
             }
 
@@ -197,19 +206,19 @@ namespace Nekoyume.Action
 
             states = states.SetState(sellerAvatarAddress, sellerAvatarState.Serialize());
             sw.Stop();
-            Log.Debug("Buy Set Seller AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Set Seller AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(buyerAvatarAddress, buyerAvatarState.Serialize());
             sw.Stop();
-            Log.Debug("Buy Set Buyer AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Set Buyer AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(ShopState.Address, shopStateDict);
             sw.Stop();
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("Buy Set ShopState: {Elapsed}", sw.Elapsed);
-            Log.Debug("Buy Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}Buy Set ShopState: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Total Executed Time: {Elapsed}", addressesHex, ended - started);
 
             return states;
         }

--- a/Lib9c/Action/Buy3.cs
+++ b/Lib9c/Action/Buy3.cs
@@ -60,7 +60,7 @@ namespace Nekoyume.Action
                 return states.SetState(ShopState.Address, MarkChanged);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(ctx);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, buyerAvatarAddress, sellerAvatarAddress);
 
             if (ctx.Signer.Equals(sellerAgentAddress))
             {

--- a/Lib9c/Action/Buy3.cs
+++ b/Lib9c/Action/Buy3.cs
@@ -59,41 +59,50 @@ namespace Nekoyume.Action
                         GoldCurrencyState.Address);
                 return states.SetState(ShopState.Address, MarkChanged);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(ctx);
 
             if (ctx.Signer.Equals(sellerAgentAddress))
             {
-                throw new InvalidAddressException("Aborted as the signer is the seller.");
+                throw new InvalidAddressException($"{addressesHex}Aborted as the signer is the seller.");
             }
 
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("Buy exec started.");
+            Log.Debug("{AddressesHex}Buy exec started", addressesHex);
 
             if (!states.TryGetAvatarState(ctx.Signer, buyerAvatarAddress, out var buyerAvatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the buyer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the buyer was failed to load.");
             }
             sw.Stop();
-            Log.Debug("Buy Get Buyer AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Get Buyer AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!buyerAvatarState.worldInformation.IsStageCleared(GameConfig.RequireClearedStageLevel.ActionsInShop))
             {
                 buyerAvatarState.worldInformation.TryGetLastClearedStageId(out var current);
-                throw new NotEnoughClearedStageLevelException(GameConfig.RequireClearedStageLevel.ActionsInShop, current);
+                throw new NotEnoughClearedStageLevelException(
+                    addressesHex,
+                    GameConfig.RequireClearedStageLevel.ActionsInShop,
+                    current);
             }
 
             if (!states.TryGetState(ShopState.Address, out Bencodex.Types.Dictionary shopStateDict))
             {
-                throw new FailedLoadStateException("Aborted as the shop state was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the shop state was failed to load.");
             }
 
             sw.Stop();
-            Log.Debug("Buy Get ShopState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Get ShopState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
-            Log.Debug("Execute Buy; buyer: {Buyer} seller: {Seller}", buyerAvatarAddress, sellerAvatarAddress);
+            Log.Debug(
+                "{AddressesHex}Execute Buy; buyer: {Buyer} seller: {Seller}",
+                addressesHex,
+                buyerAvatarAddress,
+                sellerAvatarAddress);
             // 상점에서 구매할 아이템을 찾는다.
             Dictionary products = (Dictionary)shopStateDict["products"];
 
@@ -101,7 +110,7 @@ namespace Nekoyume.Action
             if (!products.ContainsKey(productIdSerialized))
             {
                 throw new ItemDoesNotExistException(
-                    $"Aborted as the shop item ({productId}) was failed to get from the shop."
+                    $"{addressesHex}Aborted as the shop item ({productId}) was failed to get from the shop."
                 );
             }
 
@@ -109,21 +118,21 @@ namespace Nekoyume.Action
             if (!shopItem.SellerAgentAddress.Equals(sellerAgentAddress))
             {
                 throw new ItemDoesNotExistException(
-                    $"Aborted as the shop item ({productId}) of seller ({shopItem.SellerAgentAddress}) is different from ({sellerAgentAddress})."
+                    $"{addressesHex}Aborted as the shop item ({productId}) of seller ({shopItem.SellerAgentAddress}) is different from ({sellerAgentAddress})."
                 );
             }
             sw.Stop();
-            Log.Debug($"Buy Get Item: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Buy Get Item: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!states.TryGetAvatarState(sellerAgentAddress, sellerAvatarAddress, out var sellerAvatarState))
             {
                 throw new FailedLoadStateException(
-                    $"Aborted as the seller agent/avatar was failed to load from {sellerAgentAddress}/{sellerAvatarAddress}."
+                    $"{addressesHex}Aborted as the seller agent/avatar was failed to load from {sellerAgentAddress}/{sellerAvatarAddress}."
                 );
             }
             sw.Stop();
-            Log.Debug($"Buy Get Seller AgentAvatarStates: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Buy Get Seller AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             // 돈은 있냐?
@@ -133,7 +142,7 @@ namespace Nekoyume.Action
                 throw new InsufficientBalanceException(
                     ctx.Signer,
                     buyerBalance,
-                    $"Aborted as the buyer ({ctx.Signer}) has no sufficient gold: {buyerBalance} < {shopItem.Price}"
+                    $"{addressesHex}Aborted as the buyer ({ctx.Signer}) has no sufficient gold: {buyerBalance} < {shopItem.Price}"
                 );
             }
 
@@ -204,19 +213,19 @@ namespace Nekoyume.Action
 
             states = states.SetState(sellerAvatarAddress, sellerAvatarState.Serialize());
             sw.Stop();
-            Log.Debug("Buy Set Seller AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Set Seller AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(buyerAvatarAddress, buyerAvatarState.Serialize());
             sw.Stop();
-            Log.Debug("Buy Set Buyer AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Set Buyer AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(ShopState.Address, shopStateDict);
             sw.Stop();
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("Buy Set ShopState: {Elapsed}", sw.Elapsed);
-            Log.Debug("Buy Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}Buy Set ShopState: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Total Executed Time: {Elapsed}", addressesHex, ended - started);
 
             return states;
         }

--- a/Lib9c/Action/Buy4.cs
+++ b/Lib9c/Action/Buy4.cs
@@ -59,41 +59,47 @@ namespace Nekoyume.Action
                         GoldCurrencyState.Address);
                 return states.SetState(ShopState.Address, MarkChanged);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(ctx);
 
             if (ctx.Signer.Equals(sellerAgentAddress))
             {
-                throw new InvalidAddressException("Aborted as the signer is the seller.");
+                throw new InvalidAddressException($"{addressesHex}Aborted as the signer is the seller.");
             }
 
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("Buy exec started.");
+            Log.Debug("{AddressesHex}Buy exec started", addressesHex);
 
             if (!states.TryGetAvatarState(ctx.Signer, buyerAvatarAddress, out var buyerAvatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the buyer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the buyer was failed to load.");
             }
             sw.Stop();
-            Log.Debug("Buy Get Buyer AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Get Buyer AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!buyerAvatarState.worldInformation.IsStageCleared(GameConfig.RequireClearedStageLevel.ActionsInShop))
             {
                 buyerAvatarState.worldInformation.TryGetLastClearedStageId(out var current);
-                throw new NotEnoughClearedStageLevelException(GameConfig.RequireClearedStageLevel.ActionsInShop, current);
+                throw new NotEnoughClearedStageLevelException(addressesHex, GameConfig.RequireClearedStageLevel.ActionsInShop, current);
             }
 
             if (!states.TryGetState(ShopState.Address, out Bencodex.Types.Dictionary shopStateDict))
             {
-                throw new FailedLoadStateException("Aborted as the shop state was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the shop state was failed to load.");
             }
 
             sw.Stop();
-            Log.Debug("Buy Get ShopState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Get ShopState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
-            Log.Debug("Execute Buy; buyer: {Buyer} seller: {Seller}", buyerAvatarAddress, sellerAvatarAddress);
+            Log.Debug(
+                "{AddressesHex}Execute Buy; buyer: {Buyer} seller: {Seller}",
+                addressesHex,
+                buyerAvatarAddress,
+                sellerAvatarAddress);
             // 상점에서 구매할 아이템을 찾는다.
             Dictionary products = (Dictionary)shopStateDict["products"];
 
@@ -101,7 +107,7 @@ namespace Nekoyume.Action
             if (!products.ContainsKey(productIdSerialized))
             {
                 throw new ItemDoesNotExistException(
-                    $"Aborted as the shop item ({productId}) was failed to get from the shop."
+                    $"{addressesHex}Aborted as the shop item ({productId}) was failed to get from the shop."
                 );
             }
 
@@ -109,21 +115,21 @@ namespace Nekoyume.Action
             if (!shopItem.SellerAgentAddress.Equals(sellerAgentAddress))
             {
                 throw new ItemDoesNotExistException(
-                    $"Aborted as the shop item ({productId}) of seller ({shopItem.SellerAgentAddress}) is different from ({sellerAgentAddress})."
+                    $"{addressesHex}Aborted as the shop item ({productId}) of seller ({shopItem.SellerAgentAddress}) is different from ({sellerAgentAddress})."
                 );
             }
             sw.Stop();
-            Log.Debug($"Buy Get Item: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Buy Get Item: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!states.TryGetAvatarState(sellerAgentAddress, sellerAvatarAddress, out var sellerAvatarState))
             {
                 throw new FailedLoadStateException(
-                    $"Aborted as the seller agent/avatar was failed to load from {sellerAgentAddress}/{sellerAvatarAddress}."
+                    $"{addressesHex}Aborted as the seller agent/avatar was failed to load from {sellerAgentAddress}/{sellerAvatarAddress}."
                 );
             }
             sw.Stop();
-            Log.Debug($"Buy Get Seller AgentAvatarStates: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Buy Get Seller AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             // 돈은 있냐?
@@ -133,7 +139,7 @@ namespace Nekoyume.Action
                 throw new InsufficientBalanceException(
                     ctx.Signer,
                     buyerBalance,
-                    $"Aborted as the buyer ({ctx.Signer}) has no sufficient gold: {buyerBalance} < {shopItem.Price}"
+                    $"{addressesHex}Aborted as the buyer ({ctx.Signer}) has no sufficient gold: {buyerBalance} < {shopItem.Price}"
                 );
             }
 
@@ -204,19 +210,19 @@ namespace Nekoyume.Action
 
             states = states.SetState(sellerAvatarAddress, sellerAvatarState.Serialize());
             sw.Stop();
-            Log.Debug("Buy Set Seller AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Set Seller AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(buyerAvatarAddress, buyerAvatarState.Serialize());
             sw.Stop();
-            Log.Debug("Buy Set Buyer AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Set Buyer AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(ShopState.Address, shopStateDict);
             sw.Stop();
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("Buy Set ShopState: {Elapsed}", sw.Elapsed);
-            Log.Debug("Buy Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}Buy Set ShopState: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Debug("{AddressesHex}Buy Total Executed Time: {Elapsed}", addressesHex, ended - started);
 
             return states;
         }

--- a/Lib9c/Action/Buy4.cs
+++ b/Lib9c/Action/Buy4.cs
@@ -60,7 +60,7 @@ namespace Nekoyume.Action
                 return states.SetState(ShopState.Address, MarkChanged);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(ctx);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, buyerAvatarAddress, sellerAvatarAddress);
 
             if (ctx.Signer.Equals(sellerAgentAddress))
             {

--- a/Lib9c/Action/ChargeActionPoint.cs
+++ b/Lib9c/Action/ChargeActionPoint.cs
@@ -25,6 +25,8 @@ namespace Nekoyume.Action
             {
                 return states.SetState(avatarAddress, MarkChanged);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(context);
 
             if (!states.TryGetAgentAvatarStates(context.Signer, avatarAddress, out var _, out var avatarState))
             {
@@ -35,7 +37,7 @@ namespace Nekoyume.Action
             var apStone = ItemFactory.CreateMaterial(row);
             if (!avatarState.inventory.RemoveFungibleItem(apStone))
             {
-                Log.Error($"Not enough item {apStone}");
+                Log.Error("{AddressesHex}Not enough item {ApStone}", addressesHex, apStone);
                 return states;
             }
 

--- a/Lib9c/Action/ChargeActionPoint.cs
+++ b/Lib9c/Action/ChargeActionPoint.cs
@@ -26,7 +26,7 @@ namespace Nekoyume.Action
                 return states.SetState(avatarAddress, MarkChanged);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
 
             if (!states.TryGetAgentAvatarStates(context.Signer, avatarAddress, out var _, out var avatarState))
             {

--- a/Lib9c/Action/CombinationConsumable.cs
+++ b/Lib9c/Action/CombinationConsumable.cs
@@ -120,7 +120,7 @@ namespace Nekoyume.Action
                     .SetState(slotAddress, MarkChanged);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
 
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/CombinationConsumable.cs
+++ b/Lib9c/Action/CombinationConsumable.cs
@@ -119,46 +119,50 @@ namespace Nekoyume.Action
                     .SetState(ctx.Signer, MarkChanged)
                     .SetState(slotAddress, MarkChanged);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(context);
 
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("Combination exec started.");
+            Log.Debug("{AddressesHex}Combination exec started", addressesHex);
 
             if (!states.TryGetAvatarState(ctx.Signer, AvatarAddress, out AvatarState avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
 
             sw.Stop();
-            Log.Debug("Combination Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Combination Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!avatarState.worldInformation.IsStageCleared(GameConfig.RequireClearedStageLevel.CombinationEquipmentAction))
             {
                 avatarState.worldInformation.TryGetLastClearedStageId(out var current);
                 throw new NotEnoughClearedStageLevelException(
-                    GameConfig.RequireClearedStageLevel.CombinationEquipmentAction, current);
+                    addressesHex,
+                    GameConfig.RequireClearedStageLevel.CombinationEquipmentAction,
+                    current);
             }
 
             var slotState = states.GetCombinationSlotState(AvatarAddress, slotIndex);
             if (slotState is null)
             {
-                throw new FailedLoadStateException($"Aborted as the slot state is failed to load: # {slotIndex}");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the slot state is failed to load: # {slotIndex}");
             }
 
             if(!slotState.Validate(avatarState, ctx.BlockIndex))
             {
                 throw new CombinationSlotUnlockException(
-                    $"Aborted as the slot state is invalid: {slotState} @ {slotIndex}");
+                    $"{addressesHex}Aborted as the slot state is invalid: {slotState} @ {slotIndex}");
             }
 
-            Log.Debug("Execute Combination; player: {Player}", AvatarAddress);
+            Log.Debug("{AddressesHex}Execute Combination; player: {Player}", addressesHex, AvatarAddress);
             var consumableItemSheet = states.GetSheet<ConsumableItemSheet>();
             var recipeRow = states.GetSheet<ConsumableItemRecipeSheet>().Values.FirstOrDefault(r => r.Id == recipeId);
             if (recipeRow is null)
             {
-                throw new SheetRowNotFoundException(nameof(ConsumableItemRecipeSheet), recipeId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(ConsumableItemRecipeSheet), recipeId);
             }
             var materials = new Dictionary<Material, int>();
             foreach (var materialInfo in recipeRow.Materials.OrderBy(r => r.Id))
@@ -175,12 +179,12 @@ namespace Nekoyume.Action
                 else
                 {
                     throw new NotEnoughMaterialException(
-                        $"Aborted as the player has no enough material ({materialId} * {count})");
+                        $"{addressesHex}Aborted as the player has no enough material ({materialId} * {count})");
                 }
             }
 
             sw.Stop();
-            Log.Debug("Combination Remove Materials: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Combination Remove Materials: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var result = new ResultModel
@@ -194,7 +198,7 @@ namespace Nekoyume.Action
             if (avatarState.actionPoint < costAP)
             {
                 throw new NotEnoughActionPointException(
-                    $"Aborted due to insufficient action point: {avatarState.actionPoint} < {costAP}"
+                    $"{addressesHex}Aborted due to insufficient action point: {avatarState.actionPoint} < {costAP}"
                 );
             }
 
@@ -204,13 +208,13 @@ namespace Nekoyume.Action
 
             var resultConsumableItemId = recipeRow.ResultConsumableItemId;
             sw.Stop();
-            Log.Debug("Combination Get Food id: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Combination Get Food id: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
             result.recipeId = recipeRow.Id;
 
             if (!consumableItemSheet.TryGetValue(resultConsumableItemId, out var consumableItemRow))
             {
-                throw new SheetRowNotFoundException(nameof(ConsumableItemSheet), resultConsumableItemId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(ConsumableItemSheet), resultConsumableItemId);
             }
 
             // 조합 결과 획득.
@@ -229,7 +233,7 @@ namespace Nekoyume.Action
             avatarState.Update(mail);
             avatarState.UpdateFromCombination(itemUsable);
             sw.Stop();
-            Log.Debug("Combination Update AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Combination Update AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var materialSheet = states.GetSheet<MaterialItemSheet>();
@@ -240,9 +244,9 @@ namespace Nekoyume.Action
             states = states.SetState(AvatarAddress, avatarState.Serialize());
             slotState.Update(result, ctx.BlockIndex, requiredBlockIndex);
             sw.Stop();
-            Log.Debug("Combination Set AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Combination Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("Combination Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}Combination Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(slotAddress, slotState.Serialize());
         }

--- a/Lib9c/Action/CombinationConsumable2.cs
+++ b/Lib9c/Action/CombinationConsumable2.cs
@@ -78,7 +78,7 @@ namespace Nekoyume.Action
                     .SetState(slotAddress, MarkChanged);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
 
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/CombinationConsumable2.cs
+++ b/Lib9c/Action/CombinationConsumable2.cs
@@ -77,46 +77,50 @@ namespace Nekoyume.Action
                     .SetState(ctx.Signer, MarkChanged)
                     .SetState(slotAddress, MarkChanged);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(context);
 
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("Combination exec started.");
+            Log.Debug("{AddressesHex}Combination exec started", addressesHex);
 
             if (!states.TryGetAvatarState(ctx.Signer, AvatarAddress, out AvatarState avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
 
             sw.Stop();
-            Log.Debug("Combination Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Combination Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!avatarState.worldInformation.IsStageCleared(GameConfig.RequireClearedStageLevel.CombinationEquipmentAction))
             {
                 avatarState.worldInformation.TryGetLastClearedStageId(out var current);
                 throw new NotEnoughClearedStageLevelException(
-                    GameConfig.RequireClearedStageLevel.CombinationEquipmentAction, current);
+                    addressesHex,
+                    GameConfig.RequireClearedStageLevel.CombinationEquipmentAction,
+                    current);
             }
 
             var slotState = states.GetCombinationSlotState(AvatarAddress, slotIndex);
             if (slotState is null)
             {
-                throw new FailedLoadStateException($"Aborted as the slot state is failed to load: # {slotIndex}");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the slot state is failed to load: # {slotIndex}");
             }
 
             if(!slotState.Validate(avatarState, ctx.BlockIndex))
             {
                 throw new CombinationSlotUnlockException(
-                    $"Aborted as the slot state is invalid: {slotState} @ {slotIndex}");
+                    $"{addressesHex}Aborted as the slot state is invalid: {slotState} @ {slotIndex}");
             }
 
-            Log.Debug("Execute Combination; player: {Player}", AvatarAddress);
+            Log.Debug("{AddressesHex}Execute Combination; player: {Player}", addressesHex, AvatarAddress);
             var consumableItemSheet = states.GetSheet<ConsumableItemSheet>();
             var recipeRow = states.GetSheet<ConsumableItemRecipeSheet>().Values.FirstOrDefault(r => r.Id == recipeId);
             if (recipeRow is null)
             {
-                throw new SheetRowNotFoundException(nameof(ConsumableItemRecipeSheet), recipeId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(ConsumableItemRecipeSheet), recipeId);
             }
             var materials = new Dictionary<Material, int>();
             foreach (var materialInfo in recipeRow.Materials.OrderBy(r => r.Id))
@@ -133,12 +137,12 @@ namespace Nekoyume.Action
                 else
                 {
                     throw new NotEnoughMaterialException(
-                        $"Aborted as the player has no enough material ({materialId} * {count})");
+                        $"{addressesHex}Aborted as the player has no enough material ({materialId} * {count})");
                 }
             }
 
             sw.Stop();
-            Log.Debug("Combination Remove Materials: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Combination Remove Materials: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var result = new CombinationConsumable.ResultModel
@@ -152,7 +156,7 @@ namespace Nekoyume.Action
             if (avatarState.actionPoint < costAP)
             {
                 throw new NotEnoughActionPointException(
-                    $"Aborted due to insufficient action point: {avatarState.actionPoint} < {costAP}"
+                    $"{addressesHex}Aborted due to insufficient action point: {avatarState.actionPoint} < {costAP}"
                 );
             }
 
@@ -162,13 +166,13 @@ namespace Nekoyume.Action
 
             var resultConsumableItemId = recipeRow.ResultConsumableItemId;
             sw.Stop();
-            Log.Debug("Combination Get Food id: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Combination Get Food id: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
             result.recipeId = recipeRow.Id;
 
             if (!consumableItemSheet.TryGetValue(resultConsumableItemId, out var consumableItemRow))
             {
-                throw new SheetRowNotFoundException(nameof(ConsumableItemSheet), resultConsumableItemId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(ConsumableItemSheet), resultConsumableItemId);
             }
 
             // 조합 결과 획득.
@@ -187,7 +191,7 @@ namespace Nekoyume.Action
             avatarState.UpdateV2(mail);
             avatarState.UpdateFromCombination(itemUsable);
             sw.Stop();
-            Log.Debug("Combination Update AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Combination Update AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var materialSheet = states.GetSheet<MaterialItemSheet>();
@@ -198,9 +202,9 @@ namespace Nekoyume.Action
             states = states.SetState(AvatarAddress, avatarState.Serialize());
             slotState.Update(result, ctx.BlockIndex, requiredBlockIndex);
             sw.Stop();
-            Log.Debug("Combination Set AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Combination Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("Combination Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}Combination Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(slotAddress, slotState.Serialize());
         }

--- a/Lib9c/Action/CombinationConsumable3.cs
+++ b/Lib9c/Action/CombinationConsumable3.cs
@@ -78,7 +78,7 @@ namespace Nekoyume.Action
                     .SetState(slotAddress, MarkChanged);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
 
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/CombinationConsumable3.cs
+++ b/Lib9c/Action/CombinationConsumable3.cs
@@ -77,46 +77,50 @@ namespace Nekoyume.Action
                     .SetState(ctx.Signer, MarkChanged)
                     .SetState(slotAddress, MarkChanged);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(context);
 
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("Combination exec started.");
+            Log.Debug("{AddressesHex}Combination exec started.", addressesHex);
 
             if (!states.TryGetAvatarState(ctx.Signer, AvatarAddress, out AvatarState avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
 
             sw.Stop();
-            Log.Debug("Combination Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Combination Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!avatarState.worldInformation.IsStageCleared(GameConfig.RequireClearedStageLevel.CombinationEquipmentAction))
             {
                 avatarState.worldInformation.TryGetLastClearedStageId(out var current);
                 throw new NotEnoughClearedStageLevelException(
-                    GameConfig.RequireClearedStageLevel.CombinationEquipmentAction, current);
+                    addressesHex,
+                    GameConfig.RequireClearedStageLevel.CombinationEquipmentAction,
+                    current);
             }
 
             var slotState = states.GetCombinationSlotState(AvatarAddress, slotIndex);
             if (slotState is null)
             {
-                throw new FailedLoadStateException($"Aborted as the slot state is failed to load: # {slotIndex}");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the slot state is failed to load: # {slotIndex}");
             }
 
             if(!slotState.Validate(avatarState, ctx.BlockIndex))
             {
                 throw new CombinationSlotUnlockException(
-                    $"Aborted as the slot state is invalid: {slotState} @ {slotIndex}");
+                    $"{addressesHex}Aborted as the slot state is invalid: {slotState} @ {slotIndex}");
             }
 
-            Log.Debug("Execute Combination; player: {Player}", AvatarAddress);
+            Log.Debug("{AddressesHex}Execute Combination; player: {Player}", addressesHex, AvatarAddress);
             var consumableItemSheet = states.GetSheet<ConsumableItemSheet>();
             var recipeRow = states.GetSheet<ConsumableItemRecipeSheet>().Values.FirstOrDefault(r => r.Id == recipeId);
             if (recipeRow is null)
             {
-                throw new SheetRowNotFoundException(nameof(ConsumableItemRecipeSheet), recipeId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(ConsumableItemRecipeSheet), recipeId);
             }
             var materials = new Dictionary<Material, int>();
             foreach (var materialInfo in recipeRow.Materials.OrderBy(r => r.Id))
@@ -133,12 +137,12 @@ namespace Nekoyume.Action
                 else
                 {
                     throw new NotEnoughMaterialException(
-                        $"Aborted as the player has no enough material ({materialId} * {count})");
+                        $"{addressesHex}Aborted as the player has no enough material ({materialId} * {count})");
                 }
             }
 
             sw.Stop();
-            Log.Debug("Combination Remove Materials: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Combination Remove Materials: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var result = new CombinationConsumable.ResultModel
@@ -152,7 +156,7 @@ namespace Nekoyume.Action
             if (avatarState.actionPoint < costAP)
             {
                 throw new NotEnoughActionPointException(
-                    $"Aborted due to insufficient action point: {avatarState.actionPoint} < {costAP}"
+                    $"{addressesHex}Aborted due to insufficient action point: {avatarState.actionPoint} < {costAP}"
                 );
             }
 
@@ -162,13 +166,13 @@ namespace Nekoyume.Action
 
             var resultConsumableItemId = recipeRow.ResultConsumableItemId;
             sw.Stop();
-            Log.Debug("Combination Get Food id: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Combination Get Food id: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
             result.recipeId = recipeRow.Id;
 
             if (!consumableItemSheet.TryGetValue(resultConsumableItemId, out var consumableItemRow))
             {
-                throw new SheetRowNotFoundException(nameof(ConsumableItemSheet), resultConsumableItemId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(ConsumableItemSheet), resultConsumableItemId);
             }
 
             // 조합 결과 획득.
@@ -187,7 +191,7 @@ namespace Nekoyume.Action
             avatarState.UpdateV3(mail);
             avatarState.UpdateFromCombination(itemUsable);
             sw.Stop();
-            Log.Debug("Combination Update AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Combination Update AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var materialSheet = states.GetSheet<MaterialItemSheet>();
@@ -198,9 +202,9 @@ namespace Nekoyume.Action
             states = states.SetState(AvatarAddress, avatarState.Serialize());
             slotState.Update(result, ctx.BlockIndex, requiredBlockIndex);
             sw.Stop();
-            Log.Debug("Combination Set AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Combination Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("Combination Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}Combination Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(slotAddress, slotState.Serialize());
         }

--- a/Lib9c/Action/CombinationEquipment.cs
+++ b/Lib9c/Action/CombinationEquipment.cs
@@ -48,23 +48,25 @@ namespace Nekoyume.Action
                     .SetState(ctx.Signer, MarkChanged)
                     .MarkBalanceChanged(GoldCurrencyMock, ctx.Signer, BlacksmithAddress);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(context);
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, AvatarAddress, out var agentState,
                 out var avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
 
             var slotState = states.GetCombinationSlotState(AvatarAddress, SlotIndex);
             if (slotState is null)
             {
-                throw new FailedLoadStateException("Aborted as the slot state is failed to load");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the slot state is failed to load");
             }
 
             if (!slotState.Validate(avatarState, ctx.BlockIndex))
             {
                 throw new CombinationSlotUnlockException(
-                    $"Aborted as the slot state is invalid: {slotState} @ {SlotIndex}");
+                    $"{addressesHex}Aborted as the slot state is invalid: {slotState} @ {SlotIndex}");
             }
 
             var recipeSheet = states.GetSheet<EquipmentItemRecipeSheet>();
@@ -74,7 +76,7 @@ namespace Nekoyume.Action
             // 레시피 검증
             if (!recipeSheet.TryGetValue(RecipeId, out var recipe))
             {
-                throw new SheetRowNotFoundException(nameof(EquipmentItemRecipeSheet), RecipeId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(EquipmentItemRecipeSheet), RecipeId);
             }
 
             if (!(SubRecipeId is null))
@@ -82,7 +84,7 @@ namespace Nekoyume.Action
                 if (!recipe.SubRecipeIds.Contains((int) SubRecipeId))
                 {
                     throw new SheetRowColumnException(
-                        $"Aborted as the sub recipe {SubRecipeId} was failed to load from the sheet."
+                        $"{addressesHex}Aborted as the sub recipe {SubRecipeId} was failed to load from the sheet."
                     );
                 }
             }
@@ -91,18 +93,18 @@ namespace Nekoyume.Action
             if (!avatarState.worldInformation.IsStageCleared(recipe.UnlockStage))
             {
                 avatarState.worldInformation.TryGetLastClearedStageId(out var current);
-                throw new NotEnoughClearedStageLevelException(recipe.UnlockStage, current);
+                throw new NotEnoughClearedStageLevelException(addressesHex, recipe.UnlockStage, current);
             }
 
             if (!materialSheet.TryGetValue(recipe.MaterialId, out var material))
             {
-                throw new SheetRowNotFoundException(nameof(MaterialItemSheet), recipe.MaterialId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(MaterialItemSheet), recipe.MaterialId);
             }
 
             if (!avatarState.inventory.RemoveMaterial(material.ItemId, recipe.MaterialCount))
             {
                 throw new NotEnoughMaterialException(
-                    $"Aborted as the player has no enough material ({material} * {recipe.MaterialCount})"
+                    $"{addressesHex}Aborted as the player has no enough material ({material} * {recipe.MaterialCount})"
                 );
             }
 
@@ -116,7 +118,7 @@ namespace Nekoyume.Action
             // 장비 제작
             if (!equipmentItemSheet.TryGetValue(recipe.ResultEquipmentId, out var equipRow))
             {
-                throw new SheetRowNotFoundException(nameof(equipmentItemSheet), recipe.ResultEquipmentId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(equipmentItemSheet), recipe.ResultEquipmentId);
             }
 
             var requiredBlockIndex = ctx.BlockIndex + recipe.RequiredBlockIndex;
@@ -134,7 +136,7 @@ namespace Nekoyume.Action
                 var subId = (int) SubRecipeId;
                 if (!subSheet.TryGetValue(subId, out var subRecipe))
                 {
-                    throw new SheetRowNotFoundException(nameof(EquipmentItemSubRecipeSheet), subId);
+                    throw new SheetRowNotFoundException(addressesHex, nameof(EquipmentItemSubRecipeSheet), subId);
                 }
 
                 requiredBlockIndex += subRecipe.RequiredBlockIndex;
@@ -145,14 +147,14 @@ namespace Nekoyume.Action
                 {
                     if (!materialSheet.TryGetValue(materialInfo.Id, out var subMaterialRow))
                     {
-                        throw new SheetRowNotFoundException(nameof(MaterialItemSheet), materialInfo.Id);
+                        throw new SheetRowNotFoundException(addressesHex, nameof(MaterialItemSheet), materialInfo.Id);
                     }
 
                     if (!avatarState.inventory.RemoveMaterial(subMaterialRow.ItemId,
                         materialInfo.Count))
                     {
                         throw new NotEnoughMaterialException(
-                            $"Aborted as the player has no enough material ({subMaterialRow} * {materialInfo.Count})"
+                            $"{addressesHex}Aborted as the player has no enough material ({subMaterialRow} * {materialInfo.Count})"
                         );
                     }
 
@@ -170,7 +172,7 @@ namespace Nekoyume.Action
             if (agentBalance < (states.GetGoldCurrency() * requiredGold) || avatarState.actionPoint < requiredActionPoint)
             {
                 throw new NotEnoughActionPointException(
-                    $"Aborted due to insufficient action point: {avatarState.actionPoint} < {requiredActionPoint}"
+                    $"{addressesHex}Aborted due to insufficient action point: {avatarState.actionPoint} < {requiredActionPoint}"
                 );
             }
 

--- a/Lib9c/Action/CombinationEquipment.cs
+++ b/Lib9c/Action/CombinationEquipment.cs
@@ -49,7 +49,7 @@ namespace Nekoyume.Action
                     .MarkBalanceChanged(GoldCurrencyMock, ctx.Signer, BlacksmithAddress);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, AvatarAddress, out var agentState,
                 out var avatarState))

--- a/Lib9c/Action/CombinationEquipment2.cs
+++ b/Lib9c/Action/CombinationEquipment2.cs
@@ -48,23 +48,25 @@ namespace Nekoyume.Action
                     .SetState(ctx.Signer, MarkChanged)
                     .MarkBalanceChanged(GoldCurrencyMock, ctx.Signer, BlacksmithAddress);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(context);
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, AvatarAddress, out var agentState,
                 out var avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
 
             var slotState = states.GetCombinationSlotState(AvatarAddress, SlotIndex);
             if (slotState is null)
             {
-                throw new FailedLoadStateException("Aborted as the slot state is failed to load");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the slot state is failed to load");
             }
 
             if (!slotState.Validate(avatarState, ctx.BlockIndex))
             {
                 throw new CombinationSlotUnlockException(
-                    $"Aborted as the slot state is invalid: {slotState} @ {SlotIndex}");
+                    $"{addressesHex}Aborted as the slot state is invalid: {slotState} @ {SlotIndex}");
             }
 
             var recipeSheet = states.GetSheet<EquipmentItemRecipeSheet>();
@@ -74,7 +76,7 @@ namespace Nekoyume.Action
             // 레시피 검증
             if (!recipeSheet.TryGetValue(RecipeId, out var recipe))
             {
-                throw new SheetRowNotFoundException(nameof(EquipmentItemRecipeSheet), RecipeId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(EquipmentItemRecipeSheet), RecipeId);
             }
 
             if (!(SubRecipeId is null))
@@ -82,7 +84,7 @@ namespace Nekoyume.Action
                 if (!recipe.SubRecipeIds.Contains((int) SubRecipeId))
                 {
                     throw new SheetRowColumnException(
-                        $"Aborted as the sub recipe {SubRecipeId} was failed to load from the sheet."
+                        $"{addressesHex}Aborted as the sub recipe {SubRecipeId} was failed to load from the sheet."
                     );
                 }
             }
@@ -91,18 +93,18 @@ namespace Nekoyume.Action
             if (!avatarState.worldInformation.IsStageCleared(recipe.UnlockStage))
             {
                 avatarState.worldInformation.TryGetLastClearedStageId(out var current);
-                throw new NotEnoughClearedStageLevelException(recipe.UnlockStage, current);
+                throw new NotEnoughClearedStageLevelException(addressesHex, recipe.UnlockStage, current);
             }
 
             if (!materialSheet.TryGetValue(recipe.MaterialId, out var material))
             {
-                throw new SheetRowNotFoundException(nameof(MaterialItemSheet), recipe.MaterialId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(MaterialItemSheet), recipe.MaterialId);
             }
 
             if (!avatarState.inventory.RemoveMaterial(material.ItemId, recipe.MaterialCount))
             {
                 throw new NotEnoughMaterialException(
-                    $"Aborted as the player has no enough material ({material} * {recipe.MaterialCount})"
+                    $"{addressesHex}Aborted as the player has no enough material ({material} * {recipe.MaterialCount})"
                 );
             }
 
@@ -116,7 +118,7 @@ namespace Nekoyume.Action
             // 장비 제작
             if (!equipmentItemSheet.TryGetValue(recipe.ResultEquipmentId, out var equipRow))
             {
-                throw new SheetRowNotFoundException(nameof(equipmentItemSheet), recipe.ResultEquipmentId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(equipmentItemSheet), recipe.ResultEquipmentId);
             }
 
             var requiredBlockIndex = ctx.BlockIndex + recipe.RequiredBlockIndex;
@@ -134,7 +136,7 @@ namespace Nekoyume.Action
                 var subId = (int) SubRecipeId;
                 if (!subSheet.TryGetValue(subId, out var subRecipe))
                 {
-                    throw new SheetRowNotFoundException(nameof(EquipmentItemSubRecipeSheet), subId);
+                    throw new SheetRowNotFoundException(addressesHex, nameof(EquipmentItemSubRecipeSheet), subId);
                 }
 
                 requiredBlockIndex += subRecipe.RequiredBlockIndex;
@@ -145,14 +147,14 @@ namespace Nekoyume.Action
                 {
                     if (!materialSheet.TryGetValue(materialInfo.Id, out var subMaterialRow))
                     {
-                        throw new SheetRowNotFoundException(nameof(MaterialItemSheet), materialInfo.Id);
+                        throw new SheetRowNotFoundException(addressesHex, nameof(MaterialItemSheet), materialInfo.Id);
                     }
 
                     if (!avatarState.inventory.RemoveMaterial(subMaterialRow.ItemId,
                         materialInfo.Count))
                     {
                         throw new NotEnoughMaterialException(
-                            $"Aborted as the player has no enough material ({subMaterialRow} * {materialInfo.Count})"
+                            $"{addressesHex}Aborted as the player has no enough material ({subMaterialRow} * {materialInfo.Count})"
                         );
                     }
 
@@ -170,7 +172,7 @@ namespace Nekoyume.Action
             if (agentBalance < (states.GetGoldCurrency() * requiredGold) || avatarState.actionPoint < requiredActionPoint)
             {
                 throw new NotEnoughActionPointException(
-                    $"Aborted due to insufficient action point: {avatarState.actionPoint} < {requiredActionPoint}"
+                    $"{addressesHex}Aborted due to insufficient action point: {avatarState.actionPoint} < {requiredActionPoint}"
                 );
             }
 

--- a/Lib9c/Action/CombinationEquipment2.cs
+++ b/Lib9c/Action/CombinationEquipment2.cs
@@ -49,7 +49,7 @@ namespace Nekoyume.Action
                     .MarkBalanceChanged(GoldCurrencyMock, ctx.Signer, BlacksmithAddress);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, AvatarAddress, out var agentState,
                 out var avatarState))

--- a/Lib9c/Action/CombinationEquipment3.cs
+++ b/Lib9c/Action/CombinationEquipment3.cs
@@ -49,7 +49,7 @@ namespace Nekoyume.Action
                     .MarkBalanceChanged(GoldCurrencyMock, ctx.Signer, BlacksmithAddress);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, AvatarAddress, out var agentState,
                 out var avatarState))

--- a/Lib9c/Action/CombinationEquipment4.cs
+++ b/Lib9c/Action/CombinationEquipment4.cs
@@ -49,7 +49,7 @@ namespace Nekoyume.Action
                     .MarkBalanceChanged(GoldCurrencyMock, ctx.Signer, BlacksmithAddress);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, AvatarAddress, out var agentState,
                 out var avatarState))

--- a/Lib9c/Action/CreateAvatar.cs
+++ b/Lib9c/Action/CreateAvatar.cs
@@ -75,44 +75,50 @@ namespace Nekoyume.Action
                     .SetState(Addresses.Ranking, MarkChanged)
                     .MarkBalanceChanged(GoldCurrencyMock, GoldCurrencyState.Address, context.Signer);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(context);
 
-            Log.Warning($"{nameof(CreateAvatar)} is deprecated. Please use ${nameof(CreateAvatar2)}");
+            Log.Warning(
+                "{AddressesHex}{CreateAvatar} is deprecated. Please use {CreateAvatar2}",
+                addressesHex,
+                nameof(CreateAvatar),
+                nameof(CreateAvatar2));
 
             if (!Regex.IsMatch(name, GameConfig.AvatarNickNamePattern))
             {
                 throw new InvalidNamePatternException(
-                    $"Aborted as the input name {name} does not follow the allowed name pattern.");
+                    $"{addressesHex}Aborted as the input name {name} does not follow the allowed name pattern.");
             }
 
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("CreateAvatar exec started.");
+            Log.Debug("{AddressesHex}CreateAvatar exec started", addressesHex);
             AgentState existingAgentState = states.GetAgentState(ctx.Signer);
             var agentState = existingAgentState ?? new AgentState(ctx.Signer);
             var avatarState = states.GetAvatarState(avatarAddress);
             if (!(avatarState is null))
             {
                 throw new InvalidAddressException(
-                    $"Aborted as there is already an avatar at {avatarAddress}.");
+                    $"{addressesHex}Aborted as there is already an avatar at {avatarAddress}.");
             }
 
             if (!(0 <= index && index < GameConfig.SlotCount))
             {
                 throw new AvatarIndexOutOfRangeException(
-                    $"Aborted as the index is out of range #{index}.");
+                    $"{addressesHex}Aborted as the index is out of range #{index}.");
             }
 
             if (agentState.avatarAddresses.ContainsKey(index))
             {
                 throw new AvatarIndexAlreadyUsedException(
-                    $"Aborted as the signer already has an avatar at index #{index}.");
+                    $"{addressesHex}Aborted as the signer already has an avatar at index #{index}.");
             }
             sw.Stop();
-            Log.Debug("CreateAvatar Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}CreateAvatar Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
-            Log.Debug("Execute CreateAvatar; player: {AvatarAddress}", avatarAddress);
+            Log.Debug("{AddressesHex}Execute CreateAvatar; player: {AvatarAddress}", addressesHex, avatarAddress);
 
             agentState.avatarAddresses.Add(index, avatarAddress);
 
@@ -142,9 +148,9 @@ namespace Nekoyume.Action
             avatarState.UpdateQuestRewards(materialItemSheet);
 
             sw.Stop();
-            Log.Debug("CreateAvatar CreateAvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}CreateAvatar CreateAvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("CreateAvatar Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}CreateAvatar Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(ctx.Signer, agentState.Serialize())
                 .SetState(Addresses.Ranking, rankingState.Serialize())

--- a/Lib9c/Action/CreateAvatar.cs
+++ b/Lib9c/Action/CreateAvatar.cs
@@ -76,13 +76,9 @@ namespace Nekoyume.Action
                     .MarkBalanceChanged(GoldCurrencyMock, GoldCurrencyState.Address, context.Signer);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
 
-            Log.Warning(
-                "{AddressesHex}{CreateAvatar} is deprecated. Please use {CreateAvatar2}",
-                addressesHex,
-                nameof(CreateAvatar),
-                nameof(CreateAvatar2));
+            Log.Warning("{AddressesHex}create_avatar is deprecated. Please use create_avatar2", addressesHex);
 
             if (!Regex.IsMatch(name, GameConfig.AvatarNickNamePattern))
             {

--- a/Lib9c/Action/CreateAvatar2.cs
+++ b/Lib9c/Action/CreateAvatar2.cs
@@ -80,42 +80,44 @@ namespace Nekoyume.Action
                     .SetState(Addresses.Ranking, MarkChanged)
                     .MarkBalanceChanged(GoldCurrencyMock, GoldCurrencyState.Address, context.Signer);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(context);
 
             if (!Regex.IsMatch(name, GameConfig.AvatarNickNamePattern))
             {
                 throw new InvalidNamePatternException(
-                    $"Aborted as the input name {name} does not follow the allowed name pattern.");
+                    $"{addressesHex}Aborted as the input name {name} does not follow the allowed name pattern.");
             }
 
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("CreateAvatar exec started.");
+            Log.Debug("{AddressesHex}CreateAvatar exec started", addressesHex);
             AgentState existingAgentState = states.GetAgentState(ctx.Signer);
             var agentState = existingAgentState ?? new AgentState(ctx.Signer);
             var avatarState = states.GetAvatarState(avatarAddress);
             if (!(avatarState is null))
             {
                 throw new InvalidAddressException(
-                    $"Aborted as there is already an avatar at {avatarAddress}.");
+                    $"{addressesHex}Aborted as there is already an avatar at {avatarAddress}.");
             }
 
             if (!(0 <= index && index < GameConfig.SlotCount))
             {
                 throw new AvatarIndexOutOfRangeException(
-                    $"Aborted as the index is out of range #{index}.");
+                    $"{addressesHex}Aborted as the index is out of range #{index}.");
             }
 
             if (agentState.avatarAddresses.ContainsKey(index))
             {
                 throw new AvatarIndexAlreadyUsedException(
-                    $"Aborted as the signer already has an avatar at index #{index}.");
+                    $"{addressesHex}Aborted as the signer already has an avatar at index #{index}.");
             }
             sw.Stop();
-            Log.Debug("CreateAvatar Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}CreateAvatar Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
-            Log.Debug("Execute CreateAvatar; player: {AvatarAddress}", avatarAddress);
+            Log.Debug("{AddressesHex}Execute CreateAvatar; player: {AvatarAddress}", addressesHex, avatarAddress);
 
             agentState.avatarAddresses.Add(index, avatarAddress);
 
@@ -145,9 +147,9 @@ namespace Nekoyume.Action
             avatarState.UpdateQuestRewards(materialItemSheet);
 
             sw.Stop();
-            Log.Debug("CreateAvatar CreateAvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}CreateAvatar CreateAvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("CreateAvatar Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}CreateAvatar Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(ctx.Signer, agentState.Serialize())
                 .SetState(Addresses.Ranking, rankingState.Serialize())

--- a/Lib9c/Action/CreateAvatar2.cs
+++ b/Lib9c/Action/CreateAvatar2.cs
@@ -81,7 +81,7 @@ namespace Nekoyume.Action
                     .MarkBalanceChanged(GoldCurrencyMock, GoldCurrencyState.Address, context.Signer);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
 
             if (!Regex.IsMatch(name, GameConfig.AvatarNickNamePattern))
             {

--- a/Lib9c/Action/DailyReward.cs
+++ b/Lib9c/Action/DailyReward.cs
@@ -22,16 +22,18 @@ namespace Nekoyume.Action
             {
                 return states.SetState(avatarAddress, MarkChanged);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(context);
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, avatarAddress, out _, out AvatarState avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
 
             var gameConfigState = states.GetGameConfigState();
             if (gameConfigState is null)
             {
-                throw new FailedLoadStateException("Aborted as the game config was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the game config was failed to load.");
             }
 
             if (ctx.BlockIndex - avatarState.dailyRewardReceivedIndex >= gameConfigState.DailyRewardInterval)

--- a/Lib9c/Action/DailyReward.cs
+++ b/Lib9c/Action/DailyReward.cs
@@ -23,7 +23,7 @@ namespace Nekoyume.Action
                 return states.SetState(avatarAddress, MarkChanged);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, avatarAddress, out _, out AvatarState avatarState))
             {

--- a/Lib9c/Action/HackAndSlash.cs
+++ b/Lib9c/Action/HackAndSlash.cs
@@ -67,12 +67,18 @@ namespace Nekoyume.Action
                 states = states.SetState(WeeklyArenaAddress, MarkChanged);
                 return states.SetState(ctx.Signer, MarkChanged);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(context);
 
-            Log.Warning($"{nameof(HackAndSlash)} is deprecated. Please use ${nameof(HackAndSlash2)}");
+            Log.Warning(
+                "{AddressesHex}{HackAndSlash} is deprecated. Please use {HackAndSlash2}",
+                addressesHex,
+                nameof(HackAndSlash),
+                nameof(HackAndSlash2));
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("HAS exec started.");
+            Log.Debug("{AddressesHex}HAS exec started", addressesHex);
 
             if (!states.TryGetAgentAvatarStates(
                 ctx.Signer,
@@ -80,17 +86,17 @@ namespace Nekoyume.Action
                 out AgentState agentState,
                 out AvatarState avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
 
             sw.Stop();
-            Log.Debug("HAS Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
 
             if (avatarState.RankingMapAddress != RankingMapAddress)
             {
-                throw new InvalidAddressException("Invalid ranking map address");
+                throw new InvalidAddressException($"{addressesHex}Invalid ranking map address");
             }
 
             // worldId와 stageId가 유효한지 확인합니다.
@@ -98,21 +104,21 @@ namespace Nekoyume.Action
 
             if (!worldSheet.TryGetValue(worldId, out var worldRow, false))
             {
-                throw new SheetRowNotFoundException(nameof(WorldSheet), worldId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(WorldSheet), worldId);
             }
 
             if (stageId < worldRow.StageBegin ||
                 stageId > worldRow.StageEnd)
             {
                 throw new SheetRowColumnException(
-                    $"{worldId} world is not contains {worldRow.Id} stage: " +
+                    $"{addressesHex}{worldId} world is not contains {worldRow.Id} stage: " +
                     $"{worldRow.StageBegin}-{worldRow.StageEnd}");
             }
 
             var stageSheet = states.GetSheet<StageSheet>();
             if (!stageSheet.TryGetValue(stageId, out var stageRow))
             {
-                throw new SheetRowNotFoundException(nameof(StageSheet), stageId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(StageSheet), stageId);
             }
 
             var worldInformation = avatarState.worldInformation;
@@ -124,7 +130,7 @@ namespace Nekoyume.Action
 
             if (!world.IsUnlocked)
             {
-                throw new InvalidWorldException($"{worldId} is locked.");
+                throw new InvalidWorldException($"{addressesHex}{worldId} is locked.");
             }
 
             if (world.StageBegin != worldRow.StageBegin ||
@@ -137,7 +143,7 @@ namespace Nekoyume.Action
                 !world.IsStageCleared && stageId != world.StageBegin)
             {
                 throw new InvalidStageException(
-                    $"Aborted as the stage ({worldId}/{stageId}) is not cleared; " +
+                    $"{addressesHex}Aborted as the stage ({worldId}/{stageId}) is not cleared; " +
                     $"cleared stage: {world.StageClearedId}"
                 );
             }
@@ -149,7 +155,7 @@ namespace Nekoyume.Action
             if (avatarState.actionPoint < stageRow.CostAP)
             {
                 throw new NotEnoughActionPointException(
-                    $"Aborted due to insufficient action point: " +
+                    $"{addressesHex}Aborted due to insufficient action point: " +
                     $"{avatarState.actionPoint} < {stageRow.CostAP}"
                 );
             }
@@ -160,7 +166,7 @@ namespace Nekoyume.Action
 
             avatarState.EquipEquipments(equipments);
             sw.Stop();
-            Log.Debug("HAS Unequip items: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Unequip items: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             var characterSheet = states.GetSheet<CharacterSheet>();
@@ -174,16 +180,17 @@ namespace Nekoyume.Action
             );
 
             sw.Stop();
-            Log.Debug("HAS Initialize Simulator: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Initialize Simulator: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             simulator.Simulate();
             sw.Stop();
-            Log.Debug("HAS Simulator.Simulate(): {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Simulator.Simulate(): {Elapsed}", addressesHex, sw.Elapsed);
 
             Log.Debug(
-                "Execute HackAndSlash({AvatarAddress}); worldId: {WorldId}, stageId: {StageId}, result: {Result}, " +
+                "{AddressesHex}Execute HackAndSlash({AvatarAddress}); worldId: {WorldId}, stageId: {StageId}, result: {Result}, " +
                 "clearWave: {ClearWave}, totalWave: {TotalWave}",
+                addressesHex,
                 avatarAddress,
                 worldId,
                 stageId,
@@ -206,7 +213,7 @@ namespace Nekoyume.Action
             }
 
             sw.Stop();
-            Log.Debug("HAS ClearStage: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS ClearStage: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             avatarState.Update(simulator);
@@ -218,7 +225,7 @@ namespace Nekoyume.Action
             states = states.SetState(avatarAddress, avatarState.Serialize());
 
             sw.Stop();
-            Log.Debug("HAS Set AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             if (states.TryGetState(RankingMapAddress, out Dictionary d) && simulator.Log.IsClear)
@@ -227,19 +234,19 @@ namespace Nekoyume.Action
                 ranking.Update(avatarState);
 
                 sw.Stop();
-                Log.Debug("HAS Update RankingState: {Elapsed}", sw.Elapsed);
+                Log.Debug("{AddressesHex}HAS Update RankingState: {Elapsed}", addressesHex, sw.Elapsed);
                 sw.Restart();
 
                 var serialized = ranking.Serialize();
 
                 sw.Stop();
-                Log.Debug("HAS Serialize RankingState: {Elapsed}", sw.Elapsed);
+                Log.Debug("{AddressesHex}HAS Serialize RankingState: {Elapsed}", addressesHex, sw.Elapsed);
                 sw.Restart();
                 states = states.SetState(RankingMapAddress, serialized);
             }
 
             sw.Stop();
-            Log.Debug("HAS Set RankingState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Set RankingState: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             if (simulator.Log.stageId >= GameConfig.RequireClearedStageLevel.ActionsInRankingBoard &&
@@ -261,12 +268,12 @@ namespace Nekoyume.Action
                     }
 
                     sw.Stop();
-                    Log.Debug("HAS Update WeeklyArenaState: {Elapsed}", sw.Elapsed);
+                    Log.Debug("{AddressesHex}HAS Update WeeklyArenaState: {Elapsed}", addressesHex, sw.Elapsed);
 
                     sw.Restart();
                     var weeklySerialized = weekly.Serialize();
                     sw.Stop();
-                    Log.Debug("HAS Serialize RankingState: {Elapsed}", sw.Elapsed);
+                    Log.Debug("{AddressesHex}HAS Serialize RankingState: {Elapsed}", addressesHex, sw.Elapsed);
 
                     states = states.SetState(weekly.address, weeklySerialized);
                 }
@@ -275,7 +282,7 @@ namespace Nekoyume.Action
             Result = simulator.Log;
 
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("HAS Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}HAS Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states.SetState(ctx.Signer, agentState.Serialize());
         }
     }

--- a/Lib9c/Action/HackAndSlash.cs
+++ b/Lib9c/Action/HackAndSlash.cs
@@ -68,13 +68,9 @@ namespace Nekoyume.Action
                 return states.SetState(ctx.Signer, MarkChanged);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
 
-            Log.Warning(
-                "{AddressesHex}{HackAndSlash} is deprecated. Please use {HackAndSlash2}",
-                addressesHex,
-                nameof(HackAndSlash),
-                nameof(HackAndSlash2));
+            Log.Warning("{AddressesHex}hack_and_slash is deprecated. Please use hack_and_slash2", addressesHex);
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;

--- a/Lib9c/Action/HackAndSlash2.cs
+++ b/Lib9c/Action/HackAndSlash2.cs
@@ -66,25 +66,27 @@ namespace Nekoyume.Action
                 states = states.SetState(WeeklyArenaAddress, MarkChanged);
                 return states.SetState(ctx.Signer, MarkChanged);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(context);
 
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("HAS exec started.");
+            Log.Debug("{AddressesHex}HAS exec started", addressesHex);
 
             if (!states.TryGetAvatarState(ctx.Signer, avatarAddress, out AvatarState avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
 
             sw.Stop();
-            Log.Debug("HAS Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
 
             if (avatarState.RankingMapAddress != RankingMapAddress)
             {
-                throw new InvalidAddressException("Invalid ranking map address");
+                throw new InvalidAddressException($"{addressesHex}Invalid ranking map address");
             }
 
             // worldId와 stageId가 유효한지 확인합니다.
@@ -92,21 +94,21 @@ namespace Nekoyume.Action
 
             if (!worldSheet.TryGetValue(worldId, out var worldRow, false))
             {
-                throw new SheetRowNotFoundException(nameof(WorldSheet), worldId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(WorldSheet), worldId);
             }
 
             if (stageId < worldRow.StageBegin ||
                 stageId > worldRow.StageEnd)
             {
                 throw new SheetRowColumnException(
-                    $"{worldId} world is not contains {worldRow.Id} stage: " +
+                    $"{addressesHex}{worldId} world is not contains {worldRow.Id} stage: " +
                     $"{worldRow.StageBegin}-{worldRow.StageEnd}");
             }
 
             var stageSheet = states.GetSheet<StageSheet>();
             if (!stageSheet.TryGetValue(stageId, out var stageRow))
             {
-                throw new SheetRowNotFoundException(nameof(StageSheet), stageId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(StageSheet), stageId);
             }
 
             var worldInformation = avatarState.worldInformation;
@@ -118,7 +120,7 @@ namespace Nekoyume.Action
 
             if (!world.IsUnlocked)
             {
-                throw new InvalidWorldException($"{worldId} is locked.");
+                throw new InvalidWorldException($"{addressesHex}{worldId} is locked.");
             }
 
             if (world.StageBegin != worldRow.StageBegin ||
@@ -131,7 +133,7 @@ namespace Nekoyume.Action
                 !world.IsStageCleared && stageId != world.StageBegin)
             {
                 throw new InvalidStageException(
-                    $"Aborted as the stage ({worldId}/{stageId}) is not cleared; " +
+                    $"{addressesHex}Aborted as the stage ({worldId}/{stageId}) is not cleared; " +
                     $"cleared stage: {world.StageClearedId}"
                 );
             }
@@ -146,7 +148,7 @@ namespace Nekoyume.Action
             if (avatarState.actionPoint < stageRow.CostAP)
             {
                 throw new NotEnoughActionPointException(
-                    $"Aborted due to insufficient action point: " +
+                    $"{addressesHex}Aborted due to insufficient action point: " +
                     $"{avatarState.actionPoint} < {stageRow.CostAP}"
                 );
             }
@@ -157,7 +159,7 @@ namespace Nekoyume.Action
 
             avatarState.EquipEquipments(equipments);
             sw.Stop();
-            Log.Debug("HAS Unequip items: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Unequip items: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             var characterSheet = states.GetSheet<CharacterSheet>();
@@ -172,16 +174,17 @@ namespace Nekoyume.Action
             );
 
             sw.Stop();
-            Log.Debug("HAS Initialize Simulator: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Initialize Simulator: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             simulator.Simulate();
             sw.Stop();
-            Log.Debug("HAS Simulator.Simulate(): {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Simulator.Simulate(): {Elapsed}", addressesHex, sw.Elapsed);
 
             Log.Debug(
-                "Execute HackAndSlash({AvatarAddress}); worldId: {WorldId}, stageId: {StageId}, result: {Result}, " +
+                "{AddressesHex}Execute HackAndSlash({AvatarAddress}); worldId: {WorldId}, stageId: {StageId}, result: {Result}, " +
                 "clearWave: {ClearWave}, totalWave: {TotalWave}",
+                addressesHex,
                 avatarAddress,
                 worldId,
                 stageId,
@@ -204,7 +207,7 @@ namespace Nekoyume.Action
             }
 
             sw.Stop();
-            Log.Debug("HAS ClearStage: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS ClearStage: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             avatarState.Update(simulator);
@@ -216,7 +219,7 @@ namespace Nekoyume.Action
             states = states.SetState(avatarAddress, avatarState.Serialize());
 
             sw.Stop();
-            Log.Debug("HAS Set AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             if (states.TryGetState(RankingMapAddress, out Dictionary d) && simulator.Log.IsClear)
@@ -225,19 +228,19 @@ namespace Nekoyume.Action
                 ranking.Update(avatarState);
 
                 sw.Stop();
-                Log.Debug("HAS Update RankingState: {Elapsed}", sw.Elapsed);
+                Log.Debug("{AddressesHex}HAS Update RankingState: {Elapsed}", addressesHex, sw.Elapsed);
                 sw.Restart();
 
                 var serialized = ranking.Serialize();
 
                 sw.Stop();
-                Log.Debug("HAS Serialize RankingState: {Elapsed}", sw.Elapsed);
+                Log.Debug("{AddressesHex}HAS Serialize RankingState: {Elapsed}", addressesHex, sw.Elapsed);
                 sw.Restart();
                 states = states.SetState(RankingMapAddress, serialized);
             }
 
             sw.Stop();
-            Log.Debug("HAS Set RankingState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Set RankingState: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             if (simulator.Log.stageId >= GameConfig.RequireClearedStageLevel.ActionsInRankingBoard &&
@@ -259,12 +262,12 @@ namespace Nekoyume.Action
                     }
 
                     sw.Stop();
-                    Log.Debug("HAS Update WeeklyArenaState: {Elapsed}", sw.Elapsed);
+                    Log.Debug("{AddressesHex}HAS Update WeeklyArenaState: {Elapsed}", addressesHex, sw.Elapsed);
 
                     sw.Restart();
                     var weeklySerialized = weekly.Serialize();
                     sw.Stop();
-                    Log.Debug("HAS Serialize RankingState: {Elapsed}", sw.Elapsed);
+                    Log.Debug("{AddressesHex}HAS Serialize RankingState: {Elapsed}", addressesHex, sw.Elapsed);
 
                     states = states.SetState(weekly.address, weeklySerialized);
                 }
@@ -273,7 +276,7 @@ namespace Nekoyume.Action
             Result = simulator.Log;
 
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("HAS Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}HAS Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states;
         }
     }

--- a/Lib9c/Action/HackAndSlash2.cs
+++ b/Lib9c/Action/HackAndSlash2.cs
@@ -67,7 +67,7 @@ namespace Nekoyume.Action
                 return states.SetState(ctx.Signer, MarkChanged);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
 
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/HackAndSlash3.cs
+++ b/Lib9c/Action/HackAndSlash3.cs
@@ -66,25 +66,27 @@ namespace Nekoyume.Action
                 states = states.SetState(WeeklyArenaAddress, MarkChanged);
                 return states.SetState(ctx.Signer, MarkChanged);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(context);
 
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("HAS exec started.");
+            Log.Debug("{AddressesHex}HAS exec started", addressesHex);
 
             if (!states.TryGetAvatarState(ctx.Signer, avatarAddress, out AvatarState avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
 
             sw.Stop();
-            Log.Debug("HAS Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
 
             if (avatarState.RankingMapAddress != RankingMapAddress)
             {
-                throw new InvalidAddressException("Invalid ranking map address");
+                throw new InvalidAddressException($"{addressesHex}Invalid ranking map address");
             }
 
             // worldId와 stageId가 유효한지 확인합니다.
@@ -92,21 +94,21 @@ namespace Nekoyume.Action
 
             if (!worldSheet.TryGetValue(worldId, out var worldRow, false))
             {
-                throw new SheetRowNotFoundException(nameof(WorldSheet), worldId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(WorldSheet), worldId);
             }
 
             if (stageId < worldRow.StageBegin ||
                 stageId > worldRow.StageEnd)
             {
                 throw new SheetRowColumnException(
-                    $"{worldId} world is not contains {worldRow.Id} stage: " +
+                    $"{addressesHex}{worldId} world is not contains {worldRow.Id} stage: " +
                     $"{worldRow.StageBegin}-{worldRow.StageEnd}");
             }
 
             var stageSheet = states.GetSheet<StageSheet>();
             if (!stageSheet.TryGetValue(stageId, out var stageRow))
             {
-                throw new SheetRowNotFoundException(nameof(StageSheet), stageId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(StageSheet), stageId);
             }
 
             var worldInformation = avatarState.worldInformation;
@@ -118,7 +120,7 @@ namespace Nekoyume.Action
 
             if (!world.IsUnlocked)
             {
-                throw new InvalidWorldException($"{worldId} is locked.");
+                throw new InvalidWorldException($"{addressesHex}{worldId} is locked.");
             }
 
             if (world.StageBegin != worldRow.StageBegin ||
@@ -131,7 +133,7 @@ namespace Nekoyume.Action
                 !world.IsStageCleared && stageId != world.StageBegin)
             {
                 throw new InvalidStageException(
-                    $"Aborted as the stage ({worldId}/{stageId}) is not cleared; " +
+                    $"{addressesHex}Aborted as the stage ({worldId}/{stageId}) is not cleared; " +
                     $"cleared stage: {world.StageClearedId}"
                 );
             }
@@ -146,7 +148,7 @@ namespace Nekoyume.Action
             if (avatarState.actionPoint < stageRow.CostAP)
             {
                 throw new NotEnoughActionPointException(
-                    $"Aborted due to insufficient action point: " +
+                    $"{addressesHex}Aborted due to insufficient action point: " +
                     $"{avatarState.actionPoint} < {stageRow.CostAP}"
                 );
             }
@@ -157,7 +159,7 @@ namespace Nekoyume.Action
 
             avatarState.EquipEquipments(equipments);
             sw.Stop();
-            Log.Debug("HAS Unequip items: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Unequip items: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             var characterSheet = states.GetSheet<CharacterSheet>();
@@ -172,16 +174,17 @@ namespace Nekoyume.Action
             );
 
             sw.Stop();
-            Log.Debug("HAS Initialize Simulator: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Initialize Simulator: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             simulator.Simulate();
             sw.Stop();
-            Log.Debug("HAS Simulator.Simulate(): {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Simulator.Simulate(): {Elapsed}", addressesHex, sw.Elapsed);
 
             Log.Debug(
-                "Execute HackAndSlash({AvatarAddress}); worldId: {WorldId}, stageId: {StageId}, result: {Result}, " +
+                "{AddressesHex}Execute HackAndSlash({AvatarAddress}); worldId: {WorldId}, stageId: {StageId}, result: {Result}, " +
                 "clearWave: {ClearWave}, totalWave: {TotalWave}",
+                addressesHex,
                 avatarAddress,
                 worldId,
                 stageId,
@@ -204,7 +207,7 @@ namespace Nekoyume.Action
             }
 
             sw.Stop();
-            Log.Debug("HAS ClearStage: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS ClearStage: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             avatarState.Update(simulator);
@@ -217,7 +220,7 @@ namespace Nekoyume.Action
             states = states.SetState(avatarAddress, avatarState.Serialize());
 
             sw.Stop();
-            Log.Debug("HAS Set AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             if (states.TryGetState(RankingMapAddress, out Dictionary d) && simulator.Log.IsClear)
@@ -226,19 +229,19 @@ namespace Nekoyume.Action
                 ranking.Update(avatarState);
 
                 sw.Stop();
-                Log.Debug("HAS Update RankingState: {Elapsed}", sw.Elapsed);
+                Log.Debug("{AddressesHex}HAS Update RankingState: {Elapsed}", addressesHex, sw.Elapsed);
                 sw.Restart();
 
                 var serialized = ranking.Serialize();
 
                 sw.Stop();
-                Log.Debug("HAS Serialize RankingState: {Elapsed}", sw.Elapsed);
+                Log.Debug("{AddressesHex}HAS Serialize RankingState: {Elapsed}", addressesHex, sw.Elapsed);
                 sw.Restart();
                 states = states.SetState(RankingMapAddress, serialized);
             }
 
             sw.Stop();
-            Log.Debug("HAS Set RankingState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Set RankingState: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             if (simulator.Log.stageId >= GameConfig.RequireClearedStageLevel.ActionsInRankingBoard &&
@@ -260,12 +263,12 @@ namespace Nekoyume.Action
                     }
 
                     sw.Stop();
-                    Log.Debug("HAS Update WeeklyArenaState: {Elapsed}", sw.Elapsed);
+                    Log.Debug("{AddressesHex}HAS Update WeeklyArenaState: {Elapsed}", addressesHex, sw.Elapsed);
 
                     sw.Restart();
                     var weeklySerialized = weekly.Serialize();
                     sw.Stop();
-                    Log.Debug("HAS Serialize RankingState: {Elapsed}", sw.Elapsed);
+                    Log.Debug("{AddressesHex}HAS Serialize RankingState: {Elapsed}", addressesHex, sw.Elapsed);
 
                     states = states.SetState(weekly.address, weeklySerialized);
                 }
@@ -274,7 +277,7 @@ namespace Nekoyume.Action
             Result = simulator.Log;
 
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("HAS Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}HAS Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states;
         }
     }

--- a/Lib9c/Action/HackAndSlash3.cs
+++ b/Lib9c/Action/HackAndSlash3.cs
@@ -67,7 +67,7 @@ namespace Nekoyume.Action
                 return states.SetState(ctx.Signer, MarkChanged);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
 
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/HackAndSlash4.cs
+++ b/Lib9c/Action/HackAndSlash4.cs
@@ -67,24 +67,26 @@ namespace Nekoyume.Action
                 return states.SetState(ctx.Signer, MarkChanged);
             }
 
+            var addressesHex = GetSignerAndStateAddressesHex(context);
+
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("HAS exec started.");
+            Log.Debug("{AddressesHex}HAS exec started", addressesHex);
 
             if (!states.TryGetAvatarState(ctx.Signer, avatarAddress, out AvatarState avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
 
             sw.Stop();
-            Log.Debug("HAS Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
 
             if (avatarState.RankingMapAddress != RankingMapAddress)
             {
-                throw new InvalidAddressException("Invalid ranking map address");
+                throw new InvalidAddressException($"{addressesHex}Invalid ranking map address");
             }
 
             // worldId와 stageId가 유효한지 확인합니다.
@@ -92,21 +94,21 @@ namespace Nekoyume.Action
 
             if (!worldSheet.TryGetValue(worldId, out var worldRow, false))
             {
-                throw new SheetRowNotFoundException(nameof(WorldSheet), worldId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(WorldSheet), worldId);
             }
 
             if (stageId < worldRow.StageBegin ||
                 stageId > worldRow.StageEnd)
             {
                 throw new SheetRowColumnException(
-                    $"{worldId} world is not contains {worldRow.Id} stage: " +
+                    $"{addressesHex}{worldId} world is not contains {worldRow.Id} stage: " +
                     $"{worldRow.StageBegin}-{worldRow.StageEnd}");
             }
 
             var stageSheet = states.GetSheet<StageSheet>();
             if (!stageSheet.TryGetValue(stageId, out var stageRow))
             {
-                throw new SheetRowNotFoundException(nameof(StageSheet), stageId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(StageSheet), stageId);
             }
 
             var worldInformation = avatarState.worldInformation;
@@ -118,7 +120,7 @@ namespace Nekoyume.Action
 
             if (!world.IsUnlocked)
             {
-                throw new InvalidWorldException($"{worldId} is locked.");
+                throw new InvalidWorldException($"{addressesHex}{worldId} is locked.");
             }
 
             if (world.StageBegin != worldRow.StageBegin ||
@@ -131,7 +133,7 @@ namespace Nekoyume.Action
                 !world.IsStageCleared && stageId != world.StageBegin)
             {
                 throw new InvalidStageException(
-                    $"Aborted as the stage ({worldId}/{stageId}) is not cleared; " +
+                    $"{addressesHex}Aborted as the stage ({worldId}/{stageId}) is not cleared; " +
                     $"cleared stage: {world.StageClearedId}"
                 );
             }
@@ -146,7 +148,7 @@ namespace Nekoyume.Action
             if (avatarState.actionPoint < stageRow.CostAP)
             {
                 throw new NotEnoughActionPointException(
-                    $"Aborted due to insufficient action point: " +
+                    $"{addressesHex}Aborted due to insufficient action point: " +
                     $"{avatarState.actionPoint} < {stageRow.CostAP}"
                 );
             }
@@ -156,7 +158,7 @@ namespace Nekoyume.Action
             var items = equipments.Concat(costumes);
             avatarState.EquipItems(items);
             sw.Stop();
-            Log.Debug("HAS Unequip items: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Unequip items: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             var characterSheet = states.GetSheet<CharacterSheet>();
@@ -171,16 +173,17 @@ namespace Nekoyume.Action
                 2);
 
             sw.Stop();
-            Log.Debug("HAS Initialize Simulator: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Initialize Simulator: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             simulator.SimulateV2();
             sw.Stop();
-            Log.Debug("HAS Simulator.SimulateV2(): {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Simulator.SimulateV2(): {Elapsed}", addressesHex, sw.Elapsed);
 
             Log.Debug(
-                "Execute HackAndSlash({AvatarAddress}); worldId: {WorldId}, stageId: {StageId}, result: {Result}, " +
+                "{AddressesHex}Execute HackAndSlash({AvatarAddress}); worldId: {WorldId}, stageId: {StageId}, result: {Result}, " +
                 "clearWave: {ClearWave}, totalWave: {TotalWave}",
+                addressesHex,
                 avatarAddress,
                 worldId,
                 stageId,
@@ -203,7 +206,7 @@ namespace Nekoyume.Action
             }
 
             sw.Stop();
-            Log.Debug("HAS ClearStage: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS ClearStage: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             avatarState.Update(simulator);
@@ -216,7 +219,7 @@ namespace Nekoyume.Action
             states = states.SetState(avatarAddress, avatarState.Serialize());
 
             sw.Stop();
-            Log.Debug("HAS Set AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             if (states.TryGetState(RankingMapAddress, out Dictionary d) && simulator.Log.IsClear)
@@ -225,19 +228,19 @@ namespace Nekoyume.Action
                 ranking.Update(avatarState);
 
                 sw.Stop();
-                Log.Debug("HAS Update RankingState: {Elapsed}", sw.Elapsed);
+                Log.Debug("{AddressesHex}HAS Update RankingState: {Elapsed}", addressesHex, sw.Elapsed);
                 sw.Restart();
 
                 var serialized = ranking.Serialize();
 
                 sw.Stop();
-                Log.Debug("HAS Serialize RankingState: {Elapsed}", sw.Elapsed);
+                Log.Debug("{AddressesHex}HAS Serialize RankingState: {Elapsed}", addressesHex, sw.Elapsed);
                 sw.Restart();
                 states = states.SetState(RankingMapAddress, serialized);
             }
 
             sw.Stop();
-            Log.Debug("HAS Set RankingState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}HAS Set RankingState: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             if (simulator.Log.stageId >= GameConfig.RequireClearedStageLevel.ActionsInRankingBoard &&
@@ -259,12 +262,12 @@ namespace Nekoyume.Action
                     }
 
                     sw.Stop();
-                    Log.Debug("HAS Update WeeklyArenaState: {Elapsed}", sw.Elapsed);
+                    Log.Debug("{AddressesHex}HAS Update WeeklyArenaState: {Elapsed}", addressesHex, sw.Elapsed);
 
                     sw.Restart();
                     var weeklySerialized = weekly.Serialize();
                     sw.Stop();
-                    Log.Debug("HAS Serialize RankingState: {Elapsed}", sw.Elapsed);
+                    Log.Debug("{AddressesHex}HAS Serialize RankingState: {Elapsed}", addressesHex, sw.Elapsed);
 
                     states = states.SetState(weekly.address, weeklySerialized);
                 }
@@ -273,7 +276,7 @@ namespace Nekoyume.Action
             Result = simulator.Log;
 
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("HAS Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}HAS Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states;
         }
     }

--- a/Lib9c/Action/HackAndSlash4.cs
+++ b/Lib9c/Action/HackAndSlash4.cs
@@ -67,7 +67,7 @@ namespace Nekoyume.Action
                 return states.SetState(ctx.Signer, MarkChanged);
             }
 
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
 
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/ItemEnhancement.cs
+++ b/Lib9c/Action/ItemEnhancement.cs
@@ -84,12 +84,9 @@ namespace Nekoyume.Action
                     .SetState(slotAddress, MarkChanged);
             }
 
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
 
-            Log.Warning(
-                "{ItemEnhancement} is deprecated. Please use {ItemEnhancement2}", 
-                nameof(ItemEnhancement),
-                nameof(ItemEnhancement2));
+            Log.Warning("{AddressesHex}item_enhancement is deprecated. Please use item_enhancement2", addressesHex);
 
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/ItemEnhancement.cs
+++ b/Lib9c/Action/ItemEnhancement.cs
@@ -83,40 +83,46 @@ namespace Nekoyume.Action
                     .SetState(avatarAddress, MarkChanged)
                     .SetState(slotAddress, MarkChanged);
             }
-            Log.Warning($"{nameof(ItemEnhancement)} is deprecated. Please use ${nameof(ItemEnhancement2)}");
+
+            var addressesHex = GetSignerAndStateAddressesHex(context);
+
+            Log.Warning(
+                "{ItemEnhancement} is deprecated. Please use {ItemEnhancement2}", 
+                nameof(ItemEnhancement),
+                nameof(ItemEnhancement2));
 
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("ItemEnhancement exec started.");
+            Log.Debug("{AddressesHex}ItemEnhancement exec started", addressesHex);
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, avatarAddress, out AgentState agentState,
                 out AvatarState avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
             sw.Stop();
-            Log.Debug("ItemEnhancement Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!avatarState.inventory.TryGetNonFungibleItem(itemId, out ItemUsable enhancementItem))
             {
                 throw new ItemDoesNotExistException(
-                    $"Aborted as the NonFungibleItem ({itemId}) was failed to load from avatar's inventory."
+                    $"{addressesHex}Aborted as the NonFungibleItem ({itemId}) was failed to load from avatar's inventory."
                 );
             }
 
             if (enhancementItem.RequiredBlockIndex > context.BlockIndex)
             {
                 throw new RequiredBlockIndexException(
-                    $"Aborted as the equipment to enhance ({itemId}) is not available yet; it will be available at the block #{enhancementItem.RequiredBlockIndex}."
+                    $"{addressesHex}Aborted as the equipment to enhance ({itemId}) is not available yet; it will be available at the block #{enhancementItem.RequiredBlockIndex}."
                 );
             }
 
             if (!(enhancementItem is Equipment enhancementEquipment))
             {
                 throw new InvalidCastException(
-                    $"Aborted as the item is not a {nameof(Equipment)}, but {enhancementItem.GetType().Name}."
+                    $"{addressesHex}Aborted as the item is not a {nameof(Equipment)}, but {enhancementItem.GetType().Name}."
 
                 );
             }
@@ -124,23 +130,23 @@ namespace Nekoyume.Action
             var slotState = states.GetCombinationSlotState(avatarAddress, slotIndex);
             if (slotState is null)
             {
-                throw new FailedLoadStateException($"Aborted as the slot state was failed to load. #{slotIndex}");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the slot state was failed to load. #{slotIndex}");
             }
 
             if (!slotState.Validate(avatarState, ctx.BlockIndex))
             {
-                throw new CombinationSlotUnlockException($"Aborted as the slot state was failed to invalid. #{slotIndex}");
+                throw new CombinationSlotUnlockException($"{addressesHex}Aborted as the slot state was failed to invalid. #{slotIndex}");
             }
 
             sw.Stop();
-            Log.Debug("ItemEnhancement Get Equipment: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Get Equipment: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if(enhancementEquipment.level > 9)
             {
                 // Maximum level exceeded.
                 throw new EquipmentLevelExceededException(
-                    $"Aborted due to invalid equipment level: {enhancementEquipment.level} < 9"
+                    $"{addressesHex}Aborted due to invalid equipment level: {enhancementEquipment.level} < 9"
                 );
             }
 
@@ -154,7 +160,7 @@ namespace Nekoyume.Action
             if (avatarState.actionPoint < requiredAP)
             {
                 throw new NotEnoughActionPointException(
-                    $"Aborted due to insufficient action point: {avatarState.actionPoint} < {requiredAP}"
+                    $"{addressesHex}Aborted due to insufficient action point: {avatarState.actionPoint} < {requiredAP}"
                 );
             }
 
@@ -179,35 +185,35 @@ namespace Nekoyume.Action
                 if (!avatarState.inventory.TryGetNonFungibleItem(materialId, out ItemUsable materialItem))
                 {
                     throw new NotEnoughMaterialException(
-                        $"Aborted as the signer does not have a necessary material ({materialId})."
+                        $"{addressesHex}Aborted as the signer does not have a necessary material ({materialId})."
                     );
                 }
 
                 if (materialItem.RequiredBlockIndex > context.BlockIndex)
                 {
                     throw new RequiredBlockIndexException(
-                        $"Aborted as the material ({materialId}) is not available yet; it will be available at the block #{materialItem.RequiredBlockIndex}."
+                        $"{addressesHex}Aborted as the material ({materialId}) is not available yet; it will be available at the block #{materialItem.RequiredBlockIndex}."
                     );
                 }
 
                 if (!(materialItem is Equipment materialEquipment))
                 {
                     throw new InvalidCastException(
-                        $"Aborted as the material item is not an {nameof(Equipment)}, but {materialItem.GetType().Name}."
+                        $"{addressesHex}Aborted as the material item is not an {nameof(Equipment)}, but {materialItem.GetType().Name}."
                     );
                 }
 
                 if (materials.Contains(materialEquipment))
                 {
                     throw new DuplicateMaterialException(
-                        $"Aborted as the same material was used more than once: {materialEquipment}"
+                        $"{addressesHex}Aborted as the same material was used more than once: {materialEquipment}"
                     );
                 }
 
                 if (enhancementEquipment.ItemId == materialId)
                 {
                     throw new InvalidMaterialException(
-                        $"Aborted as an equipment to enhance ({materialId}) was used as a material too."
+                        $"{addressesHex}Aborted as an equipment to enhance ({materialId}) was used as a material too."
                     );
                 }
 
@@ -215,7 +221,7 @@ namespace Nekoyume.Action
                 {
                     // Invalid ItemSubType
                     throw new InvalidMaterialException(
-                        $"Aborted as the material item is not a {enhancementEquipment.ItemSubType}, but {materialEquipment.ItemSubType}."
+                        $"{addressesHex}Aborted as the material item is not a {enhancementEquipment.ItemSubType}, but {materialEquipment.ItemSubType}."
                     );
                 }
 
@@ -223,7 +229,7 @@ namespace Nekoyume.Action
                 {
                     // Invalid Grade
                     throw new InvalidMaterialException(
-                        $"Aborted as grades of the equipment to enhance ({enhancementEquipment.Grade}) and a material ({materialEquipment.Grade}) does not match."
+                        $"{addressesHex}Aborted as grades of the equipment to enhance ({enhancementEquipment.Grade}) and a material ({materialEquipment.Grade}) does not match."
                     );
                 }
 
@@ -231,11 +237,11 @@ namespace Nekoyume.Action
                 {
                     // Invalid level
                     throw new InvalidMaterialException(
-                        $"Aborted as levels of the equipment to enhance ({enhancementEquipment.level}) and a material ({materialEquipment.level}) does not match."
+                        $"{addressesHex}Aborted as levels of the equipment to enhance ({enhancementEquipment.level}) and a material ({materialEquipment.level}) does not match."
                     );
                 }
                 sw.Stop();
-                Log.Debug("ItemEnhancement Get Material: {Elapsed}", sw.Elapsed);
+                Log.Debug("{AddressesHex}ItemEnhancement Get Material: {Elapsed}", addressesHex, sw.Elapsed);
                 sw.Restart();
                 materialEquipment.Unequip();
                 materials.Add(materialEquipment);
@@ -248,7 +254,7 @@ namespace Nekoyume.Action
             var requiredBlockIndex = ctx.BlockIndex + RequiredBlockCount;
             enhancementEquipment.Update(requiredBlockIndex);
             sw.Stop();
-            Log.Debug("ItemEnhancement Upgrade Equipment: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Upgrade Equipment: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             result.gold = 0;
@@ -258,7 +264,7 @@ namespace Nekoyume.Action
                 avatarState.inventory.RemoveNonFungibleItem(material);
             }
             sw.Stop();
-            Log.Debug("ItemEnhancement Remove Materials: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Remove Materials: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
             var mail = new ItemEnhanceMail(result, ctx.BlockIndex, ctx.Random.GenerateRandomGuid(), requiredBlockIndex);
             result.id = mail.id;
@@ -273,13 +279,13 @@ namespace Nekoyume.Action
             slotState.Update(result, ctx.BlockIndex, requiredBlockIndex);
 
             sw.Stop();
-            Log.Debug("ItemEnhancement Update AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Update AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
             states = states.SetState(avatarAddress, avatarState.Serialize());
             sw.Stop();
-            Log.Debug("ItemEnhancement Set AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("ItemEnhancement Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}ItemEnhancement Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states.SetState(slotAddress, slotState.Serialize());
         }
 

--- a/Lib9c/Action/ItemEnhancement2.cs
+++ b/Lib9c/Action/ItemEnhancement2.cs
@@ -46,38 +46,41 @@ namespace Nekoyume.Action
                     .SetState(avatarAddress, MarkChanged)
                     .SetState(slotAddress, MarkChanged);
             }
+
+            var addressesHex = GetSignerAndStateAddressesHex(context);
+            
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("ItemEnhancement exec started.");
+            Log.Debug("{AddressesHex}ItemEnhancement exec started", addressesHex);
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, avatarAddress, out AgentState agentState,
                 out AvatarState avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
             sw.Stop();
-            Log.Debug("ItemEnhancement Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!avatarState.inventory.TryGetNonFungibleItem(itemId, out ItemUsable enhancementItem))
             {
                 throw new ItemDoesNotExistException(
-                    $"Aborted as the NonFungibleItem ({itemId}) was failed to load from avatar's inventory."
+                    $"{addressesHex}Aborted as the NonFungibleItem ({itemId}) was failed to load from avatar's inventory."
                 );
             }
 
             if (enhancementItem.RequiredBlockIndex > context.BlockIndex)
             {
                 throw new RequiredBlockIndexException(
-                    $"Aborted as the equipment to enhance ({itemId}) is not available yet; it will be available at the block #{enhancementItem.RequiredBlockIndex}."
+                    $"{addressesHex}Aborted as the equipment to enhance ({itemId}) is not available yet; it will be available at the block #{enhancementItem.RequiredBlockIndex}."
                 );
             }
 
             if (!(enhancementItem is Equipment enhancementEquipment))
             {
                 throw new InvalidCastException(
-                    $"Aborted as the item is not a {nameof(Equipment)}, but {enhancementItem.GetType().Name}."
+                    $"{addressesHex}Aborted as the item is not a {nameof(Equipment)}, but {enhancementItem.GetType().Name}."
 
                 );
             }
@@ -85,23 +88,23 @@ namespace Nekoyume.Action
             var slotState = states.GetCombinationSlotState(avatarAddress, slotIndex);
             if (slotState is null)
             {
-                throw new FailedLoadStateException($"Aborted as the slot state was failed to load. #{slotIndex}");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the slot state was failed to load. #{slotIndex}");
             }
 
             if (!slotState.Validate(avatarState, ctx.BlockIndex))
             {
-                throw new CombinationSlotUnlockException($"Aborted as the slot state was failed to invalid. #{slotIndex}");
+                throw new CombinationSlotUnlockException($"{addressesHex}Aborted as the slot state was failed to invalid. #{slotIndex}");
             }
 
             sw.Stop();
-            Log.Debug("ItemEnhancement Get Equipment: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Get Equipment: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if(enhancementEquipment.level > 9)
             {
                 // Maximum level exceeded.
                 throw new EquipmentLevelExceededException(
-                    $"Aborted due to invalid equipment level: {enhancementEquipment.level} < 9"
+                    $"{addressesHex}Aborted due to invalid equipment level: {enhancementEquipment.level} < 9"
                 );
             }
 
@@ -115,7 +118,7 @@ namespace Nekoyume.Action
             if (avatarState.actionPoint < requiredAP)
             {
                 throw new NotEnoughActionPointException(
-                    $"Aborted due to insufficient action point: {avatarState.actionPoint} < {requiredAP}"
+                    $"{addressesHex}Aborted due to insufficient action point: {avatarState.actionPoint} < {requiredAP}"
                 );
             }
 
@@ -137,28 +140,28 @@ namespace Nekoyume.Action
             if (!avatarState.inventory.TryGetNonFungibleItem(materialId, out ItemUsable materialItem))
             {
                 throw new NotEnoughMaterialException(
-                    $"Aborted as the signer does not have a necessary material ({materialId})."
+                    $"{addressesHex}Aborted as the signer does not have a necessary material ({materialId})."
                 );
             }
 
             if (materialItem.RequiredBlockIndex > context.BlockIndex)
             {
                 throw new RequiredBlockIndexException(
-                    $"Aborted as the material ({materialId}) is not available yet; it will be available at the block #{materialItem.RequiredBlockIndex}."
+                    $"{addressesHex}Aborted as the material ({materialId}) is not available yet; it will be available at the block #{materialItem.RequiredBlockIndex}."
                 );
             }
 
             if (!(materialItem is Equipment materialEquipment))
             {
                 throw new InvalidCastException(
-                    $"Aborted as the material item is not an {nameof(Equipment)}, but {materialItem.GetType().Name}."
+                    $"{addressesHex}Aborted as the material item is not an {nameof(Equipment)}, but {materialItem.GetType().Name}."
                 );
             }
 
             if (enhancementEquipment.ItemId == materialId)
             {
                 throw new InvalidMaterialException(
-                    $"Aborted as an equipment to enhance ({materialId}) was used as a material too."
+                    $"{addressesHex}Aborted as an equipment to enhance ({materialId}) was used as a material too."
                 );
             }
 
@@ -166,7 +169,7 @@ namespace Nekoyume.Action
             {
                 // Invalid ItemSubType
                 throw new InvalidMaterialException(
-                    $"Aborted as the material item is not a {enhancementEquipment.ItemSubType}, but {materialEquipment.ItemSubType}."
+                    $"{addressesHex}Aborted as the material item is not a {enhancementEquipment.ItemSubType}, but {materialEquipment.ItemSubType}."
                 );
             }
 
@@ -174,7 +177,7 @@ namespace Nekoyume.Action
             {
                 // Invalid Grade
                 throw new InvalidMaterialException(
-                    $"Aborted as grades of the equipment to enhance ({enhancementEquipment.Grade}) and a material ({materialEquipment.Grade}) does not match."
+                    $"{addressesHex}Aborted as grades of the equipment to enhance ({enhancementEquipment.Grade}) and a material ({materialEquipment.Grade}) does not match."
                 );
             }
 
@@ -182,11 +185,11 @@ namespace Nekoyume.Action
             {
                 // Invalid level
                 throw new InvalidMaterialException(
-                    $"Aborted as levels of the equipment to enhance ({enhancementEquipment.level}) and a material ({materialEquipment.level}) does not match."
+                    $"{addressesHex}Aborted as levels of the equipment to enhance ({enhancementEquipment.level}) and a material ({materialEquipment.level}) does not match."
                 );
             }
             sw.Stop();
-            Log.Debug("ItemEnhancement Get Material: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Get Material: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
             materialEquipment.Unequip();
 
@@ -197,14 +200,14 @@ namespace Nekoyume.Action
             var requiredBlockIndex = ctx.BlockIndex + RequiredBlockCount;
             enhancementEquipment.Update(requiredBlockIndex);
             sw.Stop();
-            Log.Debug("ItemEnhancement Upgrade Equipment: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Upgrade Equipment: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             result.gold = 0;
 
             avatarState.inventory.RemoveNonFungibleItem(materialId);
             sw.Stop();
-            Log.Debug("ItemEnhancement Remove Materials: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Remove Materials: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
             var mail = new ItemEnhanceMail(result, ctx.BlockIndex, ctx.Random.GenerateRandomGuid(), requiredBlockIndex);
             result.id = mail.id;
@@ -219,13 +222,13 @@ namespace Nekoyume.Action
             slotState.Update(result, ctx.BlockIndex, requiredBlockIndex);
 
             sw.Stop();
-            Log.Debug("ItemEnhancement Update AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Update AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
             states = states.SetState(avatarAddress, avatarState.Serialize());
             sw.Stop();
-            Log.Debug("ItemEnhancement Set AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("ItemEnhancement Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}ItemEnhancement Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states.SetState(slotAddress, slotState.Serialize());
         }
 

--- a/Lib9c/Action/ItemEnhancement2.cs
+++ b/Lib9c/Action/ItemEnhancement2.cs
@@ -47,7 +47,7 @@ namespace Nekoyume.Action
                     .SetState(slotAddress, MarkChanged);
             }
 
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
             
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/ItemEnhancement3.cs
+++ b/Lib9c/Action/ItemEnhancement3.cs
@@ -46,38 +46,41 @@ namespace Nekoyume.Action
                     .SetState(avatarAddress, MarkChanged)
                     .SetState(slotAddress, MarkChanged);
             }
+
+            var addressesHex = GetSignerAndStateAddressesHex(context);
+            
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("ItemEnhancement exec started.");
+            Log.Debug("{AddressesHex}ItemEnhancement exec started", addressesHex);
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, avatarAddress, out AgentState agentState,
                 out AvatarState avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
             sw.Stop();
-            Log.Debug("ItemEnhancement Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!avatarState.inventory.TryGetNonFungibleItem(itemId, out ItemUsable enhancementItem))
             {
                 throw new ItemDoesNotExistException(
-                    $"Aborted as the NonFungibleItem ({itemId}) was failed to load from avatar's inventory."
+                    $"{addressesHex}Aborted as the NonFungibleItem ({itemId}) was failed to load from avatar's inventory."
                 );
             }
 
             if (enhancementItem.RequiredBlockIndex > context.BlockIndex)
             {
                 throw new RequiredBlockIndexException(
-                    $"Aborted as the equipment to enhance ({itemId}) is not available yet; it will be available at the block #{enhancementItem.RequiredBlockIndex}."
+                    $"{addressesHex}Aborted as the equipment to enhance ({itemId}) is not available yet; it will be available at the block #{enhancementItem.RequiredBlockIndex}."
                 );
             }
 
             if (!(enhancementItem is Equipment enhancementEquipment))
             {
                 throw new InvalidCastException(
-                    $"Aborted as the item is not a {nameof(Equipment)}, but {enhancementItem.GetType().Name}."
+                    $"{addressesHex}Aborted as the item is not a {nameof(Equipment)}, but {enhancementItem.GetType().Name}."
 
                 );
             }
@@ -85,23 +88,23 @@ namespace Nekoyume.Action
             var slotState = states.GetCombinationSlotState(avatarAddress, slotIndex);
             if (slotState is null)
             {
-                throw new FailedLoadStateException($"Aborted as the slot state was failed to load. #{slotIndex}");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the slot state was failed to load. #{slotIndex}");
             }
 
             if (!slotState.Validate(avatarState, ctx.BlockIndex))
             {
-                throw new CombinationSlotUnlockException($"Aborted as the slot state was failed to invalid. #{slotIndex}");
+                throw new CombinationSlotUnlockException($"{addressesHex}Aborted as the slot state was failed to invalid. #{slotIndex}");
             }
 
             sw.Stop();
-            Log.Debug("ItemEnhancement Get Equipment: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Get Equipment: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if(enhancementEquipment.level > 9)
             {
                 // Maximum level exceeded.
                 throw new EquipmentLevelExceededException(
-                    $"Aborted due to invalid equipment level: {enhancementEquipment.level} < 9"
+                    $"{addressesHex}Aborted due to invalid equipment level: {enhancementEquipment.level} < 9"
                 );
             }
 
@@ -115,7 +118,7 @@ namespace Nekoyume.Action
             if (avatarState.actionPoint < requiredAP)
             {
                 throw new NotEnoughActionPointException(
-                    $"Aborted due to insufficient action point: {avatarState.actionPoint} < {requiredAP}"
+                    $"{addressesHex}Aborted due to insufficient action point: {avatarState.actionPoint} < {requiredAP}"
                 );
             }
 
@@ -137,28 +140,28 @@ namespace Nekoyume.Action
             if (!avatarState.inventory.TryGetNonFungibleItem(materialId, out ItemUsable materialItem))
             {
                 throw new NotEnoughMaterialException(
-                    $"Aborted as the signer does not have a necessary material ({materialId})."
+                    $"{addressesHex}Aborted as the signer does not have a necessary material ({materialId})."
                 );
             }
 
             if (materialItem.RequiredBlockIndex > context.BlockIndex)
             {
                 throw new RequiredBlockIndexException(
-                    $"Aborted as the material ({materialId}) is not available yet; it will be available at the block #{materialItem.RequiredBlockIndex}."
+                    $"{addressesHex}Aborted as the material ({materialId}) is not available yet; it will be available at the block #{materialItem.RequiredBlockIndex}."
                 );
             }
 
             if (!(materialItem is Equipment materialEquipment))
             {
                 throw new InvalidCastException(
-                    $"Aborted as the material item is not an {nameof(Equipment)}, but {materialItem.GetType().Name}."
+                    $"{addressesHex}Aborted as the material item is not an {nameof(Equipment)}, but {materialItem.GetType().Name}."
                 );
             }
 
             if (enhancementEquipment.ItemId == materialId)
             {
                 throw new InvalidMaterialException(
-                    $"Aborted as an equipment to enhance ({materialId}) was used as a material too."
+                    $"{addressesHex}Aborted as an equipment to enhance ({materialId}) was used as a material too."
                 );
             }
 
@@ -166,7 +169,7 @@ namespace Nekoyume.Action
             {
                 // Invalid ItemSubType
                 throw new InvalidMaterialException(
-                    $"Aborted as the material item is not a {enhancementEquipment.ItemSubType}, but {materialEquipment.ItemSubType}."
+                    $"{addressesHex}Aborted as the material item is not a {enhancementEquipment.ItemSubType}, but {materialEquipment.ItemSubType}."
                 );
             }
 
@@ -174,7 +177,7 @@ namespace Nekoyume.Action
             {
                 // Invalid Grade
                 throw new InvalidMaterialException(
-                    $"Aborted as grades of the equipment to enhance ({enhancementEquipment.Grade}) and a material ({materialEquipment.Grade}) does not match."
+                    $"{addressesHex}Aborted as grades of the equipment to enhance ({enhancementEquipment.Grade}) and a material ({materialEquipment.Grade}) does not match."
                 );
             }
 
@@ -182,11 +185,11 @@ namespace Nekoyume.Action
             {
                 // Invalid level
                 throw new InvalidMaterialException(
-                    $"Aborted as levels of the equipment to enhance ({enhancementEquipment.level}) and a material ({materialEquipment.level}) does not match."
+                    $"{addressesHex}Aborted as levels of the equipment to enhance ({enhancementEquipment.level}) and a material ({materialEquipment.level}) does not match."
                 );
             }
             sw.Stop();
-            Log.Debug("ItemEnhancement Get Material: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Get Material: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
             materialEquipment.Unequip();
 
@@ -197,14 +200,14 @@ namespace Nekoyume.Action
             var requiredBlockIndex = ctx.BlockIndex + RequiredBlockCount;
             enhancementEquipment.Update(requiredBlockIndex);
             sw.Stop();
-            Log.Debug("ItemEnhancement Upgrade Equipment: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Upgrade Equipment: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             result.gold = 0;
 
             avatarState.inventory.RemoveNonFungibleItem(materialId);
             sw.Stop();
-            Log.Debug("ItemEnhancement Remove Materials: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Remove Materials: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
             var mail = new ItemEnhanceMail(result, ctx.BlockIndex, ctx.Random.GenerateRandomGuid(), requiredBlockIndex);
             result.id = mail.id;
@@ -219,13 +222,13 @@ namespace Nekoyume.Action
             slotState.Update(result, ctx.BlockIndex, requiredBlockIndex);
 
             sw.Stop();
-            Log.Debug("ItemEnhancement Update AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Update AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
             states = states.SetState(avatarAddress, avatarState.Serialize());
             sw.Stop();
-            Log.Debug("ItemEnhancement Set AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("ItemEnhancement Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}ItemEnhancement Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states.SetState(slotAddress, slotState.Serialize());
         }
 

--- a/Lib9c/Action/ItemEnhancement3.cs
+++ b/Lib9c/Action/ItemEnhancement3.cs
@@ -47,7 +47,7 @@ namespace Nekoyume.Action
                     .SetState(slotAddress, MarkChanged);
             }
 
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
             
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/ItemEnhancement4.cs
+++ b/Lib9c/Action/ItemEnhancement4.cs
@@ -44,38 +44,41 @@ namespace Nekoyume.Action
                     .SetState(avatarAddress, MarkChanged)
                     .SetState(slotAddress, MarkChanged);
             }
+
+            var addressesHex = GetSignerAndStateAddressesHex(context);
+            
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("ItemEnhancement exec started.");
+            Log.Debug("{AddressesHex}ItemEnhancement exec started", addressesHex);
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, avatarAddress, out AgentState agentState,
                 out AvatarState avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
             sw.Stop();
-            Log.Debug("ItemEnhancement Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Get AgentAvatarStates: {Elapsed}", addressesHex , sw.Elapsed);
             sw.Restart();
 
             if (!avatarState.inventory.TryGetNonFungibleItem(itemId, out ItemUsable enhancementItem))
             {
                 throw new ItemDoesNotExistException(
-                    $"Aborted as the NonFungibleItem ({itemId}) was failed to load from avatar's inventory."
+                    $"{addressesHex}Aborted as the NonFungibleItem ({itemId}) was failed to load from avatar's inventory."
                 );
             }
 
             if (enhancementItem.RequiredBlockIndex > context.BlockIndex)
             {
                 throw new RequiredBlockIndexException(
-                    $"Aborted as the equipment to enhance ({itemId}) is not available yet; it will be available at the block #{enhancementItem.RequiredBlockIndex}."
+                    $"{addressesHex}Aborted as the equipment to enhance ({itemId}) is not available yet; it will be available at the block #{enhancementItem.RequiredBlockIndex}."
                 );
             }
 
             if (!(enhancementItem is Equipment enhancementEquipment))
             {
                 throw new InvalidCastException(
-                    $"Aborted as the item is not a {nameof(Equipment)}, but {enhancementItem.GetType().Name}."
+                    $"{addressesHex}Aborted as the item is not a {nameof(Equipment)}, but {enhancementItem.GetType().Name}."
 
                 );
             }
@@ -83,23 +86,23 @@ namespace Nekoyume.Action
             var slotState = states.GetCombinationSlotState(avatarAddress, slotIndex);
             if (slotState is null)
             {
-                throw new FailedLoadStateException($"Aborted as the slot state was failed to load. #{slotIndex}");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the slot state was failed to load. #{slotIndex}");
             }
 
             if (!slotState.Validate(avatarState, ctx.BlockIndex))
             {
-                throw new CombinationSlotUnlockException($"Aborted as the slot state was failed to invalid. #{slotIndex}");
+                throw new CombinationSlotUnlockException($"{addressesHex}Aborted as the slot state was failed to invalid. #{slotIndex}");
             }
 
             sw.Stop();
-            Log.Debug("ItemEnhancement Get Equipment: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Get Equipment: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (enhancementEquipment.level > 9)
             {
                 // Maximum level exceeded.
                 throw new EquipmentLevelExceededException(
-                    $"Aborted due to invalid equipment level: {enhancementEquipment.level} < 9"
+                    $"{addressesHex}Aborted due to invalid equipment level: {enhancementEquipment.level} < 9"
                 );
             }
 
@@ -113,7 +116,7 @@ namespace Nekoyume.Action
             if (avatarState.actionPoint < requiredAP)
             {
                 throw new NotEnoughActionPointException(
-                    $"Aborted due to insufficient action point: {avatarState.actionPoint} < {requiredAP}"
+                    $"{addressesHex}Aborted due to insufficient action point: {avatarState.actionPoint} < {requiredAP}"
                 );
             }
 
@@ -135,28 +138,28 @@ namespace Nekoyume.Action
             if (!avatarState.inventory.TryGetNonFungibleItem(materialId, out ItemUsable materialItem))
             {
                 throw new NotEnoughMaterialException(
-                    $"Aborted as the signer does not have a necessary material ({materialId})."
+                    $"{addressesHex}Aborted as the signer does not have a necessary material ({materialId})."
                 );
             }
 
             if (materialItem.RequiredBlockIndex > context.BlockIndex)
             {
                 throw new RequiredBlockIndexException(
-                    $"Aborted as the material ({materialId}) is not available yet; it will be available at the block #{materialItem.RequiredBlockIndex}."
+                    $"{addressesHex}Aborted as the material ({materialId}) is not available yet; it will be available at the block #{materialItem.RequiredBlockIndex}."
                 );
             }
 
             if (!(materialItem is Equipment materialEquipment))
             {
                 throw new InvalidCastException(
-                    $"Aborted as the material item is not an {nameof(Equipment)}, but {materialItem.GetType().Name}."
+                    $"{addressesHex}Aborted as the material item is not an {nameof(Equipment)}, but {materialItem.GetType().Name}."
                 );
             }
 
             if (enhancementEquipment.ItemId == materialId)
             {
                 throw new InvalidMaterialException(
-                    $"Aborted as an equipment to enhance ({materialId}) was used as a material too."
+                    $"{addressesHex}Aborted as an equipment to enhance ({materialId}) was used as a material too."
                 );
             }
 
@@ -164,7 +167,7 @@ namespace Nekoyume.Action
             {
                 // Invalid ItemSubType
                 throw new InvalidMaterialException(
-                    $"Aborted as the material item is not a {enhancementEquipment.ItemSubType}, but {materialEquipment.ItemSubType}."
+                    $"{addressesHex}Aborted as the material item is not a {enhancementEquipment.ItemSubType}, but {materialEquipment.ItemSubType}."
                 );
             }
 
@@ -172,7 +175,7 @@ namespace Nekoyume.Action
             {
                 // Invalid Grade
                 throw new InvalidMaterialException(
-                    $"Aborted as grades of the equipment to enhance ({enhancementEquipment.Grade}) and a material ({materialEquipment.Grade}) does not match."
+                    $"{addressesHex}Aborted as grades of the equipment to enhance ({enhancementEquipment.Grade}) and a material ({materialEquipment.Grade}) does not match."
                 );
             }
 
@@ -180,11 +183,11 @@ namespace Nekoyume.Action
             {
                 // Invalid level
                 throw new InvalidMaterialException(
-                    $"Aborted as levels of the equipment to enhance ({enhancementEquipment.level}) and a material ({materialEquipment.level}) does not match."
+                    $"{addressesHex}Aborted as levels of the equipment to enhance ({enhancementEquipment.level}) and a material ({materialEquipment.level}) does not match."
                 );
             }
             sw.Stop();
-            Log.Debug("ItemEnhancement Get Material: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Get Material: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
             materialEquipment.Unequip();
 
@@ -195,14 +198,14 @@ namespace Nekoyume.Action
             var requiredBlockIndex = ctx.BlockIndex + RequiredBlockCount;
             enhancementEquipment.Update(requiredBlockIndex);
             sw.Stop();
-            Log.Debug("ItemEnhancement Upgrade Equipment: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Upgrade Equipment: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             result.gold = requiredNCG;
 
             avatarState.inventory.RemoveNonFungibleItem(materialId);
             sw.Stop();
-            Log.Debug("ItemEnhancement Remove Materials: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Remove Materials: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
             var mail = new ItemEnhanceMail(result, ctx.BlockIndex, ctx.Random.GenerateRandomGuid(), requiredBlockIndex);
             result.id = mail.id;
@@ -217,13 +220,13 @@ namespace Nekoyume.Action
             slotState.Update(result, ctx.BlockIndex, requiredBlockIndex);
 
             sw.Stop();
-            Log.Debug("ItemEnhancement Update AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Update AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
             states = states.SetState(avatarAddress, avatarState.Serialize());
             sw.Stop();
-            Log.Debug("ItemEnhancement Set AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("ItemEnhancement Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}ItemEnhancement Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states.SetState(slotAddress, slotState.Serialize());
         }
 

--- a/Lib9c/Action/ItemEnhancement4.cs
+++ b/Lib9c/Action/ItemEnhancement4.cs
@@ -45,7 +45,7 @@ namespace Nekoyume.Action
                     .SetState(slotAddress, MarkChanged);
             }
 
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
             
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/ItemEnhancement5.cs
+++ b/Lib9c/Action/ItemEnhancement5.cs
@@ -44,38 +44,41 @@ namespace Nekoyume.Action
                     .SetState(avatarAddress, MarkChanged)
                     .SetState(slotAddress, MarkChanged);
             }
+
+            var addressesHex = GetSignerAndStateAddressesHex(context);
+            
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("ItemEnhancement exec started.");
+            Log.Debug("{AddressesHex}ItemEnhancement exec started", addressesHex);
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, avatarAddress, out AgentState agentState,
                 out AvatarState avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
             sw.Stop();
-            Log.Debug("ItemEnhancement Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!avatarState.inventory.TryGetNonFungibleItem(itemId, out ItemUsable enhancementItem))
             {
                 throw new ItemDoesNotExistException(
-                    $"Aborted as the NonFungibleItem ({itemId}) was failed to load from avatar's inventory."
+                    $"{addressesHex}Aborted as the NonFungibleItem ({itemId}) was failed to load from avatar's inventory."
                 );
             }
 
             if (enhancementItem.RequiredBlockIndex > context.BlockIndex)
             {
                 throw new RequiredBlockIndexException(
-                    $"Aborted as the equipment to enhance ({itemId}) is not available yet; it will be available at the block #{enhancementItem.RequiredBlockIndex}."
+                    $"{addressesHex}Aborted as the equipment to enhance ({itemId}) is not available yet; it will be available at the block #{enhancementItem.RequiredBlockIndex}."
                 );
             }
 
             if (!(enhancementItem is Equipment enhancementEquipment))
             {
                 throw new InvalidCastException(
-                    $"Aborted as the item is not a {nameof(Equipment)}, but {enhancementItem.GetType().Name}."
+                    $"{addressesHex}Aborted as the item is not a {nameof(Equipment)}, but {enhancementItem.GetType().Name}."
 
                 );
             }
@@ -83,23 +86,23 @@ namespace Nekoyume.Action
             var slotState = states.GetCombinationSlotState(avatarAddress, slotIndex);
             if (slotState is null)
             {
-                throw new FailedLoadStateException($"Aborted as the slot state was failed to load. #{slotIndex}");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the slot state was failed to load. #{slotIndex}");
             }
 
             if (!slotState.Validate(avatarState, ctx.BlockIndex))
             {
-                throw new CombinationSlotUnlockException($"Aborted as the slot state was failed to invalid. #{slotIndex}");
+                throw new CombinationSlotUnlockException($"{addressesHex}Aborted as the slot state was failed to invalid. #{slotIndex}");
             }
 
             sw.Stop();
-            Log.Debug("ItemEnhancement Get Equipment: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Get Equipment: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (enhancementEquipment.level > 9)
             {
                 // Maximum level exceeded.
                 throw new EquipmentLevelExceededException(
-                    $"Aborted due to invalid equipment level: {enhancementEquipment.level} < 9"
+                    $"{addressesHex}Aborted due to invalid equipment level: {enhancementEquipment.level} < 9"
                 );
             }
 
@@ -113,7 +116,7 @@ namespace Nekoyume.Action
             if (avatarState.actionPoint < requiredAP)
             {
                 throw new NotEnoughActionPointException(
-                    $"Aborted due to insufficient action point: {avatarState.actionPoint} < {requiredAP}"
+                    $"{addressesHex}Aborted due to insufficient action point: {avatarState.actionPoint} < {requiredAP}"
                 );
             }
 
@@ -135,28 +138,28 @@ namespace Nekoyume.Action
             if (!avatarState.inventory.TryGetNonFungibleItem(materialId, out ItemUsable materialItem))
             {
                 throw new NotEnoughMaterialException(
-                    $"Aborted as the signer does not have a necessary material ({materialId})."
+                    $"{addressesHex}Aborted as the signer does not have a necessary material ({materialId})."
                 );
             }
 
             if (materialItem.RequiredBlockIndex > context.BlockIndex)
             {
                 throw new RequiredBlockIndexException(
-                    $"Aborted as the material ({materialId}) is not available yet; it will be available at the block #{materialItem.RequiredBlockIndex}."
+                    $"{addressesHex}Aborted as the material ({materialId}) is not available yet; it will be available at the block #{materialItem.RequiredBlockIndex}."
                 );
             }
 
             if (!(materialItem is Equipment materialEquipment))
             {
                 throw new InvalidCastException(
-                    $"Aborted as the material item is not an {nameof(Equipment)}, but {materialItem.GetType().Name}."
+                    $"{addressesHex}Aborted as the material item is not an {nameof(Equipment)}, but {materialItem.GetType().Name}."
                 );
             }
 
             if (enhancementEquipment.ItemId == materialId)
             {
                 throw new InvalidMaterialException(
-                    $"Aborted as an equipment to enhance ({materialId}) was used as a material too."
+                    $"{addressesHex}Aborted as an equipment to enhance ({materialId}) was used as a material too."
                 );
             }
 
@@ -164,7 +167,7 @@ namespace Nekoyume.Action
             {
                 // Invalid ItemSubType
                 throw new InvalidMaterialException(
-                    $"Aborted as the material item is not a {enhancementEquipment.ItemSubType}, but {materialEquipment.ItemSubType}."
+                    $"{addressesHex}Aborted as the material item is not a {enhancementEquipment.ItemSubType}, but {materialEquipment.ItemSubType}."
                 );
             }
 
@@ -172,7 +175,7 @@ namespace Nekoyume.Action
             {
                 // Invalid Grade
                 throw new InvalidMaterialException(
-                    $"Aborted as grades of the equipment to enhance ({enhancementEquipment.Grade}) and a material ({materialEquipment.Grade}) does not match."
+                    $"{addressesHex}Aborted as grades of the equipment to enhance ({enhancementEquipment.Grade}) and a material ({materialEquipment.Grade}) does not match."
                 );
             }
 
@@ -180,11 +183,11 @@ namespace Nekoyume.Action
             {
                 // Invalid level
                 throw new InvalidMaterialException(
-                    $"Aborted as levels of the equipment to enhance ({enhancementEquipment.level}) and a material ({materialEquipment.level}) does not match."
+                    $"{addressesHex}Aborted as levels of the equipment to enhance ({enhancementEquipment.level}) and a material ({materialEquipment.level}) does not match."
                 );
             }
             sw.Stop();
-            Log.Debug("ItemEnhancement Get Material: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Get Material: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
             materialEquipment.Unequip();
 
@@ -195,14 +198,14 @@ namespace Nekoyume.Action
             var requiredBlockIndex = ctx.BlockIndex + RequiredBlockCount;
             enhancementEquipment.Update(requiredBlockIndex);
             sw.Stop();
-            Log.Debug("ItemEnhancement Upgrade Equipment: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Upgrade Equipment: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             result.gold = requiredNCG;
 
             avatarState.inventory.RemoveNonFungibleItem(materialId);
             sw.Stop();
-            Log.Debug("ItemEnhancement Remove Materials: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Remove Materials: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
             var mail = new ItemEnhanceMail(result, ctx.BlockIndex, ctx.Random.GenerateRandomGuid(), requiredBlockIndex);
             result.id = mail.id;
@@ -217,13 +220,13 @@ namespace Nekoyume.Action
             slotState.Update(result, ctx.BlockIndex, requiredBlockIndex);
 
             sw.Stop();
-            Log.Debug("ItemEnhancement Update AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Update AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
             states = states.SetState(avatarAddress, avatarState.Serialize());
             sw.Stop();
-            Log.Debug("ItemEnhancement Set AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}ItemEnhancement Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("ItemEnhancement Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}ItemEnhancement Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states.SetState(slotAddress, slotState.Serialize());
         }
 

--- a/Lib9c/Action/ItemEnhancement5.cs
+++ b/Lib9c/Action/ItemEnhancement5.cs
@@ -45,7 +45,7 @@ namespace Nekoyume.Action
                     .SetState(slotAddress, MarkChanged);
             }
 
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
             
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/MimisbrunnrBattle.cs
+++ b/Lib9c/Action/MimisbrunnrBattle.cs
@@ -66,25 +66,27 @@ namespace Nekoyume.Action
                 states = states.SetState(avatarAddress, MarkChanged);
                 return states.SetState(WeeklyArenaAddress, MarkChanged);
             }
+
+            var addressesHex = GetSignerAndStateAddressesHex(context);
             
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("Mimisbrunnr exec started.");
+            Log.Debug("{AddressesHex}Mimisbrunnr exec started", addressesHex);
 
             if (!states.TryGetAvatarState(ctx.Signer, avatarAddress, out AvatarState avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
             
             sw.Stop();
-            Log.Debug("Mimisbrunnr Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Mimisbrunnr Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             
             sw.Restart();
 
             if (avatarState.RankingMapAddress != RankingMapAddress)
             {
-                throw new InvalidAddressException("Invalid ranking map address");
+                throw new InvalidAddressException($"{addressesHex}Invalid ranking map address");
             }
             
             var worldSheet = states.GetSheet<WorldSheet>();
@@ -98,14 +100,14 @@ namespace Nekoyume.Action
                 stageId > worldRow.StageEnd)
             {
                 throw new SheetRowColumnException(
-                    $"{worldId} world is not contains {worldRow.Id} stage: " +
+                    $"{addressesHex}{worldId} world is not contains {worldRow.Id} stage: " +
                     $"{worldRow.StageBegin}-{worldRow.StageEnd}");
             }
             
             var stageSheet = states.GetSheet<StageSheet>();
             if (!stageSheet.TryGetValue(stageId, out var stageRow))
             {
-                throw new SheetRowNotFoundException(nameof(StageSheet), stageId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(StageSheet), stageId);
             }
             
             var worldInformation = avatarState.worldInformation;
@@ -136,7 +138,7 @@ namespace Nekoyume.Action
             
             if (!world.IsUnlocked)
             {
-                throw new InvalidWorldException($"{worldId} is locked.");
+                throw new InvalidWorldException($"{addressesHex}{worldId} is locked.");
             }
          
             if (world.StageBegin != worldRow.StageBegin ||
@@ -149,7 +151,7 @@ namespace Nekoyume.Action
                 !world.IsStageCleared && stageId != world.StageBegin)
             {
                 throw new InvalidStageException(
-                    $"Aborted as the stage ({worldId}/{stageId}) is not cleared; " +
+                    $"{addressesHex}Aborted as the stage ({worldId}/{stageId}) is not cleared; " +
                     $"cleared stage: {world.StageClearedId}"
                 );
             }
@@ -158,7 +160,7 @@ namespace Nekoyume.Action
             var mimisbrunnrSheet = states.GetSheet<MimisbrunnrSheet>();
             if (!mimisbrunnrSheet.TryGetValue(stageId, out var mimisbrunnrSheetRow))
             {
-                throw new SheetRowNotFoundException("MimisbrunnrSheet", stageId);
+                throw new SheetRowNotFoundException(addressesHex, "MimisbrunnrSheet", stageId);
             }
             
             foreach (var equipmentId in equipments)
@@ -169,12 +171,12 @@ namespace Nekoyume.Action
                     if (!mimisbrunnrSheetRow.ElementalTypes.Exists(x => x == elementalType))
                     {
                         throw new InvalidElementalException(
-                            $"ElementalType of {equipmentId} does not match.");
+                            $"{addressesHex}ElementalType of {equipmentId} does not match.");
                     }
                 }
             }
             sw.Stop();
-            Log.Debug("Mimisbrunnr Check Equipments ElementalType: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Mimisbrunnr Check Equipments ElementalType: {Elapsed}", addressesHex, sw.Elapsed);
 
             avatarState.ValidateEquipments(equipments, context.BlockIndex);
             avatarState.ValidateConsumable(foods, context.BlockIndex);
@@ -184,7 +186,7 @@ namespace Nekoyume.Action
             if (avatarState.actionPoint < stageRow.CostAP)
             {
                 throw new NotEnoughActionPointException(
-                    $"Aborted due to insufficient action point: " +
+                    $"{addressesHex}Aborted due to insufficient action point: " +
                     $"{avatarState.actionPoint} < {stageRow.CostAP}"
                 );
             }
@@ -194,7 +196,7 @@ namespace Nekoyume.Action
             equippableItem.AddRange(equipments);
             avatarState.EquipItems(equippableItem);
             sw.Stop();
-            Log.Debug("Mimisbrunnr Unequip items: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Mimisbrunnr Unequip items: {Elapsed}", addressesHex, sw.Elapsed);
             
             sw.Restart();
             var costumeStatSheet = states.GetSheet<CostumeStatSheet>();
@@ -208,16 +210,17 @@ namespace Nekoyume.Action
                 costumeStatSheet
             );
             sw.Stop();
-            Log.Debug("Mimisbrunnr Initialize Simulator: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Mimisbrunnr Initialize Simulator: {Elapsed}", addressesHex, sw.Elapsed);
             
             sw.Restart();
             simulator.Simulate();
             sw.Stop();
-            Log.Debug("Mimisbrunnr Simulator.Simulate(): {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Mimisbrunnr Simulator.Simulate(): {Elapsed}", addressesHex, sw.Elapsed);
             
             Log.Debug(
-                "Execute Mimisbrunnr({AvatarAddress}); worldId: {WorldId}, stageId: {StageId}, result: {Result}, " +
+                "{AddressesHex}Execute Mimisbrunnr({AvatarAddress}); worldId: {WorldId}, stageId: {StageId}, result: {Result}, " +
                 "clearWave: {ClearWave}, totalWave: {TotalWave}",
+                addressesHex,
                 avatarAddress,
                 worldId,
                 stageId,
@@ -238,7 +241,7 @@ namespace Nekoyume.Action
                 );
             }
             sw.Stop();
-            Log.Debug("Mimisbrunnr ClearStage: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Mimisbrunnr ClearStage: {Elapsed}", addressesHex, sw.Elapsed);
             
             sw.Restart();
             avatarState.Update(simulator);
@@ -251,7 +254,7 @@ namespace Nekoyume.Action
             states = states.SetState(avatarAddress, avatarState.Serialize());
 
             sw.Stop();
-            Log.Debug("Mimisbrunnr Set AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Mimisbrunnr Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             
             sw.Restart();
             if (states.TryGetState(RankingMapAddress, out Dictionary d) && simulator.Log.IsClear)
@@ -260,19 +263,19 @@ namespace Nekoyume.Action
                 ranking.Update(avatarState);
 
                 sw.Stop();
-                Log.Debug("Mimisbrunnr Update RankingState: {Elapsed}", sw.Elapsed);
+                Log.Debug("{AddressesHex}Mimisbrunnr Update RankingState: {Elapsed}", addressesHex, sw.Elapsed);
                 sw.Restart();
 
                 var serialized = ranking.Serialize();
 
                 sw.Stop();
-                Log.Debug("Mimisbrunnr Serialize RankingState: {Elapsed}", sw.Elapsed);
+                Log.Debug("{AddressesHex}Mimisbrunnr Serialize RankingState: {Elapsed}", addressesHex, sw.Elapsed);
                 sw.Restart();
                 states = states.SetState(RankingMapAddress, serialized);
             }
 
             sw.Stop();
-            Log.Debug("Mimisbrunnr Set RankingState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Mimisbrunnr Set RankingState: {Elapsed}", addressesHex, sw.Elapsed);
             
             sw.Restart();
             if (simulator.Log.stageId >= GameConfig.RequireClearedStageLevel.ActionsInRankingBoard &&
@@ -295,12 +298,12 @@ namespace Nekoyume.Action
                     }
 
                     sw.Stop();
-                    Log.Debug("Mimisbrunnr Update WeeklyArenaState: {Elapsed}", sw.Elapsed);
+                    Log.Debug("{AddressesHex}Mimisbrunnr Update WeeklyArenaState: {Elapsed}", addressesHex, sw.Elapsed);
 
                     sw.Restart();
                     var weeklySerialized = weekly.Serialize();
                     sw.Stop();
-                    Log.Debug("Mimisbrunnr Serialize RankingState: {Elapsed}", sw.Elapsed);
+                    Log.Debug("{AddressesHex}Mimisbrunnr Serialize RankingState: {Elapsed}", addressesHex, sw.Elapsed);
 
                     states = states.SetState(weekly.address, weeklySerialized);
                 }
@@ -309,7 +312,7 @@ namespace Nekoyume.Action
             Result = simulator.Log;
 
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("Mimisbrunnr Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}Mimisbrunnr Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states;
         }
     }

--- a/Lib9c/Action/MimisbrunnrBattle.cs
+++ b/Lib9c/Action/MimisbrunnrBattle.cs
@@ -67,7 +67,7 @@ namespace Nekoyume.Action
                 return states.SetState(WeeklyArenaAddress, MarkChanged);
             }
 
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
             
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/MimisbrunnrBattle2.cs
+++ b/Lib9c/Action/MimisbrunnrBattle2.cs
@@ -66,11 +66,13 @@ namespace Nekoyume.Action
                 states = states.SetState(avatarAddress, MarkChanged);
                 return states.SetState(WeeklyArenaAddress, MarkChanged);
             }
+
+            var addressesHex = GetSignerAndStateAddressesHex(context);
             
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("Mimisbrunnr exec started.");
+            Log.Debug("{AddressesHex}Mimisbrunnr exec started", addressesHex);
 
             if (!states.TryGetAvatarState(ctx.Signer, avatarAddress, out AvatarState avatarState))
             {
@@ -78,34 +80,34 @@ namespace Nekoyume.Action
             }
             
             sw.Stop();
-            Log.Debug("Mimisbrunnr Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Mimisbrunnr Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             
             sw.Restart();
 
             if (avatarState.RankingMapAddress != RankingMapAddress)
             {
-                throw new InvalidAddressException("Invalid ranking map address");
+                throw new InvalidAddressException($"{addressesHex}Invalid ranking map address");
             }
             
             var worldSheet = states.GetSheet<WorldSheet>();
             var worldUnlockSheet = states.GetSheet<WorldUnlockSheet>();
             if (!worldSheet.TryGetValue(worldId, out var worldRow, false))
             {
-                throw new SheetRowNotFoundException(nameof(WorldSheet), worldId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(WorldSheet), worldId);
             }
 
             if (stageId < worldRow.StageBegin ||
                 stageId > worldRow.StageEnd)
             {
                 throw new SheetRowColumnException(
-                    $"{worldId} world is not contains {worldRow.Id} stage: " +
+                    $"{addressesHex}{worldId} world is not contains {worldRow.Id} stage: " +
                     $"{worldRow.StageBegin}-{worldRow.StageEnd}");
             }
             
             var stageSheet = states.GetSheet<StageSheet>();
             if (!stageSheet.TryGetValue(stageId, out var stageRow))
             {
-                throw new SheetRowNotFoundException(nameof(StageSheet), stageId);
+                throw new SheetRowNotFoundException(addressesHex, nameof(StageSheet), stageId);
             }
             
             var worldInformation = avatarState.worldInformation;
@@ -136,7 +138,7 @@ namespace Nekoyume.Action
             
             if (!world.IsUnlocked)
             {
-                throw new InvalidWorldException($"{worldId} is locked.");
+                throw new InvalidWorldException($"{addressesHex}{worldId} is locked.");
             }
          
             if (world.StageBegin != worldRow.StageBegin ||
@@ -149,7 +151,7 @@ namespace Nekoyume.Action
                 !world.IsStageCleared && stageId != world.StageBegin)
             {
                 throw new InvalidStageException(
-                    $"Aborted as the stage ({worldId}/{stageId}) is not cleared; " +
+                    $"{addressesHex}Aborted as the stage ({worldId}/{stageId}) is not cleared; " +
                     $"cleared stage: {world.StageClearedId}"
                 );
             }
@@ -158,7 +160,7 @@ namespace Nekoyume.Action
             var mimisbrunnrSheet = states.GetSheet<MimisbrunnrSheet>();
             if (!mimisbrunnrSheet.TryGetValue(stageId, out var mimisbrunnrSheetRow))
             {
-                throw new SheetRowNotFoundException("MimisbrunnrSheet", stageId);
+                throw new SheetRowNotFoundException("MimisbrunnrSheet", addressesHex, stageId);
             }
             
             foreach (var equipmentId in equipments)
@@ -169,12 +171,12 @@ namespace Nekoyume.Action
                     if (!mimisbrunnrSheetRow.ElementalTypes.Exists(x => x == elementalType))
                     {
                         throw new InvalidElementalException(
-                            $"ElementalType of {equipmentId} does not match.");
+                            $"{addressesHex}ElementalType of {equipmentId} does not match.");
                     }
                 }
             }
             sw.Stop();
-            Log.Debug("Mimisbrunnr Check Equipments ElementalType: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Mimisbrunnr Check Equipments ElementalType: {Elapsed}", addressesHex, sw.Elapsed);
 
             avatarState.ValidateEquipmentsV2(equipments, context.BlockIndex);
             avatarState.ValidateConsumable(foods, context.BlockIndex);
@@ -184,7 +186,7 @@ namespace Nekoyume.Action
             if (avatarState.actionPoint < stageRow.CostAP)
             {
                 throw new NotEnoughActionPointException(
-                    $"Aborted due to insufficient action point: " +
+                    $"{addressesHex}Aborted due to insufficient action point: " +
                     $"{avatarState.actionPoint} < {stageRow.CostAP}"
                 );
             }
@@ -194,7 +196,7 @@ namespace Nekoyume.Action
             equippableItem.AddRange(equipments);
             avatarState.EquipItems(equippableItem);
             sw.Stop();
-            Log.Debug("Mimisbrunnr Unequip items: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Mimisbrunnr Unequip items: {Elapsed}", addressesHex, sw.Elapsed);
             
             sw.Restart();
             var costumeStatSheet = states.GetSheet<CostumeStatSheet>();
@@ -208,16 +210,17 @@ namespace Nekoyume.Action
                 costumeStatSheet,
                 2);
             sw.Stop();
-            Log.Debug("Mimisbrunnr Initialize Simulator: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Mimisbrunnr Initialize Simulator: {Elapsed}", addressesHex, sw.Elapsed);
             
             sw.Restart();
             simulator.SimulateV2();
             sw.Stop();
-            Log.Debug("Mimisbrunnr Simulator.Simulate(): {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Mimisbrunnr Simulator.Simulate(): {Elapsed}", addressesHex, sw.Elapsed);
             
             Log.Debug(
-                "Execute Mimisbrunnr({AvatarAddress}); worldId: {WorldId}, stageId: {StageId}, result: {Result}, " +
+                "{AddressesHex}Execute Mimisbrunnr({AvatarAddress}); worldId: {WorldId}, stageId: {StageId}, result: {Result}, " +
                 "clearWave: {ClearWave}, totalWave: {TotalWave}",
+                addressesHex,
                 avatarAddress,
                 worldId,
                 stageId,
@@ -238,7 +241,7 @@ namespace Nekoyume.Action
                 );
             }
             sw.Stop();
-            Log.Debug("Mimisbrunnr ClearStage: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Mimisbrunnr ClearStage: {Elapsed}", addressesHex, sw.Elapsed);
             
             sw.Restart();
             avatarState.Update(simulator);
@@ -251,7 +254,7 @@ namespace Nekoyume.Action
             states = states.SetState(avatarAddress, avatarState.Serialize());
 
             sw.Stop();
-            Log.Debug("Mimisbrunnr Set AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Mimisbrunnr Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             
             sw.Restart();
             if (states.TryGetState(RankingMapAddress, out Dictionary d) && simulator.Log.IsClear)
@@ -260,19 +263,19 @@ namespace Nekoyume.Action
                 ranking.Update(avatarState);
 
                 sw.Stop();
-                Log.Debug("Mimisbrunnr Update RankingState: {Elapsed}", sw.Elapsed);
+                Log.Debug("{AddressesHex}Mimisbrunnr Update RankingState: {Elapsed}", addressesHex, sw.Elapsed);
                 sw.Restart();
 
                 var serialized = ranking.Serialize();
 
                 sw.Stop();
-                Log.Debug("Mimisbrunnr Serialize RankingState: {Elapsed}", sw.Elapsed);
+                Log.Debug("{AddressesHex}Mimisbrunnr Serialize RankingState: {Elapsed}", addressesHex, sw.Elapsed);
                 sw.Restart();
                 states = states.SetState(RankingMapAddress, serialized);
             }
 
             sw.Stop();
-            Log.Debug("Mimisbrunnr Set RankingState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Mimisbrunnr Set RankingState: {Elapsed}", addressesHex, sw.Elapsed);
             
             sw.Restart();
             if (simulator.Log.stageId >= GameConfig.RequireClearedStageLevel.ActionsInRankingBoard &&
@@ -295,12 +298,12 @@ namespace Nekoyume.Action
                     }
 
                     sw.Stop();
-                    Log.Debug("Mimisbrunnr Update WeeklyArenaState: {Elapsed}", sw.Elapsed);
+                    Log.Debug("{AddressesHex}Mimisbrunnr Update WeeklyArenaState: {Elapsed}", addressesHex, sw.Elapsed);
 
                     sw.Restart();
                     var weeklySerialized = weekly.Serialize();
                     sw.Stop();
-                    Log.Debug("Mimisbrunnr Serialize RankingState: {Elapsed}", sw.Elapsed);
+                    Log.Debug("{AddressesHex}Mimisbrunnr Serialize RankingState: {Elapsed}", addressesHex, sw.Elapsed);
 
                     states = states.SetState(weekly.address, weeklySerialized);
                 }
@@ -309,7 +312,7 @@ namespace Nekoyume.Action
             Result = simulator.Log;
 
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("Mimisbrunnr Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}Mimisbrunnr Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states;
         }
     }

--- a/Lib9c/Action/MimisbrunnrBattle2.cs
+++ b/Lib9c/Action/MimisbrunnrBattle2.cs
@@ -67,7 +67,7 @@ namespace Nekoyume.Action
                 return states.SetState(WeeklyArenaAddress, MarkChanged);
             }
 
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
             
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/NotEnoughClearedStageLevelException.cs
+++ b/Lib9c/Action/NotEnoughClearedStageLevelException.cs
@@ -10,8 +10,8 @@ namespace Nekoyume.Action
         {
         }
 
-        public NotEnoughClearedStageLevelException(int require, int current) : this(
-            $"Aborted as the signer is not cleared the minimum stage level required: {current} < {require}.")
+        public NotEnoughClearedStageLevelException(string addressesHex, int require, int current) : this(
+            $"{addressesHex}Aborted as the signer is not cleared the minimum stage level required: {current} < {require}.")
         {
         }
 

--- a/Lib9c/Action/NotEnoughFungibleAssetValueException.cs
+++ b/Lib9c/Action/NotEnoughFungibleAssetValueException.cs
@@ -13,44 +13,42 @@ namespace Nekoyume.Action
         {
         }
 
-        public NotEnoughFungibleAssetValueException(string require, string current)
-            : this(
-                $"Aborted as the signer's balance is insufficient to pay entrance fee/stake: {current} < {require}.")
+        public NotEnoughFungibleAssetValueException(string addressesHex, string require, string current)
+            : base(
+                $"{addressesHex}Aborted as the signer's balance is insufficient to pay entrance fee/stake: {current} < {require}.")
         {
         }
 
         public NotEnoughFungibleAssetValueException(
+            string addressesHex,
             FungibleAssetValue require,
-            FungibleAssetValue current) : this(require.ToString(), current.ToString())
+            FungibleAssetValue current) : this(addressesHex, require.ToString(), current.ToString())
         {
         }
 
         public NotEnoughFungibleAssetValueException(
+            string addressesHex,
             FungibleAssetValue require,
-            BigInteger current)
-            : this(require.ToString(), current.ToString(CultureInfo.InvariantCulture))
+            BigInteger current) : this(addressesHex, require.ToString(), current.ToString(CultureInfo.InvariantCulture))
         {
         }
 
         public NotEnoughFungibleAssetValueException(
+            string addressesHex,
             BigInteger require,
-            FungibleAssetValue current)
-            : this(require.ToString(CultureInfo.InvariantCulture), current.ToString())
+            FungibleAssetValue current) : this(addressesHex, require.ToString(CultureInfo.InvariantCulture), current.ToString())
         {
         }
 
         public NotEnoughFungibleAssetValueException(
+            string addressesHex,
             BigInteger require,
             BigInteger current)
-            : this(
-                require.ToString(CultureInfo.InvariantCulture),
-                current.ToString(CultureInfo.InvariantCulture))
+            : this(addressesHex, require.ToString(CultureInfo.InvariantCulture), current.ToString(CultureInfo.InvariantCulture))
         {
         }
 
-        public NotEnoughFungibleAssetValueException(
-            SerializationInfo info,
-            StreamingContext context) : base(info, context)
+        public NotEnoughFungibleAssetValueException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/Lib9c/Action/NotEnoughWeeklyArenaChallengeCountException.cs
+++ b/Lib9c/Action/NotEnoughWeeklyArenaChallengeCountException.cs
@@ -6,12 +6,13 @@ namespace Nekoyume.Action
     [Serializable]
     public class NotEnoughWeeklyArenaChallengeCountException : Exception
     {
+        public const string BaseMessage = "Aborted as the arena state reached the daily limit."; 
+        
         public NotEnoughWeeklyArenaChallengeCountException(string message) : base(message)
         {
         }
 
-        public NotEnoughWeeklyArenaChallengeCountException()
-            : this("Aborted as the arena state reached the daily limit.")
+        public NotEnoughWeeklyArenaChallengeCountException() : base(BaseMessage)
         {
         }
 

--- a/Lib9c/Action/PatchTableSheet.cs
+++ b/Lib9c/Action/PatchTableSheet.cs
@@ -27,17 +27,25 @@ namespace Nekoyume.Action
                     .SetState(GameConfigState.Address, MarkChanged);
             }
 
+            var addressesHex = GetSignerAndStateAddressesHex(context);
+
             CheckPermission(context);
 
             var sheets = states.GetState(sheetAddress);
             var value = sheets is null ? string.Empty : sheets.ToDotnetString();
 
-            Log.Debug($"[{ctx.BlockIndex}] {TableName} was patched by {ctx.Signer.ToHex()}\n" +
-                      "before:\n" +
-                      value +
-                      "\n" +
-                      "after:\n" +
-                      TableCsv
+            Log.Debug(
+                "{AddressesHex}[{BlockIndex}] {TableName} was patched by {Signer}\n" +
+                "before:\n" +
+                "{Value}\n" +
+                "after:\n" +
+                "{TableCsv}",
+                addressesHex,
+                ctx.BlockIndex,
+                TableName,
+                ctx.Signer.ToHex(),
+                value,
+                TableCsv
             );
 
             states = states.SetState(sheetAddress, TableCsv.Serialize());

--- a/Lib9c/Action/PatchTableSheet.cs
+++ b/Lib9c/Action/PatchTableSheet.cs
@@ -27,7 +27,7 @@ namespace Nekoyume.Action
                     .SetState(GameConfigState.Address, MarkChanged);
             }
 
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context);
 
             CheckPermission(context);
 
@@ -35,15 +35,13 @@ namespace Nekoyume.Action
             var value = sheets is null ? string.Empty : sheets.ToDotnetString();
 
             Log.Debug(
-                "{AddressesHex}[{BlockIndex}] {TableName} was patched by {Signer}\n" +
+                "{AddressesHex}{TableName} was patched\n" +
                 "before:\n" +
                 "{Value}\n" +
                 "after:\n" +
                 "{TableCsv}",
                 addressesHex,
-                ctx.BlockIndex,
                 TableName,
-                ctx.Signer.ToHex(),
                 value,
                 TableCsv
             );

--- a/Lib9c/Action/RankingBattle.cs
+++ b/Lib9c/Action/RankingBattle.cs
@@ -43,7 +43,7 @@ namespace Nekoyume.Action
                     .MarkBalanceChanged(GoldCurrencyMock, ctx.Signer, WeeklyArenaAddress);
             }
 
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress, EnemyAddress);
 
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/RankingBattle.cs
+++ b/Lib9c/Action/RankingBattle.cs
@@ -43,27 +43,30 @@ namespace Nekoyume.Action
                     .MarkBalanceChanged(GoldCurrencyMock, ctx.Signer, WeeklyArenaAddress);
             }
 
+            var addressesHex = GetSignerAndStateAddressesHex(context);
+
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
             Log.Debug(
-                "RankingBattle exec started. costume: ({CostumeIds}), equipment: ({EquipmentIds})",
+                "{AddressesHex}RankingBattle exec started. costume: ({CostumeIds}), equipment: ({EquipmentIds})",
+                addressesHex,
                 string.Join(",", costumeIds),
                 string.Join(",", equipmentIds)
             );
 
             if (AvatarAddress.Equals(EnemyAddress))
             {
-                throw new InvalidAddressException("Aborted as the signer tried to battle for themselves.");
+                throw new InvalidAddressException($"{addressesHex}Aborted as the signer tried to battle for themselves.");
             }
 
             if (!states.TryGetAvatarState(ctx.Signer, AvatarAddress, out var avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
 
             sw.Stop();
-            Log.Debug("RankingBattle Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var items = equipmentIds.Concat(costumeIds);
@@ -73,19 +76,20 @@ namespace Nekoyume.Action
             avatarState.ValidateCostume(costumeIds);
 
             sw.Stop();
-            Log.Debug("RankingBattle Validate Equipments: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Validate Equipments: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             avatarState.EquipItems(items);
 
             sw.Stop();
-            Log.Debug("RankingBattle Equip Equipments: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Equip Equipments: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!avatarState.worldInformation.TryGetUnlockedWorldByStageClearedBlockIndex(out var world) ||
                 world.StageClearedId < GameConfig.RequireClearedStageLevel.ActionsInRankingBoard)
             {
                 throw new NotEnoughClearedStageLevelException(
+                    addressesHex,
                     GameConfig.RequireClearedStageLevel.ActionsInRankingBoard,
                     world.StageClearedId);
             }
@@ -93,17 +97,17 @@ namespace Nekoyume.Action
             var enemyAvatarState = states.GetAvatarState(EnemyAddress);
             if (enemyAvatarState is null)
             {
-                throw new FailedLoadStateException($"Aborted as the avatar state of the opponent ({EnemyAddress}) was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the opponent ({EnemyAddress}) was failed to load.");
             }
 
             sw.Stop();
-            Log.Debug("RankingBattle Get Enemy AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Get Enemy AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var weeklyArenaState = states.GetWeeklyArenaState(WeeklyArenaAddress);
 
             sw.Stop();
-            Log.Debug("RankingBattle Get WeeklyArenaState ({Address}): {Elapsed}", WeeklyArenaAddress, sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Get WeeklyArenaState ({Address}): {Elapsed}", addressesHex, WeeklyArenaAddress, sw.Elapsed);
             sw.Restart();
 
             if (weeklyArenaState.Ended)
@@ -114,7 +118,7 @@ namespace Nekoyume.Action
             var costumeStatSheet = states.GetSheet<CostumeStatSheet>();
 
             sw.Stop();
-            Log.Debug("RankingBattle Get CostumeStatSheet: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Get CostumeStatSheet: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!weeklyArenaState.ContainsKey(AvatarAddress))
@@ -122,7 +126,7 @@ namespace Nekoyume.Action
                 var characterSheet = states.GetSheet<CharacterSheet>();
                 weeklyArenaState.SetV2(avatarState, characterSheet, costumeStatSheet);
                 sw.Stop();
-                Log.Debug("RankingBattle Set AvatarInfo: {Elapsed}", sw.Elapsed);
+                Log.Debug("{AddressesHex}RankingBattle Set AvatarInfo: {Elapsed}", addressesHex, sw.Elapsed);
                 sw.Restart();
             }
 
@@ -130,7 +134,8 @@ namespace Nekoyume.Action
 
             if (arenaInfo.DailyChallengeCount <= 0)
             {
-                throw new NotEnoughWeeklyArenaChallengeCountException();
+                throw new NotEnoughWeeklyArenaChallengeCountException(
+                    addressesHex + NotEnoughWeeklyArenaChallengeCountException.BaseMessage);
             }
 
             if (!arenaInfo.Active)
@@ -140,13 +145,13 @@ namespace Nekoyume.Action
 
             if (!weeklyArenaState.ContainsKey(EnemyAddress))
             {
-                throw new WeeklyArenaStateNotContainsAvatarAddressException(EnemyAddress);
+                throw new WeeklyArenaStateNotContainsAvatarAddressException(addressesHex, EnemyAddress);
             }
 
-            Log.Debug(weeklyArenaState.address.ToHex());
+            Log.Debug("{WeeklyArenaStateAddress}", weeklyArenaState.address.ToHex());
 
             sw.Stop();
-            Log.Debug("RankingBattle Validate ArenaInfo: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Validate ArenaInfo: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var simulator = new RankingSimulator(
@@ -164,14 +169,16 @@ namespace Nekoyume.Action
 
             sw.Stop();
             Log.Debug(
-                "RankingBattle Simulate() with equipment:({Equipment}), costume:({Costume}): {Elapsed}",
+                "{AddressesHex}RankingBattle Simulate() with equipment:({Equipment}), costume:({Costume}): {Elapsed}",
+                addressesHex,
                 string.Join(",", simulator.Player.Equipments.Select(r => r.ItemId)),
                 string.Join(",", simulator.Player.Costumes.Select(r => r.ItemId)),
                 sw.Elapsed
             );
 
             Log.Debug(
-                "Execute RankingBattle({AvatarAddress}); result: {Result} event count: {EventCount}",
+                "{AddressesHex}Execute RankingBattle({AvatarAddress}); result: {Result} event count: {EventCount}",
+                addressesHex,
                 AvatarAddress,
                 simulator.Log.result,
                 simulator.Log.Count
@@ -182,24 +189,28 @@ namespace Nekoyume.Action
 
             foreach (var itemBase in simulator.Reward.OrderBy(i => i.Id))
             {
-                Log.Debug($"RankingBattle Add Reward Item({itemBase.Id}): {{Elapsed}}", sw.Elapsed);
+                Log.Debug(
+                    "{AddressesHex}RankingBattle Add Reward Item({ItemBaseId}): {Elapsed}",
+                    addressesHex,
+                    itemBase.Id,
+                    sw.Elapsed);
                 avatarState.inventory.AddItem(itemBase);
             }
 
             states = states.SetState(WeeklyArenaAddress, weeklyArenaState.Serialize());
 
             sw.Stop();
-            Log.Debug("RankingBattle Serialize WeeklyArenaState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Serialize WeeklyArenaState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(AvatarAddress, avatarState.Serialize());
 
             sw.Stop();
-            Log.Debug("RankingBattle Serialize AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Serialize AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("RankingBattle Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}RankingBattle Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states;
         }
 

--- a/Lib9c/Action/RankingBattle2.cs
+++ b/Lib9c/Action/RankingBattle2.cs
@@ -43,7 +43,7 @@ namespace Nekoyume.Action
                     .MarkBalanceChanged(GoldCurrencyMock, ctx.Signer, WeeklyArenaAddress);
             }
 
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress, EnemyAddress);
             
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/RankingBattle2.cs
+++ b/Lib9c/Action/RankingBattle2.cs
@@ -43,40 +43,44 @@ namespace Nekoyume.Action
                     .MarkBalanceChanged(GoldCurrencyMock, ctx.Signer, WeeklyArenaAddress);
             }
 
+            var addressesHex = GetSignerAndStateAddressesHex(context);
+            
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
             Log.Debug(
-                "RankingBattle exec started. costume: ({CostumeIds}), equipment: ({EquipmentIds})",
+                "{AddressesHex}RankingBattle exec started. costume: ({CostumeIds}), equipment: ({EquipmentIds})",
+                addressesHex,
                 string.Join(",", costumeIds),
                 string.Join(",", equipmentIds)
             );
 
             if (AvatarAddress.Equals(EnemyAddress))
             {
-                throw new InvalidAddressException("Aborted as the signer tried to battle for themselves.");
+                throw new InvalidAddressException($"{addressesHex}Aborted as the signer tried to battle for themselves.");
             }
 
             if (!states.TryGetAvatarState(ctx.Signer, AvatarAddress, out var avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
 
             sw.Stop();
-            Log.Debug("RankingBattle Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             avatarState.ValidateEquipments(equipmentIds, context.BlockIndex);
             avatarState.ValidateConsumable(consumableIds, context.BlockIndex);
 
             sw.Stop();
-            Log.Debug("RankingBattle Validate Equipments: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Validate Equipments: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!avatarState.worldInformation.TryGetUnlockedWorldByStageClearedBlockIndex(out var world) ||
                 world.StageClearedId < GameConfig.RequireClearedStageLevel.ActionsInRankingBoard)
             {
                 throw new NotEnoughClearedStageLevelException(
+                    addressesHex,
                     GameConfig.RequireClearedStageLevel.ActionsInRankingBoard,
                     world.StageClearedId);
             }
@@ -86,40 +90,42 @@ namespace Nekoyume.Action
             avatarState.ValidateCostume(new HashSet<int>(costumeIds));
 
             sw.Stop();
-            Log.Debug("RankingBattle Equip Equipments: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Equip Equipments: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var enemyAvatarState = states.GetAvatarState(EnemyAddress);
             if (enemyAvatarState is null)
             {
-                throw new FailedLoadStateException($"Aborted as the avatar state of the opponent ({EnemyAddress}) was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the opponent ({EnemyAddress}) was failed to load.");
             }
 
             sw.Stop();
-            Log.Debug("RankingBattle Get Enemy AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Get Enemy AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var weeklyArenaState = states.GetWeeklyArenaState(WeeklyArenaAddress);
 
             sw.Stop();
-            Log.Debug("RankingBattle Get WeeklyArenaState ({Address}): {Elapsed}", WeeklyArenaAddress, sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Get WeeklyArenaState ({Address}): {Elapsed}", addressesHex, WeeklyArenaAddress, sw.Elapsed);
             sw.Restart();
 
             if (weeklyArenaState.Ended)
             {
-                throw new WeeklyArenaStateAlreadyEndedException();
+                throw new WeeklyArenaStateAlreadyEndedException(
+                    addressesHex + WeeklyArenaStateAlreadyEndedException.BaseMessage);
             }
 
             if (!weeklyArenaState.ContainsKey(AvatarAddress))
             {
-                throw new WeeklyArenaStateNotContainsAvatarAddressException(AvatarAddress);
+                throw new WeeklyArenaStateNotContainsAvatarAddressException(addressesHex, AvatarAddress);
             }
 
             var arenaInfo = weeklyArenaState[AvatarAddress];
 
             if (arenaInfo.DailyChallengeCount <= 0)
             {
-                throw new NotEnoughWeeklyArenaChallengeCountException();
+                throw new NotEnoughWeeklyArenaChallengeCountException(
+                    addressesHex + NotEnoughWeeklyArenaChallengeCountException.BaseMessage);
             }
 
             if (!arenaInfo.Active)
@@ -129,17 +135,17 @@ namespace Nekoyume.Action
 
             if (!weeklyArenaState.ContainsKey(EnemyAddress))
             {
-                throw new WeeklyArenaStateNotContainsAvatarAddressException(EnemyAddress);
+                throw new WeeklyArenaStateNotContainsAvatarAddressException(addressesHex, EnemyAddress);
             }
 
             sw.Stop();
-            Log.Debug("RankingBattle Validate ArenaInfo: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Validate ArenaInfo: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var costumeStatSheet = states.GetSheet<CostumeStatSheet>();
 
             sw.Stop();
-            Log.Debug("RankingBattle Get CostumeStatSheet: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Get CostumeStatSheet: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var simulator = new RankingSimulator(
@@ -157,14 +163,16 @@ namespace Nekoyume.Action
 
             sw.Stop();
             Log.Debug(
-                "RankingBattle Simulate() with equipment:({Equipment}), costume:({Costume}): {Elapsed}",
+                "{AddressesHex}RankingBattle Simulate() with equipment:({Equipment}), costume:({Costume}): {Elapsed}",
+                addressesHex,
                 string.Join(",", simulator.Player.Equipments.Select(r => r.ItemId)),
                 string.Join(",", simulator.Player.Costumes.Select(r => r.ItemId)),
                 sw.Elapsed
             );
 
             Log.Debug(
-                "Execute RankingBattle({AvatarAddress}); result: {Result} event count: {EventCount}",
+                "{AddressesHex}Execute RankingBattle({AvatarAddress}); result: {Result} event count: {EventCount}",
+                addressesHex,
                 AvatarAddress,
                 simulator.Log.result,
                 simulator.Log.Count
@@ -175,24 +183,28 @@ namespace Nekoyume.Action
 
             foreach (var itemBase in simulator.Reward.OrderBy(i => i.Id))
             {
-                Log.Debug($"RankingBattle Add Reward Item({itemBase.Id}): {{Elapsed}}", sw.Elapsed);
+                Log.Debug(
+                    "{AddressesHex}RankingBattle Add Reward Item({ItemBaseId}): {Elapsed}",
+                    addressesHex,
+                    itemBase.Id,
+                    sw.Elapsed);
                 avatarState.inventory.AddItem(itemBase);
             }
 
             states = states.SetState(WeeklyArenaAddress, weeklyArenaState.Serialize());
 
             sw.Stop();
-            Log.Debug("RankingBattle Serialize WeeklyArenaState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Serialize WeeklyArenaState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(AvatarAddress, avatarState.Serialize());
 
             sw.Stop();
-            Log.Debug("RankingBattle Serialize AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Serialize AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("RankingBattle Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}RankingBattle Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states;
         }
 

--- a/Lib9c/Action/RankingBattle3.cs
+++ b/Lib9c/Action/RankingBattle3.cs
@@ -42,28 +42,31 @@ namespace Nekoyume.Action
                     .SetState(ctx.Signer, MarkChanged)
                     .MarkBalanceChanged(GoldCurrencyMock, ctx.Signer, WeeklyArenaAddress);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(context);
 
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
             Log.Debug(
-                "RankingBattle exec started. costume: ({CostumeIds}), equipment: ({EquipmentIds})",
+                "{AddressesHex}RankingBattle exec started. costume: ({CostumeIds}), equipment: ({EquipmentIds})",
+                addressesHex,
                 string.Join(",", costumeIds),
                 string.Join(",", equipmentIds)
             );
 
             if (AvatarAddress.Equals(EnemyAddress))
             {
-                throw new InvalidAddressException("Aborted as the signer tried to battle for themselves.");
+                throw new InvalidAddressException($"{addressesHex}Aborted as the signer tried to battle for themselves.");
             }
 
             if (!states.TryGetAvatarState(ctx.Signer, AvatarAddress, out var avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
 
             sw.Stop();
-            Log.Debug("RankingBattle Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var items = equipmentIds.Concat(costumeIds);
@@ -73,19 +76,20 @@ namespace Nekoyume.Action
             avatarState.ValidateCostume(costumeIds);
 
             sw.Stop();
-            Log.Debug("RankingBattle Validate Equipments: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Validate Equipments: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             avatarState.EquipItems(items);
 
             sw.Stop();
-            Log.Debug("RankingBattle Equip Equipments: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Equip Equipments: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!avatarState.worldInformation.TryGetUnlockedWorldByStageClearedBlockIndex(out var world) ||
                 world.StageClearedId < GameConfig.RequireClearedStageLevel.ActionsInRankingBoard)
             {
                 throw new NotEnoughClearedStageLevelException(
+                    addressesHex,
                     GameConfig.RequireClearedStageLevel.ActionsInRankingBoard,
                     world.StageClearedId);
             }
@@ -93,34 +97,36 @@ namespace Nekoyume.Action
             var enemyAvatarState = states.GetAvatarState(EnemyAddress);
             if (enemyAvatarState is null)
             {
-                throw new FailedLoadStateException($"Aborted as the avatar state of the opponent ({EnemyAddress}) was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the opponent ({EnemyAddress}) was failed to load.");
             }
 
             sw.Stop();
-            Log.Debug("RankingBattle Get Enemy AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Get Enemy AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var weeklyArenaState = states.GetWeeklyArenaState(WeeklyArenaAddress);
 
             sw.Stop();
-            Log.Debug("RankingBattle Get WeeklyArenaState ({Address}): {Elapsed}", WeeklyArenaAddress, sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Get WeeklyArenaState ({Address}): {Elapsed}", addressesHex, WeeklyArenaAddress, sw.Elapsed);
             sw.Restart();
 
             if (weeklyArenaState.Ended)
             {
-                throw new WeeklyArenaStateAlreadyEndedException();
+                throw new WeeklyArenaStateAlreadyEndedException(
+                    addressesHex + WeeklyArenaStateAlreadyEndedException.BaseMessage);
             }
 
             if (!weeklyArenaState.ContainsKey(AvatarAddress))
             {
-                throw new WeeklyArenaStateNotContainsAvatarAddressException(AvatarAddress);
+                throw new WeeklyArenaStateNotContainsAvatarAddressException(addressesHex, AvatarAddress);
             }
 
             var arenaInfo = weeklyArenaState[AvatarAddress];
 
             if (arenaInfo.DailyChallengeCount <= 0)
             {
-                throw new NotEnoughWeeklyArenaChallengeCountException();
+                throw new NotEnoughWeeklyArenaChallengeCountException(
+                    addressesHex + NotEnoughWeeklyArenaChallengeCountException.BaseMessage);
             }
 
             if (!arenaInfo.Active)
@@ -130,19 +136,19 @@ namespace Nekoyume.Action
 
             if (!weeklyArenaState.ContainsKey(EnemyAddress))
             {
-                throw new WeeklyArenaStateNotContainsAvatarAddressException(EnemyAddress);
+                throw new WeeklyArenaStateNotContainsAvatarAddressException(addressesHex, EnemyAddress);
             }
 
-            Log.Debug(weeklyArenaState.address.ToHex());
+            Log.Debug("{WeeklyArenaStateAddress}", weeklyArenaState.address.ToHex());
 
             sw.Stop();
-            Log.Debug("RankingBattle Validate ArenaInfo: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Validate ArenaInfo: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var costumeStatSheet = states.GetSheet<CostumeStatSheet>();
 
             sw.Stop();
-            Log.Debug("RankingBattle Get CostumeStatSheet: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Get CostumeStatSheet: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var simulator = new RankingSimulator(
@@ -160,14 +166,16 @@ namespace Nekoyume.Action
 
             sw.Stop();
             Log.Debug(
-                "RankingBattle Simulate() with equipment:({Equipment}), costume:({Costume}): {Elapsed}",
+                "{AddressesHex}RankingBattle Simulate() with equipment:({Equipment}), costume:({Costume}): {Elapsed}",
+                addressesHex,
                 string.Join(",", simulator.Player.Equipments.Select(r => r.ItemId)),
                 string.Join(",", simulator.Player.Costumes.Select(r => r.ItemId)),
                 sw.Elapsed
             );
 
             Log.Debug(
-                "Execute RankingBattle({AvatarAddress}); result: {Result} event count: {EventCount}",
+                "{AddressesHex}Execute RankingBattle({AvatarAddress}); result: {Result} event count: {EventCount}",
+                addressesHex,
                 AvatarAddress,
                 simulator.Log.result,
                 simulator.Log.Count
@@ -178,24 +186,28 @@ namespace Nekoyume.Action
 
             foreach (var itemBase in simulator.Reward.OrderBy(i => i.Id))
             {
-                Log.Debug($"RankingBattle Add Reward Item({itemBase.Id}): {{Elapsed}}", sw.Elapsed);
+                Log.Debug(
+                    "{AddressesHex}RankingBattle Add Reward Item({ItemBaseId}): {Elapsed}",
+                    addressesHex,
+                    itemBase.Id,
+                    sw.Elapsed);
                 avatarState.inventory.AddItem(itemBase);
             }
 
             states = states.SetState(WeeklyArenaAddress, weeklyArenaState.Serialize());
 
             sw.Stop();
-            Log.Debug("RankingBattle Serialize WeeklyArenaState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Serialize WeeklyArenaState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(AvatarAddress, avatarState.Serialize());
 
             sw.Stop();
-            Log.Debug("RankingBattle Serialize AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}RankingBattle Serialize AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("RankingBattle Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}RankingBattle Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states;
         }
 

--- a/Lib9c/Action/RankingBattle3.cs
+++ b/Lib9c/Action/RankingBattle3.cs
@@ -43,7 +43,7 @@ namespace Nekoyume.Action
                     .MarkBalanceChanged(GoldCurrencyMock, ctx.Signer, WeeklyArenaAddress);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress, EnemyAddress);
 
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/RankingBattle4.cs
+++ b/Lib9c/Action/RankingBattle4.cs
@@ -43,7 +43,7 @@ namespace Nekoyume.Action
                     .MarkBalanceChanged(GoldCurrencyMock, ctx.Signer, WeeklyArenaAddress);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress, EnemyAddress);
 
             Log.Warning("ranking_battle is deprecated. Please use ranking_battle2");
             if (AvatarAddress.Equals(EnemyAddress))

--- a/Lib9c/Action/RankingBattle4.cs
+++ b/Lib9c/Action/RankingBattle4.cs
@@ -42,11 +42,13 @@ namespace Nekoyume.Action
                     .SetState(ctx.Signer, MarkChanged)
                     .MarkBalanceChanged(GoldCurrencyMock, ctx.Signer, WeeklyArenaAddress);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(context);
 
-            Log.Warning($"{nameof(RankingBattle)} is deprecated. Please use ${nameof(RankingBattle2)}");
+            Log.Warning("ranking_battle is deprecated. Please use ranking_battle2");
             if (AvatarAddress.Equals(EnemyAddress))
             {
-                throw new InvalidAddressException("Aborted as the signer tried to battle for themselves.");
+                throw new InvalidAddressException($"{addressesHex}Aborted as the signer tried to battle for themselves.");
             }
 
             if (!states.TryGetAgentAvatarStates(
@@ -55,7 +57,7 @@ namespace Nekoyume.Action
                 out var agentState,
                 out var avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
 
             var costumes = new HashSet<int>(costumeIds);
@@ -68,6 +70,7 @@ namespace Nekoyume.Action
                 world.StageClearedId < GameConfig.RequireClearedStageLevel.ActionsInRankingBoard)
             {
                 throw new NotEnoughClearedStageLevelException(
+                    addressesHex,
                     GameConfig.RequireClearedStageLevel.ActionsInRankingBoard,
                     world.StageClearedId);
             }
@@ -78,26 +81,28 @@ namespace Nekoyume.Action
             var enemyAvatarState = states.GetAvatarState(EnemyAddress);
             if (enemyAvatarState is null)
             {
-                throw new FailedLoadStateException($"Aborted as the avatar state of the opponent ({EnemyAddress}) was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the opponent ({EnemyAddress}) was failed to load.");
             }
 
             var weeklyArenaState = states.GetWeeklyArenaState(WeeklyArenaAddress);
 
             if (weeklyArenaState.Ended)
             {
-                throw new WeeklyArenaStateAlreadyEndedException();
+                throw new WeeklyArenaStateAlreadyEndedException(
+                    addressesHex + WeeklyArenaStateAlreadyEndedException.BaseMessage);
             }
 
             if (!weeklyArenaState.ContainsKey(AvatarAddress))
             {
-                throw new WeeklyArenaStateNotContainsAvatarAddressException(AvatarAddress);
+                throw new WeeklyArenaStateNotContainsAvatarAddressException(addressesHex, AvatarAddress);
             }
 
             var arenaInfo = weeklyArenaState[AvatarAddress];
 
             if (arenaInfo.DailyChallengeCount <= 0)
             {
-                throw new NotEnoughWeeklyArenaChallengeCountException();
+                throw new NotEnoughWeeklyArenaChallengeCountException(
+                    addressesHex + NotEnoughWeeklyArenaChallengeCountException.BaseMessage);
             }
 
             if (!arenaInfo.Active)
@@ -109,7 +114,7 @@ namespace Nekoyume.Action
                 }
                 catch (InvalidOperationException)
                 {
-                    throw new NotEnoughFungibleAssetValueException(EntranceFee, agentBalance);
+                    throw new NotEnoughFungibleAssetValueException(addressesHex, EntranceFee, agentBalance);
                 }
 
                 if (agentBalance >= new FungibleAssetValue(agentBalance.Currency, EntranceFee, 0))
@@ -127,16 +132,16 @@ namespace Nekoyume.Action
                 }
                 else
                 {
-                    throw new NotEnoughFungibleAssetValueException(EntranceFee, agentBalance);
+                    throw new NotEnoughFungibleAssetValueException(addressesHex, EntranceFee, agentBalance);
                 }
             }
 
             if (!weeklyArenaState.ContainsKey(EnemyAddress))
             {
-                throw new WeeklyArenaStateNotContainsAvatarAddressException(EnemyAddress);
+                throw new WeeklyArenaStateNotContainsAvatarAddressException(addressesHex, EnemyAddress);
             }
 
-            Log.Debug(weeklyArenaState.address.ToHex());
+            Log.Debug("{WeeklyArenaStateAddress}", weeklyArenaState.address.ToHex());
 
             var simulator = new RankingSimulator(
                 ctx.Random,

--- a/Lib9c/Action/RapidCombination.cs
+++ b/Lib9c/Action/RapidCombination.cs
@@ -61,38 +61,40 @@ namespace Nekoyume.Action
                     .SetState(slotAddress, MarkChanged);
             }
 
-            Log.Warning($"{nameof(RapidCombination)} is deprecated. Please use ${nameof(RapidCombination2)}");
+            var addressesHex = GetSignerAndStateAddressesHex(context);
+
+            Log.Warning("{AddressesHex}rapid_combination is deprecated. Please use rapid_combination2", addressesHex);
             if (!states.TryGetAgentAvatarStates(
                 context.Signer,
                 avatarAddress,
                 out var agentState,
                 out var avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
 
             var slotState = states.GetCombinationSlotState(avatarAddress, slotIndex);
             if (slotState?.Result is null)
             {
-                throw new CombinationSlotResultNullException($"CombinationSlot Result is null. ({avatarAddress}), ({slotIndex})");
+                throw new CombinationSlotResultNullException($"{addressesHex}CombinationSlot Result is null. ({avatarAddress}), ({slotIndex})");
             }
 
             if (!slotState.Validate(avatarState, context.BlockIndex))
             {
                 throw new CombinationSlotUnlockException(
-                    $"Aborted as the slot state is invalid. slot index: {slotIndex}, context block index: {context.BlockIndex}");
+                    $"{addressesHex}Aborted as the slot state is invalid. slot index: {slotIndex}, context block index: {context.BlockIndex}");
             }
 
             var diff = slotState.Result.itemUsable.RequiredBlockIndex - context.BlockIndex;
             if (diff <= 0)
             {
-                throw new RequiredBlockIndexException($"Already met the required block index. context block index: {context.BlockIndex}, required block index: {slotState.Result.itemUsable.RequiredBlockIndex}");
+                throw new RequiredBlockIndexException($"{addressesHex}Already met the required block index. context block index: {context.BlockIndex}, required block index: {slotState.Result.itemUsable.RequiredBlockIndex}");
             }
 
             var gameConfigState = states.GetGameConfigState();
             if (gameConfigState is null)
             {
-                throw new FailedLoadStateException("Aborted as the GameConfigState was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the GameConfigState was failed to load.");
             }
 
             var count = CalculateHourglassCount(gameConfigState, diff);
@@ -102,7 +104,7 @@ namespace Nekoyume.Action
             if (!avatarState.inventory.RemoveFungibleItem(hourGlass, count))
             {
                 throw new NotEnoughMaterialException(
-                    $"Aborted as the player has no enough material ({row.Id} * {count})");
+                    $"{addressesHex}Aborted as the player has no enough material ({row.Id} * {count})");
             }
 
             slotState.Update(context.BlockIndex, hourGlass, count);

--- a/Lib9c/Action/RapidCombination.cs
+++ b/Lib9c/Action/RapidCombination.cs
@@ -61,7 +61,7 @@ namespace Nekoyume.Action
                     .SetState(slotAddress, MarkChanged);
             }
 
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
 
             Log.Warning("{AddressesHex}rapid_combination is deprecated. Please use rapid_combination2", addressesHex);
             if (!states.TryGetAgentAvatarStates(

--- a/Lib9c/Action/RapidCombination2.cs
+++ b/Lib9c/Action/RapidCombination2.cs
@@ -35,6 +35,8 @@ namespace Nekoyume.Action
                     .SetState(avatarAddress, MarkChanged)
                     .SetState(slotAddress, MarkChanged);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(context);
 
             if (!states.TryGetAgentAvatarStates(
                 context.Signer,
@@ -42,31 +44,31 @@ namespace Nekoyume.Action
                 out var agentState,
                 out var avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
 
             var slotState = states.GetCombinationSlotState(avatarAddress, slotIndex);
             if (slotState?.Result is null)
             {
-                throw new CombinationSlotResultNullException($"CombinationSlot Result is null. ({avatarAddress}), ({slotIndex})");
+                throw new CombinationSlotResultNullException($"{addressesHex}CombinationSlot Result is null. ({avatarAddress}), ({slotIndex})");
             }
 
             if(!avatarState.worldInformation.IsStageCleared(slotState.UnlockStage))
             {
                 avatarState.worldInformation.TryGetLastClearedStageId(out var current);
-                throw new NotEnoughClearedStageLevelException(slotState.UnlockStage, current);
+                throw new NotEnoughClearedStageLevelException(addressesHex, slotState.UnlockStage, current);
             }
 
             var diff = slotState.Result.itemUsable.RequiredBlockIndex - context.BlockIndex;
             if (diff <= 0)
             {
-                throw new RequiredBlockIndexException($"Already met the required block index. context block index: {context.BlockIndex}, required block index: {slotState.Result.itemUsable.RequiredBlockIndex}");
+                throw new RequiredBlockIndexException($"{addressesHex}Already met the required block index. context block index: {context.BlockIndex}, required block index: {slotState.Result.itemUsable.RequiredBlockIndex}");
             }
 
             var gameConfigState = states.GetGameConfigState();
             if (gameConfigState is null)
             {
-                throw new FailedLoadStateException("Aborted as the GameConfigState was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the GameConfigState was failed to load.");
             }
 
             var count = RapidCombination.CalculateHourglassCount(gameConfigState, diff);
@@ -76,7 +78,7 @@ namespace Nekoyume.Action
             if (!avatarState.inventory.RemoveFungibleItem(hourGlass, count))
             {
                 throw new NotEnoughMaterialException(
-                    $"Aborted as the player has no enough material ({row.Id} * {count})");
+                    $"{addressesHex}Aborted as the player has no enough material ({row.Id} * {count})");
             }
 
             slotState.Update(context.BlockIndex, hourGlass, count);

--- a/Lib9c/Action/RapidCombination2.cs
+++ b/Lib9c/Action/RapidCombination2.cs
@@ -36,7 +36,7 @@ namespace Nekoyume.Action
                     .SetState(slotAddress, MarkChanged);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
 
             if (!states.TryGetAgentAvatarStates(
                 context.Signer,

--- a/Lib9c/Action/RedeemCode.cs
+++ b/Lib9c/Action/RedeemCode.cs
@@ -44,7 +44,7 @@ namespace Nekoyume.Action
                 return states;
             }
 
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
 
             if (!states.TryGetAvatarState(context.Signer, AvatarAddress, out AvatarState avatarState))
             {

--- a/Lib9c/Action/RedeemCode.cs
+++ b/Lib9c/Action/RedeemCode.cs
@@ -44,6 +44,8 @@ namespace Nekoyume.Action
                 return states;
             }
 
+            var addressesHex = GetSignerAndStateAddressesHex(context);
+
             if (!states.TryGetAvatarState(context.Signer, AvatarAddress, out AvatarState avatarState))
             {
                 return states;
@@ -62,12 +64,12 @@ namespace Nekoyume.Action
             }
             catch (InvalidRedeemCodeException)
             {
-                Log.Error("Invalid Code");
+                Log.Error("{AddressesHex}Invalid Code", addressesHex);
                 throw;
             }
             catch (DuplicateRedeemException e)
             {
-                Log.Warning(e.Message);
+                Log.Warning("{AddressesHex}{Message}", addressesHex, e.Message);
                 throw;
             }
 

--- a/Lib9c/Action/Sell.cs
+++ b/Lib9c/Action/Sell.cs
@@ -46,7 +46,7 @@ namespace Nekoyume.Action
                 return states.SetState(ctx.Signer, MarkChanged);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, sellerAvatarAddress);
             
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/Sell.cs
+++ b/Lib9c/Action/Sell.cs
@@ -45,56 +45,59 @@ namespace Nekoyume.Action
                 states = states.SetState(sellerAvatarAddress, MarkChanged);
                 return states.SetState(ctx.Signer, MarkChanged);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(context);
+            
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("Sell exec started.");
+            Log.Debug("{AddressesHex}Sell exec started", addressesHex);
 
 
             if (price.Sign < 0)
             {
-                throw new InvalidPriceException($"Aborted as the price is less than zero: {price}.");
+                throw new InvalidPriceException($"{addressesHex}Aborted as the price is less than zero: {price}.");
             }
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, sellerAvatarAddress, out AgentState agentState, out AvatarState avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
             sw.Stop();
-            Log.Debug("Sell Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!avatarState.worldInformation.IsStageCleared(GameConfig.RequireClearedStageLevel.ActionsInShop))
             {
                 avatarState.worldInformation.TryGetLastClearedStageId(out var current);
-                throw new NotEnoughClearedStageLevelException(GameConfig.RequireClearedStageLevel.ActionsInShop, current);
+                throw new NotEnoughClearedStageLevelException(addressesHex, GameConfig.RequireClearedStageLevel.ActionsInShop, current);
             }
 
-            Log.Debug("Sell IsStageCleared: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell IsStageCleared: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
             if (!states.TryGetState(ShopState.Address, out Bencodex.Types.Dictionary shopStateDict))
             {
-                throw new FailedLoadStateException("Aborted as the shop state was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the shop state was failed to load.");
             }
 
-            Log.Debug("Sell Get ShopState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell Get ShopState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
-            Log.Debug("Execute Sell; seller: {SellerAvatarAddress}", sellerAvatarAddress);
+            Log.Debug("{AddressesHex}Execute Sell; seller: {SellerAvatarAddress}", addressesHex, sellerAvatarAddress);
 
             // 인벤토리에서 판매할 아이템을 선택하고 수량을 조절한다.
             if (!avatarState.inventory.TryGetNonFungibleItem(itemId, out ItemUsable nonFungibleItem))
             {
                 throw new ItemDoesNotExistException(
-                    $"Aborted as the NonFungibleItem ({itemId}) was failed to load from avatar's inventory."
+                    $"{addressesHex}Aborted as the NonFungibleItem ({itemId}) was failed to load from avatar's inventory."
                 );
             }
 
             if (nonFungibleItem.RequiredBlockIndex > context.BlockIndex)
             {
                 throw new RequiredBlockIndexException(
-                    $"Aborted as the equipment to enhance ({itemId}) is not available yet; it will be available at the block #{nonFungibleItem.RequiredBlockIndex}."
+                    $"{addressesHex}Aborted as the equipment to enhance ({itemId}) is not available yet; it will be available at the block #{nonFungibleItem.RequiredBlockIndex}."
                 );
             }
 
@@ -121,7 +124,7 @@ namespace Nekoyume.Action
             shopStateDict = shopStateDict.SetItem("products", products);
 
             sw.Stop();
-            Log.Debug("Sell Get Register Item: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell Get Register Item: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             avatarState.updatedAt = ctx.BlockIndex;
@@ -129,14 +132,14 @@ namespace Nekoyume.Action
 
             states = states.SetState(sellerAvatarAddress, avatarState.Serialize());
             sw.Stop();
-            Log.Debug("Sell Set AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(ShopState.Address, shopStateDict);
             sw.Stop();
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("Sell Set ShopState: {Elapsed}", sw.Elapsed);
-            Log.Debug("Sell Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}Sell Set ShopState: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell Total Executed Time: {Elapsed}", addressesHex, ended - started);
 
             return states;
         }

--- a/Lib9c/Action/Sell2.cs
+++ b/Lib9c/Action/Sell2.cs
@@ -45,44 +45,47 @@ namespace Nekoyume.Action
                 states = states.SetState(sellerAvatarAddress, MarkChanged);
                 return states.SetState(ctx.Signer, MarkChanged);
             }
+            
+            var addressesHex = GetSignerAndStateAddressesHex(context);
+            
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("Sell exec started.");
+            Log.Debug("{AddressesHex}Sell exec started.");
 
 
             if (price.Sign < 0)
             {
-                throw new InvalidPriceException($"Aborted as the price is less than zero: {price}.");
+                throw new InvalidPriceException($"{addressesHex}Aborted as the price is less than zero: {price}.");
             }
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, sellerAvatarAddress, out AgentState agentState, out AvatarState avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
             sw.Stop();
-            Log.Debug("Sell Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!avatarState.worldInformation.IsStageCleared(GameConfig.RequireClearedStageLevel.ActionsInShop))
             {
                 avatarState.worldInformation.TryGetLastClearedStageId(out var current);
-                throw new NotEnoughClearedStageLevelException(GameConfig.RequireClearedStageLevel.ActionsInShop, current);
+                throw new NotEnoughClearedStageLevelException(addressesHex, GameConfig.RequireClearedStageLevel.ActionsInShop, current);
             }
 
-            Log.Debug("Sell IsStageCleared: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell IsStageCleared: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
 
             if (!states.TryGetState(ShopState.Address, out Bencodex.Types.Dictionary shopStateDict))
             {
-                throw new FailedLoadStateException("Aborted as the shop state was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the shop state was failed to load.");
             }
 
-            Log.Debug("Sell Get ShopState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell Get ShopState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
-            Log.Debug("Execute Sell; seller: {SellerAvatarAddress}", sellerAvatarAddress);
+            Log.Debug("{AddressesHex}Execute Sell; seller: {SellerAvatarAddress}", addressesHex, sellerAvatarAddress);
 
             var productId = context.Random.GenerateRandomGuid();
             ShopItem shopItem;
@@ -93,7 +96,7 @@ namespace Nekoyume.Action
                 if (equipment.RequiredBlockIndex > context.BlockIndex)
                 {
                     throw new RequiredBlockIndexException(
-                        $"Aborted as the equipment to enhance ({itemId}) is not available yet; it will be available at the block #{equipment.RequiredBlockIndex}."
+                        $"{addressesHex}Aborted as the equipment to enhance ({itemId}) is not available yet; it will be available at the block #{equipment.RequiredBlockIndex}."
                     );
                 }
 
@@ -120,7 +123,7 @@ namespace Nekoyume.Action
             else
             {
                 throw new ItemDoesNotExistException(
-                    $"Aborted as the NonFungibleItem ({itemId}) was failed to load from avatar's inventory.");
+                    $"{addressesHex}Aborted as the NonFungibleItem ({itemId}) was failed to load from avatar's inventory.");
             }
 
             IValue shopItemSerialized = shopItem.Serialize();
@@ -131,7 +134,7 @@ namespace Nekoyume.Action
             shopStateDict = shopStateDict.SetItem("products", products);
 
             sw.Stop();
-            Log.Debug("Sell Get Register Item: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell Get Register Item: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             avatarState.updatedAt = ctx.BlockIndex;
@@ -139,14 +142,14 @@ namespace Nekoyume.Action
 
             states = states.SetState(sellerAvatarAddress, avatarState.Serialize());
             sw.Stop();
-            Log.Debug("Sell Set AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(ShopState.Address, shopStateDict);
             sw.Stop();
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("Sell Set ShopState: {Elapsed}", sw.Elapsed);
-            Log.Debug("Sell Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}Sell Set ShopState: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell Total Executed Time: {Elapsed}", addressesHex, ended - started);
 
             return states;
         }

--- a/Lib9c/Action/Sell2.cs
+++ b/Lib9c/Action/Sell2.cs
@@ -46,12 +46,12 @@ namespace Nekoyume.Action
                 return states.SetState(ctx.Signer, MarkChanged);
             }
             
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, sellerAvatarAddress);
             
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("{AddressesHex}Sell exec started.");
+            Log.Debug("{AddressesHex}Sell exec started", addressesHex);
 
 
             if (price.Sign < 0)

--- a/Lib9c/Action/Sell3.cs
+++ b/Lib9c/Action/Sell3.cs
@@ -46,7 +46,7 @@ namespace Nekoyume.Action
                 return states.SetState(ctx.Signer, MarkChanged);
             }
 
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, sellerAvatarAddress);
             
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/Sell3.cs
+++ b/Lib9c/Action/Sell3.cs
@@ -45,44 +45,47 @@ namespace Nekoyume.Action
                 states = states.SetState(sellerAvatarAddress, MarkChanged);
                 return states.SetState(ctx.Signer, MarkChanged);
             }
+
+            var addressesHex = GetSignerAndStateAddressesHex(context);
+            
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("Sell exec started.");
+            Log.Debug("{AddressesHex}Sell exec started", addressesHex);
 
 
             if (price.Sign < 0)
             {
-                throw new InvalidPriceException($"Aborted as the price is less than zero: {price}.");
+                throw new InvalidPriceException($"{addressesHex}Aborted as the price is less than zero: {price}.");
             }
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, sellerAvatarAddress, out AgentState agentState, out AvatarState avatarState))
             {
-                throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
             sw.Stop();
-            Log.Debug("Sell Get AgentAvatarStates: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!avatarState.worldInformation.IsStageCleared(GameConfig.RequireClearedStageLevel.ActionsInShop))
             {
                 avatarState.worldInformation.TryGetLastClearedStageId(out var current);
-                throw new NotEnoughClearedStageLevelException(GameConfig.RequireClearedStageLevel.ActionsInShop, current);
+                throw new NotEnoughClearedStageLevelException(addressesHex, GameConfig.RequireClearedStageLevel.ActionsInShop, current);
             }
 
-            Log.Debug("Sell IsStageCleared: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell IsStageCleared: {Elapsed}", addressesHex, sw.Elapsed);
 
             sw.Restart();
 
             if (!states.TryGetState(ShopState.Address, out Bencodex.Types.Dictionary shopStateDict))
             {
-                throw new FailedLoadStateException("Aborted as the shop state was failed to load.");
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the shop state was failed to load.");
             }
 
-            Log.Debug("Sell Get ShopState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell Get ShopState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
-            Log.Debug("Execute Sell; seller: {SellerAvatarAddress}", sellerAvatarAddress);
+            Log.Debug("{AddressesHex}Execute Sell; seller: {SellerAvatarAddress}", addressesHex, sellerAvatarAddress);
 
             var productId = context.Random.GenerateRandomGuid();
             ShopItem shopItem;
@@ -91,7 +94,7 @@ namespace Nekoyume.Action
             {
                 if (itemUsable.RequiredBlockIndex > context.BlockIndex)
                 {
-                    throw new RequiredBlockIndexException($"Aborted as the itemUsable to enhance ({itemId}) is not available yet; it will be available at the block #{itemUsable.RequiredBlockIndex}.");
+                    throw new RequiredBlockIndexException($"{addressesHex}Aborted as the itemUsable to enhance ({itemId}) is not available yet; it will be available at the block #{itemUsable.RequiredBlockIndex}.");
                 }
             }
 
@@ -126,7 +129,7 @@ namespace Nekoyume.Action
             else
             {
                 throw new ItemDoesNotExistException(
-                    $"Aborted as the NonFungibleItem ({itemId}) was failed to load from avatar's inventory.");
+                    $"{addressesHex}Aborted as the NonFungibleItem ({itemId}) was failed to load from avatar's inventory.");
             }
 
             IValue shopItemSerialized = shopItem.Serialize();
@@ -137,7 +140,7 @@ namespace Nekoyume.Action
             shopStateDict = shopStateDict.SetItem("products", products);
 
             sw.Stop();
-            Log.Debug("Sell Get Register Item: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell Get Register Item: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             avatarState.updatedAt = ctx.BlockIndex;
@@ -145,14 +148,14 @@ namespace Nekoyume.Action
 
             states = states.SetState(sellerAvatarAddress, avatarState.Serialize());
             sw.Stop();
-            Log.Debug("Sell Set AvatarState: {Elapsed}", sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(ShopState.Address, shopStateDict);
             sw.Stop();
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug("Sell Set ShopState: {Elapsed}", sw.Elapsed);
-            Log.Debug("Sell Total Executed Time: {Elapsed}", ended - started);
+            Log.Debug("{AddressesHex}Sell Set ShopState: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell Total Executed Time: {Elapsed}", addressesHex, ended - started);
 
             return states;
         }

--- a/Lib9c/Action/SellCancellation.cs
+++ b/Lib9c/Action/SellCancellation.cs
@@ -71,7 +71,7 @@ namespace Nekoyume.Action
                 return states.SetState(sellerAvatarAddress, MarkChanged);
             }
 
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, sellerAvatarAddress);
             
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/SellCancellation.cs
+++ b/Lib9c/Action/SellCancellation.cs
@@ -70,17 +70,20 @@ namespace Nekoyume.Action
                 states = states.SetState(ShopState.Address, MarkChanged);
                 return states.SetState(sellerAvatarAddress, MarkChanged);
             }
+
+            var addressesHex = GetSignerAndStateAddressesHex(context);
+            
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug($"Sell Cancel exec started.");
+            Log.Debug("{AddressesHex}Sell Cancel exec started", addressesHex);
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, sellerAvatarAddress, out _, out var avatarState))
             {
                 return states;
             }
             sw.Stop();
-            Log.Debug($"Sell Cancel Get AgentAvatarStates: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!avatarState.worldInformation.TryGetUnlockedWorldByStageClearedBlockIndex(
@@ -98,7 +101,7 @@ namespace Nekoyume.Action
                 return states;
             }
             sw.Stop();
-            Log.Debug($"Sell Cancel Get ShopState: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Get ShopState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             // 상점에서 아이템을 빼온다.
@@ -116,13 +119,13 @@ namespace Nekoyume.Action
             shopStateDict = shopStateDict.SetItem("products", products);
 
             sw.Stop();
-            Log.Debug($"Sell Cancel Get Unregister Item: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Get Unregister Item: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             //9c-beta 브랜치에서는 블록 인덱스도 확인 해야함 (이전 블록 유효성 보장)
             if (outUnregisteredItem.SellerAvatarAddress != sellerAvatarAddress)
             {
-                Log.Error("Invalid Avatar Address");
+                Log.Error("{AddressesHex}Invalid Avatar Address", addressesHex);
                 return states;
             }
 
@@ -140,19 +143,19 @@ namespace Nekoyume.Action
             avatarState.updatedAt = ctx.BlockIndex;
             avatarState.blockIndex = ctx.BlockIndex;
             sw.Stop();
-            Log.Debug($"Sell Cancel Update AvatarState: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Update AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(sellerAvatarAddress, avatarState.Serialize());
             sw.Stop();
-            Log.Debug($"Sell Cancel Set AvatarState: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(ShopState.Address, shopStateDict);
             sw.Stop();
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug($"Sell Cancel Set ShopState: {sw.Elapsed}");
-            Log.Debug($"Sell Cancel Total Executed Time: {ended - started}");
+            Log.Debug("{AddressesHex}Sell Cancel Set ShopState: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell Cancel Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states;
         }
     }

--- a/Lib9c/Action/SellCancellation2.cs
+++ b/Lib9c/Action/SellCancellation2.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using Bencodex.Types;
 using Libplanet;
 using Libplanet.Action;
@@ -42,17 +41,20 @@ namespace Nekoyume.Action
                 states = states.SetState(ShopState.Address, MarkChanged);
                 return states.SetState(sellerAvatarAddress, MarkChanged);
             }
+
+            var addressesHex = GetSignerAndStateAddressesHex(context);
+            
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug($"Sell Cancel exec started.");
+            Log.Debug("{AddressesHex}Sell Cancel exec started", addressesHex);
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, sellerAvatarAddress, out _, out var avatarState))
             {
                 return states;
             }
             sw.Stop();
-            Log.Debug($"Sell Cancel Get AgentAvatarStates: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!avatarState.worldInformation.TryGetUnlockedWorldByStageClearedBlockIndex(
@@ -70,7 +72,7 @@ namespace Nekoyume.Action
                 return states;
             }
             sw.Stop();
-            Log.Debug($"Sell Cancel Get ShopState: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Get ShopState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             // 상점에서 아이템을 빼온다.
@@ -88,13 +90,13 @@ namespace Nekoyume.Action
             shopStateDict = shopStateDict.SetItem("products", products);
 
             sw.Stop();
-            Log.Debug($"Sell Cancel Get Unregister Item: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Get Unregister Item: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             //9c-beta 브랜치에서는 블록 인덱스도 확인 해야함 (이전 블록 유효성 보장)
             if (outUnregisteredItem.SellerAvatarAddress != sellerAvatarAddress)
             {
-                Log.Error("Invalid Avatar Address");
+                Log.Error("{AddressesHex}Invalid Avatar Address", addressesHex);
                 return states;
             }
 
@@ -112,19 +114,19 @@ namespace Nekoyume.Action
             avatarState.updatedAt = ctx.BlockIndex;
             avatarState.blockIndex = ctx.BlockIndex;
             sw.Stop();
-            Log.Debug($"Sell Cancel Update AvatarState: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Update AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(sellerAvatarAddress, avatarState.Serialize());
             sw.Stop();
-            Log.Debug($"Sell Cancel Set AvatarState: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(ShopState.Address, shopStateDict);
             sw.Stop();
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug($"Sell Cancel Set ShopState: {sw.Elapsed}");
-            Log.Debug($"Sell Cancel Total Executed Time: {ended - started}");
+            Log.Debug("{AddressesHex}Sell Cancel Set ShopState: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell Cancel Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states;
         }
     }

--- a/Lib9c/Action/SellCancellation2.cs
+++ b/Lib9c/Action/SellCancellation2.cs
@@ -42,7 +42,7 @@ namespace Nekoyume.Action
                 return states.SetState(sellerAvatarAddress, MarkChanged);
             }
 
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, sellerAvatarAddress);
             
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/SellCancellation3.cs
+++ b/Lib9c/Action/SellCancellation3.cs
@@ -42,7 +42,7 @@ namespace Nekoyume.Action
                 return states.SetState(sellerAvatarAddress, MarkChanged);
             }
 
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, sellerAvatarAddress);
             
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/SellCancellation3.cs
+++ b/Lib9c/Action/SellCancellation3.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using Bencodex.Types;
 using Libplanet;
 using Libplanet.Action;
@@ -42,17 +41,20 @@ namespace Nekoyume.Action
                 states = states.SetState(ShopState.Address, MarkChanged);
                 return states.SetState(sellerAvatarAddress, MarkChanged);
             }
+
+            var addressesHex = GetSignerAndStateAddressesHex(context);
+            
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug($"Sell Cancel exec started.");
+            Log.Debug("{AddressesHex}Sell Cancel exec started", addressesHex);
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, sellerAvatarAddress, out _, out var avatarState))
             {
                 return states;
             }
             sw.Stop();
-            Log.Debug($"Sell Cancel Get AgentAvatarStates: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!avatarState.worldInformation.TryGetUnlockedWorldByStageClearedBlockIndex(
@@ -70,7 +72,7 @@ namespace Nekoyume.Action
                 return states;
             }
             sw.Stop();
-            Log.Debug($"Sell Cancel Get ShopState: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Get ShopState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             // 상점에서 아이템을 빼온다.
@@ -88,13 +90,13 @@ namespace Nekoyume.Action
             shopStateDict = shopStateDict.SetItem("products", products);
 
             sw.Stop();
-            Log.Debug($"Sell Cancel Get Unregister Item: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Get Unregister Item: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             //9c-beta 브랜치에서는 블록 인덱스도 확인 해야함 (이전 블록 유효성 보장)
             if (outUnregisteredItem.SellerAvatarAddress != sellerAvatarAddress)
             {
-                Log.Error("Invalid Avatar Address");
+                Log.Error("{AddressesHex}Invalid Avatar Address", addressesHex);
                 return states;
             }
 
@@ -124,19 +126,19 @@ namespace Nekoyume.Action
             avatarState.blockIndex = ctx.BlockIndex;
 
             sw.Stop();
-            Log.Debug($"Sell Cancel Update AvatarState: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Update AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(sellerAvatarAddress, avatarState.Serialize());
             sw.Stop();
-            Log.Debug($"Sell Cancel Set AvatarState: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(ShopState.Address, shopStateDict);
             sw.Stop();
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug($"Sell Cancel Set ShopState: {sw.Elapsed}");
-            Log.Debug($"Sell Cancel Total Executed Time: {ended - started}");
+            Log.Debug("{AddressesHex}Sell Cancel Set ShopState: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell Cancel Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states;
         }
     }

--- a/Lib9c/Action/SellCancellation4.cs
+++ b/Lib9c/Action/SellCancellation4.cs
@@ -42,7 +42,7 @@ namespace Nekoyume.Action
                 return states.SetState(sellerAvatarAddress, MarkChanged);
             }
 
-            var addressesHex = GetSignerAndStateAddressesHex(context);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, sellerAvatarAddress);
             
             var sw = new Stopwatch();
             sw.Start();

--- a/Lib9c/Action/SellCancellation4.cs
+++ b/Lib9c/Action/SellCancellation4.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using Bencodex.Types;
 using Libplanet;
 using Libplanet.Action;
@@ -42,17 +41,20 @@ namespace Nekoyume.Action
                 states = states.SetState(ShopState.Address, MarkChanged);
                 return states.SetState(sellerAvatarAddress, MarkChanged);
             }
+
+            var addressesHex = GetSignerAndStateAddressesHex(context);
+            
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Debug($"Sell Cancel exec started.");
+            Log.Debug("{AddressesHex}Sell Cancel exec started", addressesHex);
 
             if (!states.TryGetAgentAvatarStates(ctx.Signer, sellerAvatarAddress, out _, out var avatarState))
             {
                 return states;
             }
             sw.Stop();
-            Log.Debug($"Sell Cancel Get AgentAvatarStates: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             if (!avatarState.worldInformation.TryGetUnlockedWorldByStageClearedBlockIndex(
@@ -70,7 +72,7 @@ namespace Nekoyume.Action
                 return states;
             }
             sw.Stop();
-            Log.Debug($"Sell Cancel Get ShopState: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Get ShopState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             // 상점에서 아이템을 빼온다.
@@ -88,13 +90,13 @@ namespace Nekoyume.Action
             shopStateDict = shopStateDict.SetItem("products", products);
 
             sw.Stop();
-            Log.Debug($"Sell Cancel Get Unregister Item: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Get Unregister Item: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             //9c-beta 브랜치에서는 블록 인덱스도 확인 해야함 (이전 블록 유효성 보장)
             if (outUnregisteredItem.SellerAvatarAddress != sellerAvatarAddress)
             {
-                Log.Error("Invalid Avatar Address");
+                Log.Error("{AddressesHex}Invalid Avatar Address", addressesHex);
                 return states;
             }
 
@@ -124,19 +126,19 @@ namespace Nekoyume.Action
             avatarState.blockIndex = ctx.BlockIndex;
 
             sw.Stop();
-            Log.Debug($"Sell Cancel Update AvatarState: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Update AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(sellerAvatarAddress, avatarState.Serialize());
             sw.Stop();
-            Log.Debug($"Sell Cancel Set AvatarState: {sw.Elapsed}");
+            Log.Debug("{AddressesHex}Sell Cancel Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states.SetState(ShopState.Address, shopStateDict);
             sw.Stop();
             var ended = DateTimeOffset.UtcNow;
-            Log.Debug($"Sell Cancel Set ShopState: {sw.Elapsed}");
-            Log.Debug($"Sell Cancel Total Executed Time: {ended - started}");
+            Log.Debug("{AddressesHex}Sell Cancel Set ShopState: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Debug("{AddressesHex}Sell Cancel Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states;
         }
     }

--- a/Lib9c/Action/WeeklyArenaStateAlreadyEndedException.cs
+++ b/Lib9c/Action/WeeklyArenaStateAlreadyEndedException.cs
@@ -6,12 +6,13 @@ namespace Nekoyume.Action
     [Serializable]
     public class WeeklyArenaStateAlreadyEndedException : Exception
     {
+        public const string BaseMessage = "Aborted as the weekly arena state already ended.";
+        
         public WeeklyArenaStateAlreadyEndedException(string message) : base(message)
         {
         }
 
-        public WeeklyArenaStateAlreadyEndedException()
-            : this("Aborted as the weekly arena state already ended.")
+        public WeeklyArenaStateAlreadyEndedException() : base(BaseMessage)
         {
         }
 

--- a/Lib9c/Action/WeeklyArenaStateNotContainsAvatarAddressException.cs
+++ b/Lib9c/Action/WeeklyArenaStateNotContainsAvatarAddressException.cs
@@ -12,8 +12,8 @@ namespace Nekoyume.Action
         {
         }
 
-        public WeeklyArenaStateNotContainsAvatarAddressException(Address avatarAddress)
-            : this($"Aborted as the weekly arena state not contains {avatarAddress}.")
+        public WeeklyArenaStateNotContainsAvatarAddressException(string addressesHex, Address avatarAddress)
+            : this($"{addressesHex}Aborted as the weekly arena state not contains {avatarAddress.ToHex()}.")
         {
         }
 

--- a/Lib9c/Model/Item/ItemBase.cs
+++ b/Lib9c/Model/Item/ItemBase.cs
@@ -90,5 +90,15 @@ namespace Nekoyume.Model.Item
                 .Add("item_sub_type", ItemSubType.Serialize())
                 .Add("grade", Grade.Serialize())
                 .Add("elemental_type", ElementalType.Serialize());
+
+        public override string ToString()
+        {
+            return
+                $"{nameof(Id)}: {Id}" +
+                $", {nameof(Grade)}: {Grade}" +
+                $", {nameof(ItemType)}: {ItemType}" +
+                $", {nameof(ItemSubType)}: {ItemSubType}" +
+                $", {nameof(ElementalType)}: {ElementalType}";
+        }
     }
 }

--- a/Lib9c/Model/Item/Material.cs
+++ b/Lib9c/Model/Item/Material.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Security.Cryptography;
-using Bencodex;
 using Bencodex.Types;
 using Libplanet;
 using Nekoyume.Model.State;
@@ -62,5 +61,11 @@ namespace Nekoyume.Model.Item
                 [(Text) "item_id"] = ItemId.Serialize()
             }.Union((Dictionary) base.Serialize()));
 #pragma warning restore LAA1002
+
+        public override string ToString()
+        {
+            return base.ToString() +
+                   $", {nameof(ItemId)}: {ItemId}";
+        }
     }
 }

--- a/Lib9c/TableData/Exceptions.cs
+++ b/Lib9c/TableData/Exceptions.cs
@@ -40,8 +40,13 @@ namespace Nekoyume.TableData
         {
         }
 
-        public SheetRowNotFoundException(string sheetName, string condition, string value) : base(
-            $"{sheetName}: {condition} - {value}")
+        public SheetRowNotFoundException(string sheetName, string condition, string value) :
+            base($"{sheetName}: {condition} - {value}")
+        {
+        }
+        
+        public SheetRowNotFoundException(string addressesHex, string sheetName, int intKey)
+            : base($"{addressesHex}{sheetName}: Key - {intKey.ToString(CultureInfo.InvariantCulture)}")
         {
         }
 


### PR DESCRIPTION
- Add `ActionBase.GetSignerAndOtherAddressesHex()`
- Use `ActionBase.GetSignerAndOtherAddressesHex()` in all of logs and exception messages that contained from all of `GameAction`

```cs
public class FooGameAction
{
  public Address address1;
  public Address address2;

  public void Execute(context)
  {
    var addressesHex = GetSignerAndOtherAddressesHex(context, address1, address2);
    Log.Debug("{AddressesHex}Some log messages", addressesHex);
    throw new Exception($"{addressesHex}Some exception messages");
  }
}

```
