### PR TITLE
feat: introduce `RenewAdminState` action

### DIFF
--- a/.Lib9c.Tests/Action/RenewAdminStateTest.cs
+++ b/.Lib9c.Tests/Action/RenewAdminStateTest.cs
@@ -1,0 +1,48 @@
+namespace Lib9c.Tests.Action
+{
+    using System;
+    using System.Collections.Immutable;
+    using Bencodex.Types;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Crypto;
+    using Nekoyume;
+    using Nekoyume.Action;
+    using Nekoyume.Model.State;
+    using Xunit;
+
+    public class RenewAdminStateTest
+    {
+        private IAccountStateDelta _stateDelta;
+        private long _validUntil;
+        private AdminState _adminState;
+        private PrivateKey _adminPrivateKey;
+
+        public RenewAdminStateTest()
+        {
+            _adminPrivateKey = new PrivateKey();
+            _validUntil = new Random().Next();
+            _adminState = new AdminState(_adminPrivateKey.ToAddress(), _validUntil);
+            _stateDelta =
+                new State(ImmutableDictionary<Address, IValue>.Empty.Add(
+                    Addresses.Admin,
+                    _adminState.Serialize()));
+        }
+
+        [Fact]
+        public void Execute()
+        {
+            var newValidUntil = _validUntil + 1000;
+            var action = new RenewAdminState(newValidUntil);
+            var stateDelta = action.Execute(new ActionContext
+            {
+                PreviousStates = _stateDelta,
+                Signer = _adminPrivateKey.ToAddress(),
+            });
+
+            var adminState = new AdminState((Bencodex.Types.Dictionary)stateDelta.GetState(Addresses.Admin));
+            Assert.Equal(newValidUntil, adminState.ValidUntil);
+            Assert.NotEqual(_validUntil, adminState.ValidUntil);
+        }
+    }
+}

--- a/.Lib9c.Tests/Action/RenewAdminStateTest.cs
+++ b/.Lib9c.Tests/Action/RenewAdminStateTest.cs
@@ -60,5 +60,22 @@ namespace Lib9c.Tests.Action
                 });
             });
         }
+
+        [Fact]
+        public void RenewAdminStateEvenAlreadyExpired()
+        {
+            var newValidUntil = _validUntil + 1000;
+            var action = new RenewAdminState(newValidUntil);
+            var stateDelta = action.Execute(new ActionContext
+            {
+                BlockIndex = _validUntil + 1,
+                PreviousStates = _stateDelta,
+                Signer = _adminPrivateKey.ToAddress(),
+            });
+
+            var adminState = new AdminState((Bencodex.Types.Dictionary)stateDelta.GetState(Addresses.Admin));
+            Assert.Equal(newValidUntil, adminState.ValidUntil);
+            Assert.NotEqual(_validUntil, adminState.ValidUntil);
+        }
     }
 }

--- a/.Lib9c.Tests/Action/RenewAdminStateTest.cs
+++ b/.Lib9c.Tests/Action/RenewAdminStateTest.cs
@@ -44,5 +44,21 @@ namespace Lib9c.Tests.Action
             Assert.Equal(newValidUntil, adminState.ValidUntil);
             Assert.NotEqual(_validUntil, adminState.ValidUntil);
         }
+
+        [Fact]
+        public void RejectSignerExceptAdminAddress()
+        {
+            var newValidUntil = _validUntil + 1000;
+            var action = new RenewAdminState(newValidUntil);
+            Assert.Throws<PermissionDeniedException>(() =>
+            {
+                var userPrivateKey = new PrivateKey();
+                action.Execute(new ActionContext
+                {
+                    PreviousStates = _stateDelta,
+                    Signer = userPrivateKey.ToAddress(),
+                });
+            });
+        }
     }
 }

--- a/.Lib9c.Tools/SubCommand/Tx.cs
+++ b/.Lib9c.Tools/SubCommand/Tx.cs
@@ -88,6 +88,7 @@ namespace Lib9c.Tools.SubCommand
                         nameof(Nekoyume.Action.MigrationActivatedAccountsState) => new MigrationActivatedAccountsState(),
                         nameof(Nekoyume.Action.MigrationAvatarState) => new MigrationAvatarState(),
                         nameof(Nekoyume.Action.CreatePendingActivations) => new CreatePendingActivations(),
+                        nameof(Nekoyume.Action.RenewAdminState) => new RenewAdminState(),
                         _ => throw new CommandExitedException($"Can't determine given action type: {type}", 128),
                     };
                     action.LoadPlainValue(plainValue);
@@ -258,8 +259,12 @@ namespace Lib9c.Tools.SubCommand
             long newValidUntil
         )
         {
-            PolymorphicAction<ActionBase> action = new RenewAdminState(newValidUntil);
-            byte[] raw = _codec.Encode(action.PlainValue);
+            RenewAdminState action = new RenewAdminState(newValidUntil);
+            var encoded = new List(
+                (Text) nameof(Nekoyume.Action.RenewAdminState),
+                action.PlainValue
+            );
+            byte[] raw = _codec.Encode(encoded);
             Console.WriteLine(ByteUtil.Hex(raw));
         }
     }

--- a/.Lib9c.Tools/SubCommand/Tx.cs
+++ b/.Lib9c.Tools/SubCommand/Tx.cs
@@ -252,8 +252,11 @@ namespace Lib9c.Tools.SubCommand
             Console.WriteLine(ByteUtil.Hex(raw));
         }
 
-        [Command("Create RenewAdminState action and dump it.")]
-        public void RenewAdminState(long newValidUntil)
+        [Command(Description = "Create RenewAdminState action and dump it.")]
+        public void RenewAdminState(
+            [Argument("NEW-VALID-UNTIL")]
+            long newValidUntil
+        )
         {
             PolymorphicAction<ActionBase> action = new RenewAdminState(newValidUntil);
             byte[] raw = _codec.Encode(action.PlainValue);

--- a/.Lib9c.Tools/SubCommand/Tx.cs
+++ b/.Lib9c.Tools/SubCommand/Tx.cs
@@ -15,6 +15,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using Libplanet.Action;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
 namespace Lib9c.Tools.SubCommand
@@ -248,6 +249,14 @@ namespace Lib9c.Tools.SubCommand
                }
            );
             byte[] raw = _codec.Encode(encoded);
+            Console.WriteLine(ByteUtil.Hex(raw));
+        }
+
+        [Command("Create RenewAdminState action and dump it.")]
+        public void RenewAdminState(long newValidUntil)
+        {
+            PolymorphicAction<ActionBase> action = new RenewAdminState(newValidUntil);
+            byte[] raw = _codec.Encode(action.PlainValue);
             Console.WriteLine(ByteUtil.Hex(raw));
         }
     }

--- a/Lib9c/Action/RenewAdminState.cs
+++ b/Lib9c/Action/RenewAdminState.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Bencodex.Types;
+using Libplanet.Action;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Action
+{
+    [Serializable]
+    [ActionType("renew_admin_state")]
+    public class RenewAdminState : GameAction
+    {
+        private const string NewValidUntilKey = "new_valid_until";
+        public long NewValidUntil {get; internal set; }
+
+        public RenewAdminState()
+        {
+        }
+
+        public RenewAdminState(long newValidUntil)
+        {
+            NewValidUntil = newValidUntil;
+        }
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            var states = context.PreviousStates;
+            if (context.Rehearsal)
+            {
+                return states
+                    .SetState(Addresses.Admin, MarkChanged);
+            }
+
+            CheckPermission(context);
+
+            if (TryGetAdminState(context, out AdminState adminState))
+            {
+                var newAdminState = new AdminState(adminState.AdminAddress, NewValidUntil);
+                states = states.SetState(Addresses.Admin,
+                    newAdminState.Serialize());
+            }
+
+            return states;
+        }
+
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            new Dictionary<string, IValue>
+            {
+                [NewValidUntilKey] = (Integer)NewValidUntil,
+            }.ToImmutableDictionary();
+
+        protected override void LoadPlainValueInternal(IImmutableDictionary<string, IValue> plainValue)
+        {
+            NewValidUntil = plainValue[NewValidUntilKey].ToLong();
+        }
+    }
+}

--- a/Lib9c/Action/RenewAdminState.cs
+++ b/Lib9c/Action/RenewAdminState.cs
@@ -32,10 +32,13 @@ namespace Nekoyume.Action
                     .SetState(Addresses.Admin, MarkChanged);
             }
 
-            CheckPermission(context);
-
             if (TryGetAdminState(context, out AdminState adminState))
             {
+                if (context.Signer != adminState.AdminAddress)
+                {
+                    throw new PermissionDeniedException(adminState, context.Signer);
+                }
+
                 var newAdminState = new AdminState(adminState.AdminAddress, NewValidUntil);
                 states = states.SetState(Addresses.Admin,
                     newAdminState.Serialize());


### PR DESCRIPTION
## Background

The `AdminState` will be soon expired after the 3153600 block number. When the `AdminState` was expired, some actions like `PatchTableSheet` and `CreatePendingAccount` will not work. But the Proof-of-Stake or other system is not built yet.

## Description

So this pull request introduces `RenewAdminState` action which renew `AdminState.ValidUntil` field. It requires Admin permission so it should be executed before the block 3153600.