### PR TITLE
Use Libplanet 0.21.1 (instead of bleeding edge)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,15 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+    - run: |
+        set -e
+        pushd .Libplanet/
+        git fetch origin 'refs/tags/*:refs/tags/*'
+        if ! git describe --exact-match; then
+          echo "The unreleased Libplanet shouldn't be used." > /dev/stderr
+          exit 1
+        fi
+        popd
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:


### PR DESCRIPTION
Unreleased version of Libplanet shouldn't be used.  Instead, use the latest released version: <https://github.com/planetarium/libplanet/releases/tag/0.21.1>.