### PR TITLE
Max transactions removed from `ReorgMiner.MineBlockAsync()`

### DIFF
--- a/Lib9c/BlockHelper.cs
+++ b/Lib9c/BlockHelper.cs
@@ -27,7 +27,6 @@ namespace Nekoyume
             IImmutableSet<Address> activatedAccounts = null,
             bool isActivateAdminAddress = false,
             IEnumerable<string> credits = null,
-            int maximumTransactions = 100,
             PrivateKey privateKey = null,
             DateTimeOffset? timestamp = null
         )
@@ -69,7 +68,7 @@ namespace Nekoyume
             {
                 initialStatesAction,
             };
-            var blockAction = new BlockPolicySource(Log.Logger).GetPolicy(5000000, maximumTransactions).BlockAction;
+            var blockAction = new BlockPolicySource(Log.Logger).GetPolicy().BlockAction;
             return
                 BlockChain<PolymorphicAction<ActionBase>>.MakeGenesisBlock(
                     HashAlgorithmType.Of<SHA256>(),


### PR DESCRIPTION
Unless there is a specific reason, max transactions per block should be controlled by policy.