### PR TITLE
Bump Libplanet

### DIFF
--- a/Lib9c/DebugPolicy.cs
+++ b/Lib9c/DebugPolicy.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -10,6 +11,8 @@ namespace Lib9c
 {
     public class DebugPolicy : IBlockPolicy<PolymorphicAction<ActionBase>>
     {
+        public IComparer<IBlockExcerpt> CanonicalChainComparer { get; } = new TotalDifficultyComparer();
+
         public IAction BlockAction { get; } = new RewardGold();
 
         public InvalidBlockException ValidateNextBlock(


### PR DESCRIPTION
Bumps `Libplanet` submodule to  [`1515c8edf684b3e021a6a7042736d2ad96aa0f37`](https://github.com/planetarium/libplanet/commits/1515c8edf684b3e021a6a7042736d2ad96aa0f37).