### PR TITLE
Optimize miner to append block

### DIFF
--- a/Lib9c/Miner.cs
+++ b/Lib9c/Miner.cs
@@ -82,10 +82,9 @@ namespace Nekoyume.BlockChain
                     _privateKey,
                     DateTimeOffset.UtcNow,
                     cancellationToken: cancellationToken,
-                    append: false,
+                    append: true,
                     txPriority: txPriority);
 
-                _chain.Append(block);
                 if (_swarm is Swarm<NCAction> s && s.Running)
                 {
                     s.BroadcastBlock(block);


### PR DESCRIPTION
Originally, `Miner` mined block and append it in two steps. But `BlockChain<T>.MineBlock()` supports to append block in once to avoid evaluating actions again.