### PR TITLE
Fix compile error

### DIFF
--- a/Lib9c/Policy/BlockPolicySource.cs
+++ b/Lib9c/Policy/BlockPolicySource.cs
@@ -111,7 +111,7 @@ namespace Nekoyume.BlockChain.Policy
             PermissionedMiningPolicy? permissionedMiningPolicy)
         {
 #if UNITY_EDITOR
-            return new Lib9c.DebugPolicy();
+            return new DebugPolicy();
 #else
             return new BlockPolicy(
                 new RewardGold(),


### PR DESCRIPTION
### Description

1. namespace of DebugPolicy was changed `Lib9c` to `Nekoyume.BlockChain.Policy` in this [commit](https://github.com/planetarium/lib9c/commit/451fba16b558122761fccc60efb0b271e8a59a6f)
2. This made compile error in unity, so I fixed it.

### Related link

https://github.com/planetarium/lib9c/commit/451fba16b558122761fccc60efb0b271e8a59a6f