### PR TITLE
Specialized authorized miner behavior option removed from Miner

### DIFF
--- a/.Lib9c.Tests/MinerTest.cs
+++ b/.Lib9c.Tests/MinerTest.cs
@@ -37,7 +37,7 @@ namespace Lib9c.Tests
             );
 
             var minerKey = new PrivateKey();
-            var miner = new Miner(blockChain, null, minerKey, false);
+            var miner = new Miner(blockChain, null, minerKey);
             Block<NCAction> mined = await miner.MineBlockAsync(default);
             Transaction<NCAction> tx = Assert.Single(mined.Transactions);
 

--- a/.Lib9c.Tests/Policy/BlockPolicyTest.cs
+++ b/.Lib9c.Tests/Policy/BlockPolicyTest.cs
@@ -332,7 +332,7 @@ namespace Lib9c.Tests
                 await blockChain.MineBlock(stranger);
             });
             // Old proof mining still works.
-            new Miner(blockChain, null, minerKeys[0], true).StageProofTransaction();
+            new Miner(blockChain, null, minerKeys[0]).StageProofTransaction();
             await blockChain.MineBlock(minerKeys[0]);
 
             // Index 3. Anyone can mine.
@@ -405,7 +405,7 @@ namespace Lib9c.Tests
                 genesis,
                 renderers: new[] { blockPolicySource.BlockRenderer }
             );
-            var minerObj = new Miner(blockChain, null, minerKey, true);
+            var minerObj = new Miner(blockChain, null, minerKey);
 
             var dateTimeOffset = DateTimeOffset.MinValue;
 

--- a/Lib9c/Miner.cs
+++ b/Lib9c/Miner.cs
@@ -38,8 +38,6 @@ namespace Nekoyume.BlockChain
             new Address("B892052f1E10bf700143dd9bEcd81E31CD7f7095"),
         }.ToImmutableHashSet();
 
-        public bool AuthorizedMiner { get; }
-
         public Address Address => _privateKey.ToAddress();
 
         public Transaction<NCAction> StageProofTransaction()
@@ -66,14 +64,6 @@ namespace Nekoyume.BlockChain
             Block<NCAction> block = null;
             try
             {
-                if (AuthorizedMiner)
-                {
-                    _chain
-                        .GetStagedTransactionIds()
-                        .Select(txid => _chain.GetTransaction(txid)).ToList()
-                        .ForEach(tx => _chain.UnstageTransaction(tx));
-                }
-
                 IEnumerable<Transaction<NCAction>> bannedTxs = _chain.GetStagedTransactionIds()
                     .Select(txId => _chain.GetTransaction(txId))
                     .Where(tx => _bannedAccounts.Contains(tx.Signer));
@@ -142,14 +132,12 @@ namespace Nekoyume.BlockChain
         public Miner(
             BlockChain<NCAction> chain,
             Swarm<NCAction> swarm,
-            PrivateKey privateKey,
-            bool authorizedMiner
+            PrivateKey privateKey
         )
         {
             _chain = chain ?? throw new ArgumentNullException(nameof(chain));
             _swarm = swarm;
             _privateKey = privateKey;
-            AuthorizedMiner = authorizedMiner;
         }
 
         public static IComparer<Transaction<NCAction>> GetProofTxPriority(


### PR DESCRIPTION
Partially addresses https://github.com/planetarium/NineChronicles.Headless/issues/853.
Should be also included in https://github.com/planetarium/NineChronicles.Headless/pull/857 once this is merged.