### PR TITLE
add blockhash to actionbase and action renderer

### DIFF
--- a/.Lib9c.Tests/Action/ActionEvaluationTest.cs
+++ b/.Lib9c.Tests/Action/ActionEvaluationTest.cs
@@ -5,6 +5,7 @@ namespace Lib9c.Tests.Action
     using Bencodex.Types;
     using Libplanet;
     using Libplanet.Assets;
+    using Libplanet.Blocks;
     using Nekoyume.Action;
     using Xunit;
 
@@ -15,6 +16,7 @@ namespace Lib9c.Tests.Action
         {
             var currency = new Currency("NCG", 2, minters: null);
             var signer = default(Address);
+            var blockHash = default(BlockHash);
             var blockIndex = 1234;
             var states = new State()
                 .SetState(signer, (Text)"ANYTHING")
@@ -30,6 +32,7 @@ namespace Lib9c.Tests.Action
             {
                 Action = action,
                 Signer = signer,
+                BlockHash = blockHash,
                 BlockIndex = blockIndex,
                 PreviousStates = states,
                 OutputStates = states,
@@ -44,6 +47,7 @@ namespace Lib9c.Tests.Action
 
             // FIXME We should equality check more precisely.
             Assert.Equal(evaluation.Signer, deserialized.Signer);
+            Assert.Equal(evaluation.BlockHash, deserialized.BlockHash);
             Assert.Equal(evaluation.BlockIndex, deserialized.BlockIndex);
             var dict = (Dictionary)deserialized.OutputStates.GetState(default);
             Assert.Equal("value", (Text)dict["key"]);

--- a/Lib9c/Action/ActionBase.cs
+++ b/Lib9c/Action/ActionBase.cs
@@ -11,9 +11,10 @@ using Bencodex;
 using Bencodex.Types;
 using Libplanet;
 using Libplanet.Action;
+using Libplanet.Assets;
+using Libplanet.Blocks;
 using Serilog;
 using Nekoyume.Model.State;
-using Libplanet.Assets;
 #if UNITY_EDITOR || UNITY_STANDALONE
 using UniRx;
 #else
@@ -193,6 +194,8 @@ namespace Nekoyume.Action
 
             public Address Signer { get; set; }
 
+            public BlockHash BlockHash { get; set; }
+
             public long BlockIndex { get; set; }
 
             public IAccountStateDelta OutputStates { get; set; }
@@ -205,6 +208,7 @@ namespace Nekoyume.Action
             {
                 Action = FromBytes((byte[]) info.GetValue("action", typeof(byte[])));
                 Signer = new Address((byte[]) info.GetValue("signer", typeof(byte[])));
+                BlockHash = new BlockHash((byte[]) info.GetValue("blockHash", typeof(byte[])));
                 BlockIndex = info.GetInt64("blockIndex");
                 OutputStates = new AccountStateDelta((byte[]) info.GetValue("outputStates", typeof(byte[])));
                 Exception = (Exception) info.GetValue("exc", typeof(Exception));
@@ -215,6 +219,7 @@ namespace Nekoyume.Action
             {
                 info.AddValue("action", ToBytes(Action));
                 info.AddValue("signer", Signer.ToByteArray());
+                info.AddValue("blockHash", BlockHash.ToByteArray());
                 info.AddValue("blockIndex", BlockIndex);
                 info.AddValue("outputStates", ToBytes(OutputStates, OutputStates.UpdatedAddresses));
                 info.AddValue("exc", Exception);

--- a/Lib9c/Renderer/ActionRenderer.cs
+++ b/Lib9c/Renderer/ActionRenderer.cs
@@ -39,6 +39,7 @@ namespace Lib9c.Renderer
             {
                 Action = GetActionBase(action),
                 Signer = context.Signer,
+                BlockHash = context.BlockHash,
                 BlockIndex = context.BlockIndex,
                 OutputStates = nextStates,
                 PreviousStates = context.PreviousStates,
@@ -55,6 +56,7 @@ namespace Lib9c.Renderer
             {
                 Action = GetActionBase(action),
                 Signer = context.Signer,
+                BlockHash = context.BlockHash,
                 BlockIndex = context.BlockIndex,
                 OutputStates = nextStates,
                 PreviousStates = context.PreviousStates,
@@ -72,6 +74,7 @@ namespace Lib9c.Renderer
             {
                 Action = GetActionBase(action),
                 Signer = context.Signer,
+                BlockHash = context.BlockHash,
                 BlockIndex = context.BlockIndex,
                 OutputStates = context.PreviousStates,
                 Exception = exception,
@@ -90,6 +93,7 @@ namespace Lib9c.Renderer
                 Action = GetActionBase(action),
                 Signer = context.Signer,
                 BlockIndex = context.BlockIndex,
+                BlockHash = context.BlockHash,
                 OutputStates = context.PreviousStates,
                 Exception = exception,
                 PreviousStates = context.PreviousStates,
@@ -139,6 +143,7 @@ namespace Lib9c.Renderer
             {
                 Action = (T) eval.Action,
                 Signer = eval.Signer,
+                BlockHash = eval.BlockHash,
                 BlockIndex = eval.BlockIndex,
                 OutputStates = eval.OutputStates,
                 Exception = eval.Exception,
@@ -155,6 +160,7 @@ namespace Lib9c.Renderer
             {
                 Action = (T) eval.Action,
                 Signer = eval.Signer,
+                BlockHash = eval.BlockHash,
                 BlockIndex = eval.BlockIndex,
                 OutputStates = eval.OutputStates,
                 Exception = eval.Exception,
@@ -170,6 +176,7 @@ namespace Lib9c.Renderer
             {
                 Action = eval.Action,
                 Signer = eval.Signer,
+                BlockHash = eval.BlockHash,
                 BlockIndex = eval.BlockIndex,
                 OutputStates = eval.OutputStates,
                 Exception = eval.Exception,
@@ -185,6 +192,7 @@ namespace Lib9c.Renderer
             {
                 Action = eval.Action,
                 Signer = eval.Signer,
+                BlockHash = eval.BlockHash,
                 BlockIndex = eval.BlockIndex,
                 OutputStates = eval.OutputStates,
                 Exception = eval.Exception,


### PR DESCRIPTION
This PR adds a `BlockHash` property to `ActionBase` in response to the updated `IActionContext` in [Libplanet](https://github.com/planetarium/libplanet/commit/25c52a9968812cc683de4bced7547bfc6b51f7e7).