### PR TITLE
Upgrade Libplanet to 0.23.0 & lazy-load only needed subtrees

### DIFF
--- a/.Lib9c.Tests/Action/HackAndSlash7Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash7Test.cs
@@ -7,6 +7,7 @@
     using System.Linq;
     using System.Runtime.Serialization.Formatters.Binary;
     using Bencodex.Types;
+    using Lib9c.Tests.Model;
     using Libplanet;
     using Libplanet.Action;
     using Libplanet.Crypto;
@@ -14,7 +15,6 @@
     using Nekoyume.Action;
     using Nekoyume.Battle;
     using Nekoyume.Model;
-    using Nekoyume.Model.BattleStatus;
     using Nekoyume.Model.Item;
     using Nekoyume.Model.Mail;
     using Nekoyume.Model.Quest;

--- a/.Lib9c.Tests/Action/HackAndSlash8Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash8Test.cs
@@ -7,6 +7,7 @@
     using System.Linq;
     using System.Runtime.Serialization.Formatters.Binary;
     using Bencodex.Types;
+    using Lib9c.Tests.Model;
     using Libplanet;
     using Libplanet.Action;
     using Libplanet.Crypto;
@@ -14,7 +15,6 @@
     using Nekoyume.Action;
     using Nekoyume.Battle;
     using Nekoyume.Model;
-    using Nekoyume.Model.BattleStatus;
     using Nekoyume.Model.Item;
     using Nekoyume.Model.Mail;
     using Nekoyume.Model.Quest;

--- a/.Lib9c.Tests/Action/HackAndSlash9Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash9Test.cs
@@ -7,6 +7,7 @@
     using System.Linq;
     using System.Runtime.Serialization.Formatters.Binary;
     using Bencodex.Types;
+    using Lib9c.Tests.Model;
     using Libplanet;
     using Libplanet.Action;
     using Libplanet.Crypto;

--- a/.Lib9c.Tests/Action/HackAndSlashTest.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashTest.cs
@@ -7,6 +7,7 @@ namespace Lib9c.Tests.Action
     using System.Linq;
     using System.Runtime.Serialization.Formatters.Binary;
     using Bencodex.Types;
+    using Lib9c.Tests.Model;
     using Libplanet;
     using Libplanet.Action;
     using Libplanet.Crypto;
@@ -292,7 +293,7 @@ namespace Lib9c.Tests.Action
             Assert.True(avatarState.worldInformation.IsStageCleared(stageId));
 
             var avatarWorldQuests = avatarState.questList.OfType<WorldQuest>().ToList();
-            Assert.Equal(worldQuestSheet.Count, avatarWorldQuests.Count);
+            Assert.Equal(worldQuestSheet.Count, avatarWorldQuests.Count());
             Assert.Empty(avatarState.questList.completedQuestIds);
             Assert.Equal(2, avatarState.inventory.Items.Count);
 
@@ -323,7 +324,7 @@ namespace Lib9c.Tests.Action
 
             avatarState = state.GetAvatarStateV2(avatarState.address);
             avatarWorldQuests = avatarState.questList.OfType<WorldQuest>().ToList();
-            Assert.Equal(worldQuestSheet.Count, avatarWorldQuests.Count);
+            Assert.Equal(worldQuestSheet.Count, avatarWorldQuests.Count());
             Assert.Single(avatarWorldQuests, e => e.Goal == stageId && e.Complete);
         }
 

--- a/.Lib9c.Tests/Lib9c.Tests.csproj
+++ b/.Lib9c.Tests/Lib9c.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>8.0</LangVersion>
     <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -17,6 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DiffPlex" Version="1.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />

--- a/.Lib9c.Tests/Model/QuestListExtensions.cs
+++ b/.Lib9c.Tests/Model/QuestListExtensions.cs
@@ -1,0 +1,17 @@
+namespace Lib9c.Tests.Model
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Nekoyume.Model.Quest;
+
+    public static class QuestListExtensions
+    {
+        public static IEnumerable<T> OfType<T>(this QuestList quests)
+            where T : Quest
+        =>
+            quests.EnumerateLazyQuestStates()
+                .Select(l => l.State)
+                .OfType<T>()
+                .OrderBy(q => q.Id);
+    }
+}

--- a/.Lib9c.Tests/Model/QuestListTest.cs
+++ b/.Lib9c.Tests/Model/QuestListTest.cs
@@ -23,25 +23,6 @@ namespace Lib9c.Tests.Model
             new UpdateListQuestsCountException("test"));
 
         [Fact]
-        public void GetEnumerator()
-        {
-            var list = new QuestList(
-                _tableSheets.QuestSheet,
-                _tableSheets.QuestRewardSheet,
-                _tableSheets.QuestItemRewardSheet,
-                _tableSheets.EquipmentItemRecipeSheet,
-                _tableSheets.EquipmentItemSubRecipeSheet
-            ).ToList();
-
-            for (var i = 0; i < list.Count - 1; i++)
-            {
-                var quest = list[i];
-                var next = list[i + 1];
-                Assert.True(quest.Id < next.Id);
-            }
-        }
-
-        [Fact]
         public void UpdateItemTypeCollectQuestDeterministic()
         {
             var expectedItemIds = new List<int>

--- a/.Lib9c.Tests/Model/State/LazyStateTest.cs
+++ b/.Lib9c.Tests/Model/State/LazyStateTest.cs
@@ -1,0 +1,128 @@
+namespace Lib9c.Tests.Model.State
+{
+    using System.Collections.Generic;
+    using Bencodex.Types;
+    using Lib9c.Tests.TestHelper;
+    using Libplanet;
+    using Nekoyume.Model.State;
+    using Xunit;
+    using LazySampleState = Nekoyume.Model.State.LazyState<
+        Lib9c.Tests.Model.State.LazyStateTest.SampleState,
+        Bencodex.Types.Dictionary
+    >;
+
+    public class LazyStateTest
+    {
+        private readonly Address _address;
+        private readonly SampleState _state;
+        private readonly Dictionary _serializedEncoding;
+        private readonly LazyState<SampleState, Dictionary> _loaded;
+        private readonly LazyState<SampleState, Dictionary> _unloaded;
+
+        public LazyStateTest()
+        {
+            _address = new Address("66eD03107F270d082AC1F71d8E50375f9372d8fC");
+            _state = new SampleState(_address, 123L, "hello");
+            _serializedEncoding = (Dictionary)_state.Serialize();
+            _loaded = new LazySampleState(_state);
+            _unloaded = new LazySampleState(_serializedEncoding, d => new SampleState(d));
+        }
+
+        [Fact]
+        public void State()
+        {
+            Assert.Same(_state, _loaded.State);
+            Assert.True(_loaded.GetStateOrSerializedEncoding(out _, out _));
+            Assert.False(_unloaded.GetStateOrSerializedEncoding(out _, out _));
+
+            var state = _unloaded.State;
+            Assert.Equal(123L, state.Foo);
+            Assert.Equal("hello", state.Bar);
+            Assert.True(_unloaded.GetStateOrSerializedEncoding(out _, out _));
+
+            Assert.Same(state, _unloaded.State);
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            _loaded.Serialize().ShouldBe(_serializedEncoding);
+            Assert.True(_loaded.GetStateOrSerializedEncoding(out _, out _));
+
+            Assert.Same(_serializedEncoding, _unloaded.Serialize());
+            Assert.False(_unloaded.GetStateOrSerializedEncoding(out _, out _));
+
+            _unloaded.State.Foo = 456L;
+            Assert.Equal(
+                456L,
+                (long)((Dictionary)_unloaded.Serialize()).GetValue<Integer>("foo")
+            );
+            Assert.True(_unloaded.GetStateOrSerializedEncoding(out _, out _));
+        }
+
+        [Fact]
+        public void LoadState()
+        {
+            Assert.Same(_state, LazySampleState.LoadState(_loaded));
+            Assert.True(_loaded.GetStateOrSerializedEncoding(out _, out _));
+            Assert.False(_unloaded.GetStateOrSerializedEncoding(out _, out _));
+
+            var state = LazySampleState.LoadState(_unloaded);
+            Assert.Equal(123L, state.Foo);
+            Assert.Equal("hello", state.Bar);
+            Assert.True(_unloaded.GetStateOrSerializedEncoding(out _, out _));
+
+            Assert.Same(state, LazySampleState.LoadState(_unloaded));
+        }
+
+        [Fact]
+        public void LoadStatePair()
+        {
+            var loadedPair = LazySampleState.LoadStatePair(KeyValuePair.Create('k', _loaded));
+            Assert.Equal('k', loadedPair.Key);
+            Assert.Same(_state, loadedPair.Value);
+            Assert.True(_loaded.GetStateOrSerializedEncoding(out _, out _));
+            Assert.False(_unloaded.GetStateOrSerializedEncoding(out _, out _));
+
+            var unloadedPair = LazySampleState.LoadStatePair(KeyValuePair.Create('K', _unloaded));
+            Assert.Equal('K', unloadedPair.Key);
+            Assert.Equal(123L, unloadedPair.Value.Foo);
+            Assert.Equal("hello", unloadedPair.Value.Bar);
+            Assert.True(_unloaded.GetStateOrSerializedEncoding(out _, out _));
+
+            var unloadedPair2 = LazySampleState.LoadStatePair(KeyValuePair.Create(2, _unloaded));
+            Assert.Equal(2, unloadedPair2.Key);
+            Assert.Same(unloadedPair.Value, unloadedPair2.Value);
+        }
+
+        public class SampleState : State
+        {
+            public SampleState(Address address, long foo, string bar)
+                : base(address)
+            {
+                Foo = foo;
+                Bar = bar;
+            }
+
+            public SampleState(Dictionary serialized)
+                : base(serialized)
+            {
+                Foo = serialized.GetValue<Integer>("foo");
+                Bar = serialized.GetValue<Text>("bar");
+            }
+
+            public SampleState(IValue iValue)
+                : this((Dictionary)iValue)
+            {
+            }
+
+            public long Foo { get; set; }
+
+            public string Bar { get; set; }
+
+            public override IValue Serialize() => ((Dictionary)base.Serialize())
+                .Add("foo", Foo)
+                .Add("bar", Bar);
+        }
+    }
+}

--- a/.Lib9c.Tests/TestHelper/BencodexHelper.cs
+++ b/.Lib9c.Tests/TestHelper/BencodexHelper.cs
@@ -1,0 +1,53 @@
+namespace Lib9c.Tests.TestHelper
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Bencodex.Types;
+    using DiffPlex.DiffBuilder;
+    using DiffPlex.DiffBuilder.Model;
+    using Xunit.Sdk;
+
+    public static class BencodexHelper
+    {
+        public static void ShouldBe(this IValue actual, IValue expected) =>
+            AssertEquals(expected, actual);
+
+        public static void AssertEquals(IValue expected, IValue actual)
+        {
+            bool equal = (expected is null && actual is null) ||
+                         (expected is Null && actual is Null) ||
+                         (expected is Bencodex.Types.Boolean && actual is Bencodex.Types.Boolean &&
+                          expected.Equals(actual)) ||
+                         (expected is Integer && actual is Integer && expected.Equals(actual)) ||
+                         (expected is Binary && actual is Binary && expected.Equals(actual)) ||
+                         (expected is Text && actual is Text && expected.Equals(actual)) ||
+                         (expected is List && actual is List && expected.Equals(actual)) ||
+                         (expected is Dictionary && actual is Dictionary && expected.Equals(actual));
+            if (equal)
+            {
+                return;
+            }
+
+            string expectedInspection = expected?.ToString() ?? "(null)";
+            string actualInspection = actual?.ToString() ?? "(null)";
+            DiffPaneModel diffModel = InlineDiffBuilder.Diff(expectedInspection, actualInspection);
+            var prefixes = new Dictionary<ChangeType, string>
+            {
+                [ChangeType.Deleted] = "-",
+                [ChangeType.Inserted] = "+",
+                [ChangeType.Unchanged] = " ",
+            };
+
+            string diff = string.Join(
+                Environment.NewLine,
+                diffModel.Lines.Select(line =>
+                    (prefixes.TryGetValue(line.Type, out string prefix) ? prefix : " ") + line.Text
+                )
+            );
+            throw new XunitException(
+                "Two Bencodex values are not equal.\n--- Expected\n+++ Actual\n\n" + diff
+            );
+        }
+    }
+}

--- a/.Lib9c.Tools/Lib9c.Tools.csproj
+++ b/.Lib9c.Tools/Lib9c.Tools.csproj
@@ -21,6 +21,7 @@
       <PackageReference Include="Cocona.Lite" Version="1.5.0" />
       <PackageReference Include="Serilog" Version="2.10.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
+      <PackageReference Include="Planetarium.RocksDbSharp" Version="6.2.4-planetarium" />
     </ItemGroup>
 
 </Project>

--- a/.Lib9c.Tools/Program.cs
+++ b/.Lib9c.Tools/Program.cs
@@ -6,6 +6,7 @@ namespace Lib9c.Tools
     [HasSubCommands(typeof(Account), Description = "Query about accounts.")]
     [HasSubCommands(typeof(Genesis), Description = "Manage genesis block.")]
     [HasSubCommands(typeof(Market), Description = "Query about market.")]
+    [HasSubCommands(typeof(State), Description = "Manage states.")]
     [HasSubCommands(typeof(Tx), Description = "Manage transactions.")]
     class Program
     {

--- a/.Lib9c.Tools/SubCommand/Account.cs
+++ b/.Lib9c.Tools/SubCommand/Account.cs
@@ -38,7 +38,7 @@ namespace Lib9c.Tools.SubCommand
         {
             using Logger logger = Utils.ConfigureLogger(verbose);
             TextWriter stderr = Console.Error;
-            (BlockChain<NCAction> chain, IStore store) =
+            (BlockChain<NCAction> chain, IStore store, _, _) =
                 Utils.GetBlockChain(logger, storePath, chainId);
 
             Block<NCAction> offset = Utils.ParseBlockOffset(chain, block);

--- a/.Lib9c.Tools/SubCommand/Market.cs
+++ b/.Lib9c.Tools/SubCommand/Market.cs
@@ -51,7 +51,7 @@ namespace Lib9c.Tools.SubCommand
         {
             using Logger logger = Utils.ConfigureLogger(verbose);
             TextWriter stderr = Console.Error;
-            (BlockChain<NCAction> chain, IStore store) =
+            (BlockChain<NCAction> chain, IStore store, _, _) =
                 Utils.GetBlockChain(logger, storePath, chainId);
 
             HashSet<ItemSubType> itemTypes = null;

--- a/.Lib9c.Tools/SubCommand/State.cs
+++ b/.Lib9c.Tools/SubCommand/State.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Security.Cryptography;
+using Cocona;
+using Libplanet;
+using Libplanet.Blockchain;
+using Libplanet.Blockchain.Policies;
+using Libplanet.Blocks;
+using Libplanet.Store;
+using Libplanet.Store.Trie;
+using Serilog.Core;
+using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
+
+namespace Lib9c.Tools.SubCommand
+{
+    public class State
+    {
+        [Command("Rebuild the entire states by executing the chain from the genesis.")]
+        public void Rebuild(
+            [Option('v', Description = "Print more logs.")]
+            bool verbose,
+            [Option('s', Description = "Path to the chain store.")]
+            string storePath,
+            [Option('c', Description = "Optional chain ID.  Default is the canonical chain ID.")]
+            Guid? chainId = null,
+            [Option(
+                't',
+                Description = "Optional topmost block to execute last.  Tip by default.")]
+            string topmost = null,
+            [Option('b', Description = "Bypass the state root hash check.")]
+            bool bypassStateRootHashCheck = false
+        )
+        {
+            using Logger logger = Utils.ConfigureLogger(verbose);
+            TextWriter stderr = Console.Error;
+            (
+                BlockChain<NCAction> chain,
+                IStore store,
+                IKeyValueStore stateKvStore,
+                IStateStore stateStore
+            ) = Utils.GetBlockChain(logger, storePath, chainId);
+            Block<NCAction> genesis = chain.Genesis;
+            Block<NCAction> tip = Utils.ParseBlockOffset(chain, topmost);
+
+            stderr.WriteLine("Clear the existing state store...");
+            foreach (byte[] key in stateKvStore.ListKeys())
+            {
+                stateKvStore.Delete(key);
+            }
+
+            stderr.WriteLine("It will execute all actions (tx actions & block actions)");
+            stderr.WriteLine(
+                "  ...from the block #{0} {1}",
+                "0".PadRight(tip.Index.ToString(CultureInfo.InvariantCulture).Length),
+                genesis.Hash);
+            stderr.WriteLine("    ...to the block #{0} {1}.", tip.Index, tip.Hash);
+
+            IBlockPolicy<NCAction> policy = chain.Policy;
+            (Block<NCAction>, string)? invalidStateRootHashBlock = null;
+            long totalBlocks = tip.Index + 1L;
+            long blocksExecuted = 0L;
+            long txsExecuted = 0L;
+            DateTimeOffset started = DateTimeOffset.Now;
+            foreach (BlockHash blockHash in chain.BlockHashes)
+            {
+                Block<NCAction> block =
+                    store.GetBlock<NCAction>(policy.GetHashAlgorithm, blockHash);
+                var preEvalBlock = new PreEvaluationBlock<NCAction>(
+                    block,
+                    block.HashAlgorithm,
+                    block.Nonce,
+                    block.PreEvaluationHash
+                );
+                stderr.WriteLine(
+                    "[{0}/{1}] Executing block #{2} {3}...",
+                    block.Index,
+                    tip.Index,
+                    block.Index,
+                    block.Hash
+                );
+                HashDigest<SHA256> stateRootHash = block.Index < 1
+                    ? preEvalBlock.DetermineStateRootHash(chain.Policy.BlockAction, stateStore)
+                    : preEvalBlock.DetermineStateRootHash(chain);
+                DateTimeOffset now = DateTimeOffset.Now;
+                if (invalidStateRootHashBlock is null && !stateRootHash.Equals(block.StateRootHash))
+                {
+                    string message =
+                        $"Unexpected state root hash for block #{block.Index} {block.Hash}.\n" +
+                        $"  Expected: {block.StateRootHash}\n  Actual:   {stateRootHash}";
+                    if (!bypassStateRootHashCheck)
+                    {
+                        throw new CommandExitedException(message, 1);
+                    }
+
+                    stderr.WriteLine(message);
+                    invalidStateRootHashBlock = (block, message);
+                }
+
+                blocksExecuted++;
+                txsExecuted += block.Transactions.Count;
+                TimeSpan elapsed = now - started;
+
+                if (blocksExecuted >= totalBlocks || block.Hash.Equals(tip.Hash))
+                {
+                    stderr.WriteLine("Elapsed: {0:c}.", elapsed);
+                    break;
+                }
+                else
+                {
+                    TimeSpan estimatedRemaining =
+                        elapsed / blocksExecuted * (totalBlocks - blocksExecuted);
+                    stderr.WriteLine(
+                        "Elapsed: {0:c}, estimated remaining: {1:c}.",
+                        elapsed,
+                        estimatedRemaining
+                    );
+                }
+            }
+
+            if (invalidStateRootHashBlock is { } b)
+            {
+                stderr.WriteLine(
+                    "Note that the state root hash check is bypassed, " +
+                    "but there was an invalid state root hash for block #{0} {1}.  {2}",
+                    b.Item1.Index,
+                    b.Item1.Hash,
+                    b.Item2
+                );
+            }
+
+            TimeSpan totalElapsed = DateTimeOffset.Now - started;
+            stderr.WriteLine("Total elapsed: {0:c}", totalElapsed);
+            stderr.WriteLine("Avg block execution time: {0:c}", totalElapsed / totalBlocks);
+            stderr.WriteLine("Avg tx execution time: {0:c}", totalElapsed / txsExecuted);
+        }
+    }
+}

--- a/.Lib9c.Tools/Utils.cs
+++ b/.Lib9c.Tools/Utils.cs
@@ -44,15 +44,15 @@ namespace Lib9c.Tools
         ) GetBlockChain(
             ILogger logger,
             string storePath,
-            Guid? chainId = null
+            Guid? chainId = null,
+            IKeyValueStore stateKeyValueStore = null
         )
         {
             var policySource = new BlockPolicySource(logger);
             IBlockPolicy<NCAction> policy = policySource.GetPolicy();
             IStagePolicy<NCAction> stagePolicy = new VolatileStagePolicy<NCAction>();
             IStore store = new RocksDBStore(storePath);
-            IKeyValueStore stateKeyValueStore =
-                new RocksDBKeyValueStore(Path.Combine(storePath, "states"));
+            stateKeyValueStore ??= new RocksDBKeyValueStore(Path.Combine(storePath, "states"));
             IStateStore stateStore = new TrieStateStore(stateKeyValueStore);
             Guid chainIdValue
                 = chainId ??

--- a/.Lib9c.Tools/Utils.cs
+++ b/.Lib9c.Tools/Utils.cs
@@ -36,7 +36,12 @@ namespace Lib9c.Tools
             return logConfig.CreateLogger();
         }
 
-        public static (BlockChain<NCAction> Chain, IStore Store) GetBlockChain(
+        public static (
+            BlockChain<NCAction> Chain,
+            IStore Store,
+            IKeyValueStore StateKVStore,
+            IStateStore StateStore
+        ) GetBlockChain(
             ILogger logger,
             string storePath,
             Guid? chainId = null
@@ -81,7 +86,7 @@ namespace Lib9c.Tools
                 stateStore,
                 genesis
             );
-            return (chain, store);
+            return (chain, store, stateKeyValueStore, stateStore);
         }
 
         public static Address ParseAddress(string address)

--- a/Lib9c/Action/Buy0.cs
+++ b/Lib9c/Action/Buy0.cs
@@ -206,13 +206,13 @@ namespace Nekoyume.Action
             sellerAvatarState.UpdateQuestRewards2(materialSheet);
 
             //Avoid InvalidBlockStateRootHashException to 50000 index.
-            if (sellerAvatarState.questList.Any(q => q.Complete && !q.IsPaidInAction))
+            if (sellerAvatarState.questList.UnpaidCompleteQuests.Any())
             {
                 var prevIds = sellerAvatarState.questList.completedQuestIds;
                 sellerAvatarState.UpdateQuestRewards(materialSheet);
                 sellerAvatarState.questList.completedQuestIds = prevIds;
             }
-            if (context.BlockIndex != 4742 && buyerAvatarState.questList.Any(q => q.Complete && !q.IsPaidInAction))
+            if (context.BlockIndex != 4742 && buyerAvatarState.questList.UnpaidCompleteQuests.Any())
             {
                 var prevIds = buyerAvatarState.questList.completedQuestIds;
                 buyerAvatarState.UpdateQuestRewards(materialSheet);

--- a/Lib9c/Action/CombinationEquipment0.cs
+++ b/Lib9c/Action/CombinationEquipment0.cs
@@ -218,7 +218,7 @@ namespace Nekoyume.Action
             avatarState.UpdateQuestRewards(materialSheet);
 
             //Avoid InvalidBlockStateRootHashException to 50000 index.
-            if (avatarState.questList.Any(q => q.Complete && !q.IsPaidInAction))
+            if (avatarState.questList.UnpaidCompleteQuests.Any())
             {
                 var prevIds = avatarState.questList.completedQuestIds;
                 avatarState.UpdateQuestRewards(materialSheet);

--- a/Lib9c/Action/HackAndSlash2.cs
+++ b/Lib9c/Action/HackAndSlash2.cs
@@ -218,7 +218,7 @@ namespace Nekoyume.Action
             avatarState.UpdateQuestRewards2(materialSheet);
 
             //Avoid InvalidBlockStateRootHashException to 50000 index.
-            if (avatarState.questList.Any(q => q.Complete && !q.IsPaidInAction))
+            if (avatarState.questList.UnpaidCompleteQuests.Any())
             {
                 var prevIds = avatarState.questList.completedQuestIds;
                 avatarState.UpdateQuestRewards(materialSheet);

--- a/Lib9c/Model/Item/Inventory.cs
+++ b/Lib9c/Model/Item/Inventory.cs
@@ -8,7 +8,6 @@ using Libplanet;
 using Nekoyume.Action;
 using Nekoyume.Battle;
 using Nekoyume.Model.State;
-using Nekoyume.TableData;
 using Serilog;
 
 namespace Nekoyume.Model.Item
@@ -23,21 +22,23 @@ namespace Nekoyume.Model.Item
         public class Item : IState, IComparer<Item>, IComparable<Item>
 #pragma warning restore S1210 // "Equals" and the comparison operators should be overridden when implementing "IComparable"
         {
-            public ItemBase item;
+            public LazyState<ItemBase, Dictionary> _item;
+            public ItemBase item => _item.State;
             public int count = 0;
             public ILock Lock;
             public bool Locked => !(Lock is null);
 
             public Item(ItemBase itemBase, int count = 1)
             {
-                item = itemBase;
+                _item = new LazyState<ItemBase, Dictionary>(itemBase);
                 this.count = count;
             }
 
             public Item(Bencodex.Types.Dictionary serialized)
             {
-                item = ItemFactory.Deserialize(
-                    (Bencodex.Types.Dictionary) serialized["item"]
+                _item = new LazyState<ItemBase, Dictionary>(
+                    (Bencodex.Types.Dictionary)serialized["item"],
+                    ItemFactory.Deserialize
                 );
                 count = (int) ((Integer) serialized["count"]).Value;
                 if (serialized.ContainsKey("l"))
@@ -98,7 +99,7 @@ namespace Nekoyume.Model.Item
             {
                 var innerDict = new Dictionary<IKey, IValue>
                 {
-                    [(Text) "item"] = item.Serialize(),
+                    [(Text) "item"] = _item.Serialize(),
                     [(Text) "count"] = (Integer) count,
                 };
                 if (Locked)

--- a/Lib9c/Model/Quest/Quest.cs
+++ b/Lib9c/Model/Quest/Quest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using Bencodex.Types;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
@@ -71,12 +72,12 @@ namespace Nekoyume.Model.Quest
 
         protected Quest(Dictionary serialized)
         {
-            Complete = ((Bencodex.Types.Boolean) serialized["complete"]).Value;
+            Complete = IsQuestComplete(serialized);
             Goal = (int) ((Integer) serialized["goal"]).Value;
             _current = (int) ((Integer) serialized["current"]).Value;
-            Id = (int) ((Integer) serialized["id"]).Value;
+            Id = GetQuestId(serialized);
             Reward = new QuestReward((Dictionary) serialized["reward"]);
-            IsPaidInAction = serialized["isPaidInAction"].ToNullableBoolean() ?? false;
+            IsPaidInAction = IsQuestPaidInAction(serialized);
         }
 
         public abstract string GetProgressText();
@@ -131,5 +132,17 @@ namespace Nekoyume.Model.Quest
         {
             return Deserialize((Dictionary) arg);
         }
+
+        public static int GetQuestId(Dictionary serialized) =>
+            serialized.GetValue<Integer>("id");
+
+        public static int GetQuestId(IValue serialized) =>
+            GetQuestId((Dictionary)serialized);
+
+        public static bool IsQuestComplete(Dictionary serialized) =>
+            serialized.GetValue<Bencodex.Types.Boolean>("complete");
+
+        public static bool IsQuestPaidInAction(Dictionary serialized) =>
+            serialized["isPaidInAction"].ToNullableBoolean() ?? false;
     }
 }

--- a/Lib9c/Model/Quest/QuestReward.cs
+++ b/Lib9c/Model/Quest/QuestReward.cs
@@ -2,40 +2,68 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.Serialization;
+using Bencodex;
 using Bencodex.Types;
 using Nekoyume.Model.State;
 
 namespace Nekoyume.Model.Quest
 {
     [Serializable]
-    public class QuestReward : IState
+    public class QuestReward : IState, ISerializable
     {
-        public readonly Dictionary<int, int> ItemMap;
+        private static Codec _codec = new Codec();
+        private Dictionary _serialized;
+        private Dictionary<int, int> _itemMap;
 
         public QuestReward(Dictionary<int, int> map)
         {
-            ItemMap = map
+            _itemMap = map
                 .ToDictionary(kv => kv.Key, kv => kv.Value
             );
         }
 
         public QuestReward(Dictionary serialized)
         {
-            ItemMap = serialized.ToDictionary(
-                kv => kv.Key.ToInteger(),
-                kv => kv.Value.ToInteger()
-            );
+            _serialized = serialized;
         }
 
-        public IValue Serialize() => new Dictionary(
+        private QuestReward(SerializationInfo info, StreamingContext context)
+            : this((Dictionary)_codec.Decode((byte[])info.GetValue("serialized", typeof(byte[]))))
+        {
+        }
+
+        public Dictionary<int, int> ItemMap
+        {
+            get
+            {
+                if (_itemMap is null)
+                {
+                    _itemMap = _serialized.ToDictionary(
+                        kv => kv.Key.ToInteger(),
+                        kv => kv.Value.ToInteger()
+                    );
+                    _serialized = null;
+                }
+
+                return _itemMap;
+            }
+        }
+
+        public IValue Serialize() => _serialized ?? new Dictionary(
 #pragma warning disable LAA1002
-            ItemMap.Select(kv =>
+            _itemMap.Select(kv =>
+#pragma warning restore LAA1002
                 new KeyValuePair<IKey, IValue>(
                     (Text)kv.Key.ToString(CultureInfo.InvariantCulture),
                     (Text)kv.Value.ToString(CultureInfo.InvariantCulture)
                 )
             )
-#pragma warning restore LAA1002
         );
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue("serialized", _codec.Encode(Serialize()));
+        }
     }
 }

--- a/Lib9c/Model/State/ArenaInfo.cs
+++ b/Lib9c/Model/State/ArenaInfo.cs
@@ -90,7 +90,7 @@ namespace Nekoyume.Model.State
             Level = serialized.GetInteger("level");
             ArmorId = serialized.GetInteger("armorId");
             CombatPoint = serialized.GetInteger("combatPoint");
-            Active = serialized.GetBoolean("active");
+            Active = IsActive(serialized);
             DailyChallengeCount = serialized.GetInteger("dailyChallengeCount");
             Score = serialized.GetInteger("score");
             Receive = serialized["receive"].ToBoolean();
@@ -258,5 +258,8 @@ namespace Nekoyume.Model.State
 
             return 1;
         }
+
+        public static bool IsActive(Dictionary serialized) =>
+            serialized.GetBoolean("active");
     }
 }

--- a/Lib9c/Model/State/AvatarState.cs
+++ b/Lib9c/Model/State/AvatarState.cs
@@ -517,7 +517,7 @@ namespace Nekoyume.Model.State
         public void UpdateQuestRewards(MaterialItemSheet materialItemSheet)
         {
             var completedQuests = questList
-                .Where(quest => quest.Complete && !quest.IsPaidInAction)
+                .UnpaidCompleteQuests
                 .ToList();
             // 완료되었지만 보상을 받지 않은 퀘스트를 return 문에서 Select 하지 않고 미리 저장하는 이유는
             // 지연된 실행에 의해, return 시점에서 이미 모든 퀘스트의 보상 처리가 완료된 상태에서
@@ -535,7 +535,7 @@ namespace Nekoyume.Model.State
         public void UpdateQuestRewards2(MaterialItemSheet materialItemSheet)
         {
             var completedQuests = questList
-                .Where(quest => quest.Complete && !quest.IsPaidInAction)
+                .UnpaidCompleteQuests
                 .ToList();
             // 완료되었지만 보상을 받지 않은 퀘스트를 return 문에서 Select 하지 않고 미리 저장하는 이유는
             // 지연된 실행에 의해, return 시점에서 이미 모든 퀘스트의 보상 처리가 완료된 상태에서

--- a/Lib9c/Model/State/LazyState.cs
+++ b/Lib9c/Model/State/LazyState.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Bencodex.Types;
+
+namespace Nekoyume.Model.State
+{
+    [Serializable]
+    public sealed class LazyState<TState, TEncoding> : IState, ISerializable
+        where TState : IState
+        where TEncoding : IValue
+    {
+        private TEncoding _serialized;
+        private Func<TEncoding, TState> _loader;
+        private TState _loaded;
+
+        public LazyState(TState loadedValue)
+        {
+            _loaded = loadedValue;
+        }
+
+        public LazyState(TEncoding serialized, Func<TEncoding, TState> loader)
+        {
+            _serialized = serialized;
+            _loader = loader;
+        }
+
+        private LazyState(SerializationInfo info, StreamingContext context)
+        {
+            _loaded = (TState)info.GetValue(nameof(State), typeof(TState));
+        }
+
+        public TState State
+        {
+            get
+            {
+                if (_loaded == null)
+                {
+                    _loaded = _loader(_serialized);
+                    _serialized = default;
+                    _loader = null;
+                }
+
+                return _loaded;
+            }
+        }
+
+        public bool GetStateOrSerializedEncoding(out TState loadedState, out TEncoding serialized)
+        {
+            if (_loaded == null)
+            {
+                loadedState = default;
+                serialized = _serialized;
+                return false;
+            }
+
+            loadedState = _loaded;
+            serialized = default;
+            return true;
+        }
+
+        public IValue Serialize() =>
+            GetStateOrSerializedEncoding(out TState loaded, out TEncoding serialized)
+                ? loaded.Serialize()
+                : serialized;
+
+        public static TState LoadState(LazyState<TState, TEncoding> lazyState) =>
+            lazyState.State;
+
+        public static KeyValuePair<T, TState> LoadStatePair<T>(
+            KeyValuePair<T, LazyState<TState, TEncoding>> lazyPair
+        ) =>
+            new KeyValuePair<T, TState>(lazyPair.Key, lazyPair.Value.State);
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue(nameof(State), State);
+        }
+    }
+}

--- a/Lib9c/Model/State/RankingState.cs
+++ b/Lib9c/Model/State/RankingState.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.Serialization;
+using Bencodex;
 using Bencodex.Types;
 using Libplanet;
 using Nekoyume.Action;
@@ -9,28 +11,51 @@ using Nekoyume.Action;
 namespace Nekoyume.Model.State
 {
     [Serializable]
-    public class RankingState : State
+    public class RankingState : State, ISerializable
     {
+        private static readonly Codec _codec = new Codec();
         public static readonly Address Address = Addresses.Ranking;
         public const int RankingMapCapacity = 100;
-        public readonly Dictionary<Address, ImmutableHashSet<Address>> RankingMap;
+        private Dictionary<Address, ImmutableHashSet<Address>> _rankingMap;
+        private Dictionary _serialized;
 
         public RankingState() : base(Address)
         {
-            RankingMap = new Dictionary<Address, ImmutableHashSet<Address>>();
+            _rankingMap = new Dictionary<Address, ImmutableHashSet<Address>>();
             for (var i = 0; i < RankingMapCapacity; i++)
             {
-                RankingMap[Derive(i)] = new HashSet<Address>().ToImmutableHashSet();
+                _rankingMap[Derive(i)] = ImmutableHashSet<Address>.Empty;
             }
         }
 
         public RankingState(Dictionary serialized)
             : base(serialized)
         {
-            RankingMap = ((Dictionary) serialized["ranking_map"]).ToDictionary(
-                kv => kv.Key.ToAddress(),
-                kv => kv.Value.ToList(StateExtensions.ToAddress).ToImmutableHashSet()
-            );
+            _serialized = serialized;
+        }
+
+        public RankingState(SerializationInfo info, StreamingContext context)
+            : this((Dictionary)_codec.Decode(
+                (byte[])info.GetValue(nameof(_serialized), typeof(byte[]))
+            ))
+        {
+        }
+
+        public Dictionary<Address, ImmutableHashSet<Address>> RankingMap
+        {
+            get
+            {
+                if (_rankingMap is null)
+                {
+                    _rankingMap = _serialized.GetValue<Dictionary>("ranking_map").ToDictionary(
+                        kv => kv.Key.ToAddress(),
+                        kv => kv.Value.ToImmutableHashSet(StateExtensions.ToAddress)
+                    );
+                    _serialized = null;
+                }
+
+                return _rankingMap;
+            }
         }
 
         public static Address Derive(int index)
@@ -53,18 +78,22 @@ namespace Nekoyume.Model.State
             throw new RankingExceededException();
         }
 
-        public override IValue Serialize()
-        {
+        public override IValue Serialize() => _serialized ??
+            ((Dictionary)base.Serialize()).Add(
+                "ranking_map",
 #pragma warning disable LAA1002
-            var rankingMapValue = new Bencodex.Types.Dictionary(RankingMap.Select(pair =>
+                new Dictionary(RankingMap.Select(kv =>
 #pragma warning restore LAA1002
-                new KeyValuePair<IKey, IValue>(
-                    (Bencodex.Types.Binary)pair.Key.Serialize(),
-                    new Bencodex.Types.List(pair.Value
-                        .OrderBy(e => e.GetHashCode())
-                        .Select(e => e.Serialize())))));
-            return ((Bencodex.Types.Dictionary)base.Serialize())
-                .SetItem("ranking_map", rankingMapValue);
-        }
+                    new KeyValuePair<IKey, IValue>(
+                        (IKey)kv.Key.Serialize(),
+                        new List(kv.Value
+                            .OrderBy(v => v.GetHashCode())
+                            .Select(StateExtensions.Serialize))
+                    )
+                ))
+            );
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context) =>
+            info.AddValue(nameof(_serialized), _codec.Encode(Serialize()));
     }
 }

--- a/Lib9c/Model/State/StateExtensions.cs
+++ b/Lib9c/Model/State/StateExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
@@ -56,6 +57,11 @@ namespace Nekoyume.Model.State
         {
             return new HashSet<T>(serialized.ToEnumerable(deserializer));
         }
+
+        public static ImmutableHashSet<T> ToImmutableHashSet<T>(
+            this IValue serialized,
+            Func<IValue, T> deserializer
+        ) => serialized.ToEnumerable(deserializer).ToImmutableHashSet();
 
         #region Address
 


### PR DESCRIPTION
To utilize [Libplanet's recent optimization](https://github.com/planetarium/libplanet/pull/1636) which enables offloading and lazy-loading of fragmented states, I added `LazyState<TState, TEncoding>` and applied it to several model types:

- `CollectionMap`
- `RankingState`
- `WeeklyArenaState`
- `Inventory.Item`[^1]
- `WorldInformation`
- `QuestList`

It's just my first try, and I'm going to work on further optimization later.

I wanted to make it faster to execute actions, but there was no change time-wise (it's neither slower though).  Instead, it became to take much less disk space: 1.35 GB → 436 MB for about 20,000 blocks.[^2]

[^1]: I tried to work on the entire `Inventory` type, but it's quite complex to change things in it without breaking backward compatibility.
[^2]: blocks \#0 `4582250d`–[\#20000 `dc29c0d6`](https://9cscan.com/blocks/dc29c0d623a26a22427eb1645b5ed7498bd90a09a32d7d536a034cfc1a0b0767) on 9c-mainnet; about 3 days.