### PR TITLE
Ignore block without transaction

### DIFF
--- a/.Lib9c.Tests/BlockPolicyTest.cs
+++ b/.Lib9c.Tests/BlockPolicyTest.cs
@@ -346,6 +346,10 @@ namespace Lib9c.Tests
                     );
             }
 
+            blockChain.MakeTransaction(
+                adminPrivateKey,
+                new PolymorphicAction<ActionBase>[] { new DailyReward(), }
+            );
             await blockChain.MineBlock(stranger);
 
             await Assert.ThrowsAsync<InvalidMinerException>(async () =>
@@ -356,15 +360,27 @@ namespace Lib9c.Tests
             new Miner(blockChain, null, minerKeys[0], true).StageProofTransaction();
             await blockChain.MineBlock(miners[0]);
 
+            blockChain.MakeTransaction(
+                adminPrivateKey,
+                new PolymorphicAction<ActionBase>[] { new DailyReward(), }
+            );
             // it's okay because next block index is 3
             await blockChain.MineBlock(stranger);
 
+            blockChain.MakeTransaction(
+                adminPrivateKey,
+                new PolymorphicAction<ActionBase>[] { new DailyReward(), }
+            );
             // it isn't :(
             await Assert.ThrowsAsync<InvalidMinerException>(async () =>
             {
                 await blockChain.MineBlock(stranger);
             });
 
+            blockChain.MakeTransaction(
+                adminPrivateKey,
+                new PolymorphicAction<ActionBase>[] { new DailyReward(), }
+            );
             // the authorization block should be proved by a proof tx
             await Assert.ThrowsAsync<InvalidMinerException>(
                 async () => await blockChain.MineBlock(miners[1])
@@ -401,6 +417,10 @@ namespace Lib9c.Tests
             await blockChain.MineBlock(miners[1]);
 
             // it's okay because block index exceeds limitations.
+            blockChain.MakeTransaction(
+                adminPrivateKey,
+                new PolymorphicAction<ActionBase>[] { new DailyReward(), }
+            );
             await blockChain.MineBlock(stranger);
         }
 
@@ -445,7 +465,10 @@ namespace Lib9c.Tests
 
             // Index 1
             Assert.Equal(4096, policy.GetNextBlockDifficulty(blockChain));
-
+            blockChain.MakeTransaction(
+                adminPrivateKey,
+                new PolymorphicAction<ActionBase>[] { new DailyReward(), }
+            );
             dateTimeOffset += TimeSpan.FromSeconds(1);
             await blockChain.MineBlock(miner, dateTimeOffset);
 
@@ -458,7 +481,10 @@ namespace Lib9c.Tests
 
             // Index 3
             Assert.Equal(4096, policy.GetNextBlockDifficulty(blockChain));
-
+            blockChain.MakeTransaction(
+                adminPrivateKey,
+                new PolymorphicAction<ActionBase>[] { new DailyReward(), }
+            );
             dateTimeOffset += TimeSpan.FromSeconds(1);
             await blockChain.MineBlock(miner, dateTimeOffset);
 
@@ -472,6 +498,10 @@ namespace Lib9c.Tests
             // Index 5
             Assert.Equal(4096, policy.GetNextBlockDifficulty(blockChain));
 
+            blockChain.MakeTransaction(
+                adminPrivateKey,
+                new PolymorphicAction<ActionBase>[] { new DailyReward(), }
+            );
             dateTimeOffset += TimeSpan.FromSeconds(1);
             await blockChain.MineBlock(miner, dateTimeOffset);
 
@@ -484,31 +514,46 @@ namespace Lib9c.Tests
 
             // Index 7
             Assert.Equal(4098, policy.GetNextBlockDifficulty(blockChain));
-
+            blockChain.MakeTransaction(
+                adminPrivateKey,
+                new PolymorphicAction<ActionBase>[] { new DailyReward(), }
+            );
             dateTimeOffset += TimeSpan.FromSeconds(1);
             await blockChain.MineBlock(miner, dateTimeOffset);
 
             // Index 8
             Assert.Equal(4100, policy.GetNextBlockDifficulty(blockChain));
-
+            blockChain.MakeTransaction(
+                adminPrivateKey,
+                new PolymorphicAction<ActionBase>[] { new DailyReward(), }
+            );
             dateTimeOffset += TimeSpan.FromSeconds(1);
             await blockChain.MineBlock(miner, dateTimeOffset);
 
             // Index 9
             Assert.Equal(4102, policy.GetNextBlockDifficulty(blockChain));
-
+            blockChain.MakeTransaction(
+                adminPrivateKey,
+                new PolymorphicAction<ActionBase>[] { new DailyReward(), }
+            );
             dateTimeOffset += TimeSpan.FromSeconds(1);
             await blockChain.MineBlock(miner, dateTimeOffset);
 
             // Index 10
             Assert.Equal(4104, policy.GetNextBlockDifficulty(blockChain));
-
+            blockChain.MakeTransaction(
+                adminPrivateKey,
+                new PolymorphicAction<ActionBase>[] { new DailyReward(), }
+            );
             dateTimeOffset += TimeSpan.FromSeconds(1);
             await blockChain.MineBlock(miner, dateTimeOffset);
 
             // Index 11
             Assert.Equal(4106, policy.GetNextBlockDifficulty(blockChain));
-
+            blockChain.MakeTransaction(
+                adminPrivateKey,
+                new PolymorphicAction<ActionBase>[] { new DailyReward(), }
+            );
             dateTimeOffset += TimeSpan.FromSeconds(20);
             await blockChain.MineBlock(miner, dateTimeOffset);
 

--- a/Lib9c/BlockPolicy.cs
+++ b/Lib9c/BlockPolicy.cs
@@ -162,6 +162,16 @@ namespace Nekoyume.BlockChain
                     miner
                 );
             }
+            
+            // To prevent selfish mining, we define a consensus that blocks with no transactions are do not accepted. 
+            if (block.Transactions.Count <= 0)
+            {
+                return new InvalidMinerException(
+                    $"The block #{block.Index} {block.Hash}'s miner {miner} should be proven by " +
+                    "including a least one of transaction.",
+                    miner
+                );
+            }
 
             // Authority should be proven through a no-op transaction (= txs with zero actions).
             // (For backward compatibility, blocks before 1,200,000th don't have to be proven.

--- a/Lib9c/BlockPolicy.cs
+++ b/Lib9c/BlockPolicy.cs
@@ -85,7 +85,9 @@ namespace Nekoyume.BlockChain
             BlockChain<NCAction> blocks,
             Block<NCAction> nextBlock
         ) =>
-            ValidateMinerAuthority(nextBlock) ?? base.ValidateNextBlock(blocks, nextBlock);
+            ValidateBlock(nextBlock) 
+            ?? ValidateMinerAuthority(nextBlock) 
+            ?? base.ValidateNextBlock(blocks, nextBlock);
 
         public override long GetNextBlockDifficulty(BlockChain<NCAction> blocks)
         {
@@ -138,6 +140,26 @@ namespace Nekoyume.BlockChain
             return Math.Max(nextDifficulty, _minimumDifficulty);
         }
 
+        private InvalidBlockException ValidateBlock(Block<NCAction> block)
+        {
+            if (!(block.Miner is Address miner))
+            {
+                return null;
+            }
+
+            // To prevent selfish mining, we define a consensus that blocks with no transactions are do not accepted. 
+            if (block.Transactions.Count <= 0)
+            {
+                return new InvalidMinerException(
+                    $"The block #{block.Index} {block.Hash} (mined by {miner}) should " +
+                    "include at least one transaction.",
+                    miner
+                );
+            }
+
+            return null;
+        }
+        
         private InvalidBlockException ValidateMinerAuthority(Block<NCAction> block)
         {
             if (AuthorizedMinersState is null)
@@ -163,15 +185,6 @@ namespace Nekoyume.BlockChain
                 );
             }
             
-            // To prevent selfish mining, we define a consensus that blocks with no transactions are do not accepted. 
-            if (block.Transactions.Count <= 0)
-            {
-                return new InvalidMinerException(
-                    $"The block #{block.Index} {block.Hash} (mined by {miner}) should " +
-                    "include at least one transaction.",
-                    miner
-                );
-            }
 
             // Authority should be proven through a no-op transaction (= txs with zero actions).
             // (For backward compatibility, blocks before 1,200,000th don't have to be proven.

--- a/Lib9c/BlockPolicy.cs
+++ b/Lib9c/BlockPolicy.cs
@@ -167,8 +167,8 @@ namespace Nekoyume.BlockChain
             if (block.Transactions.Count <= 0)
             {
                 return new InvalidMinerException(
-                    $"The block #{block.Index} {block.Hash}'s miner {miner} should be proven by " +
-                    "including a least one of transaction.",
+                    $"The block #{block.Index} {block.Hash} (mined by {miner}) should " +
+                    "include at least one transaction.",
                     miner
                 );
             }


### PR DESCRIPTION
Blocks without transactions are not accepted to prevent selfish mining. 