### PR TITLE
chore: bump `Libplanet` into 0aaa054f14c4444ca4436e26d33df8f4b0fd9625

### DIFF
--- a/.Lib9c.Tests/Action/ActionContext.cs
+++ b/.Lib9c.Tests/Action/ActionContext.cs
@@ -3,10 +3,13 @@ namespace Lib9c.Tests.Action
     using System.Security.Cryptography;
     using Libplanet;
     using Libplanet.Action;
+    using Libplanet.Tx;
 
     public class ActionContext : IActionContext
     {
         public Address Signer { get; set; }
+
+        public TxId? TxId { get; set; }
 
         public Address Miner { get; set; }
 
@@ -28,6 +31,7 @@ namespace Lib9c.Tests.Action
             return new ActionContext
             {
                 Signer = Signer,
+                TxId = TxId,
                 Miner = Miner,
                 BlockIndex = BlockIndex,
                 Rehearsal = Rehearsal,

--- a/.Lib9c.Tests/BlockPolicyTest.cs
+++ b/.Lib9c.Tests/BlockPolicyTest.cs
@@ -627,7 +627,7 @@ namespace Lib9c.Tests
             {
             }
 
-            public IValue GetState(string stateKey, BlockHash? blockHash = null, Guid? chainId = null) =>
+            public IValue GetState(string stateKey, BlockHash? blockHash = null) =>
                 default(Null);
 
             public bool ContainsBlockStates(BlockHash blockHash) => false;

--- a/Lib9c/Action/ActionBase.cs
+++ b/Lib9c/Action/ActionBase.cs
@@ -249,7 +249,7 @@ namespace Nekoyume.Action
                                 return new Bencodex.Types.Dictionary(new[]
                                 {
                                     new KeyValuePair<IKey, IValue>((Text) "address", (Binary) ua.Key.ToByteArray()),
-                                    new KeyValuePair<IKey, IValue>((Text) "currency", c.Serialize()),
+                                    new KeyValuePair<IKey, IValue>((Text) "currency", CurrencyExtensions.Serialize(c)),
                                     new KeyValuePair<IKey, IValue>((Text) "amount", (Integer) b.RawValue),
                                 });
                             }

--- a/Lib9c/Model/Stat/StatType.cs
+++ b/Lib9c/Model/Stat/StatType.cs
@@ -64,6 +64,6 @@ namespace Nekoyume.Model.Stat
             new Binary(BitConverter.GetBytes((int) statType));
 
         public static StatType Deserialize(Binary serialized) =>
-            (StatType) BitConverter.ToInt32(serialized.Value, 0);
+            (StatType) BitConverter.ToInt32(serialized.ToByteArray(), 0);
     }
 }

--- a/Lib9c/Model/State/AgentState.cs
+++ b/Lib9c/Model/State/AgentState.cs
@@ -30,7 +30,7 @@ namespace Nekoyume.Model.State
             avatarAddresses = ((Dictionary)serialized["avatarAddresses"])
                 .Where(kv => kv.Key is Binary)
                 .ToDictionary(
-                    kv => BitConverter.ToInt32(((Binary)kv.Key).Value, 0),
+                    kv => BitConverter.ToInt32(((Binary)kv.Key).ToByteArray(), 0),
                     kv => kv.Value.ToAddress()
                 );
 #pragma warning restore LAA1002

--- a/Lib9c/Model/State/AvatarState.cs
+++ b/Lib9c/Model/State/AvatarState.cs
@@ -162,7 +162,7 @@ namespace Nekoyume.Model.State
             inventory = new Inventory((List)serialized["inventory"]);
             worldInformation = new WorldInformation((Dictionary)serialized["worldInformation"]);
             updatedAt = serialized["updatedAt"].ToLong();
-            agentAddress = new Address(((Binary)serialized["agentAddress"]).Value);
+            agentAddress = new Address(((Binary)serialized["agentAddress"]).ToByteArray());
             questList = new QuestList((Dictionary) serialized["questList"]);
             mailBox = new MailBox((List)serialized["mailBox"]);
             blockIndex = (long)((Integer)serialized["blockIndex"]).Value;

--- a/Lib9c/Model/State/GoldCurrencyState.cs
+++ b/Lib9c/Model/State/GoldCurrencyState.cs
@@ -37,7 +37,7 @@ namespace Nekoyume.Model.State
         {
             var values = new Dictionary<IKey, IValue>
             {
-                [(Text)"currency"] = Currency.Serialize()
+                [(Text)"currency"] = CurrencyExtensions.Serialize(Currency)
             };
 #pragma warning disable LAA1002
             return new Dictionary(values.Union((Dictionary)base.Serialize()));

--- a/Lib9c/Model/State/StateExtensions.cs
+++ b/Lib9c/Model/State/StateExtensions.cs
@@ -66,7 +66,7 @@ namespace Nekoyume.Model.State
             Serialize(Serialize, address);
 
         public static Address ToAddress(this IValue serialized) =>
-            new Address(((Binary)serialized).Value);
+            new Address(((Binary)serialized).ToByteArray());
 
         public static Address? ToNullableAddress(this IValue serialized) =>
             Deserialize(ToAddress, serialized);
@@ -174,7 +174,7 @@ namespace Nekoyume.Model.State
 
         public static DateTimeOffset ToDateTimeOffset(this IValue serialized) =>
             DateTimeOffset.Parse(
-                Encoding.ASCII.GetString(((Binary)serialized).Value),
+                Encoding.ASCII.GetString(((Binary)serialized).ToByteArray()),
                 null,
                 DateTimeStyles.RoundtripKind
             );
@@ -193,7 +193,7 @@ namespace Nekoyume.Model.State
             Serialize(Serialize, number);
 
         public static Guid ToGuid(this IValue serialized) =>
-            new Guid(((Binary)serialized).Value);
+            new Guid(((Binary)serialized).ToByteArray());
 
         public static Guid? ToNullableGuid(this IValue serialized) =>
             Deserialize(ToGuid, serialized);
@@ -332,7 +332,7 @@ namespace Nekoyume.Model.State
 
         public static PublicKey ToPublicKey(this IValue serialized)
         {
-            var bin = ((Binary) serialized).Value;
+            var bin = ((Binary) serialized).ToByteArray();
             return new PublicKey(bin);
         }
 
@@ -358,7 +358,7 @@ namespace Nekoyume.Model.State
 
         public static HashDigest<SHA256> ToItemId(this IValue serialized)
         {
-            return new HashDigest<SHA256>(((Binary)serialized).Value);
+            return new HashDigest<SHA256>(((Binary)serialized).ToByteArray());
         }
 
         #endregion
@@ -368,7 +368,7 @@ namespace Nekoyume.Model.State
         public static IValue Serialize(this FungibleAssetValue value) =>
             new Bencodex.Types.List(new IValue[]
             {
-                value.Currency.Serialize(),
+                CurrencyExtensions.Serialize(value.Currency),
                 value.RawValue.Serialize(),
             });
 


### PR DESCRIPTION
This pull request applies:

 - planetarium/libplanet#1242
 - planetarium/libplanet#1264
 - planetarium/libplanet#1268
 - planetarium/libplanet#1270
 - planetarium/libplanet#1271
 - planetarium/libplanet#1272
 - planetarium/libplanet#1273
 - planetarium/libplanet#1275
 - planetarium/libplanet#1277
 - planetarium/libplanet#1278
 - planetarium/libplanet#1281
 - planetarium/libplanet#1283 
 - planetarium/libplanet#1289
 - planetarium/libplanet#1291
 
 # **NOTICE**
 
 After this pull request, you should take care when you use `Currency.Serialize()` because planetarium/libplanet#1289 pull request introduced `Libplanet.Assets.Currency.Serialize()` and the method signature conflicts with `Nekoyume.CurrencyExtensions.Serialize(this Currency)`.