### PR TITLE
Build on Apple Silicon (aarch64-apple-darwin)

### DIFF
--- a/.Lib9c.Benchmarks/Lib9c.Benchmarks.csproj
+++ b/.Lib9c.Benchmarks/Lib9c.Benchmarks.csproj
@@ -5,6 +5,12 @@
         <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
+    <PropertyGroup Condition="
+      '$([System.Runtime.InteropServices.RuntimeInformation]::
+        OSArchitecture.ToString())' == 'Arm64' ">
+      <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
+
     <ItemGroup>
       <ProjectReference Include="..\.Libplanet\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
       <ProjectReference Include="..\.Libplanet\Libplanet\Libplanet.csproj" />

--- a/.Lib9c.Tests/Action/RankingBattle0Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle0Test.cs
@@ -180,9 +180,9 @@ namespace Lib9c.Tests.Action
         [InlineData(1)]
         public void ExecuteThrowFailedLoadStateException(int caseIndex)
         {
-            Address signer;
-            Address avatarAddress;
-            Address enemyAddress;
+            Address signer = default;
+            Address avatarAddress = default;
+            Address enemyAddress = default;
 
             switch (caseIndex)
             {
@@ -293,7 +293,7 @@ namespace Lib9c.Tests.Action
         public void ExecuteThrowWeeklyArenaStateNotContainsAvatarAddressException(
             int caseIndex)
         {
-            Address targetAddress;
+            Address targetAddress = default;
             switch (caseIndex)
             {
                 case 0:

--- a/.Lib9c.Tests/Action/RankingBattle2Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle2Test.cs
@@ -176,9 +176,9 @@ namespace Lib9c.Tests.Action
         [InlineData(1)]
         public void ExecuteThrowFailedLoadStateException(int caseIndex)
         {
-            Address signer;
-            Address avatarAddress;
-            Address enemyAddress;
+            Address signer = default;
+            Address avatarAddress = default;
+            Address enemyAddress = default;
 
             switch (caseIndex)
             {
@@ -289,7 +289,7 @@ namespace Lib9c.Tests.Action
         public void ExecuteThrowWeeklyArenaStateNotContainsAvatarAddressException(
             int caseIndex)
         {
-            Address targetAddress;
+            Address targetAddress = default;
             switch (caseIndex)
             {
                 case 0:

--- a/.Lib9c.Tests/Action/RankingBattle3Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle3Test.cs
@@ -176,9 +176,9 @@ namespace Lib9c.Tests.Action
         [InlineData(1)]
         public void ExecuteThrowFailedLoadStateException(int caseIndex)
         {
-            Address signer;
-            Address avatarAddress;
-            Address enemyAddress;
+            Address signer = default;
+            Address avatarAddress = default;
+            Address enemyAddress = default;
 
             switch (caseIndex)
             {
@@ -289,7 +289,7 @@ namespace Lib9c.Tests.Action
         public void ExecuteThrowWeeklyArenaStateNotContainsAvatarAddressException(
             int caseIndex)
         {
-            Address targetAddress;
+            Address targetAddress = default;
             switch (caseIndex)
             {
                 case 0:

--- a/.Lib9c.Tests/Action/RankingBattle4Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle4Test.cs
@@ -209,9 +209,9 @@ namespace Lib9c.Tests.Action
         [InlineData(1)]
         public void ExecuteThrowFailedLoadStateException(int caseIndex)
         {
-            Address signer;
-            Address avatarAddress;
-            Address enemyAddress;
+            Address signer = default;
+            Address avatarAddress = default;
+            Address enemyAddress = default;
 
             switch (caseIndex)
             {

--- a/.Lib9c.Tests/Action/RankingBattle5Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle5Test.cs
@@ -239,9 +239,9 @@
         [InlineData(1)]
         public void ExecuteThrowFailedLoadStateException(int caseIndex)
         {
-            Address signer;
-            Address avatarAddress;
-            Address enemyAddress;
+            Address signer = default;
+            Address avatarAddress = default;
+            Address enemyAddress = default;
 
             switch (caseIndex)
             {

--- a/.Lib9c.Tests/Action/RankingBattle6Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle6Test.cs
@@ -239,9 +239,9 @@ namespace Lib9c.Tests.Action
         [InlineData(1)]
         public void ExecuteThrowFailedLoadStateException(int caseIndex)
         {
-            Address signer;
-            Address avatarAddress;
-            Address enemyAddress;
+            Address signer = default;
+            Address avatarAddress = default;
+            Address enemyAddress = default;
 
             switch (caseIndex)
             {

--- a/.Lib9c.Tests/Action/RankingBattle7Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle7Test.cs
@@ -239,9 +239,9 @@
         [InlineData(1)]
         public void ExecuteThrowFailedLoadStateException(int caseIndex)
         {
-            Address signer;
-            Address avatarAddress;
-            Address enemyAddress;
+            Address signer = default;
+            Address avatarAddress = default;
+            Address enemyAddress = default;
 
             switch (caseIndex)
             {

--- a/.Lib9c.Tests/Action/RankingBattle8Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle8Test.cs
@@ -278,9 +278,9 @@
         [InlineData(1)]
         public void ExecuteThrowFailedLoadStateException(int caseIndex)
         {
-            Address signer;
-            Address avatarAddress;
-            Address enemyAddress;
+            Address signer = default;
+            Address avatarAddress = default;
+            Address enemyAddress = default;
 
             switch (caseIndex)
             {

--- a/.Lib9c.Tests/Action/RankingBattleTest.cs
+++ b/.Lib9c.Tests/Action/RankingBattleTest.cs
@@ -278,9 +278,9 @@ namespace Lib9c.Tests.Action
         [InlineData(1)]
         public void ExecuteThrowFailedLoadStateException(int caseIndex)
         {
-            Address signer;
-            Address avatarAddress;
-            Address enemyAddress;
+            Address signer = default;
+            Address avatarAddress = default;
+            Address enemyAddress = default;
 
             switch (caseIndex)
             {

--- a/.Lib9c.Tests/Lib9c.Tests.csproj
+++ b/.Lib9c.Tests/Lib9c.Tests.csproj
@@ -6,9 +6,16 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CS0162;CS8032;CS0618;CS0612</NoWarn>
+    <NoWarn>$(NoWarn);CS0162;CS8032;CS0618;CS0612;SYSLIB0011</NoWarn>
     <CodeAnalysisRuleSet>.\Lib9c.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+
+  <PropertyGroup Condition="
+    '$([System.Runtime.InteropServices.RuntimeInformation]::
+      OSArchitecture.ToString())' == 'Arm64' ">
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
@@ -19,7 +26,7 @@
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />
     <PackageReference Include="System.IO.Abstractions" Version="12.2.6" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="12.2.6" />
-    
+
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>

--- a/.Lib9c.Tests/Model/State/WeeklyArenaStateTest.cs
+++ b/.Lib9c.Tests/Model/State/WeeklyArenaStateTest.cs
@@ -164,7 +164,7 @@ namespace Lib9c.Tests.Model.State
             int expectedCount)
         {
             var weeklyArenaState = new WeeklyArenaState(new PrivateKey().ToAddress());
-            Address targetAddress;
+            Address targetAddress = default;
             var characterSheet = new CharacterSheet();
             characterSheet.Set(_sheets[nameof(CharacterSheet)]);
             for (var i = 0; i < infoCount; i++)

--- a/.Lib9c.Tools.Tests/Lib9c.Tools.Tests.csproj
+++ b/.Lib9c.Tools.Tests/Lib9c.Tools.Tests.csproj
@@ -6,6 +6,12 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
+    <PropertyGroup Condition="
+      '$([System.Runtime.InteropServices.RuntimeInformation]::
+        OSArchitecture.ToString())' == 'Arm64' ">
+      <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/.Lib9c.Tools/Lib9c.Tools.csproj
+++ b/.Lib9c.Tools/Lib9c.Tools.csproj
@@ -6,6 +6,12 @@
         <AssemblyName>9c-tools</AssemblyName>
     </PropertyGroup>
 
+    <PropertyGroup Condition="
+      '$([System.Runtime.InteropServices.RuntimeInformation]::
+        OSArchitecture.ToString())' == 'Arm64' ">
+      <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
+
     <ItemGroup>
       <ProjectReference Include="..\.Libplanet\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
       <ProjectReference Include="..\Lib9c\Lib9c.csproj" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "3.1.400",
-    "rollForward": "patch"
+    "rollForward": "major"
   }
 }


### PR DESCRIPTION
This fixes MSBuild files and *global.json* so that the entire project can be built and tested using .NET 6 on Apple Silicon (aarch64-apple-darwin), commonly known as M1 series.  On other platforms/processors, it still uses .NET Core 3.1 SDK.

Note that .NET 6 disallows value types to be used without explicit assignment: [CS0165].  So I give explicit `default` values to unassigned variables.  (These changes don't affect their semantics.)

See also my other patches done the same thing:

- <https://github.com/planetarium/libplanet/pull/1635>
- <https://github.com/planetarium/rocksdb-sharp/pull/6>
- <https://github.com/planetarium/bencodex.net/commit/cea19a5aa27030c0c58bd22ab016c102b879d4fa>

[CS0165]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0165