### PR TITLE
Restore needed props in ArenaInfo

### DIFF
--- a/Lib9c/Model/State/WeeklyArenaState.cs
+++ b/Lib9c/Model/State/WeeklyArenaState.cs
@@ -342,14 +342,12 @@ namespace Nekoyume.Model.State
         public int DailyChallengeCount { get; private set; }
         public bool Active { get; private set; }
 
-        [Obsolete("Not used anymore since v100070")]
         public readonly Address AgentAddress;
+
+        public readonly string AvatarName;
 
         [Obsolete("Not used anymore since v100070")]
         public bool Receive;
-
-        [Obsolete("Not used anymore since v100070")]
-        public readonly string AvatarName;
 
         [Obsolete("Not used anymore since v100070")]
         public int Level { get; private set; }


### PR DESCRIPTION
This PR restores AgentAddress and AvatarName on ArenaInfo to restore GraphQL API to fetch that information.