### PR TITLE
feature: add query subcommand

### DIFF
--- a/.Lib9c.Tools/Program.cs
+++ b/.Lib9c.Tools/Program.cs
@@ -6,6 +6,7 @@ namespace Lib9c.Tools
     [HasSubCommands(typeof(Genesis), Description = "Manage genesis block.")]
     [HasSubCommands(typeof(Tx), Description = "Manage transactions.")]
     [HasSubCommands(typeof(Store), Description = "Manage store.")]
+    [HasSubCommands(typeof(Query), Description = "Query Commands.")]
     class Program
     {
         static void Main(string[] args) => CoconaLiteApp.Run<Program>(args);

--- a/.Lib9c.Tools/SubCommand/Query.cs
+++ b/.Lib9c.Tools/SubCommand/Query.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Immutable;
+using Cocona;
+using Libplanet.Blocks;
+using Libplanet.RocksDBStore;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Libplanet;
+using Libplanet.Tx;
+using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
+
+namespace Lib9c.Tools.SubCommand
+{
+    public class Query
+    {
+        private static string SerializeHumanReadable<T>(T target)
+        {
+            return JsonSerializer.Serialize(target,
+                new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    Converters =
+                    {
+                        new ByteArrayStringJsonConverter()
+                    }
+                }
+            );
+        }
+        
+        private static TxId TxIdFromString(string hex) =>
+            new TxId(ByteUtil.ParseHex(hex ?? throw new ArgumentNullException(nameof(hex))));
+
+        public void BlockByIndex(
+            [Argument("HOME", Description = "root home path")]
+            string home,
+            [Argument("BLOCK-INDEX", Description = "block index")]
+            int blockIndex
+        )
+        {
+            var store = new RocksDBStore(home);
+            var chainId = store.GetCanonicalChainId();
+            if (chainId == null)
+            {
+                Console.Error.WriteLine("cannot find the main branch of the blockchain");
+                return;
+            }
+
+            var blockHash = store.IndexBlockHash(chainId.Value, blockIndex);
+            if (blockHash == null)
+            {
+                Console.Error.WriteLine($"cannot find the block with the height[{blockIndex}] within the blockchain[{chainId}]");
+                return;
+            }
+
+            var blockDigest = store.GetBlockDigest(blockHash.Value);
+            if (blockDigest == null)
+            {
+                Console.Error.WriteLine($"cannot find the block with the hash[{blockHash}]");
+            }
+            Console.WriteLine(SerializeHumanReadable(blockDigest));
+        }
+
+        public void BlockByHash(
+            [Argument("HOME", Description = "root home path")]
+            string home,
+            [Argument("BLOCK-HASH", Description = "block hash")]
+            string blockHash
+        )
+        {
+            var store = new RocksDBStore(home);
+            var blockDigest = store.GetBlockDigest(BlockHash.FromString(blockHash));
+            if (blockDigest == null)
+            {
+                Console.Error.WriteLine($"cannot find the block with the hash[{blockHash}]");
+                return;
+            }
+            Console.WriteLine(SerializeHumanReadable(blockDigest));
+        }
+        
+        public void TxById(
+            [Argument("HOME", Description = "root home path")]
+            string home,
+            [Argument("TX-ID", Description = "tx id")]
+            string strTxId
+        )
+        {
+            var store = new RocksDBStore(home);
+            var txId = TxIdFromString(strTxId);
+            var tx = store.GetTransaction<NCAction>(txId);
+            if (tx == null)
+            {
+                Console.Error.WriteLine($"cannot find the tx with the tx id[{strTxId}]");
+                return;
+            }
+            Console.WriteLine(SerializeHumanReadable(tx));
+        }
+    }
+
+    public class ByteArrayStringJsonConverter : JsonConverter<ImmutableArray<byte>>
+    {
+        public override ImmutableArray<byte> Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            var hexString = reader.GetString();
+            return ImmutableArray.Create(ByteUtil.ParseHex(hexString));
+        }
+
+        public override void Write(Utf8JsonWriter writer, ImmutableArray<byte> value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(ByteUtil.Hex(value));
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/planetarium/libplanet/issues/1284
Closes https://github.com/planetarium/libplanet/issues/1285

There are 3 commands added by this change.

### commands
* query block-by-index [home directory] [index]
* query block-by-hash [home directory] [hash]
* query tx-by-id [home directory] [txid]

### examples
```
dotnet run query block-by-index /Users/kfangw/.local/share/planetarium/9c-main-partition 100000
```

```json
{
  "HasValue": true,
  "Value": {
    "Header": {
      "ProtocolVersion": 0,
      "Index": 100000,
      "Timestamp": "2020-11-09T18:46:19.256641Z",
      "Nonce": "995b87e0bb3bd744b5ce",
      "Miner": "474cb59dea21159cefcc828b30a8d864e0b94a6b",
      "Difficulty": 5000000,
      "TotalDifficulty": {
        "IsPowerOfTwo": false,
        "IsZero": false,
        "IsOne": false,
        "IsEven": true,
        "Sign": 1
      },
      "PreviousHash": "fa5b380b377133c64ca035502d4c638b25b8af5185e21c9ce9151fe3e78cd34e",
      "TxHash": "b8979d5649e151bcf8a282bfeaa532154709774846a28f41b0fb42348d3a2557",
      "Hash": "537c14d9c169d36139d9f4cd3bef7f912fe55359b38e6c1cd2fa89010546d7b2",
      "PreEvaluationHash": "30f3b6e956e18b0d7fb760326e944380b7eb7070a7c365efb5f81f6d8a010000",
      "StateRootHash": "b61c26da3dd47539d8e1625d422509884282e01536b7dd0fcc0d7807d820fe6b"
    },
    "TxIds": [
      "5b98873d13c7da32ec4d3ce721193b7f671b5706d42b2e46e70887d4b7f06aac",
      "b4ccfef74fd8905bcdc7052eafcae5eead69b4836778e970dc84426d685552b1",
      "29e33babe523db267eb9fd0241ef1a534df9a7c49dc57ec349911e96dc4f65cb",
      "e2d87043e0f7e22a26e1dc4f8aaaa7fa69564c05a2603f1b032076ff96dcdc3f"
    ]
  }
}
```

query the block by hash`537c14d9c169d36139d9f4cd3bef7f912fe55359b38e6c1cd2fa89010546d7b2` which is extracted by the above command.
```
dotnet run query block-by-hash /Users/kfangw/.local/share/planetarium/9c-main-partition 537c14d9c169d36139d9f4cd3bef7f912fe55359b38e6c1cd2fa89010546d7b2
```
the results are equivalent
```json
{
  "HasValue": true,
  "Value": {
    "Header": {
      "ProtocolVersion": 0,
      "Index": 100000,
      "Timestamp": "2020-11-09T18:46:19.256641Z",
      "Nonce": "995b87e0bb3bd744b5ce",
      "Miner": "474cb59dea21159cefcc828b30a8d864e0b94a6b",
      "Difficulty": 5000000,
      "TotalDifficulty": {
        "IsPowerOfTwo": false,
        "IsZero": false,
        "IsOne": false,
        "IsEven": true,
        "Sign": 1
      },
      "PreviousHash": "fa5b380b377133c64ca035502d4c638b25b8af5185e21c9ce9151fe3e78cd34e",
      "TxHash": "b8979d5649e151bcf8a282bfeaa532154709774846a28f41b0fb42348d3a2557",
      "Hash": "537c14d9c169d36139d9f4cd3bef7f912fe55359b38e6c1cd2fa89010546d7b2",
      "PreEvaluationHash": "30f3b6e956e18b0d7fb760326e944380b7eb7070a7c365efb5f81f6d8a010000",
      "StateRootHash": "b61c26da3dd47539d8e1625d422509884282e01536b7dd0fcc0d7807d820fe6b"
    },
    "TxIds": [
      "5b98873d13c7da32ec4d3ce721193b7f671b5706d42b2e46e70887d4b7f06aac",
      "b4ccfef74fd8905bcdc7052eafcae5eead69b4836778e970dc84426d685552b1",
      "29e33babe523db267eb9fd0241ef1a534df9a7c49dc57ec349911e96dc4f65cb",
      "e2d87043e0f7e22a26e1dc4f8aaaa7fa69564c05a2603f1b032076ff96dcdc3f"
    ]
  }
}
```

pick a txid `5b98873d13c7da32ec4d3ce721193b7f671b5706d42b2e46e70887d4b7f06aac` and query
```
dotnet run query tx-by-id /Users/kfangw/.local/share/planetarium/9c-main-partition 5b98873d13c7da32ec4d3ce721193b7f671b5706d42b2e46e70887d4b7f06aac
```
```json
{
  "Id": {
    "ByteArray": "5b98873d13c7da32ec4d3ce721193b7f671b5706d42b2e46e70887d4b7f06aac"
  },
  "Nonce": 1370,
  "Signer": {
    "ByteArray": "22a28aeb62a9ed8df939c1d18daf1d64ff300cbb"
  },
  "UpdatedAddresses": [
    {
      "ByteArray": "22a28aeb62a9ed8df939c1d18daf1d64ff300cbb"
    },
    {
      "ByteArray": "26a23b4166e9b23c5bb16b643c2d9a6e37155b6d"
    },
    {
      "ByteArray": "e0c15f3cef3fcdcb02e181b0077d2813ebc925ca"
    },
    {
      "ByteArray": "498c9d9a6f950faab05d1346884a1cae7761fe92"
    }
  ],
  "Signature": "MEUCIQCAU8VgxygoRlSOmLz0XBV3uVmkC/tySlfkTo8/dPvAIwIgdCEU6tuhz7CX2bKQM4/UqEGvI0ktkvqZmrcSsJMmT7M=",
  "Actions": [
    {
      "InnerAction": {
        "PlainValue": {
          "Inspection": "{\n  \u0022avatarAddress\u0022: b\u0022\\x26\\xa2\\x3b\\x41\\x66\\xe9\\xb2\\x3c\\x5b\\xb1\\x6b\\x64\\x3c\\x2d\\x9a\\x6e\\x37\\x15\\x5b\\x6d\u0022,\n  \u0022costumes\u0022: [],\n  \u0022equipments\u0022: [\n    b\u0022\\x56\\xab\\x7f\\x8a\\xcb\\xe0\\x0a\\x4a\\x83\\x2a\\x52\\x3a\\x61\\xd6\\x5d\\x7a\u0022,\n    b\u0022\\x69\\x81\\x76\\xa0\\xb4\\x83\\x1f\\x42\\x91\\xf9\\x4c\\xbb\\x6b\\x2e\\x19\\xc0\u0022,\n    b\u0022\\xf8\\x51\\x23\\xa7\\x1f\\xdd\\xf8\\x4c\\xb0\\xb5\\xfe\\xbb\\x02\\xf1\\x7a\\x09\u0022,\n    b\u0022\\x65\\x88\\x4f\\xc2\\x4b\\xf4\\x94\\x44\\x96\\xcc\\x1f\\x68\\x91\\x5f\\x8a\\x6e\u0022,\n    b\u0022\\xe2\\xf7\\xe2\\xd8\\x43\\x47\\xc9\\x44\\x93\\xec\\xea\\xf4\\x9f\\x28\\x53\\xc9\u0022,\n    b\u0022\\x96\\x72\\xc9\\xe0\\x7c\\x5c\\xc2\\x41\\xb5\\xa2\\x27\\x69\\x9b\\x9f\\x5c\\x82\u0022\n  ],\n  \u0022foods\u0022: [],\n  \u0022id\u0022: b\u0022\\xcd\\x3c\\xf4\\xdc\\xce\\x2f\\xc4\\x4f\\x84\\x2a\\x7c\\xb4\\x62\\x4c\\xa3\\x3b\u0022,\n  \u0022rankingMapAddress\u0022: b\u0022\\x49\\x8c\\x9d\\x9a\\x6f\\x95\\x0f\\xaa\\xb0\\x5d\\x13\\x46\\x88\\x4a\\x1c\\xae\\x77\\x61\\xfe\\x92\u0022,\n  \u0022stageId\u0022: \u002281\u0022,\n  \u0022weeklyArenaAddress\u0022: b\u0022\\xe0\\xc1\\x5f\\x3c\\xef\\x3f\\xcd\\xcb\\x02\\xe1\\x81\\xb0\\x07\\x7d\\x28\\x13\\xeb\\xc9\\x25\\xca\u0022,\n  \u0022worldId\u0022: \u00222\u0022\n}"
        }
      },
      "PlainValue": {
        "Inspection": "{\n  \u0022type_id\u0022: \u0022hack_and_slash2\u0022,\n  \u0022values\u0022: {\n    \u0022avatarAddress\u0022: b\u0022\\x26\\xa2\\x3b\\x41\\x66\\xe9\\xb2\\x3c\\x5b\\xb1\\x6b\\x64\\x3c\\x2d\\x9a\\x6e\\x37\\x15\\x5b\\x6d\u0022,\n    \u0022costumes\u0022: [],\n    \u0022equipments\u0022: [\n      b\u0022\\x56\\xab\\x7f\\x8a\\xcb\\xe0\\x0a\\x4a\\x83\\x2a\\x52\\x3a\\x61\\xd6\\x5d\\x7a\u0022,\n      b\u0022\\x69\\x81\\x76\\xa0\\xb4\\x83\\x1f\\x42\\x91\\xf9\\x4c\\xbb\\x6b\\x2e\\x19\\xc0\u0022,\n      b\u0022\\xf8\\x51\\x23\\xa7\\x1f\\xdd\\xf8\\x4c\\xb0\\xb5\\xfe\\xbb\\x02\\xf1\\x7a\\x09\u0022,\n      b\u0022\\x65\\x88\\x4f\\xc2\\x4b\\xf4\\x94\\x44\\x96\\xcc\\x1f\\x68\\x91\\x5f\\x8a\\x6e\u0022,\n      b\u0022\\xe2\\xf7\\xe2\\xd8\\x43\\x47\\xc9\\x44\\x93\\xec\\xea\\xf4\\x9f\\x28\\x53\\xc9\u0022,\n      b\u0022\\x96\\x72\\xc9\\xe0\\x7c\\x5c\\xc2\\x41\\xb5\\xa2\\x27\\x69\\x9b\\x9f\\x5c\\x82\u0022\n    ],\n    \u0022foods\u0022: [],\n    \u0022id\u0022: b\u0022\\xcd\\x3c\\xf4\\xdc\\xce\\x2f\\xc4\\x4f\\x84\\x2a\\x7c\\xb4\\x62\\x4c\\xa3\\x3b\u0022,\n    \u0022rankingMapAddress\u0022: b\u0022\\x49\\x8c\\x9d\\x9a\\x6f\\x95\\x0f\\xaa\\xb0\\x5d\\x13\\x46\\x88\\x4a\\x1c\\xae\\x77\\x61\\xfe\\x92\u0022,\n    \u0022stageId\u0022: \u002281\u0022,\n    \u0022weeklyArenaAddress\u0022: b\u0022\\xe0\\xc1\\x5f\\x3c\\xef\\x3f\\xcd\\xcb\\x02\\xe1\\x81\\xb0\\x07\\x7d\\x28\\x13\\xeb\\xc9\\x25\\xca\u0022,\n    \u0022worldId\u0022: \u00222\u0022\n  }\n}"
      }
    }
  ],
  "Timestamp": "2020-11-09T18:45:58.87654+00:00",
  "PublicKey": {},
  "GenesisHash": {
    "HasValue": true,
    "Value": {
      "ByteArray": "4582250d0da33b06779a8475d283d5dd210c683b9b999d74d03fac4f58fa6bce",
      "BytesLength": 32
    }
  },
  "BytesLength": 736
}
```