### PR TITLE
Hardcoded authorized mining

### DIFF
--- a/.Lib9c.Tests/BlockPolicyTest.cs
+++ b/.Lib9c.Tests/BlockPolicyTest.cs
@@ -137,17 +137,22 @@ namespace Lib9c.Tests
             );
 
             var blockPolicySource = new BlockPolicySource(Logger.None);
-            IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(10000, 100);
+            AuthorizedMiningPolicy authorizedMiningPolicy = new AuthorizedMiningPolicy(
+                startIndex: 0,
+                endIndex: 10,
+                interval: 5,
+                miners: new[] { authorizedMinerPrivateKey.ToAddress() }.ToHashSet());
+            IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(
+                minimumDifficulty: 10000,
+                maxTransactionsPerBlock: 100,
+                ignoreHardcodedPolicies: false,
+                authorizedMiningPolicy: authorizedMiningPolicy,
+                permissionedMiningPolicy: null);
             IStagePolicy<PolymorphicAction<ActionBase>> stagePolicy =
                 new VolatileStagePolicy<PolymorphicAction<ActionBase>>();
             Block<PolymorphicAction<ActionBase>> genesis = MakeGenesisBlock(
                 adminAddress,
                 ImmutableHashSet.Create(adminAddress),
-                new AuthorizedMinersState(
-                    new[] { authorizedMinerPrivateKey.ToAddress() },
-                    5,
-                    10
-                ),
                 pendingActivations: new[] { ps }
             );
             using var store = new DefaultStore(null);
@@ -286,18 +291,22 @@ namespace Lib9c.Tests
             );
 
             var blockPolicySource = new BlockPolicySource(Logger.None);
+            AuthorizedMiningPolicy authorizedMiningPolicy = new AuthorizedMiningPolicy(
+                miners: miners.ToHashSet(),
+                startIndex: 0,
+                endIndex: 4,
+                interval: 2);
             IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(
                 10000,
                 100,
                 ignoreHardcodedPolicies: true,
+                authorizedMiningPolicy: authorizedMiningPolicy,
                 permissionedMiningPolicy: null);
             IStagePolicy<PolymorphicAction<ActionBase>> stagePolicy =
                 new VolatileStagePolicy<PolymorphicAction<ActionBase>>();
             Block<PolymorphicAction<ActionBase>> genesis = MakeGenesisBlock(
                 adminAddress,
-                ImmutableHashSet<Address>.Empty,
-                new AuthorizedMinersState(miners, 2, 4)
-            );
+                ImmutableHashSet<Address>.Empty);
             using var store = new DefaultStore(null);
             using var stateStore = new TrieStateStore(new DefaultKeyValueStore(null));
             var blockChain = new BlockChain<PolymorphicAction<ActionBase>>(
@@ -398,14 +407,22 @@ namespace Lib9c.Tests
             var miners = new[] { miner };
 
             var blockPolicySource = new BlockPolicySource(Logger.None);
-            IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(4096, 100);
+            AuthorizedMiningPolicy authorizedMiningPolicy = new AuthorizedMiningPolicy(
+                miners: miners.ToHashSet(),
+                startIndex: 0,
+                endIndex: 6,
+                interval: 2);
+            IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(
+                minimumDifficulty: 4096,
+                maxTransactionsPerBlock: 100,
+                ignoreHardcodedPolicies: false,
+                authorizedMiningPolicy: authorizedMiningPolicy,
+                permissionedMiningPolicy: null);
             IStagePolicy<PolymorphicAction<ActionBase>> stagePolicy =
                 new VolatileStagePolicy<PolymorphicAction<ActionBase>>();
             Block<PolymorphicAction<ActionBase>> genesis = MakeGenesisBlock(
                 adminAddress,
-                ImmutableHashSet<Address>.Empty,
-                new AuthorizedMinersState(miners, 2, 6)
-            );
+                ImmutableHashSet<Address>.Empty);
             using var store = new DefaultStore(null);
             using var stateStore = new TrieStateStore(new DefaultKeyValueStore(null));
             var blockChain = new BlockChain<PolymorphicAction<ActionBase>>(
@@ -629,12 +646,14 @@ namespace Lib9c.Tests
                 blockPolicySource.GetPolicy(
                     minimumDifficulty: 50_000,
                     maxTransactionsPerBlock: 100,
+                    authorizedMiningPolicy: null,
                     permissionedMiningPolicy: new PermissionedMiningPolicy(
-                        threshold: 1,
                         miners: new[]
                         {
                             permissionedMinerKey.ToAddress(),
-                        }.ToImmutableHashSet()
+                        }.ToImmutableHashSet(),
+                        startIndex: 1,
+                        endIndex: null
                     ),
                     ignoreHardcodedPolicies: true
                 ),

--- a/.Lib9c.Tests/BlockPolicyTest.cs
+++ b/.Lib9c.Tests/BlockPolicyTest.cs
@@ -147,6 +147,7 @@ namespace Lib9c.Tests
                 maxTransactionsPerBlock: 100,
                 ignoreHardcodedPolicies: false,
                 authorizedMiningPolicy: authorizedMiningPolicy,
+                authorizedMiningNoOpTxPolicy: null,
                 permissionedMiningPolicy: null);
             IStagePolicy<PolymorphicAction<ActionBase>> stagePolicy =
                 new VolatileStagePolicy<PolymorphicAction<ActionBase>>();
@@ -296,11 +297,16 @@ namespace Lib9c.Tests
                 startIndex: 0,
                 endIndex: 4,
                 interval: 2);
+            AuthorizedMiningNoOpTxPolicy authorizedMiningNoOpTxPolicy = new AuthorizedMiningNoOpTxPolicy(
+                startIndex: 0,
+                endIndex: 4,
+                interval: 2);
             IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(
                 10000,
                 100,
                 ignoreHardcodedPolicies: true,
                 authorizedMiningPolicy: authorizedMiningPolicy,
+                authorizedMiningNoOpTxPolicy: authorizedMiningNoOpTxPolicy,
                 permissionedMiningPolicy: null);
             IStagePolicy<PolymorphicAction<ActionBase>> stagePolicy =
                 new VolatileStagePolicy<PolymorphicAction<ActionBase>>();
@@ -417,6 +423,7 @@ namespace Lib9c.Tests
                 maxTransactionsPerBlock: 100,
                 ignoreHardcodedPolicies: false,
                 authorizedMiningPolicy: authorizedMiningPolicy,
+                authorizedMiningNoOpTxPolicy: null,
                 permissionedMiningPolicy: null);
             IStagePolicy<PolymorphicAction<ActionBase>> stagePolicy =
                 new VolatileStagePolicy<PolymorphicAction<ActionBase>>();
@@ -646,16 +653,16 @@ namespace Lib9c.Tests
                 blockPolicySource.GetPolicy(
                     minimumDifficulty: 50_000,
                     maxTransactionsPerBlock: 100,
+                    ignoreHardcodedPolicies: true,
                     authorizedMiningPolicy: null,
+                    authorizedMiningNoOpTxPolicy: null,
                     permissionedMiningPolicy: new PermissionedMiningPolicy(
                         miners: new[]
                         {
                             permissionedMinerKey.ToAddress(),
                         }.ToImmutableHashSet(),
                         startIndex: 1,
-                        endIndex: null
-                    ),
-                    ignoreHardcodedPolicies: true
+                        endIndex: null)
                 ),
                 new VolatileStagePolicy<PolymorphicAction<ActionBase>>(),
                 store,

--- a/.Lib9c.Tests/BlockPolicyTest.cs
+++ b/.Lib9c.Tests/BlockPolicyTest.cs
@@ -145,7 +145,7 @@ namespace Lib9c.Tests
             IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(
                 minimumDifficulty: 10000,
                 maxTransactionsPerBlock: 100,
-                ignoreHardcodedPolicies: false,
+                minTransactionsPerBlockPolicy: null,
                 authorizedMiningPolicy: authorizedMiningPolicy,
                 authorizedMiningNoOpTxPolicy: null,
                 permissionedMiningPolicy: null);
@@ -275,7 +275,7 @@ namespace Lib9c.Tests
         }
 
         [Fact]
-        public async Task ValidateNextBlockWithAuthorizedMinersState()
+        public async Task ValidateNextBlockWithAuthorizedMiningPolicy()
         {
             var adminPrivateKey = new PrivateKey();
             var adminAddress = adminPrivateKey.ToAddress();
@@ -304,7 +304,7 @@ namespace Lib9c.Tests
             IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(
                 10000,
                 100,
-                ignoreHardcodedPolicies: true,
+                minTransactionsPerBlockPolicy: null,
                 authorizedMiningPolicy: authorizedMiningPolicy,
                 authorizedMiningNoOpTxPolicy: authorizedMiningNoOpTxPolicy,
                 permissionedMiningPolicy: null);
@@ -404,7 +404,7 @@ namespace Lib9c.Tests
         }
 
         [Fact]
-        public async Task GetNextBlockDifficultyWithAuthorizedMinersState()
+        public async Task GetNextBlockDifficultyWithAuthorizedMiningPolicy()
         {
             var adminPrivateKey = new PrivateKey();
             var adminAddress = adminPrivateKey.ToAddress();
@@ -421,7 +421,7 @@ namespace Lib9c.Tests
             IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(
                 minimumDifficulty: 4096,
                 maxTransactionsPerBlock: 100,
-                ignoreHardcodedPolicies: false,
+                minTransactionsPerBlockPolicy: null,
                 authorizedMiningPolicy: authorizedMiningPolicy,
                 authorizedMiningNoOpTxPolicy: null,
                 permissionedMiningPolicy: null);
@@ -653,7 +653,7 @@ namespace Lib9c.Tests
                 blockPolicySource.GetPolicy(
                     minimumDifficulty: 50_000,
                     maxTransactionsPerBlock: 100,
-                    ignoreHardcodedPolicies: true,
+                    minTransactionsPerBlockPolicy: null,
                     authorizedMiningPolicy: null,
                     authorizedMiningNoOpTxPolicy: null,
                     permissionedMiningPolicy: new PermissionedMiningPolicy(

--- a/Lib9c/Policy/AuthorizedMiningNoOpTxPolicy.cs
+++ b/Lib9c/Policy/AuthorizedMiningNoOpTxPolicy.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using Libplanet;
 
 namespace Nekoyume.BlockChain.Policy
 {

--- a/Lib9c/Policy/AuthorizedMiningNoOpTxPolicy.cs
+++ b/Lib9c/Policy/AuthorizedMiningNoOpTxPolicy.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Libplanet;
+
+namespace Nekoyume.BlockChain.Policy
+{
+    public struct AuthorizedMiningNoOpTxPolicy
+    {
+        public AuthorizedMiningNoOpTxPolicy(
+            long startIndex, long? endIndex, long interval)
+        {
+            if (startIndex < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    $"Value of {nameof(startIndex)} must be non-negative: {startIndex}");
+            }
+            else if (endIndex is long ei && ei < startIndex)
+            {
+                throw new ArgumentOutOfRangeException(
+                    $"Non-null {nameof(endIndex)} cannot be less than {nameof(startIndex)}.");
+            }
+            else if (interval <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    $"Value of {nameof(interval)} must be positive: {interval}");
+            }
+
+            StartIndex = startIndex;
+            EndIndex = endIndex;
+            Interval = interval;
+        }
+
+        public long StartIndex { get; private set; }
+
+        public long? EndIndex { get; private set; }
+
+        public long Interval { get; private set; }
+
+        public bool IsTargetBlockIndex(long index)
+        {
+            return index % Interval == 0
+                && StartIndex <= index
+                && (EndIndex is null
+                    || (EndIndex is long endIndex && index <= endIndex));
+        }
+
+        public static AuthorizedMiningNoOpTxPolicy Mainnet
+        {
+            get
+            {
+                AuthorizedMiningPolicy authorizedMiningPolicy = AuthorizedMiningPolicy.Mainnet;
+                return new AuthorizedMiningNoOpTxPolicy()
+                {
+                    StartIndex = BlockPolicySource.AuthorizedMiningNoOpTxHardcodedIndex,
+                    EndIndex = authorizedMiningPolicy.EndIndex,
+                    Interval = authorizedMiningPolicy.Interval,
+                };
+            }
+        }
+    }
+}

--- a/Lib9c/Policy/AuthorizedMiningPolicy.cs
+++ b/Lib9c/Policy/AuthorizedMiningPolicy.cs
@@ -56,8 +56,8 @@ namespace Nekoyume.BlockChain.Policy
         public static AuthorizedMiningPolicy Mainnet => new AuthorizedMiningPolicy()
         {
             StartIndex = 0,
-            EndIndex = 3_153_600,
-            Interval = 50,
+            EndIndex = BlockPolicySource.AuthorizedMiningPolicyEndIndex,
+            Interval = BlockPolicySource.AuthorizedMiningPolicyInterval,
             Miners = new[]
             {
                 new Address("ab1dce17dCE1Db1424BB833Af6cC087cd4F5CB6d"),

--- a/Lib9c/Policy/AuthorizedMiningPolicy.cs
+++ b/Lib9c/Policy/AuthorizedMiningPolicy.cs
@@ -5,14 +5,20 @@ using Libplanet;
 
 namespace Nekoyume.BlockChain.Policy
 {
-    public struct PermissionedMiningPolicy
+    public struct AuthorizedMiningPolicy
     {
-        public PermissionedMiningPolicy(ISet<Address> miners, long startIndex, long? endIndex)
+        public AuthorizedMiningPolicy(
+            ISet<Address> miners, long startIndex, long? endIndex, long interval)
         {
             if (endIndex is long ei && ei < startIndex)
             {
                 throw new ArgumentOutOfRangeException(
                     $"Non-null {nameof(endIndex)} cannot be less than {nameof(startIndex)}.");
+            }
+            else if (interval <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    $"Value of {nameof(interval)} must be positive.");
             }
             else if (miners.Count == 0)
             {
@@ -23,6 +29,7 @@ namespace Nekoyume.BlockChain.Policy
             Miners = miners;
             StartIndex = startIndex;
             EndIndex = endIndex;
+            Interval = interval;
         }
 
         public ISet<Address> Miners { get; private set; }
@@ -31,13 +38,16 @@ namespace Nekoyume.BlockChain.Policy
 
         public long? EndIndex { get; private set; }
 
+        public long Interval { get; private set; }
+
         public bool IsTargetBlockIndex(long index)
         {
-            return StartIndex <= index
+            return index % Interval == 0
+                && StartIndex <= index
                 && (EndIndex is long endIndex && index <= endIndex);
         }
 
-        public static PermissionedMiningPolicy Mainnet => new PermissionedMiningPolicy()
+        public static AuthorizedMiningPolicy Mainnet => new AuthorizedMiningPolicy()
         {
             Miners = new[]
             {
@@ -46,8 +56,9 @@ namespace Nekoyume.BlockChain.Policy
                 new Address("474CB59Dea21159CeFcC828b30a8D864e0b94a6B"),
                 new Address("636d187B4d434244A92B65B06B5e7da14b3810A9"),
             }.ToImmutableHashSet(),
-            StartIndex = 2_225_500,
-            EndIndex = null,
+            StartIndex = 0,
+            EndIndex = 3_153_600,
+            Interval = 50,
         };
     }
 }

--- a/Lib9c/Policy/AuthorizedMiningPolicy.cs
+++ b/Lib9c/Policy/AuthorizedMiningPolicy.cs
@@ -8,9 +8,14 @@ namespace Nekoyume.BlockChain.Policy
     public struct AuthorizedMiningPolicy
     {
         public AuthorizedMiningPolicy(
-            ISet<Address> miners, long startIndex, long? endIndex, long interval)
+            long startIndex, long? endIndex, long interval, ISet<Address> miners)
         {
-            if (endIndex is long ei && ei < startIndex)
+            if (startIndex < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    $"Value of {nameof(startIndex)} must be non-negative: {startIndex}");
+            }
+            else if (endIndex is long ei && ei < startIndex)
             {
                 throw new ArgumentOutOfRangeException(
                     $"Non-null {nameof(endIndex)} cannot be less than {nameof(startIndex)}.");
@@ -18,7 +23,7 @@ namespace Nekoyume.BlockChain.Policy
             else if (interval <= 0)
             {
                 throw new ArgumentOutOfRangeException(
-                    $"Value of {nameof(interval)} must be positive.");
+                    $"Value of {nameof(interval)} must be positive: {interval}");
             }
             else if (miners.Count == 0)
             {
@@ -44,11 +49,15 @@ namespace Nekoyume.BlockChain.Policy
         {
             return index % Interval == 0
                 && StartIndex <= index
-                && (EndIndex is long endIndex && index <= endIndex);
+                && (EndIndex is null
+                    || (EndIndex is long endIndex && index <= endIndex));
         }
 
         public static AuthorizedMiningPolicy Mainnet => new AuthorizedMiningPolicy()
         {
+            StartIndex = 0,
+            EndIndex = 3_153_600,
+            Interval = 50,
             Miners = new[]
             {
                 new Address("ab1dce17dCE1Db1424BB833Af6cC087cd4F5CB6d"),
@@ -56,9 +65,6 @@ namespace Nekoyume.BlockChain.Policy
                 new Address("474CB59Dea21159CeFcC828b30a8D864e0b94a6B"),
                 new Address("636d187B4d434244A92B65B06B5e7da14b3810A9"),
             }.ToImmutableHashSet(),
-            StartIndex = 0,
-            EndIndex = 3_153_600,
-            Interval = 50,
         };
     }
 }

--- a/Lib9c/Policy/BlockPolicySource.Utils.cs
+++ b/Lib9c/Policy/BlockPolicySource.Utils.cs
@@ -35,11 +35,24 @@ namespace Nekoyume.BlockChain.Policy
                 && admin.AdminAddress.Equals(transaction.Signer);
         }
 
-        internal static bool IsAuthorizedMinerTransaction(
-            BlockChain<NCAction> blockChain, Transaction<NCAction> transaction)
+        internal static bool IsAuthorizedMinerTransactionRaw(
+            Transaction<NCAction> transaction, AuthorizedMiningPolicy? authorizedMiningPolicy)
         {
-            return GetAuthorizedMinersState(blockChain) is AuthorizedMinersState ams
-                && ams.Miners.Contains(transaction.Signer);
+            if (authorizedMiningPolicy is AuthorizedMiningPolicy amp)
+            {
+                return amp.Miners.Contains(transaction.Signer);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        internal static Func<Transaction<NCAction>, bool> IsAuthorizedMinerTransactionFactory(
+            AuthorizedMiningPolicy? authorizedMiningPolicy)
+        {
+            return transaction => IsAuthorizedMinerTransactionRaw(
+                transaction, authorizedMiningPolicy);
         }
 
         internal static AdminState GetAdminState(
@@ -49,21 +62,6 @@ namespace Nekoyume.BlockChain.Policy
             {
                 return blockChain.GetState(AdminState.Address) is Dictionary rawAdmin
                     ? new AdminState(rawAdmin)
-                    : null;
-            }
-            catch (IncompleteBlockStatesException)
-            {
-                return null;
-            }
-        }
-
-        internal static AuthorizedMinersState GetAuthorizedMinersState(
-            BlockChain<NCAction> blockChain)
-        {
-            try
-            {
-                return blockChain.GetState(AuthorizedMinersState.Address) is Dictionary rawAms
-                    ? new AuthorizedMinersState(rawAms)
                     : null;
             }
             catch (IncompleteBlockStatesException)
@@ -149,28 +147,22 @@ namespace Nekoyume.BlockChain.Policy
         }
 
         internal static BlockPolicyViolationException ValidateMinerAuthorityRaw(
-            BlockChain<NCAction> blockChain, Block<NCAction> block, bool ignoreHardcodedPolicies)
+            Block<NCAction> block,
+            AuthorizedMiningPolicy? authorizedMiningPolicy,
+            bool ignoreHardcodedPolicies)
         {
-            Address miner = block.Miner;
-
-            // FIXME: Uninstantiated blockChain can be passed as an argument.
-            // Until this is fixed, it is crucial block index is checked first.
-            // Authorized minor validity is only checked for certain indices.
+            // For genesis block, any miner can mine.
             if (block.Index == 0)
             {
                 return null;
             }
-            if (!IsAuthorizedMiningBlockIndex(blockChain, block.Index))
-            {
-                return null;
-            }
-            // If AuthorizedMinorState is null, do not check miner authority.
-            else if (!(GetAuthorizedMinersState(blockChain) is AuthorizedMinersState ams))
+            // If not an authorized mining block index, any miner can mine.
+            else if (!IsAuthorizedMiningBlockIndexRaw(block.Index, authorizedMiningPolicy))
             {
                 return null;
             }
             // Otherwise, block's miner should be one of the authorized miners.
-            else if (!ams.Miners.Contains(miner))
+            else if (!IsAuthorizedToMineRaw(block.Miner, block.Index, authorizedMiningPolicy))
             {
                 return new BlockPolicyViolationException(
                     $"The block #{block.Index} {block.Hash} is not mined by an authorized miner.");
@@ -179,15 +171,15 @@ namespace Nekoyume.BlockChain.Policy
             // Authority is proven through a no-op transaction, i.e. a transaction
             // with zero actions, starting from ValidateMinerAuthorityNoOpHardcodedIndex.
             Transaction<NCAction>[] txs = block.Transactions.ToArray();
-            if (!txs.Any(tx => tx.Signer.Equals(miner) && !tx.Actions.Any())
+            if (!txs.Any(tx => tx.Signer.Equals(block.Miner) && !tx.Actions.Any())
                     && block.ProtocolVersion > 0)
             {
                 if (ignoreHardcodedPolicies)
                 {
                     return new BlockPolicyViolationException(
-                        $"Block #{block.Index} {block.Hash}'s miner {miner} should be proven by "
-                            + "including a no-op transaction by signed the same authority.  "
-                            + "(Forced failure)");
+                        $"Block #{block.Index} {block.Hash}'s miner {block.Miner} should be "
+                            + "proven by including a no-op transaction by signed "
+                            + "the same authority.  (Forced failure)");
                 }
                 else if (block.Index >= ValidateMinerAuthorityNoOpTxHardcodedIndex)
                 {
@@ -202,8 +194,9 @@ namespace Nekoyume.BlockChain.Policy
                     const string debug = "";
 #endif
                     return new BlockPolicyViolationException(
-                        $"Block #{block.Index} {block.Hash}'s miner {miner} should be proven by " +
-                        "including a no-op transaction by signed the same authority." + debug);
+                        $"Block #{block.Index} {block.Hash}'s miner {block.Miner} should be "
+                            + "proven by including a no-op transaction signed by "
+                            + "the same authority." + debug);
                 }
             }
 
@@ -211,31 +204,34 @@ namespace Nekoyume.BlockChain.Policy
         }
 
         internal static Func<BlockChain<NCAction>, Block<NCAction>, BlockPolicyViolationException>
-            ValidateMinerAuthorityFactory(bool ignoreHardcodedPolicies)
+            ValidateMinerAuthorityFactory(
+                AuthorizedMiningPolicy? authorizedMiningPolicy, bool ignoreHardcodedPolicies)
         {
             return (blockChain, block) =>
-                ValidateMinerAuthorityRaw(blockChain, block, ignoreHardcodedPolicies);
+                ValidateMinerAuthorityRaw(block, authorizedMiningPolicy, ignoreHardcodedPolicies);
         }
 
         internal static bool IsAllowedToMineRaw(
             BlockChain<NCAction> blockChain,
             Address miner,
             long index,
-            Func<BlockChain<NCAction>, long, bool> isPermissionedMiningBlockIndex,
-            Func<BlockChain<NCAction>, Address, long, bool> isPermissionedToMine)
+            Func<long, bool> isAuthorizedMiningBlockIndex,
+            Func<Address, long, bool> isAuthorizedToMine,
+            Func<long, bool> isPermissionedMiningBlockIndex,
+            Func<Address, long, bool> isPermissionedToMine)
         {
             // For genesis blocks, any miner is allowed to mine.
             if (index == 0)
             {
                 return true;
             }
-            else if (IsAuthorizedMiningBlockIndex(blockChain, index))
+            else if (isAuthorizedMiningBlockIndex(index))
             {
-                return IsAuthorizedToMine(blockChain, miner, index);
+                return isAuthorizedToMine(miner, index);
             }
-            else if (isPermissionedMiningBlockIndex(blockChain, index))
+            else if (isPermissionedMiningBlockIndex(index))
             {
-                return isPermissionedToMine(blockChain, miner, index);
+                return isPermissionedToMine(miner, index);
             }
 
             // If none of the conditions apply, any miner is allowed to mine.
@@ -243,12 +239,20 @@ namespace Nekoyume.BlockChain.Policy
         }
 
         internal static Func<BlockChain<NCAction>, Address, long, bool> IsAllowedToMineFactory(
-            Func<BlockChain<NCAction>, long, bool> isPermissionedMiningBlockIndex,
-            Func<BlockChain<NCAction>, Address, long, bool> isPermissionedToMine)
+            Func<long, bool> isAuthorizedMiningBlockIndex,
+            Func<Address, long, bool> isAuthorizedToMine,
+            Func<long, bool> isPermissionedMiningBlockIndex,
+            Func<Address, long, bool> isPermissionedToMine)
         {
             return (blockChain, miner, index) =>
                 IsAllowedToMineRaw(
-                    blockChain, miner, index, isPermissionedMiningBlockIndex, isPermissionedToMine);
+                    blockChain,
+                    miner,
+                    index,
+                    isAuthorizedMiningBlockIndex,
+                    isAuthorizedToMine,
+                    isPermissionedMiningBlockIndex,
+                    isPermissionedToMine);
         }
 
         /// <summary>
@@ -258,18 +262,25 @@ namespace Nekoyume.BlockChain.Policy
         /// An implementation should be agnostic about other policies affecting the same index.
         /// Policy overruling between different policies should be handled elsewhere.
         /// </remarks>
-        internal static bool IsAuthorizedMiningBlockIndex(
-            BlockChain<NCAction> blockChain, long index)
+        internal static bool IsAuthorizedMiningBlockIndexRaw(
+            long index, AuthorizedMiningPolicy? authorizedMiningPolicy)
         {
-            if (GetAuthorizedMinersState(blockChain) is AuthorizedMinersState ams)
+            if (authorizedMiningPolicy is AuthorizedMiningPolicy amp)
             {
-                return index % ams.Interval == 0 && index <= ams.ValidUntil;
+                return amp.IsTargetBlockIndex(index);
             }
             else
             {
                 return false;
             }
         }
+
+        internal static Func<long, bool> IsAuthorizedMiningBlockIndexFactory(
+            AuthorizedMiningPolicy? authorizedMiningPolicy)
+        {
+            return index => IsAuthorizedMiningBlockIndexRaw(index, authorizedMiningPolicy);
+        }
+
 
         /// <summary>
         /// Checks if given miner is allowed to mine a block with given index according to
@@ -279,26 +290,32 @@ namespace Nekoyume.BlockChain.Policy
         /// An implementation should be agnostic about other policies affecting the same index.
         /// Policy overruling between different policies should be handled elsewhere.
         /// </remarks>
-        internal static bool IsAuthorizedToMine(
-            BlockChain<NCAction> blockChain, Address miner, long index)
+        internal static bool IsAuthorizedToMineRaw(
+            Address miner, long index, AuthorizedMiningPolicy? authorizedMiningPolicy)
         {
-            if (IsAuthorizedMiningBlockIndex(blockChain, index))
+            if (IsAuthorizedMiningBlockIndexRaw(index, authorizedMiningPolicy))
             {
-                if (GetAuthorizedMinersState(blockChain) is AuthorizedMinersState ams)
+                if (authorizedMiningPolicy is AuthorizedMiningPolicy amp)
                 {
-                    return ams.Miners.Contains(miner);
+                    return amp.Miners.Contains(miner);
                 }
                 else
                 {
                     throw new ArgumentException(
-                        $"Result of {nameof(GetAuthorizedMinersState)} cannot be null.");
+                        $"Result of {nameof(authorizedMiningPolicy)} cannot be null.");
                 }
             }
             else
             {
                 throw new ArgumentException(
-                    $"Result of {nameof(IsAuthorizedMiningBlockIndex)} must be true.");
+                    $"Result of {nameof(authorizedMiningPolicy)} must be true.");
             }
+        }
+
+        internal static Func<Address, long, bool> IsAuthorizedToMineFactory(
+            AuthorizedMiningPolicy? authorizedMiningPolicy)
+        {
+            return (miner, index) => IsAuthorizedToMineRaw(miner, index, authorizedMiningPolicy);
         }
 
         /// <summary>
@@ -309,13 +326,12 @@ namespace Nekoyume.BlockChain.Policy
         /// Policy overruling between different policies should be handled elsewhere.
         /// </remarks>
         internal static bool IsPermissionedMiningBlockIndexRaw(
-            BlockChain<NCAction> blockChain,
             long index,
             PermissionedMiningPolicy? permissionedMiningPolicy)
         {
             if (permissionedMiningPolicy is PermissionedMiningPolicy pmp)
             {
-                return index >= pmp.StartIndex;
+                return pmp.IsTargetBlockIndex(index);
             }
             else
             {
@@ -323,12 +339,10 @@ namespace Nekoyume.BlockChain.Policy
             }
         }
 
-        internal static Func<BlockChain<NCAction>, long, bool>
-            IsPermissionedMiningBlockIndexFactory(
-                PermissionedMiningPolicy? permissionedMiningPolicy)
+        internal static Func<long, bool> IsPermissionedMiningBlockIndexFactory(
+            PermissionedMiningPolicy? permissionedMiningPolicy)
         {
-            return (blockChain, index) => IsPermissionedMiningBlockIndexRaw(
-                blockChain, index, permissionedMiningPolicy);
+            return index => IsPermissionedMiningBlockIndexRaw(index, permissionedMiningPolicy);
         }
 
         /// <summary>
@@ -340,12 +354,11 @@ namespace Nekoyume.BlockChain.Policy
         /// Policy overruling between different policies should be handled elsewhere.
         /// </remarks>
         internal static bool IsPermissionedToMineRaw(
-            BlockChain<NCAction> blockChain,
             Address miner,
             long index,
             PermissionedMiningPolicy? permissionedMiningPolicy)
         {
-            if (IsPermissionedMiningBlockIndexRaw(blockChain, index, permissionedMiningPolicy))
+            if (IsPermissionedMiningBlockIndexRaw(index, permissionedMiningPolicy))
             {
                 if (permissionedMiningPolicy is PermissionedMiningPolicy pmp)
                 {
@@ -364,11 +377,11 @@ namespace Nekoyume.BlockChain.Policy
             }
         }
 
-        internal static Func<BlockChain<NCAction>, Address, long, bool>
+        internal static Func<Address, long, bool>
             IsPermissionedToMineFactory(PermissionedMiningPolicy? permissionedMiningPolicy)
         {
-            return (blockChain, miner, index) => IsPermissionedToMineRaw(
-                blockChain, miner, index, permissionedMiningPolicy);
+            return (miner, index) => IsPermissionedToMineRaw(
+                miner, index, permissionedMiningPolicy);
         }
     }
 }

--- a/Lib9c/Policy/BlockPolicySource.Utils.cs
+++ b/Lib9c/Policy/BlockPolicySource.Utils.cs
@@ -109,13 +109,13 @@ namespace Nekoyume.BlockChain.Policy
             Address miner = block.Miner;
 
             // If no permission policy is given, pass validation by default.
-            if (!(permissionedMiningPolicy is PermissionedMiningPolicy policy))
+            if (!(permissionedMiningPolicy is PermissionedMiningPolicy pmp))
             {
                 return null;
             }
 
             // Predicate for permission validity.
-            if (!policy.Miners.Contains(miner) || !block.Transactions.Any(t => t.Signer.Equals(miner)))
+            if (!pmp.Miners.Contains(miner) || !block.Transactions.Any(t => t.Signer.Equals(miner)))
             {
                 if (ignoreHardcodedPolicies)
                 {
@@ -123,7 +123,7 @@ namespace Nekoyume.BlockChain.Policy
                         $"Block #{block.Index} {block.Hash} is not mined by a permissioned miner.  "
                             + "(Forced failure)");
                 }
-                else if (block.Index >= policy.Threshold)
+                else if (block.Index >= pmp.StartIndex)
                 {
                     return new BlockPolicyViolationException(
                         $"Block #{block.Index} {block.Hash} is not mined by a permissioned miner.");
@@ -315,7 +315,7 @@ namespace Nekoyume.BlockChain.Policy
         {
             if (permissionedMiningPolicy is PermissionedMiningPolicy pmp)
             {
-                return index >= pmp.Threshold;
+                return index >= pmp.StartIndex;
             }
             else
             {
@@ -347,9 +347,9 @@ namespace Nekoyume.BlockChain.Policy
         {
             if (IsPermissionedMiningBlockIndexRaw(blockChain, index, permissionedMiningPolicy))
             {
-                if (permissionedMiningPolicy is PermissionedMiningPolicy pms)
+                if (permissionedMiningPolicy is PermissionedMiningPolicy pmp)
                 {
-                    return pms.Miners.Contains(miner);
+                    return pmp.Miners.Contains(miner);
                 }
                 else
                 {

--- a/Lib9c/Policy/BlockPolicySource.cs
+++ b/Lib9c/Policy/BlockPolicySource.cs
@@ -57,6 +57,8 @@ namespace Nekoyume.BlockChain.Policy
         // FIXME: Should be finalized before release.
         public const long V100081ObsoleteIndex = 2_500_000;
 
+        public const long PermissionedMiningHardcodedIndex = 2_225_500;
+
         public readonly Dictionary<long, HashAlgorithmType> HashAlgorithmTable =
             new Dictionary<long, HashAlgorithmType> { [0] = HashAlgorithmType.Of<SHA256>() };
 
@@ -70,7 +72,9 @@ namespace Nekoyume.BlockChain.Policy
 
         public readonly LoggedRenderer<NCAction> LoggedBlockRenderer;
 
-        public BlockPolicySource(ILogger logger, LogEventLevel logEventLevel = LogEventLevel.Verbose)
+        public BlockPolicySource(
+            ILogger logger,
+            LogEventLevel logEventLevel = LogEventLevel.Verbose)
         {
             LoggedActionRenderer =
                 new LoggedActionRenderer<NCAction>(ActionRenderer, logger, logEventLevel);
@@ -85,6 +89,7 @@ namespace Nekoyume.BlockChain.Policy
                 minimumDifficulty,
                 maxTransactionsPerBlock,
                 ignoreHardcodedPolicies: false,
+                authorizedMiningPolicy: AuthorizedMiningPolicy.Mainnet,
                 permissionedMiningPolicy: PermissionedMiningPolicy.Mainnet);
 
         /// <summary>
@@ -107,17 +112,37 @@ namespace Nekoyume.BlockChain.Policy
         /// This is purely for unit testing and should be set to false for production.
         /// </para>
         /// </param>
+        /// <param name="authorizedMiningPolicy">Used for authorized mining.</param>
         /// <param name="permissionedMiningPolicy">Used for permissioned mining.</param>
         /// <returns>A <see cref="BlockPolicy"/> constructed from given parameters.</returns>
         internal IBlockPolicy<NCAction> GetPolicy(
             int minimumDifficulty,
             int maxTransactionsPerBlock,
             bool ignoreHardcodedPolicies,
+            AuthorizedMiningPolicy? authorizedMiningPolicy,
             PermissionedMiningPolicy? permissionedMiningPolicy)
         {
 #if UNITY_EDITOR
             return new DebugPolicy();
 #else
+
+            var validateNextBlockTx = ValidateNextBlockTxFactory(
+                authorizedMiningPolicy);
+            var validateNextBlock = ValidateNextBlockFactory(
+                authorizedMiningPolicy,
+                permissionedMiningPolicy,
+                ignoreHardcodedPolicies);
+            var getNextBlockDifficulty = GetNextBlockDifficultyFactory(
+                BlockInterval,
+                DifficultyStability,
+                minimumDifficulty,
+                authorizedMiningPolicy);
+            var isAllowedToMine = IsAllowedToMineFactory(
+                IsAuthorizedMiningBlockIndexFactory(authorizedMiningPolicy),
+                IsAuthorizedToMineFactory(authorizedMiningPolicy),
+                IsPermissionedMiningBlockIndexFactory(permissionedMiningPolicy),
+                IsPermissionedToMineFactory(permissionedMiningPolicy));
+
             return new BlockPolicy(
                 new RewardGold(),
                 blockInterval: BlockInterval,
@@ -128,27 +153,24 @@ namespace Nekoyume.BlockChain.Policy
 #pragma warning disable LAA1002
                 hashAlgorithmGetter: HashAlgorithmTable.ToHashAlgorithmGetter(),
 #pragma warning restore LAA1002
-                validateNextBlockTx: ValidateNextBlockTx,
-                validateNextBlock: ValidateNextBlockFactory(
-                    permissionedMiningPolicy, ignoreHardcodedPolicies),
+                validateNextBlockTx: validateNextBlockTx,
+                validateNextBlock: validateNextBlock,
                 getMaxBlockBytes: GetMaxBlockBytes,
                 getMinTransactionsPerBlock: GetMinTransactionsPerBlock,
                 getMaxTransactionsPerBlock: GetMaxTransactionsPerBlockFactory(maxTransactionsPerBlock),
                 getMaxTransactionsPerSignerPerBlock: GetMaxTransactionsPerSignerPerBlock,
-                getNextBlockDifficulty: GetNextBlockDifficultyFactory(
-                    BlockInterval, DifficultyStability, minimumDifficulty),
-                isAllowedToMine: IsAllowedToMineFactory(
-                    IsPermissionedMiningBlockIndexFactory(permissionedMiningPolicy),
-                    IsPermissionedToMineFactory(permissionedMiningPolicy)));
+                getNextBlockDifficulty: getNextBlockDifficulty,
+                isAllowedToMine: isAllowedToMine);
 #endif
         }
 
         public IEnumerable<IRenderer<NCAction>> GetRenderers() =>
             new IRenderer<NCAction>[] { BlockRenderer, LoggedActionRenderer };
 
-        public static TxPolicyViolationException ValidateNextBlockTx(
+        public static TxPolicyViolationException ValidateNextBlockTxRaw(
             BlockChain<NCAction> blockChain,
-            Transaction<NCAction> transaction)
+            Transaction<NCAction> transaction,
+            AuthorizedMiningPolicy? authorizedMiningPolicy)
         {
             // Avoid NRE when genesis block appended
             // Here, index is the index of a prospective block that transaction
@@ -172,7 +194,7 @@ namespace Nekoyume.BlockChain.Policy
             try
             {
                 // Check if it is a no-op transaction to prove it's made by the authorized miner.
-                if (IsAuthorizedMinerTransaction(blockChain, transaction))
+                if (IsAuthorizedMinerTransactionRaw(transaction, authorizedMiningPolicy))
                 {
                     // The authorization proof has to have no actions at all.
                     return transaction.Actions.Any()
@@ -243,19 +265,29 @@ namespace Nekoyume.BlockChain.Policy
             return null;
         }
 
+        public static Func<BlockChain<NCAction>, Transaction<NCAction>, TxPolicyViolationException>
+            ValidateNextBlockTxFactory(AuthorizedMiningPolicy? authorizedMiningPolicy)
+        {
+            return (blockChain, transaction) => ValidateNextBlockTxRaw(
+                blockChain, transaction, authorizedMiningPolicy);
+        }
+
+
         public static BlockPolicyViolationException ValidateNextBlockRaw(
             BlockChain<NCAction> blockChain,
             Block<NCAction> nextBlock,
+            AuthorizedMiningPolicy? authorizedMiningPolicy,
             PermissionedMiningPolicy? permissionedMiningPolicy,
             bool ignoreHardcodedPolicies)
         {
             return ValidateTxCountPerBlockRaw(nextBlock, ignoreHardcodedPolicies)
-                ?? ValidateMinerAuthorityRaw(blockChain, nextBlock, ignoreHardcodedPolicies)
+                ?? ValidateMinerAuthorityRaw(nextBlock, authorizedMiningPolicy, ignoreHardcodedPolicies)
                 ?? ValidateMinerPermissionRaw(nextBlock, permissionedMiningPolicy, ignoreHardcodedPolicies);
         }
 
         public static Func<BlockChain<NCAction>, Block<NCAction>, BlockPolicyViolationException>
             ValidateNextBlockFactory(
+                AuthorizedMiningPolicy? authorizedMiningPolicy,
                 PermissionedMiningPolicy? permissionedMiningPolicy,
                 bool ignoreHardcodedPolicies)
         {
@@ -263,6 +295,7 @@ namespace Nekoyume.BlockChain.Policy
                 ValidateNextBlockRaw(
                     blockChain,
                     nextBlock,
+                    authorizedMiningPolicy,
                     permissionedMiningPolicy,
                     ignoreHardcodedPolicies);
         }
@@ -302,6 +335,7 @@ namespace Nekoyume.BlockChain.Policy
             TimeSpan targetBlockInterval,
             long difficultyStability,
             long minimumDifficulty,
+            AuthorizedMiningPolicy? authorizedMiningPolicy,
             Func<BlockChain<NCAction>, long> defaultAlgorithm)
         {
             long index = blockChain.Count;
@@ -309,7 +343,7 @@ namespace Nekoyume.BlockChain.Policy
             if (index < 0)
             {
                 throw new InvalidBlockIndexException(
-                    $"index must be 0 or more, but its index is {index}.");
+                    $"Value of {nameof(index)} must be non-negative: {index}");
             }
             else if (index <= 1)
             {
@@ -318,20 +352,22 @@ namespace Nekoyume.BlockChain.Policy
             // FIXME: Uninstantiated blockChain can be passed as an argument.
             // Until this is fixed, it is crucial block index is checked first.
             // Authorized minor validity is only checked for certain indices.
-            else if (GetAuthorizedMinersState(blockChain) is AuthorizedMinersState ams)
+            else if (authorizedMiningPolicy is AuthorizedMiningPolicy amp)
             {
-                long prevIndex = IsAuthorizedMiningBlockIndex(blockChain, index - 1)
-                    ? index - 2
-                    : index - 1;
-                long prevPrevIndex = IsAuthorizedMiningBlockIndex(blockChain, prevIndex - 1)
-                    ? prevIndex - 2
-                    : prevIndex - 1;
+                long prevIndex = IsAuthorizedMiningBlockIndexRaw(
+                    index - 1, authorizedMiningPolicy)
+                        ? index - 2
+                        : index - 1;
+                long prevPrevIndex = IsAuthorizedMiningBlockIndexRaw(
+                    prevIndex - 1, authorizedMiningPolicy)
+                        ? prevIndex - 2
+                        : prevIndex - 1;
 
-                if (prevPrevIndex > ams.ValidUntil)
+                if (prevPrevIndex > amp.EndIndex)
                 {
                     return defaultAlgorithm(blockChain);
                 }
-                else if (IsAuthorizedMiningBlockIndex(blockChain, index)
+                else if (IsAuthorizedMiningBlockIndexRaw(index, authorizedMiningPolicy)
                     || prevIndex <= 1
                     || prevPrevIndex <= 1)
                 {
@@ -366,7 +402,8 @@ namespace Nekoyume.BlockChain.Policy
         public static Func<BlockChain<NCAction>, long> GetNextBlockDifficultyFactory(
             TimeSpan targetBlockInterval,
             long difficultyStability,
-            long minimumDifficulty)
+            long minimumDifficulty,
+            AuthorizedMiningPolicy? authorizedMiningPolicy)
         {
             return (blockChain) =>
                 GetNextBlockDifficultyRaw(
@@ -374,6 +411,7 @@ namespace Nekoyume.BlockChain.Policy
                     targetBlockInterval: targetBlockInterval,
                     difficultyStability: difficultyStability,
                     minimumDifficulty: minimumDifficulty,
+                    authorizedMiningPolicy: authorizedMiningPolicy,
                     defaultAlgorithm: DifficultyAdjustment<NCAction>.AlgorithmFactory(
                         targetBlockInterval, difficultyStability, minimumDifficulty));
         }

--- a/Lib9c/Policy/BlockPolicySource.cs
+++ b/Lib9c/Policy/BlockPolicySource.cs
@@ -37,7 +37,7 @@ namespace Nekoyume.BlockChain.Policy
         /// <summary>
         /// Starting point in which Validate restriction will apply.
         /// </summary>
-        public const long ValidateMinerAuthorityNoOpTxHardcodedIndex = 1_200_001;
+        public const long AuthorizedMiningNoOpTxHardcodedIndex = 1_200_001;
 
         /// <summary>
         /// Starting point in which MinTransactionsPerBlock restriction will apply.
@@ -90,6 +90,7 @@ namespace Nekoyume.BlockChain.Policy
                 maxTransactionsPerBlock,
                 ignoreHardcodedPolicies: false,
                 authorizedMiningPolicy: AuthorizedMiningPolicy.Mainnet,
+                authorizedMiningNoOpTxPolicy: AuthorizedMiningNoOpTxPolicy.Mainnet,
                 permissionedMiningPolicy: PermissionedMiningPolicy.Mainnet);
 
         /// <summary>
@@ -113,6 +114,7 @@ namespace Nekoyume.BlockChain.Policy
         /// </para>
         /// </param>
         /// <param name="authorizedMiningPolicy">Used for authorized mining.</param>
+        /// <param name="authorizedMiningNoOpTxPolicy">Used for no-op tx authorized mining.</param>
         /// <param name="permissionedMiningPolicy">Used for permissioned mining.</param>
         /// <returns>A <see cref="BlockPolicy"/> constructed from given parameters.</returns>
         internal IBlockPolicy<NCAction> GetPolicy(
@@ -120,16 +122,37 @@ namespace Nekoyume.BlockChain.Policy
             int maxTransactionsPerBlock,
             bool ignoreHardcodedPolicies,
             AuthorizedMiningPolicy? authorizedMiningPolicy,
+            AuthorizedMiningNoOpTxPolicy? authorizedMiningNoOpTxPolicy,
             PermissionedMiningPolicy? permissionedMiningPolicy)
         {
 #if UNITY_EDITOR
             return new DebugPolicy();
 #else
+            // Basic sanity check.
+            if (authorizedMiningPolicy is AuthorizedMiningPolicy amp
+                && authorizedMiningNoOpTxPolicy is AuthorizedMiningNoOpTxPolicy amnotp)
+            {
+                if (amnotp.StartIndex < amp.StartIndex
+                    || amnotp.EndIndex != amp.EndIndex
+                    || amnotp.Interval != amp.Interval)
+                {
+                    throw new ArgumentException(
+                        $"Invalid {nameof(authorizedMiningNoOpTxPolicy)} given as a subpolicy"
+                            + $" for given {nameof(authorizedMiningPolicy)}.");
+                }
+            }
+            else if (authorizedMiningPolicy is null && !(authorizedMiningNoOpTxPolicy is null))
+            {
+                throw new ArgumentException(
+                    $"Argument {nameof(authorizedMiningNoOpTxPolicy)} cannot be null while"
+                        + $" {nameof(authorizedMiningPolicy)} is null.");
+            }
 
             var validateNextBlockTx = ValidateNextBlockTxFactory(
                 authorizedMiningPolicy);
             var validateNextBlock = ValidateNextBlockFactory(
                 authorizedMiningPolicy,
+                authorizedMiningNoOpTxPolicy,
                 permissionedMiningPolicy,
                 ignoreHardcodedPolicies);
             var getNextBlockDifficulty = GetNextBlockDifficultyFactory(
@@ -277,17 +300,23 @@ namespace Nekoyume.BlockChain.Policy
             BlockChain<NCAction> blockChain,
             Block<NCAction> nextBlock,
             AuthorizedMiningPolicy? authorizedMiningPolicy,
+            AuthorizedMiningNoOpTxPolicy? authorizedMiningNoOpTxPolicy,
             PermissionedMiningPolicy? permissionedMiningPolicy,
             bool ignoreHardcodedPolicies)
         {
             return ValidateTxCountPerBlockRaw(nextBlock, ignoreHardcodedPolicies)
-                ?? ValidateMinerAuthorityRaw(nextBlock, authorizedMiningPolicy, ignoreHardcodedPolicies)
+                ?? ValidateMinerAuthorityRaw(
+                    nextBlock,
+                    authorizedMiningPolicy,
+                    authorizedMiningNoOpTxPolicy,
+                    ignoreHardcodedPolicies)
                 ?? ValidateMinerPermissionRaw(nextBlock, permissionedMiningPolicy, ignoreHardcodedPolicies);
         }
 
         public static Func<BlockChain<NCAction>, Block<NCAction>, BlockPolicyViolationException>
             ValidateNextBlockFactory(
                 AuthorizedMiningPolicy? authorizedMiningPolicy,
+                AuthorizedMiningNoOpTxPolicy? authorizedMiningNoOpTxPolicy,
                 PermissionedMiningPolicy? permissionedMiningPolicy,
                 bool ignoreHardcodedPolicies)
         {
@@ -296,6 +325,7 @@ namespace Nekoyume.BlockChain.Policy
                     blockChain,
                     nextBlock,
                     authorizedMiningPolicy,
+                    authorizedMiningNoOpTxPolicy,
                     permissionedMiningPolicy,
                     ignoreHardcodedPolicies);
         }

--- a/Lib9c/Policy/BlockPolicySource.cs
+++ b/Lib9c/Policy/BlockPolicySource.cs
@@ -35,12 +35,19 @@ namespace Nekoyume.BlockChain.Policy
         public const int MaxGenesisBytes = 1024 * 1024 * 15; // 15 MiB
 
         /// <summary>
-        /// Starting point in which Validate restriction will apply.
+        /// Last index in which restriction will apply.
+        /// </summary>
+        public const long AuthorizedMiningPolicyEndIndex = 3_153_600;
+
+        public const long AuthorizedMiningPolicyInterval = 50;
+
+        /// <summary>
+        /// First index in which restriction will apply.
         /// </summary>
         public const long AuthorizedMiningNoOpTxHardcodedIndex = 1_200_001;
 
         /// <summary>
-        /// Starting point in which MinTransactionsPerBlock restriction will apply.
+        /// First index in which restriction will apply.
         /// </summary>
         public const long MinTransactionsPerBlockHardcodedIndex = 2_173_701;
 
@@ -88,7 +95,7 @@ namespace Nekoyume.BlockChain.Policy
             GetPolicy(
                 minimumDifficulty,
                 maxTransactionsPerBlock,
-                ignoreHardcodedPolicies: false,
+                minTransactionsPerBlockPolicy: MinTransactionsPerBlockPolicy.Mainnet,
                 authorizedMiningPolicy: AuthorizedMiningPolicy.Mainnet,
                 authorizedMiningNoOpTxPolicy: AuthorizedMiningNoOpTxPolicy.Mainnet,
                 permissionedMiningPolicy: PermissionedMiningPolicy.Mainnet);
@@ -100,19 +107,8 @@ namespace Nekoyume.BlockChain.Policy
         /// can have.  This is ignored for genesis blocks.</param>
         /// <param name="maxTransactionsPerBlock">The maximum number of
         /// <see cref="Transaction{T}"/>s that a <see cref="Block{T}"/> can have.</param>
-        /// <param name="ignoreHardcodedPolicies">
-        /// <para>
-        /// Whether to ignore or respect hardcoded policies.
-        /// </para>
-        /// <para>
-        /// There are several policies where each policy only applies after its corresponding
-        /// hardcoded index.  Turning on this option ignores these hard coded indices and
-        /// applies said policies starting from index 0, the gensis.
-        /// </para>
-        /// <para>
-        /// This is purely for unit testing and should be set to false for production.
-        /// </para>
-        /// </param>
+        /// <param name="minTransactionsPerBlockPolicy">Used for minimum number of transactions
+        /// required per block.</param>
         /// <param name="authorizedMiningPolicy">Used for authorized mining.</param>
         /// <param name="authorizedMiningNoOpTxPolicy">Used for no-op tx authorized mining.</param>
         /// <param name="permissionedMiningPolicy">Used for permissioned mining.</param>
@@ -120,7 +116,7 @@ namespace Nekoyume.BlockChain.Policy
         internal IBlockPolicy<NCAction> GetPolicy(
             int minimumDifficulty,
             int maxTransactionsPerBlock,
-            bool ignoreHardcodedPolicies,
+            MinTransactionsPerBlockPolicy? minTransactionsPerBlockPolicy,
             AuthorizedMiningPolicy? authorizedMiningPolicy,
             AuthorizedMiningNoOpTxPolicy? authorizedMiningNoOpTxPolicy,
             PermissionedMiningPolicy? permissionedMiningPolicy)
@@ -151,15 +147,19 @@ namespace Nekoyume.BlockChain.Policy
             var validateNextBlockTx = ValidateNextBlockTxFactory(
                 authorizedMiningPolicy);
             var validateNextBlock = ValidateNextBlockFactory(
+                minTransactionsPerBlockPolicy,
                 authorizedMiningPolicy,
                 authorizedMiningNoOpTxPolicy,
-                permissionedMiningPolicy,
-                ignoreHardcodedPolicies);
+                permissionedMiningPolicy);
             var getNextBlockDifficulty = GetNextBlockDifficultyFactory(
                 BlockInterval,
                 DifficultyStability,
                 minimumDifficulty,
                 authorizedMiningPolicy);
+            var getMinTransactionsPerBlock = GetMinTransactionsPerBlockFactory(
+                minTransactionsPerBlockPolicy);
+            var getMaxTransactionsPerBlock = GetMaxTransactionsPerBlockFactory(
+                maxTransactionsPerBlock);
             var isAllowedToMine = IsAllowedToMineFactory(
                 IsAuthorizedMiningBlockIndexFactory(authorizedMiningPolicy),
                 IsAuthorizedToMineFactory(authorizedMiningPolicy),
@@ -179,8 +179,8 @@ namespace Nekoyume.BlockChain.Policy
                 validateNextBlockTx: validateNextBlockTx,
                 validateNextBlock: validateNextBlock,
                 getMaxBlockBytes: GetMaxBlockBytes,
-                getMinTransactionsPerBlock: GetMinTransactionsPerBlock,
-                getMaxTransactionsPerBlock: GetMaxTransactionsPerBlockFactory(maxTransactionsPerBlock),
+                getMinTransactionsPerBlock: getMinTransactionsPerBlock,
+                getMaxTransactionsPerBlock: getMaxTransactionsPerBlock,
                 getMaxTransactionsPerSignerPerBlock: GetMaxTransactionsPerSignerPerBlock,
                 getNextBlockDifficulty: getNextBlockDifficulty,
                 isAllowedToMine: isAllowedToMine);
@@ -299,35 +299,38 @@ namespace Nekoyume.BlockChain.Policy
         public static BlockPolicyViolationException ValidateNextBlockRaw(
             BlockChain<NCAction> blockChain,
             Block<NCAction> nextBlock,
+            MinTransactionsPerBlockPolicy? minTransactionsPerBlockPolicy,
             AuthorizedMiningPolicy? authorizedMiningPolicy,
             AuthorizedMiningNoOpTxPolicy? authorizedMiningNoOpTxPolicy,
-            PermissionedMiningPolicy? permissionedMiningPolicy,
-            bool ignoreHardcodedPolicies)
+            PermissionedMiningPolicy? permissionedMiningPolicy)
         {
-            return ValidateTxCountPerBlockRaw(nextBlock, ignoreHardcodedPolicies)
+            // FIXME: Tx count validation should be done in libplanet, not here.
+            // Should be removed once libplanet is updated.
+            return ValidateTxCountPerBlockRaw(
+                nextBlock,
+                minTransactionsPerBlockPolicy)
                 ?? ValidateMinerAuthorityRaw(
                     nextBlock,
                     authorizedMiningPolicy,
-                    authorizedMiningNoOpTxPolicy,
-                    ignoreHardcodedPolicies)
-                ?? ValidateMinerPermissionRaw(nextBlock, permissionedMiningPolicy, ignoreHardcodedPolicies);
+                    authorizedMiningNoOpTxPolicy)
+                ?? ValidateMinerPermissionRaw(nextBlock, permissionedMiningPolicy);
         }
 
         public static Func<BlockChain<NCAction>, Block<NCAction>, BlockPolicyViolationException>
             ValidateNextBlockFactory(
+                MinTransactionsPerBlockPolicy? minTransactionsPerBlockPolicy,
                 AuthorizedMiningPolicy? authorizedMiningPolicy,
                 AuthorizedMiningNoOpTxPolicy? authorizedMiningNoOpTxPolicy,
-                PermissionedMiningPolicy? permissionedMiningPolicy,
-                bool ignoreHardcodedPolicies)
+                PermissionedMiningPolicy? permissionedMiningPolicy)
         {
             return (blockChain, nextBlock) =>
                 ValidateNextBlockRaw(
                     blockChain,
                     nextBlock,
+                    minTransactionsPerBlockPolicy,
                     authorizedMiningPolicy,
                     authorizedMiningNoOpTxPolicy,
-                    permissionedMiningPolicy,
-                    ignoreHardcodedPolicies);
+                    permissionedMiningPolicy);
         }
 
         public static int GetMaxBlockBytes(long index)
@@ -335,11 +338,24 @@ namespace Nekoyume.BlockChain.Policy
             return index > 0 ? MaxBlockBytes : MaxGenesisBytes;
         }
 
-        public static int GetMinTransactionsPerBlock(long index)
+        public static int GetMinTransactionsPerBlockRaw(
+            long index, MinTransactionsPerBlockPolicy? minTransactionsPerBlockPolicy)
         {
-            return index >= MinTransactionsPerBlockHardcodedIndex
-                ? MinTransactionsPerBlock
-                : 0;
+            if (minTransactionsPerBlockPolicy is MinTransactionsPerBlockPolicy mtpbp)
+            {
+                if (mtpbp.IsTargetBlockIndex(index))
+                {
+                    return mtpbp.MinTransactionsPerBlock;
+                }
+            }
+
+            return 0;
+        }
+
+        public static Func<long, int> GetMinTransactionsPerBlockFactory(
+            MinTransactionsPerBlockPolicy? minTransactionsPerBlockPolicy)
+        {
+            return index => GetMinTransactionsPerBlockRaw(index, minTransactionsPerBlockPolicy);
         }
 
         public static int GetMaxTransactionsPerBlockRaw(long index, int maxTransactionsPerBlock)

--- a/Lib9c/Policy/MinTransactionsPerBlockPolicy.cs
+++ b/Lib9c/Policy/MinTransactionsPerBlockPolicy.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace Nekoyume.BlockChain.Policy
+{
+    public struct MinTransactionsPerBlockPolicy
+    {
+        public MinTransactionsPerBlockPolicy(
+            long startIndex, long? endIndex, int minTransactionsPerBlock)
+        {
+            if (startIndex < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    $"Value of {nameof(startIndex)} must be non-negative: {startIndex}");
+            }
+            else if (endIndex is long ei && ei < startIndex)
+            {
+                throw new ArgumentOutOfRangeException(
+                    $"Non-null {nameof(endIndex)} cannot be less than {nameof(startIndex)}.");
+            }
+
+            StartIndex = startIndex;
+            EndIndex = endIndex;
+            MinTransactionsPerBlock = minTransactionsPerBlock;
+        }
+
+        public long StartIndex { get; private set; }
+
+        public long? EndIndex { get; private set; }
+
+        public int MinTransactionsPerBlock { get; private set; }
+
+        public bool IsTargetBlockIndex(long index)
+        {
+            return StartIndex <= index
+                && (EndIndex is null
+                    || (EndIndex is long endIndex && index <= endIndex));
+        }
+
+        public static MinTransactionsPerBlockPolicy Mainnet => new MinTransactionsPerBlockPolicy()
+        {
+            StartIndex = BlockPolicySource.MinTransactionsPerBlockHardcodedIndex,
+            EndIndex = null,
+            MinTransactionsPerBlock = BlockPolicySource.MinTransactionsPerBlock,
+        };
+    }
+}

--- a/Lib9c/Policy/PermissionedMiningPolicy.cs
+++ b/Lib9c/Policy/PermissionedMiningPolicy.cs
@@ -7,9 +7,14 @@ namespace Nekoyume.BlockChain.Policy
 {
     public struct PermissionedMiningPolicy
     {
-        public PermissionedMiningPolicy(ISet<Address> miners, long startIndex, long? endIndex)
+        public PermissionedMiningPolicy(long startIndex, long? endIndex, ISet<Address> miners)
         {
-            if (endIndex is long ei && ei < startIndex)
+            if (startIndex < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    $"Value of {nameof(startIndex)} must be non-negative: {startIndex}");
+            }
+            else if (endIndex is long ei && ei < startIndex)
             {
                 throw new ArgumentOutOfRangeException(
                     $"Non-null {nameof(endIndex)} cannot be less than {nameof(startIndex)}.");
@@ -34,11 +39,14 @@ namespace Nekoyume.BlockChain.Policy
         public bool IsTargetBlockIndex(long index)
         {
             return StartIndex <= index
-                && (EndIndex is long endIndex && index <= endIndex);
+                && (EndIndex is null
+                    || (EndIndex is long endIndex && index <= endIndex));
         }
 
         public static PermissionedMiningPolicy Mainnet => new PermissionedMiningPolicy()
         {
+            StartIndex = BlockPolicySource.PermissionedMiningHardcodedIndex,
+            EndIndex = null,
             Miners = new[]
             {
                 new Address("ab1dce17dCE1Db1424BB833Af6cC087cd4F5CB6d"),
@@ -46,8 +54,6 @@ namespace Nekoyume.BlockChain.Policy
                 new Address("474CB59Dea21159CeFcC828b30a8D864e0b94a6B"),
                 new Address("636d187B4d434244A92B65B06B5e7da14b3810A9"),
             }.ToImmutableHashSet(),
-            StartIndex = 2_225_500,
-            EndIndex = null,
         };
     }
 }


### PR DESCRIPTION
Closes #645 and closes #650.

This is a continuation of #646.

As addressed in the referenced issues:
- `AuthorizedMinersState` is no longer used as a policy, but backward compatible `AuthorizedMiningPolicy` is newly implemented.
- Parameter `ignoreHardcodedPolicies` is removed. As old behavior of `ignoreHardcodedPolicies` was not clear enough.
  - This applied to only certain sub-policies but not all without clear reasoning.
  - Even when applied, there was no consistency on how it is applied to a specific policy.
  - Also there was general disregard as to how `BlockPolicy` as a whole would behave as `ignoreHardcodedPolicies` could affect multiple interdependent sub-policies.