### PR TITLE
Bump libplanet

### DIFF
--- a/.Lib9c.Benchmarks/Program.cs
+++ b/.Lib9c.Benchmarks/Program.cs
@@ -39,7 +39,7 @@ namespace Lib9c.Benchmarks
             Libplanet.Crypto.CryptoConfig.CryptoBackend = new Secp256K1CryptoBackend<SHA256>();
             var policySource = new BlockPolicySource(Log.Logger, LogEventLevel.Verbose);
             IBlockPolicy<NCAction> policy =
-                policySource.GetPolicy(BlockPolicySource.DifficultyBoundDivisor + 1, 10000);
+                policySource.GetPolicy(BlockPolicySource.DifficultyStability + 1, 10000);
             IStagePolicy<NCAction> stagePolicy = new VolatileStagePolicy<NCAction>();
             var store = new RocksDBStore(storePath);
             if (!(store.GetCanonicalChainId() is Guid chainId))

--- a/.Lib9c.Tools/Utils.cs
+++ b/.Lib9c.Tools/Utils.cs
@@ -45,7 +45,7 @@ namespace Lib9c.Tools
         {
             var policySource = new BlockPolicySource(logger);
             IBlockPolicy<NCAction> policy = policySource.GetPolicy(
-                BlockPolicySource.DifficultyBoundDivisor + 1,
+                BlockPolicySource.DifficultyStability + 1,
                 int.MaxValue
             );
             IStagePolicy<NCAction> stagePolicy = new VolatileStagePolicy<NCAction>();

--- a/Lib9c/Policy/BlockPolicy.cs
+++ b/Lib9c/Policy/BlockPolicy.cs
@@ -13,10 +13,7 @@ namespace Nekoyume.BlockChain.Policy
 {
     public class BlockPolicy : BlockPolicy<NCAction>
     {
-        private readonly long _minimumDifficulty;
-        private readonly long _difficultyStability;
-        private readonly Func<BlockChain<NCAction>, AuthorizedMinersState>
-            _getAuthorizedMinersState;
+        private readonly Func<BlockChain<NCAction>, long> _getNextBlockDifficulty;
         private readonly Func<BlockChain<NCAction>, Address, long, bool> _isAllowedToMine;
 
         public BlockPolicy(
@@ -35,7 +32,7 @@ namespace Nekoyume.BlockChain.Policy
             Func<long, int> getMinTransactionsPerBlock = null,
             Func<long, int> getMaxTransactionsPerBlock = null,
             Func<long, int> getMaxTransactionsPerSignerPerBlock = null,
-            Func<BlockChain<NCAction>, AuthorizedMinersState> getAuthorizedMinersState = null,
+            Func<BlockChain<NCAction>, long> getNextBlockDifficulty = null,
             Func<BlockChain<NCAction>, Address, long, bool> isAllowedToMine = null)
             : base(
                 blockAction: blockAction,
@@ -51,82 +48,12 @@ namespace Nekoyume.BlockChain.Policy
                 getMaxTransactionsPerBlock: getMaxTransactionsPerBlock,
                 getMaxTransactionsPerSignerPerBlock: getMaxTransactionsPerSignerPerBlock)
         {
-            _minimumDifficulty = minimumDifficulty;
-            _difficultyStability = difficultyStability;
-            _getAuthorizedMinersState = getAuthorizedMinersState;
+            _getNextBlockDifficulty = getNextBlockDifficulty;
             _isAllowedToMine = isAllowedToMine;
         }
 
-        public override long GetNextBlockDifficulty(BlockChain<NCAction> blockChain)
-        {
-            long index = blockChain.Count;
-
-            if (index < 0)
-            {
-                throw new InvalidBlockIndexException(
-                    $"index must be 0 or more, but its index is {index}.");
-            }
-            else if (index <= 1)
-            {
-                return index == 0 ? 0 : _minimumDifficulty;
-            }
-            // FIXME: Uninstantiated blockChain can be passed as an argument.
-            // Until this is fixed, it is crucial block index is checked first.
-            // Authorized minor validity is only checked for certain indices.
-            else if (GetAuthorizedMinersState(blockChain) is null)
-            {
-                return base.GetNextBlockDifficulty(blockChain);
-            }
-
-            var prevIndex = IsAuthorizedMiningBlockIndex(blockChain, index - 1)
-                ? index - 2
-                : index - 1;
-            var beforePrevIndex = IsAuthorizedMiningBlockIndex(blockChain, prevIndex - 1)
-                ? prevIndex - 2
-                : prevIndex - 1;
-
-            if (beforePrevIndex > GetAuthorizedMinersState(blockChain).ValidUntil)
-            {
-                return base.GetNextBlockDifficulty(blockChain);
-            }
-
-            if (IsAuthorizedMiningBlockIndex(blockChain, index)
-                || prevIndex <= 1
-                || beforePrevIndex <= 1)
-            {
-                return _minimumDifficulty;
-            }
-
-            var prevBlock = blockChain[prevIndex];
-            var beforePrevBlock = blockChain[beforePrevIndex];
-
-            DateTimeOffset beforePrevTimestamp = beforePrevBlock.Timestamp;
-            DateTimeOffset prevTimestamp = prevBlock.Timestamp;
-            TimeSpan timeDiff = prevTimestamp - beforePrevTimestamp;
-            long timeDiffMilliseconds = (long)timeDiff.TotalMilliseconds;
-            const long minimumMultiplier = -99;
-            long multiplier = 1 - timeDiffMilliseconds / (long)BlockInterval.TotalMilliseconds;
-            multiplier = Math.Max(multiplier, minimumMultiplier);
-
-            var prevDifficulty = prevBlock.Difficulty;
-            var offset = prevDifficulty / _difficultyStability;
-            long nextDifficulty = prevDifficulty + (offset * multiplier);
-
-            return Math.Max(nextDifficulty, _minimumDifficulty);
-        }
-
-        public bool IsAuthorizedMiningBlockIndex(BlockChain<NCAction> blockChain, long index)
-        {
-            // FIXME: Uninstantiated blockChain can be passed as an argument.
-            // Until this is fixed, it is crucial block index is checked first.
-            return index > 0
-                && GetAuthorizedMinersState(blockChain) is AuthorizedMinersState ams
-                && index <= ams.ValidUntil
-                && index % ams.Interval == 0;
-        }
-
-        public AuthorizedMinersState GetAuthorizedMinersState(BlockChain<NCAction> blockChain) =>
-            _getAuthorizedMinersState(blockChain);
+        public override long GetNextBlockDifficulty(BlockChain<NCAction> blockChain) =>
+             _getNextBlockDifficulty(blockChain);
 
         public bool IsAllowedToMine(BlockChain<NCAction> blockChain, Address miner, long index) =>
             _isAllowedToMine(blockChain, miner, index);

--- a/Lib9c/Policy/BlockPolicy.cs
+++ b/Lib9c/Policy/BlockPolicy.cs
@@ -14,7 +14,7 @@ namespace Nekoyume.BlockChain.Policy
     public class BlockPolicy : BlockPolicy<NCAction>
     {
         private readonly long _minimumDifficulty;
-        private readonly long _difficultyBoundDivisor;
+        private readonly long _difficultyStability;
         private readonly Func<BlockChain<NCAction>, AuthorizedMinersState>
             _getAuthorizedMinersState;
         private readonly Func<BlockChain<NCAction>, Address, long, bool> _isAllowedToMine;
@@ -22,8 +22,8 @@ namespace Nekoyume.BlockChain.Policy
         public BlockPolicy(
             IAction blockAction,
             TimeSpan blockInterval,
+            long difficultyStability,
             long minimumDifficulty,
-            int difficultyBoundDivisor,
             PermissionedMiningPolicy? permissionedMiningPolicy,
             IComparer<IBlockExcerpt> canonicalChainComparer,
             HashAlgorithmGetter hashAlgorithmGetter,
@@ -40,8 +40,8 @@ namespace Nekoyume.BlockChain.Policy
             : base(
                 blockAction: blockAction,
                 blockInterval: blockInterval,
+                difficultyStability: difficultyStability,
                 minimumDifficulty: minimumDifficulty,
-                difficultyBoundDivisor: difficultyBoundDivisor,
                 validateNextBlockTx: validateNextBlockTx,
                 validateNextBlock: validateNextBlock,
                 canonicalChainComparer: canonicalChainComparer,
@@ -52,7 +52,7 @@ namespace Nekoyume.BlockChain.Policy
                 getMaxTransactionsPerSignerPerBlock: getMaxTransactionsPerSignerPerBlock)
         {
             _minimumDifficulty = minimumDifficulty;
-            _difficultyBoundDivisor = difficultyBoundDivisor;
+            _difficultyStability = difficultyStability;
             _getAuthorizedMinersState = getAuthorizedMinersState;
             _isAllowedToMine = isAllowedToMine;
         }
@@ -109,7 +109,7 @@ namespace Nekoyume.BlockChain.Policy
             multiplier = Math.Max(multiplier, minimumMultiplier);
 
             var prevDifficulty = prevBlock.Difficulty;
-            var offset = prevDifficulty / _difficultyBoundDivisor;
+            var offset = prevDifficulty / _difficultyStability;
             long nextDifficulty = prevDifficulty + (offset * multiplier);
 
             return Math.Max(nextDifficulty, _minimumDifficulty);

--- a/Lib9c/Policy/BlockPolicy.cs
+++ b/Lib9c/Policy/BlockPolicy.cs
@@ -6,7 +6,6 @@ using Libplanet.Blocks;
 using Libplanet.Tx;
 using System;
 using System.Collections.Generic;
-using Nekoyume.Model.State;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
 namespace Nekoyume.BlockChain.Policy

--- a/Lib9c/Policy/BlockPolicySource.cs
+++ b/Lib9c/Policy/BlockPolicySource.cs
@@ -26,7 +26,7 @@ namespace Nekoyume.BlockChain.Policy
 {
     public partial class BlockPolicySource
     {
-        public const int DifficultyBoundDivisor = 2048;
+        public const int DifficultyStability = 2048;
 
         // Note: The heaviest block of 9c-main (except for the genesis) weighs 58,408 B (58 KiB).
         public const int MaxBlockBytes = 1024 * 100; // 100 KiB
@@ -121,8 +121,8 @@ namespace Nekoyume.BlockChain.Policy
             return new BlockPolicy(
                 new RewardGold(),
                 blockInterval: BlockInterval,
+                difficultyStability: DifficultyStability,
                 minimumDifficulty: minimumDifficulty,
-                difficultyBoundDivisor: DifficultyBoundDivisor,
                 permissionedMiningPolicy: permissionedMiningPolicy,
                 canonicalChainComparer: new TotalDifficultyComparer(),
 #pragma warning disable LAA1002


### PR DESCRIPTION
Closes #635.

Accommodates API changes in https://github.com/planetarium/libplanet/pull/1495.

This is a continuation of #640.

This completes binding of arguments from `BlockPolicySource` for building custom `BlockPolicy`.

----

- <https://github.com/planetarium/libplanet/pull/1495>
- <https://github.com/planetarium/lib9c/pull/646>