### PR TITLE
Remove .Result properties from `HackAndSlash` (and its likes)

### DIFF
--- a/.Lib9c.Tests/Action/HackAndSlashTest.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashTest.cs
@@ -220,8 +220,6 @@ namespace Lib9c.Tests.Action
                 RankingMapAddress = _rankingMapAddress,
             };
 
-            Assert.Null(action.Result);
-
             var nextState = action.Execute(new ActionContext
             {
                 PreviousStates = state,
@@ -234,10 +232,6 @@ namespace Lib9c.Tests.Action
             var nextAvatarState = nextState.GetAvatarStateV2(_avatarAddress);
             var newWeeklyState = nextState.GetWeeklyArenaState(0);
 
-            Assert.NotNull(action.Result);
-
-            Assert.NotEmpty(action.Result.OfType<GetReward>());
-            Assert.Equal(BattleLog.Result.Win, action.Result.result);
             Assert.Equal(contains, newWeeklyState.ContainsKey(_avatarAddress));
             Assert.True(nextAvatarState.worldInformation.IsStageCleared(stageId));
             Assert.Equal(30, nextAvatarState.mailBox.Count);
@@ -399,8 +393,6 @@ namespace Lib9c.Tests.Action
                 RankingMapAddress = _rankingMapAddress,
             };
 
-            Assert.Null(action.Result);
-
             var nextState = action.Execute(new ActionContext
             {
                 PreviousStates = state,
@@ -464,8 +456,6 @@ namespace Lib9c.Tests.Action
                 RankingMapAddress = _rankingMapAddress,
             };
 
-            Assert.Null(action.Result);
-
             var exec = Assert.Throws<DuplicateEquipmentException>(() => action.Execute(new ActionContext
             {
                 PreviousStates = state,
@@ -491,8 +481,6 @@ namespace Lib9c.Tests.Action
                 WeeklyArenaAddress = _weeklyArenaState.address,
                 RankingMapAddress = default,
             };
-
-            Assert.Null(action.Result);
 
             var exec = Assert.Throws<InvalidAddressException>(() =>
                 action.Execute(new ActionContext()
@@ -523,8 +511,6 @@ namespace Lib9c.Tests.Action
                 WeeklyArenaAddress = _weeklyArenaState.address,
             };
 
-            Assert.Null(action.Result);
-
             IAccountStateDelta state = backward ? new State() : _initialState;
             if (!backward)
             {
@@ -541,8 +527,6 @@ namespace Lib9c.Tests.Action
                 Signer = _agentAddress,
                 Random = new TestRandom(),
             }));
-
-            Assert.Null(action.Result);
 
             SerializeException<FailedLoadStateException>(exec);
         }
@@ -562,16 +546,12 @@ namespace Lib9c.Tests.Action
                 RankingMapAddress = _rankingMapAddress,
             };
 
-            Assert.Null(action.Result);
-
             var exec = Assert.Throws<SheetRowNotFoundException>(() => action.Execute(new ActionContext()
             {
                 PreviousStates = _initialState,
                 Signer = _agentAddress,
                 Random = new TestRandom(),
             }));
-
-            Assert.Null(action.Result);
 
             SerializeException<SheetRowNotFoundException>(exec);
         }
@@ -593,16 +573,12 @@ namespace Lib9c.Tests.Action
                 RankingMapAddress = _rankingMapAddress,
             };
 
-            Assert.Null(action.Result);
-
             var exec = Assert.Throws<SheetRowColumnException>(() => action.Execute(new ActionContext()
             {
                 PreviousStates = _initialState,
                 Signer = _agentAddress,
                 Random = new TestRandom(),
             }));
-
-            Assert.Null(action.Result);
 
             SerializeException<SheetRowColumnException>(exec);
         }
@@ -622,8 +598,6 @@ namespace Lib9c.Tests.Action
                 RankingMapAddress = _rankingMapAddress,
             };
 
-            Assert.Null(action.Result);
-
             var state = _initialState;
             state = state.SetState(Addresses.TableSheet.Derive(nameof(StageSheet)), "test".Serialize());
 
@@ -633,8 +607,6 @@ namespace Lib9c.Tests.Action
                 Signer = _agentAddress,
                 Random = new TestRandom(),
             }));
-
-            Assert.Null(action.Result);
 
             SerializeException<SheetRowNotFoundException>(exec);
         }
@@ -654,8 +626,6 @@ namespace Lib9c.Tests.Action
                 RankingMapAddress = _rankingMapAddress,
             };
 
-            Assert.Null(action.Result);
-
             var state = _initialState;
             var worldSheet = new WorldSheet();
             worldSheet.Set("test");
@@ -673,8 +643,6 @@ namespace Lib9c.Tests.Action
                 Signer = _agentAddress,
                 Random = new TestRandom(),
             }));
-
-            Assert.Null(action.Result);
 
             SerializeException<FailedAddWorldException>(exec);
         }
@@ -694,8 +662,6 @@ namespace Lib9c.Tests.Action
                 RankingMapAddress = _rankingMapAddress,
             };
 
-            Assert.Null(action.Result);
-
             Assert.False(_avatarState.worldInformation.IsStageCleared(51));
 
             var exec = Assert.Throws<InvalidWorldException>(() => action.Execute(new ActionContext()
@@ -704,8 +670,6 @@ namespace Lib9c.Tests.Action
                 Signer = _agentAddress,
                 Random = new TestRandom(),
             }));
-
-            Assert.Null(action.Result);
 
             SerializeException<InvalidWorldException>(exec);
         }
@@ -724,8 +688,6 @@ namespace Lib9c.Tests.Action
                 WeeklyArenaAddress = _weeklyArenaState.address,
                 RankingMapAddress = _rankingMapAddress,
             };
-
-            Assert.Null(action.Result);
 
             var avatarState = new AvatarState(_avatarState);
             avatarState.worldInformation.ClearStage(
@@ -751,8 +713,6 @@ namespace Lib9c.Tests.Action
                 Random = new TestRandom(),
             }));
 
-            Assert.Null(action.Result);
-
             SerializeException<InvalidStageException>(exec);
         }
 
@@ -771,8 +731,6 @@ namespace Lib9c.Tests.Action
                 RankingMapAddress = _rankingMapAddress,
             };
 
-            Assert.Null(action.Result);
-
             _avatarState.worldInformation.TryGetWorld(1, out var world);
             Assert.False(world.IsStageCleared);
 
@@ -782,8 +740,6 @@ namespace Lib9c.Tests.Action
                 Signer = _agentAddress,
                 Random = new TestRandom(),
             }));
-
-            Assert.Null(action.Result);
 
             SerializeException<InvalidStageException>(exec);
         }
@@ -816,8 +772,6 @@ namespace Lib9c.Tests.Action
                 RankingMapAddress = _rankingMapAddress,
             };
 
-            Assert.Null(action.Result);
-
             var state = _initialState
                 .SetState(_avatarAddress, avatarState.SerializeV2())
                 .SetState(_inventoryAddress, avatarState.inventory.Serialize());
@@ -828,8 +782,6 @@ namespace Lib9c.Tests.Action
                 Signer = _agentAddress,
                 Random = new TestRandom(),
             }));
-
-            Assert.Null(action.Result);
 
             SerializeException<RequiredBlockIndexException>(exec);
         }
@@ -869,16 +821,12 @@ namespace Lib9c.Tests.Action
                 RankingMapAddress = _rankingMapAddress,
             };
 
-            Assert.Null(action.Result);
-
             var exec = Assert.Throws<EquipmentSlotUnlockException>(() => action.Execute(new ActionContext()
             {
                 PreviousStates = state,
                 Signer = _agentAddress,
                 Random = new TestRandom(),
             }));
-
-            Assert.Null(action.Result);
 
             SerializeException<EquipmentSlotUnlockException>(exec);
         }
@@ -903,8 +851,6 @@ namespace Lib9c.Tests.Action
                 RankingMapAddress = _rankingMapAddress,
             };
 
-            Assert.Null(action.Result);
-
             var state = _initialState;
             state = state.SetState(_avatarAddress, avatarState.SerializeV2());
 
@@ -914,8 +860,6 @@ namespace Lib9c.Tests.Action
                 Signer = _agentAddress,
                 Random = new TestRandom(),
             }));
-
-            Assert.Null(action.Result);
 
             SerializeException<NotEnoughActionPointException>(exec);
         }

--- a/.Lib9c.Tests/Action/MimisbrunnrBattleTest.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattleTest.cs
@@ -1,4 +1,4 @@
-﻿namespace Lib9c.Tests.Action
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;
@@ -161,8 +161,6 @@
                 RankingMapAddress = _rankingMapAddress,
             };
 
-            Assert.Null(action.Result);
-
             var nextState = action.Execute(new ActionContext()
             {
                 PreviousStates = state,
@@ -174,10 +172,6 @@
 
             var nextAvatarState = nextState.GetAvatarStateV2(_avatarAddress);
             var newWeeklyState = nextState.GetWeeklyArenaState(0);
-            Assert.NotNull(action.Result);
-            var reward = action.Result.OfType<GetReward>();
-            Assert.NotEmpty(reward);
-            Assert.Equal(BattleLog.Result.Win, action.Result.result);
             Assert.True(nextAvatarState.worldInformation.IsStageCleared(stageId));
             Assert.Equal(30, nextAvatarState.mailBox.Count);
 
@@ -304,8 +298,6 @@
                 RankingMapAddress = default,
             };
 
-            Assert.Null(action.Result);
-
             Assert.Throws<InvalidAddressException>(() =>
             {
                 action.Execute(new ActionContext()
@@ -331,8 +323,6 @@
                 RankingMapAddress = _rankingMapAddress,
             };
 
-            Assert.Null(action.Result);
-
             Assert.Throws<SheetRowNotFoundException>(() =>
             {
                 action.Execute(new ActionContext()
@@ -357,8 +347,6 @@
                 WeeklyArenaAddress = _weeklyArenaState.address,
                 RankingMapAddress = _rankingMapAddress,
             };
-
-            Assert.Null(action.Result);
 
             Assert.Throws<SheetRowColumnException>(() =>
             {
@@ -400,7 +388,6 @@
                 RankingMapAddress = _rankingMapAddress,
             };
 
-            Assert.Null(action.Result);
             var state = _initialState;
             state = state.SetState(_avatarAddress, previousAvatarState.Serialize());
             Assert.Throws<NotEnoughActionPointException>(() =>
@@ -488,8 +475,6 @@
                 RankingMapAddress = _rankingMapAddress,
             };
 
-            Assert.Null(action.Result);
-
             Assert.Throws<InvalidWorldException>(() =>
             {
                 action.Execute(new ActionContext()
@@ -529,8 +514,6 @@
                 WeeklyArenaAddress = _weeklyArenaState.address,
                 RankingMapAddress = _rankingMapAddress,
             };
-
-            Assert.Null(action.Result);
 
             Assert.Throws<FailedAddWorldException>(() =>
             {
@@ -578,8 +561,6 @@
                 RankingMapAddress = _rankingMapAddress,
             };
 
-            Assert.Null(action.Result);
-
             action.Execute(new ActionContext
             {
                 PreviousStates = nextState,
@@ -587,13 +568,6 @@
                 Rehearsal = false,
                 Random = new TestRandom(),
             });
-
-            var spawnPlayer = action.Result.FirstOrDefault(e => e is SpawnPlayer);
-            Assert.NotNull(spawnPlayer);
-            Assert.True(spawnPlayer.Character is Player p);
-            var player = (Player)spawnPlayer.Character;
-            Assert.Equal(player.Costumes.First().ItemId, ((Costume)costume).ItemId);
-            Assert.Equal(player.Equipments.First().ItemId, equipment.ItemId);
         }
 
         [Fact]

--- a/Lib9c/Action/HackAndSlash.cs
+++ b/Lib9c/Action/HackAndSlash.cs
@@ -27,7 +27,6 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public Address WeeklyArenaAddress;
         public Address RankingMapAddress;
-        public BattleLog Result { get; private set; }
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>
@@ -300,8 +299,6 @@ namespace Nekoyume.Action
                     states = states.SetState(weekly.address, weeklySerialized);
                 }
             }
-
-            Result = simulator.Log;
 
             var ended = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}HAS Total Executed Time: {Elapsed}", addressesHex, ended - started);

--- a/Lib9c/Action/MimisbrunnrBattle.cs
+++ b/Lib9c/Action/MimisbrunnrBattle.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -7,7 +7,6 @@ using Bencodex.Types;
 using Libplanet;
 using Libplanet.Action;
 using Nekoyume.Battle;
-using Nekoyume.Model.BattleStatus;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
@@ -30,7 +29,6 @@ namespace Nekoyume.Action
         public Address RankingMapAddress;
 
         private const int AlfheimId = 2;
-        public BattleLog Result { get; private set; }
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>
@@ -320,8 +318,6 @@ namespace Nekoyume.Action
                     states = states.SetState(weekly.address, weeklySerialized);
                 }
             }
-
-            Result = simulator.Log;
 
             var ended = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}Mimisbrunnr Total Executed Time: {Elapsed}", addressesHex, ended - started);

--- a/Lib9c/Renderer/ActionRenderer.cs
+++ b/Lib9c/Renderer/ActionRenderer.cs
@@ -42,6 +42,7 @@ namespace Lib9c.Renderer
                 BlockIndex = context.BlockIndex,
                 OutputStates = nextStates,
                 PreviousStates = context.PreviousStates,
+                RandomSeed = context.Random.Seed
             });
         }
 
@@ -58,6 +59,7 @@ namespace Lib9c.Renderer
                 BlockIndex = context.BlockIndex,
                 OutputStates = nextStates,
                 PreviousStates = context.PreviousStates,
+                RandomSeed = context.Random.Seed
             });
         }
 
@@ -76,6 +78,7 @@ namespace Lib9c.Renderer
                 OutputStates = context.PreviousStates,
                 Exception = exception,
                 PreviousStates = context.PreviousStates,
+                RandomSeed = context.Random.Seed
             });
         }
 
@@ -93,6 +96,7 @@ namespace Lib9c.Renderer
                 OutputStates = context.PreviousStates,
                 Exception = exception,
                 PreviousStates = context.PreviousStates,
+                RandomSeed = context.Random.Seed
             });
         }
 
@@ -137,12 +141,13 @@ namespace Lib9c.Renderer
                 eval => eval.Action is T
             ).Select(eval => new ActionEvaluation<T>
             {
-                Action = (T) eval.Action,
+                Action = (T)eval.Action,
                 Signer = eval.Signer,
                 BlockIndex = eval.BlockIndex,
                 OutputStates = eval.OutputStates,
                 Exception = eval.Exception,
                 PreviousStates = eval.PreviousStates,
+                RandomSeed = eval.RandomSeed
             });
         }
 
@@ -153,12 +158,13 @@ namespace Lib9c.Renderer
                 eval => eval.Action is T
             ).Select(eval => new ActionEvaluation<T>
             {
-                Action = (T) eval.Action,
+                Action = (T)eval.Action,
                 Signer = eval.Signer,
                 BlockIndex = eval.BlockIndex,
                 OutputStates = eval.OutputStates,
                 Exception = eval.Exception,
                 PreviousStates = eval.PreviousStates,
+                RandomSeed = eval.RandomSeed
             });
         }
 
@@ -174,6 +180,7 @@ namespace Lib9c.Renderer
                 OutputStates = eval.OutputStates,
                 Exception = eval.Exception,
                 PreviousStates = eval.PreviousStates,
+                RandomSeed = eval.RandomSeed
             });
         }
 
@@ -189,6 +196,7 @@ namespace Lib9c.Renderer
                 OutputStates = eval.OutputStates,
                 Exception = eval.Exception,
                 PreviousStates = eval.PreviousStates,
+                RandomSeed = eval.RandomSeed
             });
         }
 
@@ -201,7 +209,7 @@ namespace Lib9c.Renderer
             {
                 return polymorphicAction.InnerAction;
             }
-            return (ActionBase) action;
+            return (ActionBase)action;
         }
     }
 }


### PR DESCRIPTION
This PR removes `.Result` property to lighten the action, reducing the memory load.