### PR TITLE
Fix a broken submodule check on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ name: main
 on:
   push:
     branches: []
+    tags: []
   pull_request:
     branches: []
 
@@ -13,7 +14,19 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    - run: |
+    - name: Check if .Libplanet refers to a tagged commit
+      if: |
+        github.event_name == 'push' && (
+          github.ref == 'refs/heads/main' ||
+          startsWith(github.ref, 'refs/heads/rc-') ||
+          startsWith(github.ref, 'refs/tags/')
+        ) ||
+        github.event_name == 'pull_request' && (
+          github.head_ref == 'refs/heads/main' ||
+          startsWith(github.head_ref, 'refs/heads/rc-') ||
+          startsWith(github.head_ref, 'refs/tags/')
+        )
+      run: |
         set -e
         pushd .Libplanet/
         git fetch origin 'refs/tags/*:refs/tags/*'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         set -e
         pushd .Libplanet/
         git fetch origin 'refs/tags/*:refs/tags/*'
-        if ! git describe --exact-match; then
+        if ! git describe --tags --exact-match; then
           echo "The unreleased Libplanet shouldn't be used." > /dev/stderr
           exit 1
         fi


### PR DESCRIPTION
This patch fixes two bugs of the *.Libplanet* submodule check on CI:

- It had disallowed *.Libplanet* to refer to an unsigned tag.  Now it is okay whether the tag is signed or not.

- It had checked if *.Libplanet* refers to a tagged commit even on the development branch.  However, as it is not convenient to make a new release of Libplanet to apply only a part of changes of unreleased Libplanet to Lib9c's development branch, now the check is skipped on the development branch.  It only runs on the main or rc- branches or tags.