### PR TITLE
Fix ActivateAccount0 handling

### DIFF
--- a/Lib9c/Action/ActivateAccount.cs
+++ b/Lib9c/Action/ActivateAccount.cs
@@ -11,7 +11,7 @@ namespace Nekoyume.Action
 {
     [Serializable]
     [ActionType("activate_account2")]
-    public class ActivateAccount : ActionBase
+    public class ActivateAccount : ActionBase, IActivateAction
     {
         public Address PendingAddress { get; private set; }
 
@@ -80,5 +80,9 @@ namespace Nekoyume.Action
             PendingAddress = asDict["pa"].ToAddress();
             Signature = (Binary) asDict["s"];
         }
+
+        public Address GetPendingAddress() => PendingAddress;
+
+        public byte[] GetSignature() => Signature;
     }
 }

--- a/Lib9c/Action/ActivateAccount0.cs
+++ b/Lib9c/Action/ActivateAccount0.cs
@@ -10,7 +10,7 @@ namespace Nekoyume.Action
 {
     [Serializable]
     [ActionType("activate_account")]
-    public class ActivateAccount0 : ActionBase
+    public class ActivateAccount0 : ActionBase, IActivateAction
     {
         public Address PendingAddress { get; private set; }
 
@@ -83,5 +83,9 @@ namespace Nekoyume.Action
             PendingAddress = asDict["pending_address"].ToAddress();
             Signature = (Binary) asDict["signature"];
         }
+
+        public Address GetPendingAddress() => PendingAddress;
+
+        public byte[] GetSignature() => Signature;
     }
 }

--- a/Lib9c/Action/IActivateAction.cs
+++ b/Lib9c/Action/IActivateAction.cs
@@ -1,0 +1,12 @@
+using Libplanet;
+
+namespace Nekoyume.Action
+{
+    internal interface IActivateAction
+    {
+        // TODO: We should convert them to property after updating C# version...
+        Address GetPendingAddress();
+
+        byte[] GetSignature();
+    }
+}

--- a/Lib9c/BlockPolicySource.cs
+++ b/Lib9c/BlockPolicySource.cs
@@ -115,10 +115,10 @@ namespace Nekoyume.BlockChain
 
                 // Check ActivateAccount
                 if (transaction.Actions.Count == 1 &&
-                    transaction.Actions.First().InnerAction is ActivateAccount aa)
+                    transaction.Actions.First().InnerAction is IActivateAction aa)
                 {
-                    return blockChain.GetState(aa.PendingAddress) is Dictionary rawPending &&
-                           new PendingActivationState(rawPending).Verify(aa);
+                    return blockChain.GetState(aa.GetPendingAddress()) is Dictionary rawPending &&
+                           new PendingActivationState(rawPending).Verify(aa.GetSignature());
                 }
 
                 // Check admin


### PR DESCRIPTION
This PR is continuous from #509 .

It allows `ActivateAccount0` from activation check for pre-migration situations and previous chain replaying.