### PR TITLE
Hotfix/hardcoded authorized mining

### DIFF
--- a/.Lib9c.Tests/BlockPolicyTest.cs
+++ b/.Lib9c.Tests/BlockPolicyTest.cs
@@ -137,17 +137,22 @@ namespace Lib9c.Tests
             );
 
             var blockPolicySource = new BlockPolicySource(Logger.None);
-            IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(10000, 100);
+            AuthorizedMiningPolicy authorizedMiningPolicy = new AuthorizedMiningPolicy(
+                startIndex: 0,
+                endIndex: 10,
+                interval: 5,
+                miners: new[] { authorizedMinerPrivateKey.ToAddress() }.ToHashSet());
+            IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(
+                minimumDifficulty: 10000,
+                maxTransactionsPerBlock: 100,
+                ignoreHardcodedPolicies: false,
+                authorizedMiningPolicy: authorizedMiningPolicy,
+                permissionedMiningPolicy: null);
             IStagePolicy<PolymorphicAction<ActionBase>> stagePolicy =
                 new VolatileStagePolicy<PolymorphicAction<ActionBase>>();
             Block<PolymorphicAction<ActionBase>> genesis = MakeGenesisBlock(
                 adminAddress,
                 ImmutableHashSet.Create(adminAddress),
-                new AuthorizedMinersState(
-                    new[] { authorizedMinerPrivateKey.ToAddress() },
-                    5,
-                    10
-                ),
                 pendingActivations: new[] { ps }
             );
             using var store = new DefaultStore(null);
@@ -286,18 +291,22 @@ namespace Lib9c.Tests
             );
 
             var blockPolicySource = new BlockPolicySource(Logger.None);
+            AuthorizedMiningPolicy authorizedMiningPolicy = new AuthorizedMiningPolicy(
+                miners: miners.ToHashSet(),
+                startIndex: 0,
+                endIndex: 4,
+                interval: 2);
             IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(
                 10000,
                 100,
                 ignoreHardcodedPolicies: true,
+                authorizedMiningPolicy: authorizedMiningPolicy,
                 permissionedMiningPolicy: null);
             IStagePolicy<PolymorphicAction<ActionBase>> stagePolicy =
                 new VolatileStagePolicy<PolymorphicAction<ActionBase>>();
             Block<PolymorphicAction<ActionBase>> genesis = MakeGenesisBlock(
                 adminAddress,
-                ImmutableHashSet<Address>.Empty,
-                new AuthorizedMinersState(miners, 2, 4)
-            );
+                ImmutableHashSet<Address>.Empty);
             using var store = new DefaultStore(null);
             using var stateStore = new TrieStateStore(new DefaultKeyValueStore(null));
             var blockChain = new BlockChain<PolymorphicAction<ActionBase>>(
@@ -398,14 +407,22 @@ namespace Lib9c.Tests
             var miners = new[] { miner };
 
             var blockPolicySource = new BlockPolicySource(Logger.None);
-            IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(4096, 100);
+            AuthorizedMiningPolicy authorizedMiningPolicy = new AuthorizedMiningPolicy(
+                miners: miners.ToHashSet(),
+                startIndex: 0,
+                endIndex: 6,
+                interval: 2);
+            IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(
+                minimumDifficulty: 4096,
+                maxTransactionsPerBlock: 100,
+                ignoreHardcodedPolicies: false,
+                authorizedMiningPolicy: authorizedMiningPolicy,
+                permissionedMiningPolicy: null);
             IStagePolicy<PolymorphicAction<ActionBase>> stagePolicy =
                 new VolatileStagePolicy<PolymorphicAction<ActionBase>>();
             Block<PolymorphicAction<ActionBase>> genesis = MakeGenesisBlock(
                 adminAddress,
-                ImmutableHashSet<Address>.Empty,
-                new AuthorizedMinersState(miners, 2, 6)
-            );
+                ImmutableHashSet<Address>.Empty);
             using var store = new DefaultStore(null);
             using var stateStore = new TrieStateStore(new DefaultKeyValueStore(null));
             var blockChain = new BlockChain<PolymorphicAction<ActionBase>>(
@@ -629,12 +646,14 @@ namespace Lib9c.Tests
                 blockPolicySource.GetPolicy(
                     minimumDifficulty: 50_000,
                     maxTransactionsPerBlock: 100,
+                    authorizedMiningPolicy: null,
                     permissionedMiningPolicy: new PermissionedMiningPolicy(
-                        threshold: 1,
                         miners: new[]
                         {
                             permissionedMinerKey.ToAddress(),
-                        }.ToImmutableHashSet()
+                        }.ToImmutableHashSet(),
+                        startIndex: 1,
+                        endIndex: null
                     ),
                     ignoreHardcodedPolicies: true
                 ),

--- a/Lib9c/Policy/AuthorizedMiningPolicy.cs
+++ b/Lib9c/Policy/AuthorizedMiningPolicy.cs
@@ -8,9 +8,14 @@ namespace Nekoyume.BlockChain.Policy
     public struct AuthorizedMiningPolicy
     {
         public AuthorizedMiningPolicy(
-            ISet<Address> miners, long startIndex, long? endIndex, long interval)
+            long startIndex, long? endIndex, long interval, ISet<Address> miners)
         {
-            if (endIndex is long ei && ei < startIndex)
+            if (startIndex < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    $"Value of {nameof(startIndex)} must be non-negative: {startIndex}");
+            }
+            else if (endIndex is long ei && ei < startIndex)
             {
                 throw new ArgumentOutOfRangeException(
                     $"Non-null {nameof(endIndex)} cannot be less than {nameof(startIndex)}.");
@@ -18,7 +23,7 @@ namespace Nekoyume.BlockChain.Policy
             else if (interval <= 0)
             {
                 throw new ArgumentOutOfRangeException(
-                    $"Value of {nameof(interval)} must be positive.");
+                    $"Value of {nameof(interval)} must be positive: {interval}");
             }
             else if (miners.Count == 0)
             {
@@ -44,11 +49,15 @@ namespace Nekoyume.BlockChain.Policy
         {
             return index % Interval == 0
                 && StartIndex <= index
-                && (EndIndex is long endIndex && index <= endIndex);
+                && (EndIndex is null
+                    || (EndIndex is long endIndex && index <= endIndex));
         }
 
         public static AuthorizedMiningPolicy Mainnet => new AuthorizedMiningPolicy()
         {
+            StartIndex = 0,
+            EndIndex = 3_153_600,
+            Interval = 50,
             Miners = new[]
             {
                 new Address("ab1dce17dCE1Db1424BB833Af6cC087cd4F5CB6d"),
@@ -56,9 +65,6 @@ namespace Nekoyume.BlockChain.Policy
                 new Address("474CB59Dea21159CeFcC828b30a8D864e0b94a6B"),
                 new Address("636d187B4d434244A92B65B06B5e7da14b3810A9"),
             }.ToImmutableHashSet(),
-            StartIndex = 0,
-            EndIndex = 3_153_600,
-            Interval = 50,
         };
     }
 }

--- a/Lib9c/Policy/BlockPolicySource.Utils.cs
+++ b/Lib9c/Policy/BlockPolicySource.Utils.cs
@@ -35,11 +35,24 @@ namespace Nekoyume.BlockChain.Policy
                 && admin.AdminAddress.Equals(transaction.Signer);
         }
 
-        internal static bool IsAuthorizedMinerTransaction(
-            BlockChain<NCAction> blockChain, Transaction<NCAction> transaction)
+        internal static bool IsAuthorizedMinerTransactionRaw(
+            Transaction<NCAction> transaction, AuthorizedMiningPolicy? authorizedMiningPolicy)
         {
-            return GetAuthorizedMinersState(blockChain) is AuthorizedMinersState ams
-                && ams.Miners.Contains(transaction.Signer);
+            if (authorizedMiningPolicy is AuthorizedMiningPolicy amp)
+            {
+                return amp.Miners.Contains(transaction.Signer);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        internal static Func<Transaction<NCAction>, bool> IsAuthorizedMinerTransactionFactory(
+            AuthorizedMiningPolicy? authorizedMiningPolicy)
+        {
+            return transaction => IsAuthorizedMinerTransactionRaw(
+                transaction, authorizedMiningPolicy);
         }
 
         internal static AdminState GetAdminState(
@@ -49,21 +62,6 @@ namespace Nekoyume.BlockChain.Policy
             {
                 return blockChain.GetState(AdminState.Address) is Dictionary rawAdmin
                     ? new AdminState(rawAdmin)
-                    : null;
-            }
-            catch (IncompleteBlockStatesException)
-            {
-                return null;
-            }
-        }
-
-        internal static AuthorizedMinersState GetAuthorizedMinersState(
-            BlockChain<NCAction> blockChain)
-        {
-            try
-            {
-                return blockChain.GetState(AuthorizedMinersState.Address) is Dictionary rawAms
-                    ? new AuthorizedMinersState(rawAms)
                     : null;
             }
             catch (IncompleteBlockStatesException)
@@ -149,28 +147,22 @@ namespace Nekoyume.BlockChain.Policy
         }
 
         internal static BlockPolicyViolationException ValidateMinerAuthorityRaw(
-            BlockChain<NCAction> blockChain, Block<NCAction> block, bool ignoreHardcodedPolicies)
+            Block<NCAction> block,
+            AuthorizedMiningPolicy? authorizedMiningPolicy,
+            bool ignoreHardcodedPolicies)
         {
-            Address miner = block.Miner;
-
-            // FIXME: Uninstantiated blockChain can be passed as an argument.
-            // Until this is fixed, it is crucial block index is checked first.
-            // Authorized minor validity is only checked for certain indices.
+            // For genesis block, any miner can mine.
             if (block.Index == 0)
             {
                 return null;
             }
-            if (!IsAuthorizedMiningBlockIndex(blockChain, block.Index))
-            {
-                return null;
-            }
-            // If AuthorizedMinorState is null, do not check miner authority.
-            else if (!(GetAuthorizedMinersState(blockChain) is AuthorizedMinersState ams))
+            // If not an authorized mining block index, any miner can mine.
+            else if (!IsAuthorizedMiningBlockIndexRaw(block.Index, authorizedMiningPolicy))
             {
                 return null;
             }
             // Otherwise, block's miner should be one of the authorized miners.
-            else if (!ams.Miners.Contains(miner))
+            else if (!IsAuthorizedToMineRaw(block.Miner, block.Index, authorizedMiningPolicy))
             {
                 return new BlockPolicyViolationException(
                     $"The block #{block.Index} {block.Hash} is not mined by an authorized miner.");
@@ -179,15 +171,15 @@ namespace Nekoyume.BlockChain.Policy
             // Authority is proven through a no-op transaction, i.e. a transaction
             // with zero actions, starting from ValidateMinerAuthorityNoOpHardcodedIndex.
             Transaction<NCAction>[] txs = block.Transactions.ToArray();
-            if (!txs.Any(tx => tx.Signer.Equals(miner) && !tx.Actions.Any())
+            if (!txs.Any(tx => tx.Signer.Equals(block.Miner) && !tx.Actions.Any())
                     && block.ProtocolVersion > 0)
             {
                 if (ignoreHardcodedPolicies)
                 {
                     return new BlockPolicyViolationException(
-                        $"Block #{block.Index} {block.Hash}'s miner {miner} should be proven by "
-                            + "including a no-op transaction by signed the same authority.  "
-                            + "(Forced failure)");
+                        $"Block #{block.Index} {block.Hash}'s miner {block.Miner} should be "
+                            + "proven by including a no-op transaction by signed "
+                            + "the same authority.  (Forced failure)");
                 }
                 else if (block.Index >= ValidateMinerAuthorityNoOpTxHardcodedIndex)
                 {
@@ -202,8 +194,9 @@ namespace Nekoyume.BlockChain.Policy
                     const string debug = "";
 #endif
                     return new BlockPolicyViolationException(
-                        $"Block #{block.Index} {block.Hash}'s miner {miner} should be proven by " +
-                        "including a no-op transaction by signed the same authority." + debug);
+                        $"Block #{block.Index} {block.Hash}'s miner {block.Miner} should be "
+                            + "proven by including a no-op transaction signed by "
+                            + "the same authority." + debug);
                 }
             }
 
@@ -211,31 +204,34 @@ namespace Nekoyume.BlockChain.Policy
         }
 
         internal static Func<BlockChain<NCAction>, Block<NCAction>, BlockPolicyViolationException>
-            ValidateMinerAuthorityFactory(bool ignoreHardcodedPolicies)
+            ValidateMinerAuthorityFactory(
+                AuthorizedMiningPolicy? authorizedMiningPolicy, bool ignoreHardcodedPolicies)
         {
             return (blockChain, block) =>
-                ValidateMinerAuthorityRaw(blockChain, block, ignoreHardcodedPolicies);
+                ValidateMinerAuthorityRaw(block, authorizedMiningPolicy, ignoreHardcodedPolicies);
         }
 
         internal static bool IsAllowedToMineRaw(
             BlockChain<NCAction> blockChain,
             Address miner,
             long index,
-            Func<BlockChain<NCAction>, long, bool> isPermissionedMiningBlockIndex,
-            Func<BlockChain<NCAction>, Address, long, bool> isPermissionedToMine)
+            Func<long, bool> isAuthorizedMiningBlockIndex,
+            Func<Address, long, bool> isAuthorizedToMine,
+            Func<long, bool> isPermissionedMiningBlockIndex,
+            Func<Address, long, bool> isPermissionedToMine)
         {
             // For genesis blocks, any miner is allowed to mine.
             if (index == 0)
             {
                 return true;
             }
-            else if (IsAuthorizedMiningBlockIndex(blockChain, index))
+            else if (isAuthorizedMiningBlockIndex(index))
             {
-                return IsAuthorizedToMine(blockChain, miner, index);
+                return isAuthorizedToMine(miner, index);
             }
-            else if (isPermissionedMiningBlockIndex(blockChain, index))
+            else if (isPermissionedMiningBlockIndex(index))
             {
-                return isPermissionedToMine(blockChain, miner, index);
+                return isPermissionedToMine(miner, index);
             }
 
             // If none of the conditions apply, any miner is allowed to mine.
@@ -243,12 +239,20 @@ namespace Nekoyume.BlockChain.Policy
         }
 
         internal static Func<BlockChain<NCAction>, Address, long, bool> IsAllowedToMineFactory(
-            Func<BlockChain<NCAction>, long, bool> isPermissionedMiningBlockIndex,
-            Func<BlockChain<NCAction>, Address, long, bool> isPermissionedToMine)
+            Func<long, bool> isAuthorizedMiningBlockIndex,
+            Func<Address, long, bool> isAuthorizedToMine,
+            Func<long, bool> isPermissionedMiningBlockIndex,
+            Func<Address, long, bool> isPermissionedToMine)
         {
             return (blockChain, miner, index) =>
                 IsAllowedToMineRaw(
-                    blockChain, miner, index, isPermissionedMiningBlockIndex, isPermissionedToMine);
+                    blockChain,
+                    miner,
+                    index,
+                    isAuthorizedMiningBlockIndex,
+                    isAuthorizedToMine,
+                    isPermissionedMiningBlockIndex,
+                    isPermissionedToMine);
         }
 
         /// <summary>
@@ -258,18 +262,25 @@ namespace Nekoyume.BlockChain.Policy
         /// An implementation should be agnostic about other policies affecting the same index.
         /// Policy overruling between different policies should be handled elsewhere.
         /// </remarks>
-        internal static bool IsAuthorizedMiningBlockIndex(
-            BlockChain<NCAction> blockChain, long index)
+        internal static bool IsAuthorizedMiningBlockIndexRaw(
+            long index, AuthorizedMiningPolicy? authorizedMiningPolicy)
         {
-            if (GetAuthorizedMinersState(blockChain) is AuthorizedMinersState ams)
+            if (authorizedMiningPolicy is AuthorizedMiningPolicy amp)
             {
-                return index % ams.Interval == 0 && index <= ams.ValidUntil;
+                return amp.IsTargetBlockIndex(index);
             }
             else
             {
                 return false;
             }
         }
+
+        internal static Func<long, bool> IsAuthorizedMiningBlockIndexFactory(
+            AuthorizedMiningPolicy? authorizedMiningPolicy)
+        {
+            return index => IsAuthorizedMiningBlockIndexRaw(index, authorizedMiningPolicy);
+        }
+
 
         /// <summary>
         /// Checks if given miner is allowed to mine a block with given index according to
@@ -279,26 +290,32 @@ namespace Nekoyume.BlockChain.Policy
         /// An implementation should be agnostic about other policies affecting the same index.
         /// Policy overruling between different policies should be handled elsewhere.
         /// </remarks>
-        internal static bool IsAuthorizedToMine(
-            BlockChain<NCAction> blockChain, Address miner, long index)
+        internal static bool IsAuthorizedToMineRaw(
+            Address miner, long index, AuthorizedMiningPolicy? authorizedMiningPolicy)
         {
-            if (IsAuthorizedMiningBlockIndex(blockChain, index))
+            if (IsAuthorizedMiningBlockIndexRaw(index, authorizedMiningPolicy))
             {
-                if (GetAuthorizedMinersState(blockChain) is AuthorizedMinersState ams)
+                if (authorizedMiningPolicy is AuthorizedMiningPolicy amp)
                 {
-                    return ams.Miners.Contains(miner);
+                    return amp.Miners.Contains(miner);
                 }
                 else
                 {
                     throw new ArgumentException(
-                        $"Result of {nameof(GetAuthorizedMinersState)} cannot be null.");
+                        $"Result of {nameof(authorizedMiningPolicy)} cannot be null.");
                 }
             }
             else
             {
                 throw new ArgumentException(
-                    $"Result of {nameof(IsAuthorizedMiningBlockIndex)} must be true.");
+                    $"Result of {nameof(authorizedMiningPolicy)} must be true.");
             }
+        }
+
+        internal static Func<Address, long, bool> IsAuthorizedToMineFactory(
+            AuthorizedMiningPolicy? authorizedMiningPolicy)
+        {
+            return (miner, index) => IsAuthorizedToMineRaw(miner, index, authorizedMiningPolicy);
         }
 
         /// <summary>
@@ -309,13 +326,12 @@ namespace Nekoyume.BlockChain.Policy
         /// Policy overruling between different policies should be handled elsewhere.
         /// </remarks>
         internal static bool IsPermissionedMiningBlockIndexRaw(
-            BlockChain<NCAction> blockChain,
             long index,
             PermissionedMiningPolicy? permissionedMiningPolicy)
         {
             if (permissionedMiningPolicy is PermissionedMiningPolicy pmp)
             {
-                return index >= pmp.StartIndex;
+                return pmp.IsTargetBlockIndex(index);
             }
             else
             {
@@ -323,12 +339,10 @@ namespace Nekoyume.BlockChain.Policy
             }
         }
 
-        internal static Func<BlockChain<NCAction>, long, bool>
-            IsPermissionedMiningBlockIndexFactory(
-                PermissionedMiningPolicy? permissionedMiningPolicy)
+        internal static Func<long, bool> IsPermissionedMiningBlockIndexFactory(
+            PermissionedMiningPolicy? permissionedMiningPolicy)
         {
-            return (blockChain, index) => IsPermissionedMiningBlockIndexRaw(
-                blockChain, index, permissionedMiningPolicy);
+            return index => IsPermissionedMiningBlockIndexRaw(index, permissionedMiningPolicy);
         }
 
         /// <summary>
@@ -340,12 +354,11 @@ namespace Nekoyume.BlockChain.Policy
         /// Policy overruling between different policies should be handled elsewhere.
         /// </remarks>
         internal static bool IsPermissionedToMineRaw(
-            BlockChain<NCAction> blockChain,
             Address miner,
             long index,
             PermissionedMiningPolicy? permissionedMiningPolicy)
         {
-            if (IsPermissionedMiningBlockIndexRaw(blockChain, index, permissionedMiningPolicy))
+            if (IsPermissionedMiningBlockIndexRaw(index, permissionedMiningPolicy))
             {
                 if (permissionedMiningPolicy is PermissionedMiningPolicy pmp)
                 {
@@ -364,11 +377,11 @@ namespace Nekoyume.BlockChain.Policy
             }
         }
 
-        internal static Func<BlockChain<NCAction>, Address, long, bool>
+        internal static Func<Address, long, bool>
             IsPermissionedToMineFactory(PermissionedMiningPolicy? permissionedMiningPolicy)
         {
-            return (blockChain, miner, index) => IsPermissionedToMineRaw(
-                blockChain, miner, index, permissionedMiningPolicy);
+            return (miner, index) => IsPermissionedToMineRaw(
+                miner, index, permissionedMiningPolicy);
         }
     }
 }

--- a/Lib9c/Policy/PermissionedMiningPolicy.cs
+++ b/Lib9c/Policy/PermissionedMiningPolicy.cs
@@ -7,9 +7,14 @@ namespace Nekoyume.BlockChain.Policy
 {
     public struct PermissionedMiningPolicy
     {
-        public PermissionedMiningPolicy(ISet<Address> miners, long startIndex, long? endIndex)
+        public PermissionedMiningPolicy(long startIndex, long? endIndex, ISet<Address> miners)
         {
-            if (endIndex is long ei && ei < startIndex)
+            if (startIndex < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    $"Value of {nameof(startIndex)} must be non-negative: {startIndex}");
+            }
+            else if (endIndex is long ei && ei < startIndex)
             {
                 throw new ArgumentOutOfRangeException(
                     $"Non-null {nameof(endIndex)} cannot be less than {nameof(startIndex)}.");
@@ -34,11 +39,14 @@ namespace Nekoyume.BlockChain.Policy
         public bool IsTargetBlockIndex(long index)
         {
             return StartIndex <= index
-                && (EndIndex is long endIndex && index <= endIndex);
+                && (EndIndex is null
+                    || (EndIndex is long endIndex && index <= endIndex));
         }
 
         public static PermissionedMiningPolicy Mainnet => new PermissionedMiningPolicy()
         {
+            StartIndex = BlockPolicySource.PermissionedMiningHardcodedIndex,
+            EndIndex = null,
             Miners = new[]
             {
                 new Address("ab1dce17dCE1Db1424BB833Af6cC087cd4F5CB6d"),
@@ -46,8 +54,6 @@ namespace Nekoyume.BlockChain.Policy
                 new Address("474CB59Dea21159CeFcC828b30a8D864e0b94a6B"),
                 new Address("636d187B4d434244A92B65B06B5e7da14b3810A9"),
             }.ToImmutableHashSet(),
-            StartIndex = 2_225_500,
-            EndIndex = null,
         };
     }
 }


### PR DESCRIPTION
This update "rolls back" on-the-fly `AuthorizedMinersState` read policy due to not being able to access states while preloading.
To conform to already updated [libplanet]'s `IBlockPolicy<T>` API and keep intact [lib9c]'s for its use by [headless], this implements `AuthorizedMiningPolicy` `class` akin to that of `PermissionedMiningPolicy`.

[libplanet]: https://github.com/planetarium/libplanet
[lib9c]: https://github.com/planetarium/lib9c
[headless]: https://github.com/planetarium/NineChronicles.Headless