### PR TITLE
Upgrade Libplanet to 0.22.0-nightly.20211124+a3eddcb

### DIFF
--- a/.Lib9c.Tests/Action/ActionEvaluationTest.cs
+++ b/.Lib9c.Tests/Action/ActionEvaluationTest.cs
@@ -191,16 +191,7 @@ namespace Lib9c.Tests.Action
                 DailyReward _ => new DailyReward(),
                 InitializeStates _ => new InitializeStates
                 {
-                    Ranking = default,
-                    Shop = default,
                     TableSheets = new Dictionary<string, string>(),
-                    GameConfig = default,
-                    RedeemCode = default,
-                    AdminAddress = default,
-                    ActivatedAccounts = default,
-                    GoldCurrency = default,
-                    GoldDistributions = default,
-                    PendingActivations = default,
                     AuthorizedMiners = Dictionary.Empty,
                     Credits = Dictionary.Empty,
                 },

--- a/.Lib9c.Tests/Action/ActivateAccountTest.cs
+++ b/.Lib9c.Tests/Action/ActivateAccountTest.cs
@@ -49,7 +49,7 @@ namespace Lib9c.Tests.Action
                     BlockIndex = 1,
                 });
 
-                Assert.Equal(default(Null), nextState.GetState(pendingActivation.address));
+                Assert.Equal(Null.Value, nextState.GetState(pendingActivation.address));
                 Assert.True(nextState.GetState(activatedAddress).ToBoolean());
             }
             else

--- a/.Lib9c.Tests/Action/MonsterCollect2Test.cs
+++ b/.Lib9c.Tests/Action/MonsterCollect2Test.cs
@@ -106,7 +106,7 @@ namespace Lib9c.Tests.Action
 
                 if (level == 0)
                 {
-                    Assert.Equal(default(Null), nextState.GetState(monsterCollectionAddress));
+                    Assert.Equal(Null.Value, nextState.GetState(monsterCollectionAddress));
                 }
                 else
                 {

--- a/.Lib9c.Tests/Action/MonsterCollectTest.cs
+++ b/.Lib9c.Tests/Action/MonsterCollectTest.cs
@@ -107,7 +107,7 @@ namespace Lib9c.Tests.Action
 
                 if (level == 0)
                 {
-                    Assert.Equal(default(Null), nextState.GetState(monsterCollectionAddress));
+                    Assert.Equal(Null.Value, nextState.GetState(monsterCollectionAddress));
                 }
                 else
                 {

--- a/.Lib9c.Tests/Model/State/StateExtensionsTest.cs
+++ b/.Lib9c.Tests/Model/State/StateExtensionsTest.cs
@@ -21,7 +21,7 @@ namespace Lib9c.Tests.Model.State
                 StateExtensions.Serialize((BigInteger?)456)
             );
             Assert.Equal(
-                default(Bencodex.Types.Null),
+                Bencodex.Types.Null.Value,
                 StateExtensions.Serialize((BigInteger?)null)
             );
         }
@@ -39,7 +39,7 @@ namespace Lib9c.Tests.Model.State
             );
             Assert.Equal(
                 (BigInteger?)null,
-                default(Bencodex.Types.Null).ToNullableBigInteger()
+                Bencodex.Types.Null.Value.ToNullableBigInteger()
             );
         }
     }

--- a/.Lib9c.Tests/Types/BencodexTypesListTest.cs
+++ b/.Lib9c.Tests/Types/BencodexTypesListTest.cs
@@ -45,7 +45,7 @@ namespace Lib9c.Tests.Types
         [InlineData(1)]
         private void DeterministicWhenSerializationWithInteger(int caseIndex)
         {
-            Bencodex.Types.List targetList;
+            Bencodex.Types.List targetList = Bencodex.Types.List.Empty;
             switch (caseIndex)
             {
                 case 0:
@@ -75,7 +75,7 @@ namespace Lib9c.Tests.Types
         [InlineData(1)]
         private void DeterministicWhenSerializationWithAddress(int caseIndex)
         {
-            Bencodex.Types.List targetList;
+            Bencodex.Types.List targetList = Bencodex.Types.List.Empty;
             switch (caseIndex)
             {
                 case 0:

--- a/.Lib9c.Tools/SubCommand/Tx.cs
+++ b/.Lib9c.Tools/SubCommand/Tx.cs
@@ -42,11 +42,8 @@ namespace Lib9c.Tools.SubCommand
             );
 
             var bencoded = new List(
-                new IValue[]
-                {
-                    (Text) nameof(TransferAsset),
-                    action.PlainValue
-                }
+                (Text)nameof(TransferAsset),
+                action.PlainValue
             );
 
             byte[] raw = _codec.Encode(bencoded);
@@ -140,11 +137,8 @@ namespace Lib9c.Tools.SubCommand
             };
 
             var bencoded = new List(
-                new IValue[]
-                {
-                    (Text) nameof(PatchTableSheet),
-                    action.PlainValue
-                }
+                (Text)nameof(PatchTableSheet),
+                action.PlainValue
             );
 
             byte[] raw = _codec.Encode(bencoded);
@@ -157,11 +151,8 @@ namespace Lib9c.Tools.SubCommand
             var action = new MigrationLegacyShop();
 
             var bencoded = new List(
-                new IValue[]
-                {
-                    (Text) nameof(Nekoyume.Action.MigrationLegacyShop),
-                    action.PlainValue
-                }
+                (Text)nameof(Nekoyume.Action.MigrationLegacyShop),
+                action.PlainValue
             );
 
             byte[] raw = _codec.Encode(bencoded);
@@ -173,11 +164,8 @@ namespace Lib9c.Tools.SubCommand
         {
             var action = new MigrationActivatedAccountsState();
             var bencoded = new List(
-                new IValue[]
-                {
-                    (Text) nameof(Nekoyume.Action.MigrationActivatedAccountsState),
-                    action.PlainValue
-                }
+                (Text)nameof(Nekoyume.Action.MigrationActivatedAccountsState),
+                action.PlainValue
             );
 
             byte[] raw = _codec.Encode(bencoded);
@@ -202,11 +190,8 @@ namespace Lib9c.Tools.SubCommand
             };
 
             var encoded = new List(
-                new IValue[]
-                {
-                    (Text) nameof(Nekoyume.Action.MigrationAvatarState),
-                    action.PlainValue
-                }
+                (Text)nameof(Nekoyume.Action.MigrationAvatarState),
+                action.PlainValue
             );
 
             byte[] raw = _codec.Encode(encoded);
@@ -224,11 +209,8 @@ namespace Lib9c.Tools.SubCommand
                 redeemCsv = tableCsv
             };
             var encoded = new List(
-                new IValue[]
-                {
-                    (Text) nameof(Nekoyume.Action.AddRedeemCode),
-                    action.PlainValue
-                }
+                (Text)nameof(Nekoyume.Action.AddRedeemCode),
+                action.PlainValue
             );
             byte[] raw = _codec.Encode(encoded);
             Console.WriteLine(ByteUtil.Hex(raw));

--- a/Lib9c/Action/ActionBase.cs
+++ b/Lib9c/Action/ActionBase.cs
@@ -26,7 +26,7 @@ namespace Nekoyume.Action
     [Serializable]
     public abstract class ActionBase : IAction
     {
-        public static readonly IValue MarkChanged = default(Null);
+        public static readonly IValue MarkChanged = Null.Value;
 
         // FIXME GoldCurrencyState 에 정의된 것과 다른데 괜찮을지 점검해봐야 합니다.
         protected static readonly Currency GoldCurrencyMock = new Currency();
@@ -63,8 +63,9 @@ namespace Nekoyume.Action
 
             public AccountStateDelta(Dictionary states, List balances)
             {
+                // This assumes `states` consists of only Binary keys:
                 _states = states.ToImmutableDictionary(
-                    kv => new Address(kv.Key.EncodeAsByteArray()),
+                    kv => new Address((Binary)kv.Key),
                     kv => kv.Value
                 );
 

--- a/Lib9c/Action/Buy5.cs
+++ b/Lib9c/Action/Buy5.cs
@@ -146,6 +146,10 @@ namespace Nekoyume.Action
                     .Select(p => (Dictionary) p)
                     .FirstOrDefault(p => p[LegacyProductIdKey].Equals(productIdSerialized));
 
+                // Since Bencodex 0.4, Dictionary/List are reference types; so their default values
+                // are not a empty container, but a null reference:
+                productSerialized = productSerialized ?? Dictionary.Empty;
+
                 bool fromLegacy = false;
                 if (productSerialized.Equals(Dictionary.Empty))
                 {

--- a/Lib9c/Action/Buy6.cs
+++ b/Lib9c/Action/Buy6.cs
@@ -149,6 +149,10 @@ namespace Nekoyume.Action
                         p[LegacyProductIdKey].Equals(productIdSerialized) &&
                         p[LegacySellerAgentAddressKey].Equals(sellerAgentSerialized));
 
+                // Since Bencodex 0.4, Dictionary/List are reference types; so their default values
+                // are not a empty container, but a null reference:
+                productSerialized = productSerialized ?? Dictionary.Empty;
+
                 bool fromLegacy = false;
                 if (productSerialized.Equals(Dictionary.Empty))
                 {

--- a/Lib9c/Action/Buy7.cs
+++ b/Lib9c/Action/Buy7.cs
@@ -290,6 +290,10 @@ namespace Nekoyume.Action
                         p[LegacySellerAvatarAddressKey].Equals(sellerAvatarSerialized) &&
                         p[LegacySellerAgentAddressKey].Equals(sellerAgentSerialized));
 
+                // Since Bencodex 0.4, Dictionary/List are reference types; so their default values
+                // are not a empty container, but a null reference:
+                productSerialized = productSerialized ?? Dictionary.Empty;
+
                 bool fromLegacy = false;
                 if (productSerialized.Equals(Dictionary.Empty))
                 {

--- a/Lib9c/Action/InitializeStates.cs
+++ b/Lib9c/Action/InitializeStates.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Bencodex.Types;
 using Libplanet.Action;
 using Nekoyume.Model.State;
 
@@ -11,25 +12,27 @@ namespace Nekoyume.Action
     [ActionType("initialize_states")]
     public class InitializeStates : GameAction
     {
-        public Bencodex.Types.Dictionary Ranking { get; set; }
-        public Bencodex.Types.Dictionary Shop { get; set; }
+        public Bencodex.Types.Dictionary Ranking { get; set; } = Dictionary.Empty;
+        public Bencodex.Types.Dictionary Shop { get; set; } = Dictionary.Empty;
         public Dictionary<string, string> TableSheets { get; set; }
-        public Bencodex.Types.Dictionary GameConfig { get; set; }
-        public Bencodex.Types.Dictionary RedeemCode { get; set; }
+        public Bencodex.Types.Dictionary GameConfig { get; set; } = Dictionary.Empty;
+        public Bencodex.Types.Dictionary RedeemCode { get; set; } = Dictionary.Empty;
 
-        public Bencodex.Types.Dictionary AdminAddress { get; set; }
+        public Bencodex.Types.Dictionary AdminAddress { get; set; } = Dictionary.Empty;
 
-        public Bencodex.Types.Dictionary ActivatedAccounts { get; set; }
+        public Bencodex.Types.Dictionary ActivatedAccounts { get; set; } = Dictionary.Empty;
 
-        public Bencodex.Types.Dictionary GoldCurrency { get; set; }
+        public Bencodex.Types.Dictionary GoldCurrency { get; set; } = Dictionary.Empty;
 
-        public Bencodex.Types.List GoldDistributions { get; set; }
+        public Bencodex.Types.List GoldDistributions { get; set; } = List.Empty;
 
-        public Bencodex.Types.List PendingActivations { get; set; }
+        public Bencodex.Types.List PendingActivations { get; set; } = List.Empty;
 
-        public Bencodex.Types.Dictionary? AuthorizedMiners { get; set; }
+        // This property can contain null:
+        public Bencodex.Types.Dictionary AuthorizedMiners { get; set; } = null;
 
-        public Bencodex.Types.Dictionary? Credits { get; set; }
+        // This property can contain null:
+        public Bencodex.Types.Dictionary Credits { get; set; } = null;
 
         public InitializeStates()
         {
@@ -138,7 +141,7 @@ namespace Nekoyume.Action
             if (!(AuthorizedMiners is null))
             {
                 states = states.SetState(
-                    AuthorizedMinersState.Address, 
+                    AuthorizedMinersState.Address,
                     AuthorizedMiners
                 );
             }
@@ -181,7 +184,7 @@ namespace Nekoyume.Action
                 .Add("gold_currency_state", GoldCurrency)
                 .Add("gold_distributions", GoldDistributions)
                 .Add("pending_activation_states", PendingActivations);
-                
+
                 if (!(AuthorizedMiners is null))
                 {
                     rv = rv.Add("authorized_miners_state", AuthorizedMiners);
@@ -191,7 +194,7 @@ namespace Nekoyume.Action
                 {
                     rv = rv.Add("credits_state", Credits);
                 }
-                
+
                 return rv;
             }
         }

--- a/Lib9c/Action/Sell4.cs
+++ b/Lib9c/Action/Sell4.cs
@@ -150,6 +150,10 @@ namespace Nekoyume.Action
                     ((Dictionary) p[productKey])[itemIdKey].Equals(nonFungibleItem.NonFungibleId.Serialize()));
 #pragma warning restore LAA1002
 
+            // Since Bencodex 0.4, Dictionary/List are reference types; so their default values
+            // are not a empty container, but a null reference:
+            productSerialized = productSerialized ?? Dictionary.Empty;
+
             // Register new ShopItem
             if (productSerialized.Equals(Dictionary.Empty))
             {

--- a/Lib9c/Action/Sell5.cs
+++ b/Lib9c/Action/Sell5.cs
@@ -221,6 +221,10 @@ namespace Nekoyume.Action
                         ((BxDictionary) p[productKey])[itemIdKey].Equals(serializedTradeId));
             }
 
+            // Since Bencodex 0.4, Dictionary/List are reference types; so their default values
+            // are not a empty container, but a null reference:
+            serializedProductDictionary = serializedProductDictionary ?? Dictionary.Empty;
+
             ShopItem shopItem;
             // Register new ShopItem
             if (serializedProductDictionary.Equals(BxDictionary.Empty))

--- a/Lib9c/Action/Sell6.cs
+++ b/Lib9c/Action/Sell6.cs
@@ -226,6 +226,10 @@ namespace Nekoyume.Action
                     });
             }
 
+            // Since Bencodex 0.4, Dictionary/List are reference types; so their default values
+            // are not a empty container, but a null reference:
+            serializedProductDictionary = serializedProductDictionary ?? Dictionary.Empty;
+
             // Remove expired ShopItem to prevent copy.
             if (!serializedProductDictionary.Equals(BxDictionary.Empty))
             {

--- a/Lib9c/Action/SellCancellation5.cs
+++ b/Lib9c/Action/SellCancellation5.cs
@@ -93,6 +93,10 @@ namespace Nekoyume.Action
                 .Select(p => (Dictionary) p)
                 .FirstOrDefault(p => p[LegacyProductIdKey].Equals(productIdSerialized));
 
+            // Since Bencodex 0.4, Dictionary/List are reference types; so their default values
+            // are not a empty container, but a null reference:
+            productSerialized = productSerialized ?? Dictionary.Empty;
+
             bool backwardCompatible = false;
             if (productSerialized.Equals(Dictionary.Empty))
             {

--- a/Lib9c/Action/SellCancellation6.cs
+++ b/Lib9c/Action/SellCancellation6.cs
@@ -94,6 +94,10 @@ namespace Nekoyume.Action
                 .Select(p => (BxDictionary) p)
                 .FirstOrDefault(p => p[LegacyProductIdKey].Equals(productIdSerialized));
 
+            // Since Bencodex 0.4, Dictionary/List are reference types; so their default values
+            // are not a empty container, but a null reference:
+            productSerialized = productSerialized ?? Dictionary.Empty;
+
             var backwardCompatible = false;
             if (productSerialized.Equals(BxDictionary.Empty))
             {

--- a/Lib9c/CurrencyExtensions.cs
+++ b/Lib9c/CurrencyExtensions.cs
@@ -11,8 +11,8 @@ namespace Nekoyume
         public static Bencodex.Types.Dictionary Serialize(this Currency currency)
         {
             IValue minters = currency.Minters is IImmutableSet<Address> m
-                ? new Bencodex.Types.List(m.Select<Address, IValue>(a => new Binary(a.ToByteArray())))
-                : (IValue) default(Null);
+                ? new Bencodex.Types.List(m.Select<Address, IValue>(a => new Binary(a.ByteArray)))
+                : (IValue)Null.Value;
             return Bencodex.Types.Dictionary.Empty
                 .Add("ticker", currency.Ticker)
                 .Add("minters", minters)

--- a/Lib9c/Model/Item/Inventory.cs
+++ b/Lib9c/Model/Item/Inventory.cs
@@ -135,7 +135,7 @@ namespace Nekoyume.Model.Item
 
         public Inventory(Bencodex.Types.List serialized) : this()
         {
-            _items.Capacity = serialized.Value.Length;
+            _items.Capacity = serialized.Count;
             foreach (IValue item in serialized)
             {
                 _items.Add(new Item((Bencodex.Types.Dictionary) item));

--- a/Lib9c/Model/Item/OrderLock.cs
+++ b/Lib9c/Model/Item/OrderLock.cs
@@ -22,8 +22,9 @@ namespace Nekoyume.Model.Item
             OrderId = serialized[1].ToGuid();
         }
 
-        public IValue Serialize() => new List()
-            .Add(Type.Serialize())
-            .Add(OrderId.Serialize());
+        public IValue Serialize() => new List(
+            Type.Serialize(),
+            OrderId.Serialize()
+        );
     }
 }

--- a/Lib9c/Model/State/ActivatedAccountsState.cs
+++ b/Lib9c/Model/State/ActivatedAccountsState.cs
@@ -50,16 +50,11 @@ namespace Nekoyume.Model.State
             Accounts = Accounts.Remove(account);
         }
 
-        public override IValue Serialize()
-        {
-            var values = new Dictionary<IKey, IValue>
-            {
-                [(Text)"accounts"] = Accounts.Select(a => a.Serialize()).Serialize()
-            };
-#pragma warning disable LAA1002
-            return new Dictionary(values.Union((Dictionary)base.Serialize()));
-#pragma warning restore LAA1002
-        }
+        public override IValue Serialize() =>
+            ((Dictionary)base.Serialize()).SetItem(
+                "accounts",
+                Accounts.Select(a => a.Serialize()).Serialize()
+            );
 
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {

--- a/Lib9c/Model/State/StateExtensions.cs
+++ b/Lib9c/Model/State/StateExtensions.cs
@@ -22,7 +22,7 @@ namespace Nekoyume.Model.State
         public static IValue Serialize<T>(Func<T, IValue> serializer, T? value)
             where T : struct
         {
-            return value is T v ? serializer(v) : default(Null);
+            return value is T v ? serializer(v) : Null.Value;
         }
 
         public static T? Deserialize<T>(Func<IValue, T> deserializer, IValue serialized)

--- a/Lib9c/Policy/BlockPolicy.cs
+++ b/Lib9c/Policy/BlockPolicy.cs
@@ -26,7 +26,7 @@ namespace Nekoyume.BlockChain.Policy
                 validateNextBlockTx = null,
             Func<BlockChain<NCAction>, Block<NCAction>, BlockPolicyViolationException>
                 validateNextBlock = null,
-            Func<long, int> getMaxBlockBytes = null,
+            Func<long, long> getMaxBlockBytes = null,
             Func<long, int> getMinTransactionsPerBlock = null,
             Func<long, int> getMaxTransactionsPerBlock = null,
             Func<long, int> getMaxTransactionsPerSignerPerBlock = null,

--- a/Lib9c/Policy/BlockPolicySource.Utils.cs
+++ b/Lib9c/Policy/BlockPolicySource.Utils.cs
@@ -8,6 +8,7 @@ using Libplanet.Blocks;
 using Libplanet.Tx;
 using Nekoyume.Action;
 using Nekoyume.Model.State;
+using static Libplanet.Blocks.BlockMarshaler;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
 namespace Nekoyume.BlockChain.Policy
@@ -76,17 +77,18 @@ namespace Nekoyume.BlockChain.Policy
 
         private static InvalidBlockBytesLengthException ValidateBlockBytesRaw(
             Block<NCAction> block,
-            IVariableSubPolicy<int> maxBlockBytesPolicy)
+            IVariableSubPolicy<long> maxBlockBytesPolicy)
         {
-            int maxBlockBytes = maxBlockBytesPolicy.Getter(block.Index);
+            long maxBlockBytes = maxBlockBytesPolicy.Getter(block.Index);
+            long blockBytes = block.MarshalBlock().EncodingLength;
 
-            if (block.BytesLength > maxBlockBytes)
+            if (blockBytes > maxBlockBytes)
             {
                 return new InvalidBlockBytesLengthException(
                     $"The size of block #{block.Index} {block.Hash} is too large " +
                     $"where the maximum number of bytes allowed is {maxBlockBytes}: " +
-                    $"{block.BytesLength}",
-                    block.BytesLength);
+                    $"{blockBytes}",
+                    blockBytes);
             }
 
             return null;

--- a/Lib9c/Policy/BlockPolicySource.cs
+++ b/Lib9c/Policy/BlockPolicySource.cs
@@ -139,7 +139,7 @@ namespace Nekoyume.BlockChain.Policy
         internal IBlockPolicy<NCAction> GetPolicy(
             long minimumDifficulty,
             IVariableSubPolicy<HashAlgorithmType> hashAlgorithmTypePolicy,
-            IVariableSubPolicy<int> maxBlockBytesPolicy,
+            IVariableSubPolicy<long> maxBlockBytesPolicy,
             IVariableSubPolicy<int> minTransactionsPerBlockPolicy,
             IVariableSubPolicy<int> maxTransactionsPerBlockPolicy,
             IVariableSubPolicy<int> maxTransactionsPerSignerPerBlockPolicy,
@@ -331,7 +331,7 @@ namespace Nekoyume.BlockChain.Policy
             BlockChain<NCAction> blockChain,
             Block<NCAction> nextBlock,
             IVariableSubPolicy<HashAlgorithmType> hashAlgorithmTypePolicy,
-            IVariableSubPolicy<int> maxBlockBytesPolicy,
+            IVariableSubPolicy<long> maxBlockBytesPolicy,
             IVariableSubPolicy<int> minTransactionsPerBlockPolicy,
             IVariableSubPolicy<int> maxTransactionsPerBlockPolicy,
             IVariableSubPolicy<int> maxTransactionsPerSignerPerBlockPolicy,

--- a/Lib9c/Policy/DebugPolicy.cs
+++ b/Lib9c/Policy/DebugPolicy.cs
@@ -35,7 +35,7 @@ namespace Nekoyume.BlockChain.Policy
             return blockChain.Count > 0 ? 1 : 0;
         }
 
-        public int GetMaxBlockBytes(long index) => int.MaxValue;
+        public long GetMaxBlockBytes(long index) => long.MaxValue;
 
         public HashAlgorithmType GetHashAlgorithm(long index) =>
             HashAlgorithmType.Of<SHA256>();

--- a/Lib9c/Policy/MaxBlockBytesPolicy.cs
+++ b/Lib9c/Policy/MaxBlockBytesPolicy.cs
@@ -4,61 +4,61 @@ using System.Linq;
 
 namespace Nekoyume.BlockChain.Policy
 {
-    public sealed class MaxBlockBytesPolicy : VariableSubPolicy<int>
+    public sealed class MaxBlockBytesPolicy : VariableSubPolicy<long>
     {
-        private MaxBlockBytesPolicy(int defaultValue)
+        private MaxBlockBytesPolicy(long defaultValue)
             : base(defaultValue)
         {
         }
 
         private MaxBlockBytesPolicy(
             MaxBlockBytesPolicy maxBlockBytesPolicy,
-            SpannedSubPolicy<int> spannedSubPolicy)
+            SpannedSubPolicy<long> spannedSubPolicy)
             : base(maxBlockBytesPolicy, spannedSubPolicy)
         {
         }
 
-        public static IVariableSubPolicy<int> Default =>
-            new MaxBlockBytesPolicy(int.MaxValue);
+        public static IVariableSubPolicy<long> Default =>
+            new MaxBlockBytesPolicy(long.MaxValue);
 
-        public static IVariableSubPolicy<int> Mainnet =>
+        public static IVariableSubPolicy<long> Mainnet =>
             Default
                 // Note: The genesis block of 9c-main weighs 11,085,640 B (11 MiB).
-                .Add(new SpannedSubPolicy<int>(
-                    startIndex: 0,
-                    value: 1024 * 1024 * 15))   // 15 MiB
+                .Add(new SpannedSubPolicy<long>(
+                    startIndex: 0L,
+                    value: 1024L * 1024L * 15L))   // 15 MiB
                 // Note: Initial analysis of the heaviest block of 9c-main
                 // (except for the genesis) weighs 58,408 B (58 KiB).
-                .Add(new SpannedSubPolicy<int>(
-                    startIndex: 1,
-                    value: 1024 * 100))         // 100 KiB
+                .Add(new SpannedSubPolicy<long>(
+                    startIndex: 1L,
+                    value: 1024L * 100L))         // 100 KiB
                 // Note: Temporary limit increase for resolving
                 // https://github.com/planetarium/NineChronicles/issues/777.
                 // Issued for v100081.  Temporary ad hoc increase was introduced
                 // around 2_500_000.
-                .Add(new SpannedSubPolicy<int>(
-                    startIndex: 2_000_001,
-                    value: 1024 * 1024 * 10))    // 10 MiB
+                .Add(new SpannedSubPolicy<long>(
+                    startIndex: 2_000_001L,
+                    value: 1024L * 1024L * 10L))    // 10 MiB
                 // Note: Reverting back to the previous limit.  Issued for v100086.
                 // FIXME: Starting index must be finalized accordingly before deployment.
-                .Add(new SpannedSubPolicy<int>(
-                    startIndex: 2_800_001,
-                    value: 1024 * 100));        // 100 KiB
+                .Add(new SpannedSubPolicy<long>(
+                    startIndex: 2_800_001L,
+                    value: 1024L * 100L));        // 100 KiB
 
         // Note: For internal testing.
-        public static IVariableSubPolicy<int> Internal =>
+        public static IVariableSubPolicy<long> Internal =>
             Default
-                .Add(new SpannedSubPolicy<int>(
-                    startIndex: 0,
-                    value: 1024 * 1024 * 15))   // 15 MiB
-                .Add(new SpannedSubPolicy<int>(
-                    startIndex: 1,
-                    value: 1024 * 100))         // 100 KiB
-                .Add(new SpannedSubPolicy<int>(
-                    startIndex: 2_000_001,
-                    value: 1024 * 1024 * 10))    // 10 MiB
-                .Add(new SpannedSubPolicy<int>(
+                .Add(new SpannedSubPolicy<long>(
+                    startIndex: 0L,
+                    value: 1024L * 1024L * 15L))   // 15 MiB
+                .Add(new SpannedSubPolicy<long>(
+                    startIndex: 1L,
+                    value: 1024L * 100L))         // 100 KiB
+                .Add(new SpannedSubPolicy<long>(
+                    startIndex: 2_000_001L,
+                    value: 1024L * 1024L * 10L))    // 10 MiB
+                .Add(new SpannedSubPolicy<long>(
                     startIndex: 2_800_001,
-                    value: 1024 * 100));        // 100 KiB
+                    value: 1024L * 100L));        // 100 KiB
     }
 }

--- a/Lib9c/TableData/Item/MaterialItemSheet.cs
+++ b/Lib9c/TableData/Item/MaterialItemSheet.cs
@@ -16,6 +16,7 @@ namespace Nekoyume.TableData
         [Serializable]
         public class Row : ItemSheet.Row, ISerializable
         {
+            private static readonly Codec _codec = new Codec();
             public HashDigest<SHA256> ItemId { get; private set; }
             public override ItemType ItemType => ItemType.Material;
 
@@ -23,7 +24,7 @@ namespace Nekoyume.TableData
 
             public Row(Bencodex.Types.Dictionary serialized) : base(serialized)
             {
-                ItemId = HashDigest<SHA256>.DeriveFrom(serialized.EncodeIntoChunks().SelectMany(b => b).ToArray());
+                ItemId = HashDigest<SHA256>.DeriveFrom(_codec.Encode(serialized));
             }
 
             protected Row(SerializationInfo info, StreamingContext context)
@@ -39,7 +40,7 @@ namespace Nekoyume.TableData
             public override void Set(IReadOnlyList<string> fields)
             {
                 base.Set(fields);
-                ItemId = HashDigest<SHA256>.DeriveFrom(Serialize().EncodeIntoChunks().SelectMany(b => b).ToArray());
+                ItemId = HashDigest<SHA256>.DeriveFrom(_codec.Encode(Serialize()));
             }
         }
 


### PR DESCRIPTION
This bump purposes to take advantage of performance improvements made from the recent (unreleased) changes of Bencodex.  See also:

- https://github.com/planetarium/libplanet/pull/1609
- https://github.com/planetarium/bencodex.net/pull/54
- https://github.com/planetarium/bencodex.net/pull/49