### PR TITLE
Improve HackAndSlash, RankingBattle execution time

### DIFF
--- a/Lib9c/Battle/RankingSimulator.cs
+++ b/Lib9c/Battle/RankingSimulator.cs
@@ -22,6 +22,7 @@ namespace Nekoyume.Battle
         private readonly ArenaInfo _arenaInfo;
         private readonly ArenaInfo _enemyInfo;
         private readonly AvatarState _avatarState;
+        private readonly int _enemyScore;
 
         public readonly WeeklyArenaRewardSheet WeeklyArenaRewardSheet;
         public override IEnumerable<ItemBase> Reward => _reward;
@@ -47,6 +48,11 @@ namespace Nekoyume.Battle
             _stageId = stageId;
             _arenaInfo = arenaInfo;
             _enemyInfo = enemyInfo;
+            if (!(enemyInfo is null))
+            {
+                _enemyScore  = enemyInfo.Score;
+            }
+
             _avatarState = avatarState;
             WeeklyArenaRewardSheet = rankingSimulatorSheets.WeeklyArenaRewardSheet;
         }
@@ -74,6 +80,31 @@ namespace Nekoyume.Battle
         {
             Player.SetCostumeStat(costumeStatSheet);
             _enemyPlayer.SetCostumeStat(costumeStatSheet);
+        }
+
+        public RankingSimulator(
+            IRandom random,
+            AvatarState avatarState,
+            AvatarState enemyAvatarState,
+            List<Guid> foods,
+            RankingSimulatorSheets rankingSimulatorSheets,
+            int stageId,
+            ArenaInfo arenaInfo,
+            int enemyScore,
+            CostumeStatSheet costumeStatSheet
+        ) : this(
+            random,
+            avatarState,
+            enemyAvatarState,
+            foods,
+            rankingSimulatorSheets,
+            stageId,
+            arenaInfo,
+            null,
+            costumeStatSheet
+        )
+        {
+            _enemyScore = enemyScore;
         }
 
         public Player Simulate()
@@ -265,7 +296,7 @@ namespace Nekoyume.Battle
                 Characters.Enqueue(character, TurnPriority / character.SPD);
             }
 
-            Log.diffScore = _arenaInfo.Update(_avatarState, _enemyInfo, Result);
+            Log.diffScore = _arenaInfo.Update(_avatarState, _enemyScore, Result);
             Log.score = _arenaInfo.Score;
 
             var itemSelector = new WeightedSelector<StageSheet.RewardData>(Random);

--- a/Lib9c/Model/State/WeeklyArenaState.cs
+++ b/Lib9c/Model/State/WeeklyArenaState.cs
@@ -455,6 +455,33 @@ namespace Nekoyume.Model.State
             return Score - current;
         }
 
+        public int Update(AvatarState avatarState, int enemyScore, BattleLog.Result result)
+        {
+            switch (result)
+            {
+                case BattleLog.Result.Win:
+                    ArenaRecord.Win++;
+                    break;
+                case BattleLog.Result.Lose:
+                    ArenaRecord.Lose++;
+                    break;
+                case BattleLog.Result.TimeOver:
+                    ArenaRecord.Draw++;
+                    return 0;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(result), result, null);
+            }
+
+            var score = ArenaScoreHelper.GetScore(Score, enemyScore, result);
+            var calculated = Score + score;
+            var current = Score;
+            Score = Math.Max(1000, calculated);
+            DailyChallengeCount--;
+            ArmorId = avatarState.GetArmorId();
+            Level = avatarState.level;
+            return Score - current;
+        }
+
         public void Activate()
         {
             Active = true;


### PR DESCRIPTION
`Lib9c.Benchmarks` result from latest 20 blocks.

before

```
Loading blocks  00:00:03.4116559
Executing actions       6438ms
Average per block       306ms
Average per tx  90ms
Average per action      76ms
Total elapsed   00:00:09.8500511
```

after

```
Loading blocks  00:00:02.6202123
Executing actions       5321ms
Average per block       253ms
Average per tx  74ms
Average per action      63ms
Total elapsed   00:00:07.9416374
```