### PR TITLE
Proof of concept: See candidate chains' generation number first

### DIFF
--- a/.Lib9c.Tests/CanonicalChainComparerTest.cs
+++ b/.Lib9c.Tests/CanonicalChainComparerTest.cs
@@ -1,0 +1,71 @@
+namespace Lib9c.Tests
+{
+    using System;
+    using System.Linq;
+    using System.Numerics;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Blockchain;
+    using Libplanet.Blocks;
+    using Nekoyume.Action;
+    using Nekoyume.Model.State;
+    using Xunit;
+
+    public class CanonicalChainComparerTest
+    {
+        private readonly BlockPerception[] _blocks;
+        private readonly DateTimeOffset _perceivedTime;
+
+        public CanonicalChainComparerTest()
+        {
+            DateTimeOffset p = DateTimeOffset.UtcNow;
+            _perceivedTime = p;
+            _blocks = new[]
+            {
+                new BlockPerception(new MockBlock { Index = 10001, TotalDifficulty = 50010 }, p),
+                new BlockPerception(new MockBlock { Index = 10002, TotalDifficulty = 50009 }, p),
+                new BlockPerception(new MockBlock { Index = 9999,  TotalDifficulty = 50011 }, p),
+            };
+        }
+
+        [Fact]
+        public void WhenAuthorizedMinersAlive()
+        {
+            IOrderedEnumerable<BlockPerception> ordered = _blocks.OrderBy(
+                p => p,
+                new CanonicalChainComparer(
+                    new AuthorizedMinersState(new Address[0], 50, 20000),
+                    TimeSpan.FromHours(3)
+                )
+            );
+
+            Assert.Equal(_blocks.Reverse(), ordered);
+        }
+
+        [Fact]
+        public void WhenAuthorizedMinersNoLongerAlive()
+        {
+            BlockPerception[] oredered = _blocks.OrderBy(
+                p => p,
+                new CanonicalChainComparer(
+                    new AuthorizedMinersState(new Address[0], 50, 5000),
+                    TimeSpan.FromHours(3)
+                )
+            ).ToArray();
+
+            Assert.Equal(new[] { _blocks[1], _blocks[0], _blocks[2] }, oredered);
+        }
+
+        public class MockBlock : IBlockExcerpt
+        {
+            public int ProtocolVersion =>
+                Block<PolymorphicAction<ActionBase>>.CurrentProtocolVersion;
+
+            public long Index { get; set; }
+
+            public BlockHash Hash => new BlockHash(new byte[32]);
+
+            public BigInteger TotalDifficulty { get; set; }
+        }
+    }
+}

--- a/Lib9c/BlockPolicy.cs
+++ b/Lib9c/BlockPolicy.cs
@@ -4,6 +4,7 @@ using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
 using Libplanet.Tx;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Lib9c;
 using Libplanet;
@@ -16,6 +17,7 @@ namespace Nekoyume.BlockChain
     {
         private readonly long _minimumDifficulty;
         private readonly long _difficultyBoundDivisor;
+        private AuthorizedMinersState _authorizedMinersState;
 
         /// <summary>
         /// Whether to ignore or respect hardcoded block indices to make older
@@ -70,7 +72,10 @@ namespace Nekoyume.BlockChain
                 maxTransactionsPerBlock: maxTransactionsPerBlock,
                 maxBlockBytes: maxBlockBytes,
                 maxGenesisBytes: maxGenesisBytes,
-                doesTransactionFollowPolicy: doesTransactionFollowPolicy
+                doesTransactionFollowPolicy: doesTransactionFollowPolicy,
+                canonicalChainComparer: new CanonicalChainComparer(
+                    null,
+                    blockInterval + blockInterval + blockInterval)
             )
         {
             _minimumDifficulty = minimumDifficulty;
@@ -79,7 +84,15 @@ namespace Nekoyume.BlockChain
                 ignoreHardcodedIndicesForBackwardCompatibility;
         }
 
-        public AuthorizedMinersState AuthorizedMinersState { get; set; }
+        public AuthorizedMinersState AuthorizedMinersState
+        {
+            get => _authorizedMinersState;
+            set
+            {
+                _authorizedMinersState = value;
+                ((CanonicalChainComparer)CanonicalChainComparer).AuthorizedMinersState = value;
+            }
+        }
 
         public override InvalidBlockException ValidateNextBlock(
             BlockChain<NCAction> blocks,

--- a/Lib9c/CanonicalChainComparer.cs
+++ b/Lib9c/CanonicalChainComparer.cs
@@ -1,0 +1,53 @@
+using Libplanet.Blockchain;
+using Nekoyume.Model.State;
+using System;
+using System.Collections.Generic;
+
+namespace Lib9c
+{
+    public class CanonicalChainComparer : IComparer<BlockPerception>
+    {
+        private readonly TotalDifficultyComparer _totalDifficultyComparer;
+
+        public CanonicalChainComparer(
+            AuthorizedMinersState authorizedMinersState,
+            TimeSpan outdateAfter
+        )
+            : this(authorizedMinersState, outdateAfter, () => DateTimeOffset.UtcNow)
+        {
+        }
+
+        public CanonicalChainComparer(
+            AuthorizedMinersState authorizedMinersState,
+            TimeSpan outdateAfter,
+            Func<DateTimeOffset> currentTimeGetter
+        )
+        {
+            AuthorizedMinersState = authorizedMinersState;
+            _totalDifficultyComparer = new TotalDifficultyComparer(outdateAfter, currentTimeGetter);
+        }
+
+        public AuthorizedMinersState AuthorizedMinersState { get; internal set; }
+
+        public int Compare(BlockPerception x, BlockPerception y)
+        {
+            if (AuthorizedMinersState is AuthorizedMinersState authorizedMinersState)
+            {
+                long xIndex = x.BlockExcerpt.Index;
+                long yIndex = y.BlockExcerpt.Index;
+                if (xIndex <= authorizedMinersState.ValidUntil ||
+                    yIndex <= authorizedMinersState.ValidUntil)
+                {
+                    long xGen = xIndex / authorizedMinersState.Interval;
+                    long yGen = yIndex / authorizedMinersState.Interval;
+                    if (xGen != yGen)
+                    {
+                        return xGen < yGen ? -1 : 1;
+                    }
+                }
+            }
+
+            return _totalDifficultyComparer.Compare(x, y);
+        }
+    }
+}


### PR DESCRIPTION
As long as we have authorized miners who authorize a chain every 50 blocks, comparing blocks before the last authorized block is unnecessary for determining the canonical chain.  This patch tries an experimental approach to compare chains' *generation number* first, and then compare total difficulties among longest generations.

For example, suppose we have 4 competing chains (tips):

| Chains:          | Chain A | Chain B | Chain C |
|------------------|---------|---------|---------|
| Tip index        | 10001   | 10002   | 9999    |
| Last authorized  | 10000   | 10000   | 9950    |
| Generation       | 200     | 200     | 199     |
| Total difficulty | 50010   | 50009   | 50011   |

Under the existing rule ([`Libplanet.Blockchain.TotalDifficultyComparer`](https://github.com/planetarium/libplanet/blob/0.11.1/Libplanet/Blockchain/TotalDifficultyComparer.cs)), the chain C is determined to be canon due to its total difficulty, even though other two candidates have more authorized blocks.

However, under the new rule (`Lib9c.CanonicalChainComparer`), the chain A is determined to be canon instead, because the new rule eliminates the chain C first due to its inferior generation number (200 vs 199), and then compares chain A & B's total difficulties.