### PR TITLE
Fixed an issue that rating is increased when won agianst higher rating

### DIFF
--- a/.Lib9c.Tests/Battle/ArenaScoreHelperTest.cs
+++ b/.Lib9c.Tests/Battle/ArenaScoreHelperTest.cs
@@ -11,27 +11,29 @@ namespace Lib9c.Tests
         public void GetScore()
         {
             var challengerRating = 10000;
-            var defenderRating = challengerRating + Math.Abs(ArenaScoreHelper.DifferLowerLimit);
-            var score = ArenaScoreHelper.GetScore(challengerRating, defenderRating, BattleLog.Result.Win);
-            Assert.Equal(ArenaScoreHelper.WinScoreMax, score);
-            score = ArenaScoreHelper.GetScore(challengerRating, defenderRating, BattleLog.Result.Lose);
-            Assert.Equal(ArenaScoreHelper.LoseScoreMin, score);
-            defenderRating++;
-            score = ArenaScoreHelper.GetScore(challengerRating, defenderRating, BattleLog.Result.Win);
-            Assert.Equal(ArenaScoreHelper.WinScoreMax, score);
-            score = ArenaScoreHelper.GetScore(challengerRating, defenderRating, BattleLog.Result.Lose);
-            Assert.Equal(ArenaScoreHelper.LoseScoreMin, score);
-
-            defenderRating = challengerRating - Math.Abs(ArenaScoreHelper.DifferUpperLimit);
-            score = ArenaScoreHelper.GetScore(challengerRating, defenderRating, BattleLog.Result.Win);
-            Assert.Equal(ArenaScoreHelper.WinScoreMin, score);
-            score = ArenaScoreHelper.GetScore(challengerRating, defenderRating, BattleLog.Result.Lose);
-            Assert.Equal(ArenaScoreHelper.LoseScoreMax, score);
-            defenderRating--;
-            score = ArenaScoreHelper.GetScore(challengerRating, defenderRating, BattleLog.Result.Win);
-            Assert.Equal(ArenaScoreHelper.WinScoreMin, score);
-            score = ArenaScoreHelper.GetScore(challengerRating, defenderRating, BattleLog.Result.Lose);
-            Assert.Equal(ArenaScoreHelper.LoseScoreMax, score);
+            var defenderRating = 9000;
+            
+            Assert.Equal(ArenaScoreHelper.GetScore(10000, 11000, BattleLog.Result.Win), 60);
+            Assert.Equal(ArenaScoreHelper.GetScore(10000, 11000, BattleLog.Result.Lose), -30);
+            
+            Assert.Equal(ArenaScoreHelper.GetScore(10000, 11001, BattleLog.Result.Win), 60);
+            Assert.Equal(ArenaScoreHelper.GetScore(10000, 11001, BattleLog.Result.Lose), -30);
+            
+            Assert.Equal(ArenaScoreHelper.GetScore(10000, 9000, BattleLog.Result.Win), 1);
+            Assert.Equal(ArenaScoreHelper.GetScore(10000, 9000, BattleLog.Result.Lose), -30);
+            
+            Assert.Equal(ArenaScoreHelper.GetScore(10000, 8999, BattleLog.Result.Win), 1);
+            Assert.Equal(ArenaScoreHelper.GetScore(10000, 8999, BattleLog.Result.Lose), -30);
+            
+            Assert.Equal(ArenaScoreHelper.GetScore(10000, 9900, BattleLog.Result.Win), 8);
+            Assert.Equal(ArenaScoreHelper.GetScore(10000, 9901, BattleLog.Result.Win), 15);
+            Assert.Equal(ArenaScoreHelper.GetScore(10000, 10000, BattleLog.Result.Win), 15);
+            Assert.Equal(ArenaScoreHelper.GetScore(10000, 10001, BattleLog.Result.Win), 20);
+            
+            Assert.Equal(ArenaScoreHelper.GetScore(10000, 9800, BattleLog.Result.Lose), -20);
+            Assert.Equal(ArenaScoreHelper.GetScore(10000, 9801, BattleLog.Result.Lose), -10);
+            Assert.Equal(ArenaScoreHelper.GetScore(10000, 10000, BattleLog.Result.Lose), -10);
+            Assert.Equal(ArenaScoreHelper.GetScore(10000, 10001, BattleLog.Result.Lose), -8);
         }
     }
 }

--- a/.Lib9c.Tests/Battle/ArenaScoreHelperTest.cs
+++ b/.Lib9c.Tests/Battle/ArenaScoreHelperTest.cs
@@ -10,9 +10,6 @@ namespace Lib9c.Tests
         [Fact]
         public void GetScore()
         {
-            var challengerRating = 10000;
-            var defenderRating = 9000;
-            
             Assert.Equal(ArenaScoreHelper.GetScore(10000, 11000, BattleLog.Result.Win), 60);
             Assert.Equal(ArenaScoreHelper.GetScore(10000, 11000, BattleLog.Result.Lose), -30);
             

--- a/Lib9c/Battle/ArenaScoreHelper.cs
+++ b/Lib9c/Battle/ArenaScoreHelper.cs
@@ -47,7 +47,7 @@ namespace Nekoyume.Battle
             var differ = challengerRating - defenderRating;
             if (differ < 0)
             {
-                foreach (var pair in CachedScore.Where(pair => pair.Key < 0).OrderBy(kv => kv.Key))
+                foreach (var pair in CachedScore.Where(pair => pair.Key < 0).OrderByDescending(kv => kv.Key))
                 {
                     if (differ < pair.Key)
                     {


### PR DESCRIPTION
Fixed an issue where the rating would increase excessively when I beat an opponent with a higher rating than me.

Step to reproduce:

```
public class Program
{
	public static void Main()
	{
		const int MyRating = 1000;
		
		for (var OpponentRating = 800; OpponentRating < 1800; OpponentRating += 20) {
			Console.WriteLine("MyRating\t" + MyRating + "\tOpponent:\t" + OpponentRating + "\tScore Earned:\t" + ArenaScoreHelper.GetScore(MyRating, OpponentRating));
		}
	}
}
```

```
MyRating    1000    Opponent:    800    Score Earned:    4
MyRating    1000    Opponent:    820    Score Earned:    8
MyRating    1000    Opponent:    840    Score Earned:    8
MyRating    1000    Opponent:    860    Score Earned:    8
MyRating    1000    Opponent:    880    Score Earned:    8
MyRating    1000    Opponent:    900    Score Earned:    8
MyRating    1000    Opponent:    920    Score Earned:    15
MyRating    1000    Opponent:    940    Score Earned:    15
MyRating    1000    Opponent:    960    Score Earned:    15
MyRating    1000    Opponent:    980    Score Earned:    15
MyRating    1000    Opponent:    1000    Score Earned:    15
MyRating    1000    Opponent:    1020    Score Earned:    60
MyRating    1000    Opponent:    1040    Score Earned:    60
MyRating    1000    Opponent:    1060    Score Earned:    60
MyRating    1000    Opponent:    1080    Score Earned:    60
MyRating    1000    Opponent:    1100    Score Earned:    60
MyRating    1000    Opponent:    1120    Score Earned:    60
MyRating    1000    Opponent:    1140    Score Earned:    60
```

I expect that rating is increased by 20 when rating is similar to opponent.