### PR TITLE
Leave proof

### DIFF
--- a/.Lib9c.Tests/MinerTest.cs
+++ b/.Lib9c.Tests/MinerTest.cs
@@ -1,0 +1,50 @@
+namespace Lib9c.Tests
+{
+    using System.Security.Cryptography;
+    using System.Threading.Tasks;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Blockchain;
+    using Libplanet.Blockchain.Policies;
+    using Libplanet.Blocks;
+    using Libplanet.Crypto;
+    using Libplanet.Store;
+    using Libplanet.Store.Trie;
+    using Libplanet.Tx;
+    using Nekoyume.Action;
+    using Nekoyume.BlockChain;
+    using Serilog.Core;
+    using Xunit;
+
+    public class MinerTest
+    {
+        [Fact]
+        public async Task Proof()
+        {
+            using var store = new DefaultStore(null);
+            using var stateStore = new TrieStateStore(new DefaultKeyValueStore(null), new DefaultKeyValueStore(null));
+            var blockPolicySource = new BlockPolicySource(Logger.None);
+            var genesis = BlockChain<PolymorphicAction<ActionBase>>.MakeGenesisBlock(HashAlgorithmType.Of<SHA256>());
+            var blockChain = new BlockChain<PolymorphicAction<ActionBase>>(
+                blockPolicySource.GetPolicy(
+                    minimumDifficulty: 50_000,
+                    maximumTransactions: 100,
+                    permissionedMiningPolicy: null,
+                    ignoreHardcodedPolicies: true
+                ),
+                new VolatileStagePolicy<PolymorphicAction<ActionBase>>(),
+                store,
+                stateStore,
+                genesis,
+                renderers: new[] { blockPolicySource.BlockRenderer }
+            );
+
+            var minerKey = new PrivateKey();
+            var miner = new Miner(blockChain, null, minerKey, false);
+            Block<PolymorphicAction<ActionBase>> mined = await miner.MineBlockAsync(100, default);
+            Transaction<PolymorphicAction<ActionBase>> tx = Assert.Single(mined.Transactions);
+
+            Assert.Equal(miner.Address, tx.Signer);
+        }
+    }
+}

--- a/Lib9c/Miner.cs
+++ b/Lib9c/Miner.cs
@@ -68,7 +68,6 @@ namespace Nekoyume.BlockChain
                         .GetStagedTransactionIds()
                         .Select(txid => _chain.GetTransaction(txid)).ToList()
                         .ForEach(tx => _chain.UnstageTransaction(tx));
-                    StageProofTransaction();
                 }
 
                 IEnumerable<Transaction<PolymorphicAction<ActionBase>>> bannedTxs = _chain.GetStagedTransactionIds()
@@ -79,6 +78,8 @@ namespace Nekoyume.BlockChain
                     _chain.UnstageTransaction(tx);
                 }
 
+                // All miner needs proof in permissioned mining.
+                StageProofTransaction();
                 block = await _chain.MineBlock(
                     Address,
                     DateTimeOffset.UtcNow,


### PR DESCRIPTION
This PR is continued from https://github.com/planetarium/lib9c/pull/584.

After enabled #584, all miners are required to submit proof tx on every block. so it adds codes for proof to default miner implementation.