### PR TITLE
Difficulty adjustment formula patch

### DIFF
--- a/Lib9c/BlockPolicy.cs
+++ b/Lib9c/BlockPolicy.cs
@@ -127,7 +127,7 @@ namespace Nekoyume.BlockChain
             DateTimeOffset prevTimestamp = prevBlock.Timestamp;
             TimeSpan timeDiff = prevTimestamp - beforePrevTimestamp;
             long timeDiffMilliseconds = (long)timeDiff.TotalMilliseconds;
-            const long minimumMultiplier = -99;
+            const long minimumMultiplier = -1;
             long multiplier = 1 - timeDiffMilliseconds / (long)BlockInterval.TotalMilliseconds;
             multiplier = Math.Max(multiplier, minimumMultiplier);
 

--- a/Lib9c/BlockPolicy.cs
+++ b/Lib9c/BlockPolicy.cs
@@ -14,6 +14,8 @@ namespace Nekoyume.BlockChain
 {
     public class BlockPolicy : BlockPolicy<NCAction>
     {
+        // Approximately starting 2021.07.01
+        private readonly long _difficultyForkIndex = 1825600;
         private readonly long _minimumDifficulty;
         private readonly long _difficultyBoundDivisor;
 
@@ -127,7 +129,7 @@ namespace Nekoyume.BlockChain
             DateTimeOffset prevTimestamp = prevBlock.Timestamp;
             TimeSpan timeDiff = prevTimestamp - beforePrevTimestamp;
             long timeDiffMilliseconds = (long)timeDiff.TotalMilliseconds;
-            const long minimumMultiplier = -1;
+            long minimumMultiplier = index > _difficultyForkIndex ? -1 : -99;
             long multiplier = 1 - timeDiffMilliseconds / (long)BlockInterval.TotalMilliseconds;
             multiplier = Math.Max(multiplier, minimumMultiplier);
 


### PR DESCRIPTION
This PR attempts to mitigate excessive difficulty degradation.

The `minimumMutliplier` value used in `BlockPolicy.GetNextBlockDifficulty()` is to prevent difficulty falling too drastically when there is a black-swan issue. However, this does not consider repeated black-swan events happening near consistently on the main chain right now. The original value `-99` used in Ethereum is rather arbitrary, and there is no good rationale behind it.

The current formula used in `libplanet` is taken from post `Homestead` Ethereum blockchain. The change suggested here would make the difficulty adjustment scheme something between pre-`Homestead` and post-`Homestead`.

As the difficulty check during append does not explicitly check equality, this PR can be removed easily.