### PR TITLE
Bug fix/remove fungible item in combination actions

### DIFF
--- a/.Lib9c.Tests/Action/CombinationEquipmentTest.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipmentTest.cs
@@ -109,7 +109,7 @@ namespace Lib9c.Tests.Action
             var equipmentRow = _tableSheets.EquipmentItemSheet[row.ResultEquipmentId];
             var equipment = ItemFactory.CreateItemUsable(equipmentRow, default, 0);
 
-            var result = new CombinationConsumable5.ResultModel()
+            var result = new CombinationConsumable5.ResultModel
             {
                 id = default,
                 gold = 0,
@@ -126,20 +126,21 @@ namespace Lib9c.Tests.Action
                 _avatarState.Update(mail);
             }
 
+            IAccountStateDelta previousState;
             if (backward)
             {
-                _initialState = _initialState.SetState(_avatarAddress, _avatarState.Serialize());
+                previousState = _initialState.SetState(_avatarAddress, _avatarState.Serialize());
             }
             else
             {
-                _initialState = _initialState
+                previousState = _initialState
                     .SetState(_avatarAddress.Derive(LegacyInventoryKey), _avatarState.inventory.Serialize())
                     .SetState(_avatarAddress.Derive(LegacyWorldInformationKey), _avatarState.worldInformation.Serialize())
                     .SetState(_avatarAddress.Derive(LegacyQuestListKey), _avatarState.questList.Serialize())
                     .SetState(_avatarAddress, _avatarState.SerializeV2());
             }
 
-            var action = new CombinationEquipment()
+            var action = new CombinationEquipment
             {
                 AvatarAddress = _avatarAddress,
                 RecipeId = row.Id,
@@ -147,22 +148,20 @@ namespace Lib9c.Tests.Action
                 SubRecipeId = 255,
             };
 
-            var nextState = action.Execute(new ActionContext()
+            var nextState = action.Execute(new ActionContext
             {
-                PreviousStates = _initialState,
+                PreviousStates = previousState,
                 Signer = _agentAddress,
                 BlockIndex = 1,
                 Random = _random,
             });
 
-            var slotState = nextState.GetCombinationSlotState(_avatarAddress, 0);
+            var nextAvatarState = nextState.GetAvatarStateV2(_avatarAddress);
+            Assert.Equal(30, nextAvatarState.mailBox.Count);
 
+            var slotState = nextState.GetCombinationSlotState(_avatarAddress, 0);
             Assert.NotNull(slotState.Result);
             Assert.NotNull(slotState.Result.itemUsable);
-
-            var nextAvatarState = nextState.GetAvatarStateV2(_avatarAddress);
-
-            Assert.Equal(30, nextAvatarState.mailBox.Count);
             Assert.Equal(2, slotState.Result.itemUsable.GetOptionCount());
 
             var goldCurrencyState = nextState.GetGoldCurrency();
@@ -201,7 +200,7 @@ namespace Lib9c.Tests.Action
 
             _initialState = _initialState.SetState(_avatarAddress, _avatarState.Serialize());
 
-            var action = new CombinationEquipment()
+            var action = new CombinationEquipment
             {
                 AvatarAddress = _avatarAddress,
                 RecipeId = row.Id,
@@ -209,7 +208,7 @@ namespace Lib9c.Tests.Action
                 SubRecipeId = 3,
             };
 
-            Assert.Throws<InsufficientBalanceException>(() => action.Execute(new ActionContext()
+            Assert.Throws<InsufficientBalanceException>(() => action.Execute(new ActionContext
             {
                 PreviousStates = _initialState,
                 Signer = _agentAddress,
@@ -220,7 +219,7 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Rehearsal()
         {
-            var action = new CombinationEquipment()
+            var action = new CombinationEquipment
             {
                 AvatarAddress = _avatarAddress,
                 RecipeId = 1,
@@ -235,7 +234,7 @@ namespace Lib9c.Tests.Action
                 )
             );
 
-            var updatedAddresses = new List<Address>()
+            var updatedAddresses = new List<Address>
             {
                 _agentAddress,
                 _avatarAddress,
@@ -248,7 +247,7 @@ namespace Lib9c.Tests.Action
 
             var state = new State();
 
-            var nextState = action.Execute(new ActionContext()
+            var nextState = action.Execute(new ActionContext
             {
                 PreviousStates = state,
                 Signer = _agentAddress,

--- a/.Lib9c.Tests/Model/Item/InventoryTest.cs
+++ b/.Lib9c.Tests/Model/Item/InventoryTest.cs
@@ -53,28 +53,316 @@
             Assert.Equal(inventory, deserialized);
         }
 
+        // Add
         [Fact]
-        public void SameMaterials_Which_NotSame_IsTradableField_Are_Contained_Separately()
+        public Inventory AddItem_Consumable()
         {
-            var row = TableSheets.MaterialItemSheet.First;
-            Assert.NotNull(row);
-            var material = ItemFactory.CreateMaterial(row);
-            var tradableMaterial = ItemFactory.CreateTradableMaterial(row);
+            var item = GetFirstConsumable();
             var inventory = new Inventory();
             Assert.Empty(inventory.Items);
-            inventory.AddItem(material);
-            Assert.Single(inventory.Items);
-            Assert.Single(inventory.Materials);
-            inventory.AddItem(tradableMaterial);
-            Assert.Equal(2, inventory.Items.Count);
-            Assert.Equal(2, inventory.Materials.Count());
-            inventory.RemoveFungibleItem2(row.ItemId);
-            Assert.Single(inventory.Items);
-            Assert.Single(inventory.Materials);
+
+            inventory.AddItem(item);
+            return AddItem_Consumable_After(inventory);
         }
 
         [Fact]
-        public void RemoveFungibleItem_NonTradableItem_Removed_Faster_Than_TradableItem()
+        public Inventory AddItem2_Consumable()
+        {
+            var item = GetFirstConsumable();
+            var inventory = new Inventory();
+            Assert.Empty(inventory.Items);
+
+            inventory.AddItem2(item);
+            return AddItem_Consumable_After(inventory);
+        }
+
+        [Fact]
+        public Inventory AddItem_Costume()
+        {
+            var item = GetFirstCostume();
+            var inventory = new Inventory();
+            Assert.Empty(inventory.Items);
+
+            inventory.AddItem(item);
+            return AddItem_Costume_After(inventory);
+        }
+
+        [Fact]
+        public Inventory AddItem2_Costume()
+        {
+            var item = GetFirstCostume();
+            var inventory = new Inventory();
+            Assert.Empty(inventory.Items);
+
+            inventory.AddItem2(item);
+            return AddItem_Costume_After(inventory);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public Inventory AddItem_Material(int count)
+        {
+            var item = GetFirstMaterial();
+            var inventory = new Inventory();
+            Assert.Empty(inventory.Items);
+
+            for (var i = 0; i < count; i++)
+            {
+                inventory.AddItem(item);
+            }
+
+            return AddItem_Material_After(inventory, count);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public Inventory AddItem2_Material(int count)
+        {
+            var item = GetFirstMaterial();
+            var inventory = new Inventory();
+            Assert.Empty(inventory.Items);
+
+            for (var i = 0; i < count; i++)
+            {
+                inventory.AddItem2(item);
+            }
+
+            return AddItem_Material_After(inventory, count);
+        }
+
+        [Fact]
+        public Inventory AddItem_Equipment()
+        {
+            var item = GetFirstEquipment();
+            var inventory = new Inventory();
+            Assert.Empty(inventory.Items);
+
+            inventory.AddItem(item);
+            return AddItem_Equipment_After(inventory);
+        }
+
+        [Fact]
+        public Inventory AddItem2_Equipment()
+        {
+            var item = GetFirstEquipment();
+            var inventory = new Inventory();
+            Assert.Empty(inventory.Items);
+
+            inventory.AddItem2(item);
+            return AddItem_Equipment_After(inventory);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public Inventory AddItem_TradableMaterial(int count)
+        {
+            var item = GetFirstTradableMaterial();
+            var inventory = new Inventory();
+            Assert.Empty(inventory.Items);
+
+            for (var i = 0; i < count; i++)
+            {
+                inventory.AddItem(item);
+            }
+
+            return AddItem_Material_After(inventory, count);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public Inventory AddItem2_TradableMaterial(int count)
+        {
+            var item = GetFirstTradableMaterial();
+            var inventory = new Inventory();
+            Assert.Empty(inventory.Items);
+
+            for (var i = 0; i < count; i++)
+            {
+                inventory.AddItem2(item);
+            }
+
+            return AddItem_Material_After(inventory, count);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public Inventory AddFungibleItem_Material(int count)
+        {
+            var item = GetFirstMaterial();
+            var inventory = new Inventory();
+            Assert.Empty(inventory.Items);
+
+            inventory.AddFungibleItem(item, count);
+            return AddItem_Material_After(inventory, count);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public Inventory AddFungibleItem2_Material(int count)
+        {
+            var item = GetFirstMaterial();
+            var inventory = new Inventory();
+            Assert.Empty(inventory.Items);
+
+            inventory.AddFungibleItem2(item, count);
+            return AddItem_Material_After(inventory, count);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public Inventory AddFungibleItem_TradableMaterial(int count)
+        {
+            var item = GetFirstTradableMaterial();
+            var inventory = new Inventory();
+            Assert.Empty(inventory.Items);
+
+            inventory.AddFungibleItem(item, count);
+            return AddItem_Material_After(inventory, count);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public Inventory AddFungibleItem2_TradableMaterial(int count)
+        {
+            var item = GetFirstTradableMaterial();
+            var inventory = new Inventory();
+            Assert.Empty(inventory.Items);
+
+            inventory.AddFungibleItem2(item, count);
+            return AddItem_Material_After(inventory, count);
+        }
+
+        [Fact]
+        public Inventory AddNonFungibleItem_Consumable()
+        {
+            var item = GetFirstConsumable();
+            var inventory = new Inventory();
+            Assert.Empty(inventory.Items);
+
+            inventory.AddNonFungibleItem(item);
+            return AddItem_Consumable_After(inventory);
+        }
+
+        [Fact]
+        public Inventory AddNonFungibleItem_Costume()
+        {
+            var item = GetFirstCostume();
+            var inventory = new Inventory();
+            Assert.Empty(inventory.Items);
+
+            inventory.AddNonFungibleItem(item);
+            return AddItem_Costume_After(inventory);
+        }
+
+        [Fact]
+        public Inventory AddNonFungibleItem_Equipment()
+        {
+            var item = GetFirstEquipment();
+            var inventory = new Inventory();
+            Assert.Empty(inventory.Items);
+
+            inventory.AddNonFungibleItem(item);
+            return AddItem_Equipment_After(inventory);
+        }
+
+        // Remove
+        [Fact]
+        public void RemoveFungibleItem_Material()
+        {
+            const int count = 3;
+            var inventory = AddItem_Material(count);
+            var item = inventory.Materials.FirstOrDefault();
+            Assert.NotNull(item);
+            Assert.False(inventory.RemoveFungibleItem(item.FungibleId, 0, count + 1));
+            Assert.False(inventory.RemoveFungibleItem(item.FungibleId, 0, 1, true));
+            Assert.True(inventory.RemoveFungibleItem(item.FungibleId, 0));
+            Assert.True(inventory.TryGetFungibleItems(item.FungibleId, out var items));
+            Assert.Equal(count - 1, items.Sum(e => e.count));
+            Assert.True(inventory.RemoveFungibleItem(item.FungibleId, 0, count - 1));
+            Assert.Empty(inventory.Materials);
+        }
+
+        [Fact]
+        public void RemoveFungibleItem2_Material()
+        {
+            const int count = 3;
+            var inventory = AddItem_Material(count);
+            var item = inventory.Materials.FirstOrDefault();
+            Assert.NotNull(item);
+            Assert.False(inventory.RemoveFungibleItem2(item.FungibleId, count + 1));
+            Assert.False(inventory.RemoveFungibleItem2(item.FungibleId, 1, true));
+            Assert.True(inventory.RemoveFungibleItem2(item.FungibleId));
+            Assert.True(inventory.TryGetFungibleItems(item.FungibleId, out var items));
+            Assert.Equal(count - 1, items.Sum(e => e.count));
+            Assert.True(inventory.RemoveFungibleItem2(item.FungibleId, count - 1));
+            Assert.Empty(inventory.Materials);
+        }
+
+        [Fact]
+        public void RemoveFungibleItem_TradableMaterial()
+        {
+            const int count = 4;
+            var inventory = AddItem_TradableMaterial(count);
+            var item = inventory.Materials.FirstOrDefault();
+            Assert.NotNull(item);
+            Assert.False(inventory.RemoveFungibleItem(item.FungibleId, 0, count + 1));
+            Assert.True(inventory.RemoveFungibleItem(item.FungibleId, 0, 1, true));
+            Assert.True(inventory.RemoveFungibleItem(item.FungibleId, 0));
+            Assert.True(inventory.TryGetFungibleItems(item.FungibleId, out var items));
+            Assert.Equal(count - 2, items.Sum(e => e.count));
+            Assert.True(inventory.RemoveFungibleItem(item.FungibleId, 0, count - 2));
+            Assert.Empty(inventory.Materials);
+        }
+
+        [Fact]
+        public void RemoveFungibleItem2_TradableMaterial()
+        {
+            const int count = 4;
+            var inventory = AddItem_TradableMaterial(count);
+            var item = inventory.Materials.FirstOrDefault();
+            Assert.NotNull(item);
+            Assert.False(inventory.RemoveFungibleItem2(item.FungibleId, count + 1));
+            Assert.True(inventory.RemoveFungibleItem2(item.FungibleId, 1, true));
+            Assert.True(inventory.RemoveFungibleItem2(item.FungibleId));
+            Assert.True(inventory.TryGetFungibleItems(item.FungibleId, out var items));
+            Assert.Equal(count - 2, items.Sum(e => e.count));
+            Assert.True(inventory.RemoveFungibleItem2(item.FungibleId, count - 2));
+            Assert.Empty(inventory.Materials);
+        }
+
+        [Fact]
+        public void RemoveFungibleItem_Remove_NonTradableItem_Faster_Than_TradableItem()
+        {
+            var row = TableSheets.MaterialItemSheet.First;
+            Assert.NotNull(row);
+            var material = ItemFactory.CreateMaterial(row);
+            var tradableMaterial = ItemFactory.CreateTradableMaterial(row);
+            var inventory = new Inventory();
+            Assert.Empty(inventory.Items);
+            inventory.AddItem(material);
+            inventory.AddItem(tradableMaterial);
+            inventory.RemoveFungibleItem(row.ItemId, 0);
+            Assert.True(inventory.Materials.First() is ITradableFungibleItem);
+            inventory.RemoveFungibleItem(row.ItemId, 0);
+            Assert.Empty(inventory.Materials);
+            inventory.AddItem(tradableMaterial);
+            inventory.AddItem(material);
+            inventory.RemoveFungibleItem(row.ItemId, 0);
+            Assert.True(inventory.Materials.First() is ITradableFungibleItem);
+            inventory.RemoveFungibleItem(row.ItemId, 0);
+            Assert.Empty(inventory.Materials);
+        }
+
+        [Fact]
+        public void RemoveFungibleItem2_Remove_NonTradableItem_Faster_Than_TradableItem()
         {
             var row = TableSheets.MaterialItemSheet.First;
             Assert.NotNull(row);
@@ -94,6 +382,28 @@
             Assert.True(inventory.Materials.First() is ITradableFungibleItem);
             inventory.RemoveFungibleItem2(row.ItemId);
             Assert.Empty(inventory.Materials);
+        }
+
+        [Fact]
+        public void RemoveNonFungibleItem()
+        {
+            var inventory = AddNonFungibleItem_Equipment();
+            Assert.Single(inventory.Equipments);
+            var item = inventory.Equipments.First();
+            Assert.NotNull(item);
+            inventory.RemoveNonFungibleItem(item.NonFungibleId);
+            Assert.Empty(inventory.Equipments);
+        }
+
+        [Fact]
+        public void RemoveNonFungibleItem2()
+        {
+            var inventory = AddNonFungibleItem_Equipment();
+            Assert.Single(inventory.Equipments);
+            var item = inventory.Equipments.First();
+            Assert.NotNull(item);
+            inventory.RemoveNonFungibleItem2(item.NonFungibleId);
+            Assert.Empty(inventory.Equipments);
         }
 
         [Fact]
@@ -154,10 +464,11 @@
             inventory.AddItem(material);
             inventory.AddItem(tradableMaterial);
             Assert.Equal(0, tradableMaterial.RequiredBlockIndex);
-            Assert.False(inventory.RemoveTradableItem(tradableItem.TradableId, 1));
-            Assert.True(inventory.RemoveTradableItem(tradableItem));
+            var tradableId = tradableItem.TradableId;
+            Assert.False(inventory.RemoveTradableItem(tradableId, 1));
+            Assert.True(inventory.RemoveTradableItem(tradableId, 0));
             Assert.False(inventory.Materials.First() is ITradableFungibleItem);
-            Assert.False(inventory.RemoveTradableItem(tradableItem));
+            Assert.False(inventory.RemoveTradableItem(tradableId, 0));
             Assert.Single(inventory.Materials);
         }
 
@@ -173,52 +484,189 @@
             Assert.Empty(inventory.Items);
             inventory.AddItem(itemUsable);
             Assert.Single(inventory.Equipments);
-            Assert.False(inventory.RemoveTradableItem(nonFungibleItem.TradableId, 1, 1));
-            Assert.True(inventory.RemoveTradableItem(nonFungibleItem));
+            var tradableId = nonFungibleItem.TradableId;
+            Assert.False(inventory.RemoveTradableItem(tradableId, 1));
+            Assert.True(inventory.RemoveTradableItem(tradableId, 0));
             Assert.Empty(inventory.Equipments);
-            Assert.False(inventory.RemoveTradableItem(nonFungibleItem));
+            Assert.False(inventory.RemoveTradableItem(tradableId, 0));
         }
 
-        [Fact]
-        public void RemoveTradableFungibleItem()
+        // Try Get
+        [Theory]
+        [InlineData(ItemType.Equipment, 0, false, true)]
+        [InlineData(ItemType.Costume, 0, false, true)]
+        [InlineData(ItemType.Consumable, 0, false, true)]
+        [InlineData(ItemType.Material, 0, false, true)]
+        [InlineData(ItemType.Equipment, 0, true, false)]
+        [InlineData(ItemType.Costume, 0, true, false)]
+        [InlineData(ItemType.Consumable, 0, true, false)]
+        [InlineData(ItemType.Material, 0, true, false)]
+        [InlineData(ItemType.Equipment, 1, false, false)]
+        [InlineData(ItemType.Costume, 1, false, false)]
+        [InlineData(ItemType.Consumable, 1, false, false)]
+        [InlineData(ItemType.Material, 1, false, false)]
+        public void TryGetTradableItems(ItemType itemType, long blockIndex, bool isLock, bool expected)
         {
-            var row = TableSheets.MaterialItemSheet.First;
-            Assert.NotNull(row);
-            var material = ItemFactory.CreateMaterial(row);
-            var tradableMaterial = ItemFactory.CreateTradableMaterial(row);
-            var inventory = new Inventory();
-            Assert.Empty(inventory.Items);
-            inventory.AddItem(material);
-            inventory.AddItem(tradableMaterial);
-            inventory.RemoveTradableFungibleItem(row.ItemId);
-            Assert.False(inventory.Materials.First() is ITradableFungibleItem);
-            Assert.False(inventory.RemoveTradableFungibleItem(row.ItemId));
-            Assert.Single(inventory.Materials);
-        }
+            ItemSheet.Row row;
+            switch (itemType)
+            {
+                case ItemType.Consumable:
+                    row = TableSheets.EquipmentItemSheet.First;
+                    break;
+                case ItemType.Costume:
+                    row = TableSheets.CostumeItemSheet.First;
+                    break;
+                case ItemType.Equipment:
+                    row = TableSheets.ConsumableItemSheet.First;
+                    break;
+                case ItemType.Material:
+                    row = TableSheets.MaterialItemSheet.First;
+                    break;
+                default:
+                    throw new Exception();
+            }
 
-        [Fact]
-        public void AddItem_TradableMaterial()
-        {
-            var row = TableSheets.MaterialItemSheet.First;
-            Assert.NotNull(row);
-            var tradableMaterial = ItemFactory.CreateTradableMaterial(row);
-            tradableMaterial.RequiredBlockIndex = 0;
             var inventory = new Inventory();
-            Assert.Empty(inventory.Items);
+            ITradableItem tradableItem;
+            if (itemType == ItemType.Material)
+            {
+                tradableItem = ItemFactory.CreateTradableMaterial((MaterialItemSheet.Row)row);
+            }
+            else
+            {
+                tradableItem = (ITradableItem)ItemFactory.CreateItem(row, new TestRandom());
+            }
 
-            inventory.AddItem(tradableMaterial);
+            tradableItem.RequiredBlockIndex = blockIndex;
+            OrderLock? orderLock = null;
+            if (isLock)
+            {
+                orderLock = new OrderLock(Guid.NewGuid());
+            }
+
+            inventory.AddItem((ItemBase)tradableItem, 1, orderLock);
             Assert.Single(inventory.Items);
-            Assert.Single(inventory.Materials);
-
-            // Add new tradable material
-            var tradableMaterial2 = ItemFactory.CreateTradableMaterial(row);
-            tradableMaterial2.RequiredBlockIndex = 1;
-            inventory.AddItem(tradableMaterial2);
-            Assert.Equal(2, inventory.Items.Count);
-            Assert.Equal(2, inventory.Materials.Count());
-            Assert.True(inventory.HasItem(row.Id, 2));
+            Assert.Equal(
+                expected,
+                inventory.TryGetTradableItems(tradableItem.TradableId, 0, 1, out var items)
+            );
+            if (expected)
+            {
+                Assert.Single(items);
+                Assert.Equal((ITradableItem)items.First().item, tradableItem);
+            }
+            else
+            {
+                Assert.Empty(items);
+            }
         }
 
+        [Fact]
+        public void TryGetTradableItems_Material_Multiple_Slot()
+        {
+            var row = TableSheets.MaterialItemSheet.First;
+            Assert.NotNull(row);
+
+            var inventory = new Inventory();
+            for (var i = 0; i < 2; i++)
+            {
+                var tradableItem = ItemFactory.CreateTradableMaterial(row);
+                tradableItem.RequiredBlockIndex = i;
+                inventory.AddItem(tradableItem, 1);
+            }
+
+            Assert.Equal(2, inventory.Items.Count);
+            inventory.TryGetTradableItems(TradableMaterial.DeriveTradableId(row.ItemId), 1, 2, out var items);
+            Assert.Equal(2, items.Count);
+            for (var index = 0; index < items.Count; index++)
+            {
+                var item = items[index];
+                Assert.Equal(1, item.count);
+                var tradableItem = (ITradableItem)item.item;
+                Assert.Equal(index, tradableItem.RequiredBlockIndex);
+            }
+        }
+
+        [Theory]
+        [InlineData(ItemType.Equipment, 0, true)]
+        [InlineData(ItemType.Costume, 0, true)]
+        [InlineData(ItemType.Consumable, 0, true)]
+        [InlineData(ItemType.Material, 0, true)]
+        [InlineData(ItemType.Equipment, 1, false)]
+        [InlineData(ItemType.Costume, 1, false)]
+        [InlineData(ItemType.Consumable, 1, false)]
+        [InlineData(ItemType.Material, 1, false)]
+        public void TryGetTradableItem(ItemType itemType, long blockIndex, bool expected)
+        {
+            ItemSheet.Row row;
+            switch (itemType)
+            {
+                case ItemType.Consumable:
+                    row = TableSheets.EquipmentItemSheet.First;
+                    break;
+                case ItemType.Costume:
+                    row = TableSheets.CostumeItemSheet.First;
+                    break;
+                case ItemType.Equipment:
+                    row = TableSheets.ConsumableItemSheet.First;
+                    break;
+                case ItemType.Material:
+                    row = TableSheets.MaterialItemSheet.First;
+                    break;
+                default:
+                    throw new Exception();
+            }
+
+            var inventory = new Inventory();
+            ITradableItem tradableItem;
+            if (itemType == ItemType.Material)
+            {
+                tradableItem = ItemFactory.CreateTradableMaterial((MaterialItemSheet.Row)row);
+            }
+            else
+            {
+                tradableItem = (ITradableItem)ItemFactory.CreateItem(row, new TestRandom());
+            }
+
+            tradableItem.RequiredBlockIndex = blockIndex;
+            inventory.AddItem((ItemBase)tradableItem, 1);
+            Assert.Single(inventory.Items);
+            Assert.Equal(
+                expected,
+                inventory.TryGetTradableItem(tradableItem.TradableId, 0, 1, out var item)
+            );
+            if (expected)
+            {
+                Assert.Equal((ITradableItem)item.item, tradableItem);
+            }
+            else
+            {
+                Assert.Null(item);
+            }
+        }
+
+        [Fact]
+        public void TryGetTradableItem_Material_Multiple_Slot()
+        {
+            var row = TableSheets.MaterialItemSheet.First;
+            Assert.NotNull(row);
+
+            var inventory = new Inventory();
+            for (var i = 0; i < 2; i++)
+            {
+                var tradableItem = ItemFactory.CreateTradableMaterial(row);
+                tradableItem.RequiredBlockIndex = i;
+                var count = 1 + i;
+                inventory.AddItem(tradableItem, count);
+                Assert.Equal(count, inventory.Items.Count);
+                inventory.TryGetTradableItem(tradableItem.TradableId, i, 1, out var inventoryItem);
+                Assert.Equal(count, inventoryItem.count);
+                var item = (ITradableItem)inventoryItem.item;
+                Assert.Equal(i, item.RequiredBlockIndex);
+            }
+        }
+
+        // Has
         [Theory]
         [InlineData(ItemType.Equipment, 1)]
         [InlineData(ItemType.Costume, 2)]
@@ -245,7 +693,7 @@
             }
 
             Assert.NotNull(row);
-            for (int i = 0; i < itemCount; i++)
+            for (var i = 0; i < itemCount; i++)
             {
                 inventory.AddItem(ItemFactory.CreateItem(row, new TestRandom()));
             }
@@ -253,6 +701,143 @@
             Assert.True(inventory.HasItem(row.Id, itemCount));
         }
 
+        [Fact]
+        public void HasFungibleItem()
+        {
+            var row = TableSheets.MaterialItemSheet.First;
+            Assert.NotNull(row);
+            var inventory = new Inventory();
+            var material = ItemFactory.CreateMaterial(row);
+            inventory.AddItem(material, 2);
+            for (var i = 0; i < 2; i++)
+            {
+                ITradableItem tradableItem = ItemFactory.CreateTradableMaterial(row);
+                tradableItem.RequiredBlockIndex = i;
+                inventory.AddItem((ItemBase)tradableItem, 2);
+            }
+
+            Assert.False(inventory.HasFungibleItem(row.ItemId, 0, 6));
+            Assert.True(inventory.HasFungibleItem(row.ItemId, 0, 4));
+            Assert.True(inventory.HasFungibleItem(row.ItemId, 1, 6));
+        }
+
+        [Fact]
+        public void SameMaterials_Which_NotSame_IsTradableField_Are_Contained_Separately()
+        {
+            var row = TableSheets.MaterialItemSheet.First;
+            Assert.NotNull(row);
+            var material = ItemFactory.CreateMaterial(row);
+            var tradableMaterial = ItemFactory.CreateTradableMaterial(row);
+            var inventory = new Inventory();
+            Assert.Empty(inventory.Items);
+            inventory.AddItem(material);
+            Assert.Single(inventory.Items);
+            Assert.Single(inventory.Materials);
+            inventory.AddItem(tradableMaterial);
+            Assert.Equal(2, inventory.Items.Count);
+            Assert.Equal(2, inventory.Materials.Count());
+            inventory.RemoveFungibleItem2(row.ItemId);
+            Assert.Single(inventory.Items);
+            Assert.Single(inventory.Materials);
+        }
+
+        // Update
+        [Theory]
+        [InlineData(ItemType.Equipment)]
+        [InlineData(ItemType.Costume)]
+        [InlineData(ItemType.Consumable)]
+        [InlineData(ItemType.Material)]
+        public void UpdateTradableItem(ItemType itemType)
+        {
+            ItemSheet.Row row;
+            switch (itemType)
+            {
+                case ItemType.Consumable:
+                    row = TableSheets.EquipmentItemSheet.First;
+                    break;
+                case ItemType.Costume:
+                    row = TableSheets.CostumeItemSheet.First;
+                    break;
+                case ItemType.Equipment:
+                    row = TableSheets.ConsumableItemSheet.First;
+                    break;
+                case ItemType.Material:
+                    row = TableSheets.MaterialItemSheet.First;
+                    break;
+                default:
+                    throw new Exception();
+            }
+
+            var inventory = new Inventory();
+            ITradableItem tradableItem;
+            if (itemType == ItemType.Material)
+            {
+                tradableItem = ItemFactory.CreateTradableMaterial((MaterialItemSheet.Row)row);
+            }
+            else
+            {
+                tradableItem = (ITradableItem)ItemFactory.CreateItem(row, new TestRandom());
+            }
+
+            inventory.AddItem((ItemBase)tradableItem, 1);
+            Assert.Single(inventory.Items);
+            var result = inventory.UpdateTradableItem(tradableItem.TradableId, 0, 1, 1);
+            Assert.Equal(1, result.RequiredBlockIndex);
+            Assert.Single(inventory.Items);
+            var inventoryItem = inventory.Items.First();
+            Assert.Equal(1, inventoryItem.count);
+            Assert.Equal(1, ((ITradableItem)inventoryItem.item).RequiredBlockIndex);
+        }
+
+        [Fact]
+        public void UpdateTradableItem_Material_Multiple_Slot()
+        {
+            var row = TableSheets.MaterialItemSheet.First;
+            Assert.NotNull(row);
+            var tradableId = TradableMaterial.DeriveTradableId(row.ItemId);
+            var inventory = new Inventory();
+            for (var i = 0; i < 2; i++)
+            {
+                ITradableItem tradableItem = ItemFactory.CreateTradableMaterial(row);
+                tradableItem.RequiredBlockIndex = i;
+                inventory.AddItem((ItemBase)tradableItem, 2);
+            }
+
+            Assert.Equal(2, inventory.Items.Count);
+            var result = inventory.UpdateTradableItem(tradableId, 0, 1, 1);
+            Assert.Equal(2, inventory.Items.Count);
+            Assert.Equal(1, result.RequiredBlockIndex);
+            Assert.True(inventory.TryGetTradableItems(tradableId, 1, 4, out var items));
+            Assert.Equal(2, items.Count);
+            for (var i = 0; i < items.Count; i++)
+            {
+                var item = items[i];
+                Assert.Equal(2 * i + 1, item.count);
+                Assert.Equal(i, ((ITradableItem)item.item).RequiredBlockIndex);
+            }
+        }
+
+        // Lock
+        [Fact]
+        public void Lock()
+        {
+            var row = TableSheets.MaterialItemSheet.First;
+            Assert.NotNull(row);
+            var material = ItemFactory.CreateMaterial(row);
+            var item = new Inventory.Item(material, 1);
+            var orderLock = new OrderLock(Guid.NewGuid());
+            Assert.False(item.Locked);
+
+            item.LockUp(orderLock);
+
+            Assert.True(item.Locked);
+
+            item.Unlock();
+
+            Assert.False(item.Locked);
+        }
+
+        // Sell
         [Theory]
         [InlineData(3, 3, 1)]
         [InlineData(3, 2, 2)]
@@ -262,7 +847,7 @@
             var inventory = new Inventory();
             var row = TableSheets.MaterialItemSheet.First;
             Assert.NotNull(row);
-            for (int i = 1; i < totalCount + 1; i++)
+            for (var i = 1; i < totalCount + 1; i++)
             {
                 var tradableItem = ItemFactory.CreateTradableMaterial(row);
                 tradableItem.RequiredBlockIndex = i;
@@ -320,316 +905,76 @@
             Assert.Equal(inventoryCount, inventory.Items.Count);
         }
 
-        [Theory]
-        [InlineData(ItemType.Equipment, 0, false, true)]
-        [InlineData(ItemType.Costume, 0, false, true)]
-        [InlineData(ItemType.Consumable, 0, false, true)]
-        [InlineData(ItemType.Material, 0, false, true)]
-        [InlineData(ItemType.Equipment, 0, true, false)]
-        [InlineData(ItemType.Costume, 0, true, false)]
-        [InlineData(ItemType.Consumable, 0, true, false)]
-        [InlineData(ItemType.Material, 0, true, false)]
-        [InlineData(ItemType.Equipment, 1, false, false)]
-        [InlineData(ItemType.Costume, 1, false, false)]
-        [InlineData(ItemType.Consumable, 1, false, false)]
-        [InlineData(ItemType.Material, 1, false, false)]
-        public void TryGetTradableItems(ItemType itemType, long blockIndex, bool isLock, bool expected)
+        private static Consumable GetFirstConsumable()
         {
-            ItemSheet.Row row;
-            switch (itemType)
-            {
-                case ItemType.Consumable:
-                    row = TableSheets.EquipmentItemSheet.First;
-                    break;
-                case ItemType.Costume:
-                    row = TableSheets.CostumeItemSheet.First;
-                    break;
-                case ItemType.Equipment:
-                    row = TableSheets.ConsumableItemSheet.First;
-                    break;
-                case ItemType.Material:
-                    row = TableSheets.MaterialItemSheet.First;
-                    break;
-                default:
-                    throw new Exception();
-            }
+            var row = TableSheets.ConsumableItemSheet.First;
+            Assert.NotNull(row);
 
-            var inventory = new Inventory();
-            ITradableItem tradableItem;
-            if (itemType == ItemType.Material)
-            {
-                tradableItem = (ITradableItem)ItemFactory.CreateTradableMaterial((MaterialItemSheet.Row)row);
-            }
-            else
-            {
-                tradableItem = (ITradableItem)ItemFactory.CreateItem(row, new TestRandom());
-            }
-
-            tradableItem.RequiredBlockIndex = blockIndex;
-            OrderLock? orderLock = null;
-            if (isLock)
-            {
-                orderLock = new OrderLock(Guid.NewGuid());
-            }
-
-            inventory.AddItem((ItemBase)tradableItem, 1, orderLock);
-            Assert.Single(inventory.Items);
-            Assert.Equal(
-                expected,
-                inventory.TryGetTradableItems(tradableItem.TradableId, 0, 1, out List<Inventory.Item> items)
-            );
-            if (expected)
-            {
-                Assert.Single(items);
-                Assert.Equal((ITradableItem)items.First().item, tradableItem);
-            }
-            else
-            {
-                Assert.Empty(items);
-            }
+            return (Consumable)ItemFactory.CreateItem(row, new TestRandom());
         }
 
-        [Fact]
-        public void TryGetTradableItems_Material_Multiple_Slot()
+        private static Costume GetFirstCostume()
+        {
+            var row = TableSheets.CostumeItemSheet.First;
+            Assert.NotNull(row);
+
+            return (Costume)ItemFactory.CreateItem(row, new TestRandom());
+        }
+
+        private static Material GetFirstMaterial()
         {
             var row = TableSheets.MaterialItemSheet.First;
             Assert.NotNull(row);
 
-            var inventory = new Inventory();
-            for (int i = 0; i < 2; i++)
-            {
-                TradableMaterial tradableItem = ItemFactory.CreateTradableMaterial(row);
-                tradableItem.RequiredBlockIndex = i;
-                inventory.AddItem(tradableItem, 1);
-            }
-
-            Assert.Equal(2, inventory.Items.Count);
-            inventory.TryGetTradableItems(TradableMaterial.DeriveTradableId(row.ItemId), 1, 2, out List<Inventory.Item> items);
-            Assert.Equal(2, items.Count);
-            for (var index = 0; index < items.Count; index++)
-            {
-                var item = items[index];
-                Assert.Equal(1, item.count);
-                ITradableItem tradableItem = (ITradableItem)item.item;
-                Assert.Equal(index, tradableItem.RequiredBlockIndex);
-            }
+            return (Material)ItemFactory.CreateItem(row, new TestRandom());
         }
 
-        [Theory]
-        [InlineData(ItemType.Equipment, 0, true)]
-        [InlineData(ItemType.Costume, 0, true)]
-        [InlineData(ItemType.Consumable, 0, true)]
-        [InlineData(ItemType.Material, 0, true)]
-        [InlineData(ItemType.Equipment, 1, false)]
-        [InlineData(ItemType.Costume, 1, false)]
-        [InlineData(ItemType.Consumable, 1, false)]
-        [InlineData(ItemType.Material, 1, false)]
-        public void TryGetTradableItem(ItemType itemType, long blockIndex, bool expected)
+        private static Equipment GetFirstEquipment()
         {
-            ItemSheet.Row row;
-            switch (itemType)
-            {
-                case ItemType.Consumable:
-                    row = TableSheets.EquipmentItemSheet.First;
-                    break;
-                case ItemType.Costume:
-                    row = TableSheets.CostumeItemSheet.First;
-                    break;
-                case ItemType.Equipment:
-                    row = TableSheets.ConsumableItemSheet.First;
-                    break;
-                case ItemType.Material:
-                    row = TableSheets.MaterialItemSheet.First;
-                    break;
-                default:
-                    throw new Exception();
-            }
+            var row = TableSheets.EquipmentItemSheet.First;
+            Assert.NotNull(row);
 
-            var inventory = new Inventory();
-            ITradableItem tradableItem;
-            if (itemType == ItemType.Material)
-            {
-                tradableItem = (ITradableItem)ItemFactory.CreateTradableMaterial((MaterialItemSheet.Row)row);
-            }
-            else
-            {
-                tradableItem = (ITradableItem)ItemFactory.CreateItem(row, new TestRandom());
-            }
-
-            tradableItem.RequiredBlockIndex = blockIndex;
-            inventory.AddItem((ItemBase)tradableItem, 1);
-            Assert.Single(inventory.Items);
-            Assert.Equal(
-                expected,
-                inventory.TryGetTradableItem(tradableItem.TradableId, 0, 1, out Inventory.Item item)
-            );
-            if (expected)
-            {
-                Assert.Equal((ITradableItem)item.item, tradableItem);
-            }
-            else
-            {
-                Assert.Null(item);
-            }
+            return (Equipment)ItemFactory.CreateItem(row, new TestRandom());
         }
 
-        [Fact]
-        public void TryGetTradableItem_Material_Multiple_Slot()
+        private static Material GetFirstTradableMaterial()
         {
             var row = TableSheets.MaterialItemSheet.First;
             Assert.NotNull(row);
 
-            var inventory = new Inventory();
-            for (int i = 0; i < 2; i++)
-            {
-                TradableMaterial tradableItem = ItemFactory.CreateTradableMaterial(row);
-                tradableItem.RequiredBlockIndex = i;
-                var count = 1 + i;
-                inventory.AddItem(tradableItem, count);
-                Assert.Equal(count, inventory.Items.Count);
-                inventory.TryGetTradableItem(tradableItem.TradableId, i, 1, out Inventory.Item inventoryItem);
-                Assert.Equal(count, inventoryItem.count);
-                ITradableItem item = (ITradableItem)inventoryItem.item;
-                Assert.Equal(i, item.RequiredBlockIndex);
-            }
+            return ItemFactory.CreateTradableMaterial(row);
         }
 
-        [Theory]
-        [InlineData(ItemType.Equipment)]
-        [InlineData(ItemType.Costume)]
-        [InlineData(ItemType.Consumable)]
-        [InlineData(ItemType.Material)]
-        public void UpdateTradableItem(ItemType itemType)
+        private static Inventory AddItem_Consumable_After(Inventory inventory)
         {
-            ItemSheet.Row row;
-            switch (itemType)
-            {
-                case ItemType.Consumable:
-                    row = TableSheets.EquipmentItemSheet.First;
-                    break;
-                case ItemType.Costume:
-                    row = TableSheets.CostumeItemSheet.First;
-                    break;
-                case ItemType.Equipment:
-                    row = TableSheets.ConsumableItemSheet.First;
-                    break;
-                case ItemType.Material:
-                    row = TableSheets.MaterialItemSheet.First;
-                    break;
-                default:
-                    throw new Exception();
-            }
-
-            var inventory = new Inventory();
-            ITradableItem tradableItem;
-            if (itemType == ItemType.Material)
-            {
-                tradableItem = ItemFactory.CreateTradableMaterial((MaterialItemSheet.Row)row);
-            }
-            else
-            {
-                tradableItem = (ITradableItem)ItemFactory.CreateItem(row, new TestRandom());
-            }
-
-            inventory.AddItem((ItemBase)tradableItem, 1);
             Assert.Single(inventory.Items);
-            ITradableItem result = inventory.UpdateTradableItem(tradableItem.TradableId, 0, 1, 1);
-            Assert.Equal(1, result.RequiredBlockIndex);
+            Assert.Single(inventory.Consumables);
+            return inventory;
+        }
+
+        private static Inventory AddItem_Costume_After(Inventory inventory)
+        {
             Assert.Single(inventory.Items);
-            Inventory.Item inventoryItem = inventory.Items.First();
-            Assert.Equal(1, inventoryItem.count);
-            Assert.Equal(1, ((ITradableItem)inventoryItem.item).RequiredBlockIndex);
+            Assert.Single(inventory.Costumes);
+            return inventory;
         }
 
-        [Fact]
-        public void UpdateTradableItem_Material_Multiple_Slot()
+        private static Inventory AddItem_Material_After(Inventory inventory, int count)
         {
-            MaterialItemSheet.Row row = TableSheets.MaterialItemSheet.First;
-            Assert.NotNull(row);
-            Guid tradableId = TradableMaterial.DeriveTradableId(row.ItemId);
-            var inventory = new Inventory();
-            for (int i = 0; i < 2; i++)
-            {
-                ITradableItem tradableItem = ItemFactory.CreateTradableMaterial(row);
-                tradableItem.RequiredBlockIndex = i;
-                inventory.AddItem((ItemBase)tradableItem, 2);
-            }
+            Assert.Single(inventory.Items);
+            Assert.Single(inventory.Materials);
+            Assert.True(inventory.TryGetFungibleItems(inventory.Materials.First().FungibleId, out var items));
+            Assert.Single(items);
+            Assert.Equal(count, items.First().count);
 
-            Assert.Equal(2, inventory.Items.Count);
-            ITradableItem result = inventory.UpdateTradableItem(tradableId, 0, 1, 1);
-            Assert.Equal(2, inventory.Items.Count);
-            Assert.Equal(1, result.RequiredBlockIndex);
-            Assert.True(inventory.TryGetTradableItems(tradableId, 1, 4, out List<Inventory.Item> items));
-            Assert.Equal(2, items.Count);
-            for (int i = 0; i < items.Count; i++)
-            {
-                var item = items[i];
-                Assert.Equal(2 * i + 1, item.count);
-                Assert.Equal(i, ((ITradableItem)item.item).RequiredBlockIndex);
-            }
+            return inventory;
         }
 
-        [Fact]
-        public void HasFungibleItem()
+        private static Inventory AddItem_Equipment_After(Inventory inventory)
         {
-            MaterialItemSheet.Row row = TableSheets.MaterialItemSheet.First;
-            Assert.NotNull(row);
-            var inventory = new Inventory();
-            Material material = ItemFactory.CreateMaterial(row);
-            inventory.AddItem(material, 2);
-            for (int i = 0; i < 2; i++)
-            {
-                ITradableItem tradableItem = ItemFactory.CreateTradableMaterial(row);
-                tradableItem.RequiredBlockIndex = i;
-                inventory.AddItem((ItemBase)tradableItem, 2);
-            }
-
-            Assert.False(inventory.HasFungibleItem(row.ItemId, 0, 6));
-            Assert.True(inventory.HasFungibleItem(row.ItemId, 0, 4));
-            Assert.True(inventory.HasFungibleItem(row.ItemId, 1, 6));
-            inventory.RemoveFungibleItem2(row.ItemId, 6);
-        }
-
-        [Fact]
-        public void RemoveFungibleItemV2()
-        {
-            MaterialItemSheet.Row row = TableSheets.MaterialItemSheet.First;
-            Assert.NotNull(row);
-            var inventory = new Inventory();
-            Material material = ItemFactory.CreateMaterial(row);
-            inventory.AddItem(material, 2);
-            for (int i = 0; i < 2; i++)
-            {
-                ITradableItem tradableItem = ItemFactory.CreateTradableMaterial(row);
-                tradableItem.RequiredBlockIndex = i;
-                inventory.AddItem((ItemBase)tradableItem, 2);
-            }
-
-            Assert.True(inventory.HasItem(row.Id, 6));
-            Assert.False(inventory.RemoveFungibleItem(row.ItemId, 0, 6));
-            Assert.True(inventory.RemoveFungibleItem(row.ItemId, 0, 2));
-            Assert.True(inventory.HasItem(row.Id, 4));
-            Assert.True(inventory.TryGetFungibleItems(row.ItemId, out List<Inventory.Item> items));
-            Assert.All(items, item => Assert.True(item.item is IFungibleItem));
-        }
-
-        [Fact]
-        public void Lock()
-        {
-            MaterialItemSheet.Row row = TableSheets.MaterialItemSheet.First;
-            Assert.NotNull(row);
-            Material material = ItemFactory.CreateMaterial(row);
-            var item = new Inventory.Item(material, 1);
-            var orderLock = new OrderLock(Guid.NewGuid());
-            Assert.False(item.Locked);
-
-            item.LockUp(orderLock);
-
-            Assert.True(item.Locked);
-
-            item.Unlock();
-
-            Assert.False(item.Locked);
+            Assert.Single(inventory.Items);
+            Assert.Single(inventory.Equipments);
+            return inventory;
         }
     }
 }

--- a/Lib9c/Action/CombinationConsumable.cs
+++ b/Lib9c/Action/CombinationConsumable.cs
@@ -181,7 +181,7 @@ namespace Nekoyume.Action
                     }
 
                     materials[material] = count;
-                    avatarState.inventory.RemoveFungibleItem(material, count);
+                    avatarState.inventory.RemoveFungibleItem(material, context.BlockIndex, count);
                 }
                 else
                 {
@@ -198,7 +198,6 @@ namespace Nekoyume.Action
             {
                 materials = materials,
                 itemType = ItemType.Consumable,
-
             };
 
             var costAP = recipeRow.RequiredActionPoint;

--- a/Lib9c/Action/CombinationConsumable0.cs
+++ b/Lib9c/Action/CombinationConsumable0.cs
@@ -192,7 +192,7 @@ namespace Nekoyume.Action
             );
             result.id = mail.id;
             avatarState.Update2(mail);
-            avatarState.UpdateFromCombination(itemUsable);
+            avatarState.UpdateFromCombination2(itemUsable);
             sw.Stop();
             Log.Verbose("{AddressesHex}Combination Update AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();

--- a/Lib9c/Action/CombinationConsumable2.cs
+++ b/Lib9c/Action/CombinationConsumable2.cs
@@ -192,7 +192,7 @@ namespace Nekoyume.Action
             );
             result.id = mail.id;
             avatarState.Update3(mail);
-            avatarState.UpdateFromCombination(itemUsable);
+            avatarState.UpdateFromCombination2(itemUsable);
             sw.Stop();
             Log.Verbose("{AddressesHex}Combination Update AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();

--- a/Lib9c/Action/CombinationConsumable3.cs
+++ b/Lib9c/Action/CombinationConsumable3.cs
@@ -192,7 +192,7 @@ namespace Nekoyume.Action
             );
             result.id = mail.id;
             avatarState.Update(mail);
-            avatarState.UpdateFromCombination(itemUsable);
+            avatarState.UpdateFromCombination2(itemUsable);
             sw.Stop();
             Log.Verbose("{AddressesHex}Combination Update AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();

--- a/Lib9c/Action/CombinationConsumable4.cs
+++ b/Lib9c/Action/CombinationConsumable4.cs
@@ -192,7 +192,7 @@ namespace Nekoyume.Action
             );
             result.id = mail.id;
             avatarState.Update(mail);
-            avatarState.UpdateFromCombination(itemUsable);
+            avatarState.UpdateFromCombination2(itemUsable);
             sw.Stop();
             Log.Verbose("{AddressesHex}Combination Update AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();

--- a/Lib9c/Action/CombinationConsumable5.cs
+++ b/Lib9c/Action/CombinationConsumable5.cs
@@ -234,7 +234,7 @@ namespace Nekoyume.Action
             );
             result.id = mail.id;
             avatarState.Update(mail);
-            avatarState.UpdateFromCombination(itemUsable);
+            avatarState.UpdateFromCombination2(itemUsable);
             sw.Stop();
             Log.Verbose("{AddressesHex}Combination Update AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();

--- a/Lib9c/Action/CombinationConsumable6.cs
+++ b/Lib9c/Action/CombinationConsumable6.cs
@@ -199,7 +199,7 @@ namespace Nekoyume.Action
             );
             result.id = mail.id;
             avatarState.Update(mail);
-            avatarState.UpdateFromCombination(itemUsable);
+            avatarState.UpdateFromCombination2(itemUsable);
             sw.Stop();
             Log.Verbose("{AddressesHex}Combination Update AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();

--- a/Lib9c/Action/CombinationEquipment.cs
+++ b/Lib9c/Action/CombinationEquipment.cs
@@ -108,10 +108,10 @@ namespace Nekoyume.Action
                 throw new SheetRowNotFoundException(addressesHex, nameof(MaterialItemSheet), recipe.MaterialId);
             }
 
-            if (!avatarState.inventory.RemoveFungibleItem(material.ItemId, recipe.MaterialCount))
+            if (!avatarState.inventory.RemoveFungibleItem(material.ItemId, context.BlockIndex, recipe.MaterialCount))
             {
                 throw new NotEnoughMaterialException(
-                    $"{addressesHex}Aborted as the player has no enough material ({material} * {recipe.MaterialCount})"
+                    $"{addressesHex}Aborted as the player has no enough material ({material} * {recipe.MaterialCount}). BlockIndex({context.BlockIndex})"
                 );
             }
 
@@ -157,11 +157,13 @@ namespace Nekoyume.Action
                         throw new SheetRowNotFoundException(addressesHex, nameof(MaterialItemSheet), materialInfo.Id);
                     }
 
-                    if (!avatarState.inventory.RemoveFungibleItem(subMaterialRow.ItemId,
+                    if (!avatarState.inventory.RemoveFungibleItem(
+                        subMaterialRow.ItemId,
+                        context.BlockIndex,
                         materialInfo.Count))
                     {
                         throw new NotEnoughMaterialException(
-                            $"{addressesHex}Aborted as the player has no enough material ({subMaterialRow} * {materialInfo.Count})"
+                            $"{addressesHex}Aborted as the player has no enough material ({subMaterialRow} * {materialInfo.Count}). BlockIndex({context.BlockIndex})"
                         );
                     }
 

--- a/Lib9c/Action/CombinationEquipment0.cs
+++ b/Lib9c/Action/CombinationEquipment0.cs
@@ -214,7 +214,7 @@ namespace Nekoyume.Action
             result.id = mail.id;
             avatarState.Update2(mail);
             avatarState.questList.UpdateCombinationEquipmentQuest(RecipeId);
-            avatarState.UpdateFromCombination(equipment);
+            avatarState.UpdateFromCombination2(equipment);
             avatarState.UpdateQuestRewards2(materialSheet);
             return states
                 .SetState(AvatarAddress, avatarState.Serialize())

--- a/Lib9c/Action/CombinationEquipment2.cs
+++ b/Lib9c/Action/CombinationEquipment2.cs
@@ -214,7 +214,7 @@ namespace Nekoyume.Action
             result.id = mail.id;
             avatarState.Update3(mail);
             avatarState.questList.UpdateCombinationEquipmentQuest(RecipeId);
-            avatarState.UpdateFromCombination(equipment);
+            avatarState.UpdateFromCombination2(equipment);
             avatarState.UpdateQuestRewards2(materialSheet);
             return states
                 .SetState(AvatarAddress, avatarState.Serialize())

--- a/Lib9c/Action/CombinationEquipment3.cs
+++ b/Lib9c/Action/CombinationEquipment3.cs
@@ -223,7 +223,7 @@ namespace Nekoyume.Action
             result.id = mail.id;
             avatarState.Update3(mail);
             avatarState.questList.UpdateCombinationEquipmentQuest(RecipeId);
-            avatarState.UpdateFromCombination(equipment);
+            avatarState.UpdateFromCombination2(equipment);
             avatarState.UpdateQuestRewards2(materialSheet);
             return states
                 .SetState(AvatarAddress, avatarState.Serialize())

--- a/Lib9c/Action/CombinationEquipment4.cs
+++ b/Lib9c/Action/CombinationEquipment4.cs
@@ -223,7 +223,7 @@ namespace Nekoyume.Action
             result.id = mail.id;
             avatarState.Update(mail);
             avatarState.questList.UpdateCombinationEquipmentQuest(RecipeId);
-            avatarState.UpdateFromCombination(equipment);
+            avatarState.UpdateFromCombination2(equipment);
             avatarState.UpdateQuestRewards2(materialSheet);
             return states
                 .SetState(AvatarAddress, avatarState.Serialize())

--- a/Lib9c/Action/CombinationEquipment5.cs
+++ b/Lib9c/Action/CombinationEquipment5.cs
@@ -223,7 +223,7 @@ namespace Nekoyume.Action
             result.id = mail.id;
             avatarState.Update(mail);
             avatarState.questList.UpdateCombinationEquipmentQuest(RecipeId);
-            avatarState.UpdateFromCombination(equipment);
+            avatarState.UpdateFromCombination2(equipment);
             avatarState.UpdateQuestRewards2(materialSheet);
             return states
                 .SetState(AvatarAddress, avatarState.Serialize())

--- a/Lib9c/Action/CombinationEquipment6.cs
+++ b/Lib9c/Action/CombinationEquipment6.cs
@@ -230,7 +230,7 @@ namespace Nekoyume.Action
             result.id = mail.id;
             avatarState.Update(mail);
             avatarState.questList.UpdateCombinationEquipmentQuest(RecipeId);
-            avatarState.UpdateFromCombination(equipment);
+            avatarState.UpdateFromCombination2(equipment);
             avatarState.UpdateQuestRewards2(materialSheet);
             return states
                 .SetState(AvatarAddress, avatarState.SerializeV2())

--- a/Lib9c/Action/ItemEnhancement0.cs
+++ b/Lib9c/Action/ItemEnhancement0.cs
@@ -235,7 +235,7 @@ namespace Nekoyume.Action
 
             avatarState.inventory.RemoveNonFungibleItem(enhancementEquipment);
             avatarState.Update2(mail);
-            avatarState.UpdateFromItemEnhancement(enhancementEquipment);
+            avatarState.UpdateFromItemEnhancement2(enhancementEquipment);
 
             var materialSheet = states.GetSheet<MaterialItemSheet>();
             avatarState.UpdateQuestRewards2(materialSheet);

--- a/Lib9c/Action/ItemEnhancement2.cs
+++ b/Lib9c/Action/ItemEnhancement2.cs
@@ -217,7 +217,7 @@ namespace Nekoyume.Action
 
             avatarState.inventory.RemoveNonFungibleItem(enhancementEquipment);
             avatarState.Update2(mail);
-            avatarState.UpdateFromItemEnhancement(enhancementEquipment);
+            avatarState.UpdateFromItemEnhancement2(enhancementEquipment);
 
             var materialSheet = states.GetSheet<MaterialItemSheet>();
             avatarState.UpdateQuestRewards2(materialSheet);

--- a/Lib9c/Action/ItemEnhancement3.cs
+++ b/Lib9c/Action/ItemEnhancement3.cs
@@ -217,7 +217,7 @@ namespace Nekoyume.Action
 
             avatarState.inventory.RemoveNonFungibleItem(enhancementEquipment);
             avatarState.Update3(mail);
-            avatarState.UpdateFromItemEnhancement(enhancementEquipment);
+            avatarState.UpdateFromItemEnhancement2(enhancementEquipment);
 
             var materialSheet = states.GetSheet<MaterialItemSheet>();
             avatarState.UpdateQuestRewards2(materialSheet);

--- a/Lib9c/Action/ItemEnhancement4.cs
+++ b/Lib9c/Action/ItemEnhancement4.cs
@@ -215,7 +215,7 @@ namespace Nekoyume.Action
 
             avatarState.inventory.RemoveNonFungibleItem(enhancementEquipment);
             avatarState.Update3(mail);
-            avatarState.UpdateFromItemEnhancement(enhancementEquipment);
+            avatarState.UpdateFromItemEnhancement2(enhancementEquipment);
 
             var materialSheet = states.GetSheet<MaterialItemSheet>();
             avatarState.UpdateQuestRewards2(materialSheet);

--- a/Lib9c/Action/ItemEnhancement5.cs
+++ b/Lib9c/Action/ItemEnhancement5.cs
@@ -215,7 +215,7 @@ namespace Nekoyume.Action
 
             avatarState.inventory.RemoveNonFungibleItem(enhancementEquipment);
             avatarState.Update(mail);
-            avatarState.UpdateFromItemEnhancement(enhancementEquipment);
+            avatarState.UpdateFromItemEnhancement2(enhancementEquipment);
 
             var materialSheet = states.GetSheet<MaterialItemSheet>();
             avatarState.UpdateQuestRewards2(materialSheet);

--- a/Lib9c/Action/ItemEnhancement6.cs
+++ b/Lib9c/Action/ItemEnhancement6.cs
@@ -218,7 +218,7 @@ namespace Nekoyume.Action
 
             avatarState.inventory.RemoveNonFungibleItem(enhancementEquipment);
             avatarState.Update(mail);
-            avatarState.UpdateFromItemEnhancement(enhancementEquipment);
+            avatarState.UpdateFromItemEnhancement2(enhancementEquipment);
 
             var materialSheet = states.GetSheet<MaterialItemSheet>();
             avatarState.UpdateQuestRewards2(materialSheet);

--- a/Lib9c/Action/ItemEnhancement7.cs
+++ b/Lib9c/Action/ItemEnhancement7.cs
@@ -225,7 +225,7 @@ namespace Nekoyume.Action
 
             avatarState.inventory.RemoveNonFungibleItem(enhancementEquipment);
             avatarState.Update(mail);
-            avatarState.UpdateFromItemEnhancement(enhancementEquipment);
+            avatarState.UpdateFromItemEnhancement2(enhancementEquipment);
 
             var materialSheet = states.GetSheet<MaterialItemSheet>();
             avatarState.UpdateQuestRewards2(materialSheet);

--- a/Lib9c/Action/Sell2.cs
+++ b/Lib9c/Action/Sell2.cs
@@ -115,7 +115,7 @@ namespace Nekoyume.Action
             else if (avatarState.inventory.TryGetNonFungibleItem<Costume>(itemId, out var costume))
             {
 #pragma warning disable 618
-                avatarState.inventory.LegacyRemoveNonFungibleItem(itemId);
+                avatarState.inventory.RemoveNonFungibleItem2(itemId);
 #pragma warning restore 618
                 costume.equipped = false;
                 shopItem = new ShopItem(

--- a/Lib9c/Model/Item/Inventory.cs
+++ b/Lib9c/Model/Item/Inventory.cs
@@ -447,9 +447,6 @@ namespace Nekoyume.Model.Item
             return true;
         }
 
-        public bool RemoveTradableFungibleItem(HashDigest<SHA256> fungibleId, int count = 1) =>
-            RemoveFungibleItem2(fungibleId, count, true);
-
         [Obsolete("Use RemoveNonFungibleItem(INonFungibleItem nonFungibleItem)")]
         public bool LegacyRemoveNonFungibleItem(Costume costume)
             => LegacyRemoveNonFungibleItem(costume.ItemId);

--- a/Lib9c/Model/Item/Inventory.cs
+++ b/Lib9c/Model/Item/Inventory.cs
@@ -422,6 +422,23 @@ namespace Nekoyume.Model.Item
         public bool RemoveNonFungibleItem(Guid nonFungibleId)
             => TryGetNonFungibleItem(nonFungibleId, out var item) && _items.Remove(item);
 
+        [Obsolete("Use RemoveNonFungibleItem(Guid nonFungibleId)")]
+        public bool RemoveNonFungibleItem2(Guid nonFungibleId)
+        {
+            var isRemoved = TryGetNonFungibleItem(nonFungibleId, out Item item);
+            if (!isRemoved) return false;
+
+            foreach (var element in _items)
+            {
+                if (element.item.Id == item.item.Id)
+                {
+                    _items.Remove(element);
+                    break;
+                }
+            }
+            return true;
+        }
+
         public bool RemoveTradableItem(ITradableItem tradableItem, int count = 1) =>
             RemoveTradableItem(tradableItem.TradableId, tradableItem.RequiredBlockIndex, count);
 
@@ -444,27 +461,6 @@ namespace Nekoyume.Model.Item
                 _items.Remove(target);
             }
 
-            return true;
-        }
-
-        [Obsolete("Use RemoveNonFungibleItem(INonFungibleItem nonFungibleItem)")]
-        public bool LegacyRemoveNonFungibleItem(Costume costume)
-            => LegacyRemoveNonFungibleItem(costume.ItemId);
-
-        [Obsolete("Use RemoveNonFungibleItem(Guid itemId)")]
-        public bool LegacyRemoveNonFungibleItem(Guid nonFungibleId)
-        {
-            var isRemoved = TryGetNonFungibleItem(nonFungibleId, out Item item);
-            if (!isRemoved) return false;
-
-            foreach (var element in _items)
-            {
-                if (element.item.Id == item.item.Id)
-                {
-                    _items.Remove(element);
-                    break;
-                }
-            }
             return true;
         }
 

--- a/Lib9c/Model/State/AvatarState.cs
+++ b/Lib9c/Model/State/AvatarState.cs
@@ -366,10 +366,30 @@ namespace Nekoyume.Model.State
             eventMap.Add(new KeyValuePair<int, int>((int)type, 1));
             UpdateGeneralQuest(new[] { type });
             UpdateCompletedQuest();
+            UpdateFromAddItem(itemUsable, false);
+        }
+
+        public void UpdateFromCombination2(ItemUsable itemUsable)
+        {
+            questList.UpdateCombinationQuest(itemUsable);
+            var type = itemUsable.ItemType == ItemType.Equipment ? QuestEventType.Equipment : QuestEventType.Consumable;
+            eventMap.Add(new KeyValuePair<int, int>((int)type, 1));
+            UpdateGeneralQuest(new[] { type });
+            UpdateCompletedQuest();
             UpdateFromAddItem2(itemUsable, false);
         }
 
         public void UpdateFromItemEnhancement(Equipment equipment)
+        {
+            questList.UpdateItemEnhancementQuest(equipment);
+            var type = QuestEventType.Enhancement;
+            eventMap.Add(new KeyValuePair<int, int>((int)type, 1));
+            UpdateGeneralQuest(new[] { type });
+            UpdateCompletedQuest();
+            UpdateFromAddItem(equipment, false);
+        }
+
+        public void UpdateFromItemEnhancement2(Equipment equipment)
         {
             questList.UpdateItemEnhancementQuest(equipment);
             var type = QuestEventType.Enhancement;


### PR DESCRIPTION
- Remove useless method
- Rename `LegacyRemoveNonFungibleItem()` to `RemoveNonfungibleItem2()` of `Inventory`
- Archive `UpdateFromCombination()` and `UpdateFromItemEnhancement()` of `AvatarState`
- Improve test for Inventory
- Fix bug of `CombinationConsumable`
- Fix bug of `CombinationEquipment`
