### PR TITLE
Implement missing interface

### DIFF
--- a/Lib9c/Action/Buy.cs
+++ b/Lib9c/Action/Buy.cs
@@ -37,7 +37,7 @@ namespace Nekoyume.Action
         public Address buyerAvatarAddress { get; set; }
         public List<(Guid orderId, int errorCode)> errors = new List<(Guid orderId, int errorCode)>();
         public IEnumerable<PurchaseInfo> purchaseInfos;
-        IEnumerable<IPurchaseInfo> IBuy5.purchaseInfos => purchaseInfos.Cast<IPurchaseInfo>();
+        IEnumerable<IPurchaseInfo> IBuy5.purchaseInfos => purchaseInfos;
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal => new Dictionary<string, IValue>
         {

--- a/Lib9c/Action/Buy9.cs
+++ b/Lib9c/Action/Buy9.cs
@@ -21,7 +21,7 @@ namespace Nekoyume.Action
     [Serializable]
     [ActionObsolete(BlockChain.Policy.BlockPolicySource.V100080ObsoleteIndex)]
     [ActionType("buy9")]
-    public class Buy9 : GameAction
+    public class Buy9 : GameAction, IBuy5
     {
         public const int TaxRate = 8;
         public const int ErrorCodeFailedLoadingState = 1;
@@ -35,9 +35,10 @@ namespace Nekoyume.Action
         public const int ErrorCodeInvalidItemType = 9;
         public const int ErrorCodeDuplicateSell = 10;
 
-        public Address buyerAvatarAddress;
+        public Address buyerAvatarAddress { get; set; }
         public List<(Guid orderId, int errorCode)> errors = new List<(Guid orderId, int errorCode)>();
         public IEnumerable<PurchaseInfo> purchaseInfos;
+        IEnumerable<IPurchaseInfo> IBuy5.purchaseInfos => purchaseInfos;
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal => new Dictionary<string, IValue>
         {

--- a/Lib9c/Action/IBuy5.cs
+++ b/Lib9c/Action/IBuy5.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Libplanet;
 using Libplanet.Action;


### PR DESCRIPTION
There are `IBuy5` interface which implemented in the `Buy` action since the `Buy5` action. But the `Buy9` action doesn't.