### PR TITLE
test: create pending activations with renew admin state

### DIFF
--- a/.Lib9c.Tests/Action/RenewAdminStateTest.cs
+++ b/.Lib9c.Tests/Action/RenewAdminStateTest.cs
@@ -87,5 +87,51 @@ namespace Lib9c.Tests.Action
 
             Assert.True(newAction.PlainValue.Equals(action.PlainValue));
         }
+
+        [Fact]
+        public void CreatePendingActivationsAfterRenewAdminState()
+        {
+            var random = new Random();
+            var nonce = new byte[40];
+            random.NextBytes(nonce);
+            var privateKey = new PrivateKey();
+
+            var createPendingActivations = new CreatePendingActivations(new[]
+            {
+                new PendingActivationState(nonce, privateKey.PublicKey),
+            });
+
+            long blockIndex = _validUntil + 1;
+            Assert.Throws<PolicyExpiredException>(() => createPendingActivations.Execute(new ActionContext
+            {
+                BlockIndex = blockIndex,
+                PreviousStates = _stateDelta,
+                Signer = _adminPrivateKey.ToAddress(),
+            }));
+
+            var newValidUntil = _validUntil + 1000;
+            var action = new RenewAdminState(newValidUntil);
+            var stateDelta = action.Execute(new ActionContext
+            {
+                BlockIndex = blockIndex,
+                PreviousStates = _stateDelta,
+                Signer = _adminPrivateKey.ToAddress(),
+            });
+
+            // After 100 blocks.
+            blockIndex += 100;
+
+            Assert.True(blockIndex < newValidUntil);
+            stateDelta = createPendingActivations.Execute(new ActionContext
+            {
+                BlockIndex = blockIndex,
+                PreviousStates = stateDelta,
+                Signer = _adminPrivateKey.ToAddress(),
+            });
+
+            Address expectedPendingActivationStateAddress =
+                PendingActivationState.DeriveAddress(nonce, privateKey.PublicKey);
+            Assert.NotNull(stateDelta.GetState(expectedPendingActivationStateAddress));
+        }
     }
 }


### PR DESCRIPTION
This pull request adds a test to simulate creating pending activations as the admin does.