### PR TITLE
Add support for previous monster collection

### DIFF
--- a/.Lib9c.Tests/Action/ClaimMonsterCollectionRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimMonsterCollectionRewardTest.cs
@@ -72,7 +72,7 @@ namespace Lib9c.Tests.Action
         [ClassData(typeof(ExecuteFixture))]
         public void Execute(int collectionLevel, long claimBlockIndex, long? receivedBlockIndex, (int, int)[] expectedRewards, Type exc)
         {
-            Address collectionAddress = MonsterCollectionState.DeriveAddress(_signer);
+            Address collectionAddress = MonsterCollectionState.DeriveAddress(_signer, 0);
             var monsterCollectionState = new MonsterCollectionState(collectionAddress, collectionLevel, 0);
             if (receivedBlockIndex is { } receivedBlockIndexNotNull)
             {
@@ -180,7 +180,7 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Execute_Throw_RequiredBlockIndexException()
         {
-            Address collectionAddress = MonsterCollectionState.DeriveAddress(_signer);
+            Address collectionAddress = MonsterCollectionState.DeriveAddress(_signer, 0);
             var monsterCollectionState = new MonsterCollectionState(collectionAddress, 1, 0);
             _state = _state.SetState(collectionAddress, monsterCollectionState.Serialize());
 
@@ -221,7 +221,10 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(LegacyInventoryKey),
                 _avatarAddress.Derive(LegacyWorldInformationKey),
                 _avatarAddress.Derive(LegacyQuestListKey),
-                MonsterCollectionState.DeriveAddress(_signer),
+                MonsterCollectionState.DeriveAddress(_signer, 0),
+                MonsterCollectionState.DeriveAddress(_signer, 1),
+                MonsterCollectionState.DeriveAddress(_signer, 2),
+                MonsterCollectionState.DeriveAddress(_signer, 3),
             };
             Assert.Equal(updatedAddresses.ToImmutableHashSet(), nextState.UpdatedAddresses);
         }

--- a/.Lib9c.Tests/Action/MonsterCollectTest.cs
+++ b/.Lib9c.Tests/Action/MonsterCollectTest.cs
@@ -53,7 +53,7 @@ namespace Lib9c.Tests.Action
         [InlineData(null, 0, 1, null, 0)]
         public void Execute(int? prevLevel, int level, long blockIndex, Type exc, int? expectedStakings)
         {
-            Address monsterCollectionAddress = MonsterCollectionState.DeriveAddress(_signer);
+            Address monsterCollectionAddress = MonsterCollectionState.DeriveAddress(_signer, 0);
             Currency currency = _initialState.GetGoldCurrency();
             FungibleAssetValue balance = currency * 10000000;
             FungibleAssetValue staked = currency * 0;
@@ -154,7 +154,6 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Rehearsal()
         {
-            Address collectionAddress = MonsterCollectionState.DeriveAddress(_signer);
             MonsterCollect action = new MonsterCollect
             {
                 level = 1,
@@ -169,7 +168,10 @@ namespace Lib9c.Tests.Action
             List<Address> updatedAddresses = new List<Address>()
             {
                 _signer,
-                collectionAddress,
+                MonsterCollectionState.DeriveAddress(_signer, 0),
+                MonsterCollectionState.DeriveAddress(_signer, 1),
+                MonsterCollectionState.DeriveAddress(_signer, 2),
+                MonsterCollectionState.DeriveAddress(_signer, 3),
             };
 
             Assert.Equal(updatedAddresses.ToImmutableHashSet(), nextState.UpdatedAddresses);

--- a/Lib9c/Action/ClaimMonsterCollectionReward.cs
+++ b/Lib9c/Action/ClaimMonsterCollectionReward.cs
@@ -21,7 +21,6 @@ namespace Nekoyume.Action
         public override IAccountStateDelta Execute(IActionContext context)
         {
             IAccountStateDelta states = context.PreviousStates;
-            Address collectionAddress = MonsterCollectionState.DeriveAddress(context.Signer);
             Address inventoryAddress = avatarAddress.Derive(LegacyInventoryKey);
             Address worldInformationAddress = avatarAddress.Derive(LegacyWorldInformationKey);
             Address questListAddress = avatarAddress.Derive(LegacyQuestListKey);
@@ -31,15 +30,20 @@ namespace Nekoyume.Action
                 return states
                     .SetState(avatarAddress, MarkChanged)
                     .SetState(inventoryAddress, MarkChanged)
-                    .SetState(collectionAddress, MarkChanged)
                     .SetState(worldInformationAddress, MarkChanged)
-                    .SetState(questListAddress, MarkChanged);
+                    .SetState(questListAddress, MarkChanged)
+                    .SetState(MonsterCollectionState.DeriveAddress(context.Signer, 0), MarkChanged)
+                    .SetState(MonsterCollectionState.DeriveAddress(context.Signer, 1), MarkChanged)
+                    .SetState(MonsterCollectionState.DeriveAddress(context.Signer, 2), MarkChanged)
+                    .SetState(MonsterCollectionState.DeriveAddress(context.Signer, 3), MarkChanged);
             }
 
-            if (!states.TryGetAvatarStateV2(context.Signer, avatarAddress, out AvatarState avatarState))
+            if (!states.TryGetAgentAvatarStatesV2(context.Signer, avatarAddress, out AgentState agentState, out AvatarState avatarState))
             {
                 throw new FailedLoadStateException($"Aborted as the avatar state of the signer failed to load.");
             }
+
+            Address collectionAddress = MonsterCollectionState.DeriveAddress(context.Signer, agentState.MonsterCollectionRound);
 
             if (!states.TryGetState(collectionAddress, out Dictionary stateDict))
             {

--- a/Lib9c/Action/ClaimMonsterCollectionReward.cs
+++ b/Lib9c/Action/ClaimMonsterCollectionReward.cs
@@ -51,22 +51,17 @@ namespace Nekoyume.Action
             }
 
             var monsterCollectionState = new MonsterCollectionState(stateDict);
+            List<MonsterCollectionRewardSheet.RewardInfo> rewards = 
+                monsterCollectionState.CalculateRewards(
+                    states.GetSheet<MonsterCollectionRewardSheet>(),
+                    context.BlockIndex
+                );
 
-            int step = monsterCollectionState.CalculateStep(context.BlockIndex);
-            if (step < 1)
+            if (rewards.Count == 0)
             {
                 throw new RequiredBlockIndexException($"{collectionAddress} is not available yet");
             }
 
-            MonsterCollectionRewardSheet monsterCollectionRewardSheet = 
-                states.GetSheet<MonsterCollectionRewardSheet>();
-            List<MonsterCollectionRewardSheet.RewardInfo> rewards =
-                monsterCollectionRewardSheet[monsterCollectionState.Level].Rewards
-                .GroupBy(ri => ri.ItemId)
-                .Select(g => new MonsterCollectionRewardSheet.RewardInfo(
-                        g.Key,
-                        g.Sum(ri => ri.Quantity) * step))
-                .ToList();
             Guid id = context.Random.GenerateRandomGuid();
             var result = new MonsterCollectionResult(id, avatarAddress, rewards);
             var mail = new MonsterCollectionMail(result, context.BlockIndex, id, context.BlockIndex);

--- a/Lib9c/Action/MonsterCollect.cs
+++ b/Lib9c/Action/MonsterCollect.cs
@@ -19,13 +19,18 @@ namespace Nekoyume.Action
         public override IAccountStateDelta Execute(IActionContext context)
         {
             IAccountStateDelta states = context.PreviousStates;
-            Address monsterCollectionAddress = MonsterCollectionState.DeriveAddress(context.Signer);
             if (context.Rehearsal)
             {
                 return states
-                    .SetState(monsterCollectionAddress, MarkChanged)
+                    .SetState(MonsterCollectionState.DeriveAddress(context.Signer, 0), MarkChanged)
+                    .SetState(MonsterCollectionState.DeriveAddress(context.Signer, 1), MarkChanged)
+                    .SetState(MonsterCollectionState.DeriveAddress(context.Signer, 2), MarkChanged)
+                    .SetState(MonsterCollectionState.DeriveAddress(context.Signer, 3), MarkChanged)
                     .SetState(context.Signer, MarkChanged)
-                    .MarkBalanceChanged(GoldCurrencyMock, context.Signer, monsterCollectionAddress);
+                    .MarkBalanceChanged(GoldCurrencyMock, context.Signer, MonsterCollectionState.DeriveAddress(context.Signer, 0))
+                    .MarkBalanceChanged(GoldCurrencyMock, context.Signer, MonsterCollectionState.DeriveAddress(context.Signer, 1))
+                    .MarkBalanceChanged(GoldCurrencyMock, context.Signer, MonsterCollectionState.DeriveAddress(context.Signer, 2))
+                    .MarkBalanceChanged(GoldCurrencyMock, context.Signer, MonsterCollectionState.DeriveAddress(context.Signer, 3));
             }
 
             MonsterCollectionSheet monsterCollectionSheet = states.GetSheet<MonsterCollectionSheet>();
@@ -45,7 +50,10 @@ namespace Nekoyume.Action
             // Set default gold value.
             FungibleAssetValue requiredGold = currency * 0;
             FungibleAssetValue balance = states.GetBalance(context.Signer, currency);
-
+            Address monsterCollectionAddress = MonsterCollectionState.DeriveAddress(
+                context.Signer,
+                agentState.MonsterCollectionRound
+            );
             if (states.TryGetState(monsterCollectionAddress, out Dictionary stateDict))
             {
                 var existingStates = new MonsterCollectionState(stateDict);

--- a/Lib9c/Model/State/MonsterCollectionState.cs
+++ b/Lib9c/Model/State/MonsterCollectionState.cs
@@ -13,13 +13,14 @@ namespace Nekoyume.Model.State
     [Serializable]
     public class MonsterCollectionState: State
     {
-        public static Address DeriveAddress(Address baseAddress)
+        // We need `round` to integrate previous states.
+        public static Address DeriveAddress(Address baseAddress, int round)
         {
             return baseAddress.Derive(
                 string.Format(
                     CultureInfo.InvariantCulture,
                     DeriveFormat,
-                    0
+                    round
                 )
             );
         }

--- a/Lib9c/Model/State/MonsterCollectionState.cs
+++ b/Lib9c/Model/State/MonsterCollectionState.cs
@@ -97,6 +97,27 @@ namespace Nekoyume.Model.State
             return step;
         }
 
+        public List<MonsterCollectionRewardSheet.RewardInfo> CalculateRewards(
+            MonsterCollectionRewardSheet sheet,
+            long blockIndex
+        )
+        {
+            int step = CalculateStep(blockIndex);
+            if (step > 0)
+            {
+                return sheet[Level].Rewards
+                    .GroupBy(ri => ri.ItemId)
+                    .Select(g => new MonsterCollectionRewardSheet.RewardInfo(
+                                g.Key,
+                                g.Sum(ri => ri.Quantity) * step))
+                    .ToList();
+            }
+            else
+            {
+                return new List<MonsterCollectionRewardSheet.RewardInfo>();
+            }
+        }
+
         public override IValue Serialize()
         {
 #pragma warning disable LAA1002


### PR DESCRIPTION
This PR extends `MonsterCollectionState.DeriveAddress()` to receive collection round for previous monster collection. it can help migration due to continuing previous state.