### PR TITLE
Removed deprecated GetPolicy() and added GetTestPolicy()

### DIFF
--- a/.Lib9c.Tests/StagePolicyTest.cs
+++ b/.Lib9c.Tests/StagePolicyTest.cs
@@ -215,7 +215,7 @@ namespace Lib9c.Tests
                 default,
                 2);
             var blockPolicySource = new BlockPolicySource(Logger.None);
-            IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy(10000, 100);
+            IBlockPolicy<PolymorphicAction<ActionBase>> policy = blockPolicySource.GetPolicy();
             BlockChain<PolymorphicAction<ActionBase>> chain =
                 BlockChainHelper.MakeBlockChain(new[] { blockPolicySource.BlockRenderer }, policy, stagePolicy);
 

--- a/Lib9c/Policy/BlockPolicySource.cs
+++ b/Lib9c/Policy/BlockPolicySource.cs
@@ -95,25 +95,26 @@ namespace Nekoyume.BlockChain.Policy
                 new LoggedRenderer<NCAction>(BlockRenderer, logger, logEventLevel);
         }
 
-        [Obsolete("Left for temporary old API compliance.")]
-        public IBlockPolicy<NCAction> GetPolicy(
-            long minimumDifficulty,
-            int maxTransactionsPerBlock) =>
+        /// <summary>
+        /// Creates an <see cref="IBlockPolicy{T}"/> instance for deployment.
+        /// </summary>
+        public IBlockPolicy<NCAction> GetPolicy() =>
             GetPolicy(
-                minimumDifficulty: minimumDifficulty,
+                minimumDifficulty: MinimumDifficulty,
                 maxBlockBytesPolicy: MaxBlockBytesPolicy.Mainnet,
                 minTransactionsPerBlockPolicy: MinTransactionsPerBlockPolicy.Mainnet,
-                maxTransactionsPerBlockPolicy: MaxTransactionsPerBlockPolicy.Default.Add(
-                    new SpannedSubPolicy<int>(
-                        startIndex: 0,
-                        value: maxTransactionsPerBlock)),
+                maxTransactionsPerBlockPolicy: MaxTransactionsPerBlockPolicy.Mainnet,
                 maxTransactionsPerSignerPerBlockPolicy: MaxTransactionsPerSignerPerBlockPolicy.Mainnet,
                 authorizedMinersPolicy: AuthorizedMinersPolicy.Mainnet,
                 permissionedMinersPolicy: PermissionedMinersPolicy.Mainnet);
 
-        public IBlockPolicy<NCAction> GetPolicy() =>
+        /// <summary>
+        /// Creates an <see cref="IBlockPolicy{T}"/> instance identical to the one deployed
+        /// except with lower minimum difficulty for faster testing and benchmarking.
+        /// </summary>
+        public IBlockPolicy<NCAction> GetTestPolicy() =>
             GetPolicy(
-                minimumDifficulty: MinimumDifficulty,
+                minimumDifficulty: DifficultyStability,
                 maxBlockBytesPolicy: MaxBlockBytesPolicy.Mainnet,
                 minTransactionsPerBlockPolicy: MinTransactionsPerBlockPolicy.Mainnet,
                 maxTransactionsPerBlockPolicy: MaxTransactionsPerBlockPolicy.Mainnet,


### PR DESCRIPTION
As [headless] uses a custom policy in several places for testing, simply removing a deprecated `GetPolicy()` results in much increased time for performing tests. From [headless]'es perspective, one might want to perform tests on a chain with a policy identical to the deployed one, but I don't think this should grant [headless] permission to "customize" the underlying [lib9c] policy on the fly, as it isn't really a proper feature that is needed for [headless] to care about. This is an ad hoc fix instead of a proper fix that would provide a set of fixtures as a part of a testing suite for [headless] to use on a [lib9c] level. 🙃 

[headless]: https://github.com/planetarium/NineChronicles.Headless
[lib9c]: https://github.com/planetarium/lib9c