### PR TITLE
feat: Auth miner consumes txs

### DIFF
--- a/.Lib9c.Tests/Action/RefineAuthMinerTest.cs
+++ b/.Lib9c.Tests/Action/RefineAuthMinerTest.cs
@@ -1,0 +1,136 @@
+﻿namespace Lib9c.Tests.Action
+{
+    using System.Collections.Immutable;
+    using System.Linq;
+    using Bencodex.Types;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Crypto;
+    using Nekoyume.Action;
+    using Nekoyume.Model.State;
+    using Xunit;
+
+    public class RefineAuthMinerTest
+    {
+        [Fact]
+        public void Execute()
+        {
+            var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
+            var miners = GetNewMiners(4);
+            var state = new State(
+                ImmutableDictionary<Address, IValue>.Empty
+                    .Add(AdminState.Address, new AdminState(admin, 100).Serialize())
+                    .Add(AuthorizedMinersState.Address, new AuthorizedMinersState(
+                        miners: miners,
+                        interval: 50,
+                        validUntil: 1000).Serialize())
+            );
+
+            var updatedMiners = GetNewMiners(10);
+            var action = new RefineAuthMiner(
+                2,
+                5000,
+                updatedMiners.ToList()
+            );
+
+            IAccountStateDelta nextState = action.Execute(new ActionContext()
+            {
+                BlockIndex = 1,
+                Miner = default,
+                PreviousStates = state,
+                Signer = admin,
+            });
+
+            var nextAuthMinersStates = new AuthorizedMinersState(
+                (Dictionary)nextState.GetState(AuthorizedMinersState.Address)!
+            );
+
+            Assert.Equal(2, nextAuthMinersStates.Interval);
+            Assert.Equal(5000, nextAuthMinersStates.ValidUntil);
+            Assert.Equal(updatedMiners.ToImmutableHashSet(), nextAuthMinersStates.Miners);
+        }
+
+        [Fact]
+        public void Rehearsal()
+        {
+            var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
+            var miners = GetNewMiners(4);
+            var state = new State(
+                ImmutableDictionary<Address, IValue>.Empty
+                    .Add(AdminState.Address, new AdminState(admin, 100).Serialize())
+                    .Add(AuthorizedMinersState.Address, new AuthorizedMinersState(
+                        miners: miners,
+                        interval: 50,
+                        validUntil: 1000).Serialize())
+            );
+
+            var updatedMiners = GetNewMiners(10);
+            var action = new RefineAuthMiner(
+                2,
+                5000,
+                updatedMiners.ToList()
+            );
+
+            IAccountStateDelta nextState = action.Execute(new ActionContext()
+            {
+                BlockIndex = 1,
+                Miner = default,
+                PreviousStates = state,
+                Signer = admin,
+                Rehearsal = true,
+            });
+
+            Assert.Contains(AuthorizedMinersState.Address, nextState.UpdatedAddresses);
+            Assert.Equal(ActionBase.MarkChanged, nextState.GetState(AuthorizedMinersState.Address));
+        }
+
+        [Fact]
+        public void CheckPermission()
+        {
+            var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
+            var miners = GetNewMiners(4);
+            var state = new State(
+                ImmutableDictionary<Address, IValue>.Empty
+                    .Add(AdminState.Address, new AdminState(admin, 100).Serialize())
+                    .Add(AuthorizedMinersState.Address, new AuthorizedMinersState(
+                        miners: miners,
+                        interval: 50,
+                        validUntil: 1000).Serialize())
+            );
+
+            var updatedMiners = GetNewMiners(10);
+            var action = new RefineAuthMiner(
+                2,
+                5000,
+                updatedMiners.ToList()
+            );
+
+            Assert.Throws<PermissionDeniedException>(() =>
+            {
+                action.Execute(new ActionContext()
+                {
+                    BlockIndex = 1,
+                    Miner = default,
+                    PreviousStates = state,
+                    Signer = new PrivateKey().ToAddress(),
+                });
+            });
+
+            Assert.Throws<PolicyExpiredException>(() =>
+            {
+                action.Execute(new ActionContext()
+                {
+                    BlockIndex = 101,
+                    Miner = default,
+                    PreviousStates = state,
+                    Signer = admin,
+                });
+            });
+        }
+
+        private static Address[] GetNewMiners(int count)
+        {
+            return Enumerable.Range(0, count).Select(i => new PrivateKey().ToAddress()).ToArray();
+        }
+    }
+}

--- a/Lib9c/Action/RefineAuthMiner.cs
+++ b/Lib9c/Action/RefineAuthMiner.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Action;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Action
+{
+    [Serializable]
+    [ActionType("refine_auth_miner")]
+    public class RefineAuthMiner : ActionBase
+    {
+        private long _interval;
+        private ImmutableHashSet<Address> _miners;
+        private long _validUntil;
+
+        public override IValue PlainValue {
+            get
+            {
+                var values = new Dictionary<IKey, IValue>
+                {
+                    [(Text) nameof(_miners)] = new List(_miners.Select(m => m.Serialize())),
+                    [(Text) nameof(_interval)] = _interval.Serialize(),
+                    [(Text) nameof(_validUntil)] = _validUntil.Serialize(),
+                };
+
+                return new Dictionary(values);
+            }
+        }
+
+        public override void LoadPlainValue(IValue plainValue)
+        {
+            var asDict = (Dictionary) plainValue;
+            _miners = ((List)asDict[nameof(_miners)]).Select(v => v.ToAddress()).ToImmutableHashSet();
+            _interval = asDict[nameof(_interval)].ToLong();
+            _validUntil = asDict[nameof(_validUntil)].ToLong();
+        }
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            IAccountStateDelta state = context.PreviousStates;
+            CheckPermission(context);
+
+            var authMinersState = new AuthorizedMinersState(_miners, _interval, _validUntil);
+            
+            return state.SetState(
+                ActivatedAccountsState.Address,
+                authMinersState.Serialize()
+            );
+        }
+    }
+}

--- a/Lib9c/BlockPolicy.cs
+++ b/Lib9c/BlockPolicy.cs
@@ -206,7 +206,7 @@ namespace Nekoyume.BlockChain
             // (For backward compatibility, blocks before 1,200,000th don't have to be proven.
             // Note that as of Feb 9, 2021, there are about 770,000+ blocks.)
             Transaction<NCAction>[] txs = block.Transactions.ToArray();
-            if (!txs.Any(tx => tx.Signer.Equals(miner) && !tx.Actions.Any()) &&
+            if (!(txs.First().Signer.Equals(miner) && !txs.First().Actions.Any()) &&
                 block.ProtocolVersion > 0 &&
                 (IgnoreHardcodedIndicesForBackwardCompatibility || block.Index > 1_200_000))
             {

--- a/Lib9c/BlockPolicy.cs
+++ b/Lib9c/BlockPolicy.cs
@@ -206,7 +206,7 @@ namespace Nekoyume.BlockChain
             // (For backward compatibility, blocks before 1,200,000th don't have to be proven.
             // Note that as of Feb 9, 2021, there are about 770,000+ blocks.)
             Transaction<NCAction>[] txs = block.Transactions.ToArray();
-            if (!(txs.First().Signer.Equals(miner) && !txs.First().Actions.Any()) &&
+            if (!txs.Any(tx => tx.Signer.Equals(miner) && !tx.Actions.Any()) &&
                 block.ProtocolVersion > 0 &&
                 (IgnoreHardcodedIndicesForBackwardCompatibility || block.Index > 1_200_000))
             {

--- a/Lib9c/Miner.cs
+++ b/Lib9c/Miner.cs
@@ -53,6 +53,8 @@ namespace Nekoyume.BlockChain
             {
                 if (AuthorizedMiner)
                 {
+                    //FIXME: Revise this code when `BlockChain` provides method StageTransactionInFront
+                    //which enqueues a transaction in front of the queue of the stage
                     var txList = _chain
                         .GetStagedTransactionIds()
                         .Select(txid => _chain.GetTransaction(txid)).ToList();

--- a/Lib9c/Miner.cs
+++ b/Lib9c/Miner.cs
@@ -53,11 +53,12 @@ namespace Nekoyume.BlockChain
             {
                 if (AuthorizedMiner)
                 {
-                    _chain
+                    var txList = _chain
                         .GetStagedTransactionIds()
-                        .Select(txid => _chain.GetTransaction(txid)).ToList()
-                        .ForEach(tx => _chain.UnstageTransaction(tx));
+                        .Select(txid => _chain.GetTransaction(txid)).ToList();
+                    txList.ForEach(tx => _chain.UnstageTransaction(tx));
                     StageProofTransaction();
+                    txList.ForEach(tx => _chain.StageTransaction(tx));
                 }
 
                 block = await _chain.MineBlock(


### PR DESCRIPTION
- Authentication miner does not omit transactions anymore.
- `refine_auth_miner` action is added to modify authentication miner states