### PR TITLE
Conditional serialize avatar in RankingBattle

### DIFF
--- a/.Lib9c.Tests/Action/AccountStateDeltaExtensionsTest.cs
+++ b/.Lib9c.Tests/Action/AccountStateDeltaExtensionsTest.cs
@@ -142,7 +142,8 @@ namespace Lib9c.Tests.Action
                     .SetState(_avatarAddress.Derive(LegacyQuestListKey), _avatarState.questList.Serialize());
             }
 
-            Assert.True(states.TryGetAvatarStateV2(_agentAddress, _avatarAddress, out _));
+            Assert.True(states.TryGetAvatarStateV2(_agentAddress, _avatarAddress, out _, out bool migrationRequired));
+            Assert.Equal(backward, migrationRequired);
         }
 
         [Theory]

--- a/.Lib9c.Tests/Action/RankingBattleTest.cs
+++ b/.Lib9c.Tests/Action/RankingBattleTest.cs
@@ -3,14 +3,10 @@ namespace Lib9c.Tests.Action
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
-    using System.IO;
     using System.Linq;
-    using System.Runtime.Serialization.Formatters.Binary;
-    using Bencodex.Types;
     using Libplanet;
     using Libplanet.Action;
     using Libplanet.Crypto;
-    using MessagePack;
     using Nekoyume;
     using Nekoyume.Action;
     using Nekoyume.Battle;
@@ -156,6 +152,7 @@ namespace Lib9c.Tests.Action
             var enemyAvatarState = _initialState.GetAvatarState(_avatar2Address);
             enemyAvatarState.inventory.AddItem(enemyCostume);
 
+            Address worldInformationAddress = _avatar1Address.Derive(LegacyWorldInformationKey);
             if (avatarBackward)
             {
                 previousState =
@@ -168,7 +165,7 @@ namespace Lib9c.Tests.Action
                         _avatar1Address.Derive(LegacyInventoryKey),
                         previousAvatar1State.inventory.Serialize())
                     .SetState(
-                        _avatar1Address.Derive(LegacyWorldInformationKey),
+                        worldInformationAddress,
                         previousAvatar1State.worldInformation.Serialize())
                     .SetState(
                         _avatar1Address.Derive(LegacyQuestListKey),
@@ -245,6 +242,9 @@ namespace Lib9c.Tests.Action
             Assert.Equal(result.score, log.score);
             Assert.Equal(result.Count, log.Count);
             Assert.Equal(result.result, log.result);
+
+            Assert.Equal(previousAvatar1State.SerializeV2(), nextAvatar1State.SerializeV2());
+            Assert.Equal(previousAvatar1State.worldInformation.Serialize(), nextAvatar1State.worldInformation.Serialize());
         }
 
         [Fact]

--- a/Lib9c/Action/AccountStateDeltaExtensions.cs
+++ b/Lib9c/Action/AccountStateDeltaExtensions.cs
@@ -241,10 +241,12 @@ namespace Nekoyume.Action
             this IAccountStateDelta states,
             Address agentAddress,
             Address avatarAddress,
-            out AvatarState avatarState
+            out AvatarState avatarState,
+            out bool migrationRequired
         )
         {
             avatarState = null;
+            migrationRequired = false;
             if (states.GetState(avatarAddress) is Dictionary serializedAvatar)
             {
                 try
@@ -262,6 +264,7 @@ namespace Nekoyume.Action
                     // BackWardCompatible.
                     if (e is KeyNotFoundException || e is FailedLoadStateException)
                     {
+                        migrationRequired = true;
                         return states.TryGetAvatarState(agentAddress, avatarAddress, out avatarState);
                     }
 

--- a/Lib9c/Action/Buy.cs
+++ b/Lib9c/Action/Buy.cs
@@ -103,7 +103,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}Buy exec started", addressesHex);
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, buyerAvatarAddress, out var buyerAvatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, buyerAvatarAddress, out var buyerAvatarState, out _))
             {
                 throw new FailedLoadStateException(
                     $"{addressesHex}Aborted as the avatar state of the buyer was failed to load.");
@@ -178,7 +178,7 @@ namespace Nekoyume.Action
                     sellerAvatarAddress);
 
 
-                if (!states.TryGetAvatarStateV2(sellerAgentAddress, sellerAvatarAddress, out var sellerAvatarState))
+                if (!states.TryGetAvatarStateV2(sellerAgentAddress, sellerAvatarAddress, out var sellerAvatarState, out _))
                 {
                     errors.Add((orderId, ErrorCodeFailedLoadingState));
                     continue;

--- a/Lib9c/Action/Buy8.cs
+++ b/Lib9c/Action/Buy8.cs
@@ -106,7 +106,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}Buy exec started", addressesHex);
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, buyerAvatarAddress, out var buyerAvatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, buyerAvatarAddress, out var buyerAvatarState, out _))
             {
                 throw new FailedLoadStateException(
                     $"{addressesHex}Aborted as the avatar state of the buyer was failed to load.");
@@ -182,7 +182,7 @@ namespace Nekoyume.Action
                     sellerAvatarAddress);
 
 
-                if (!states.TryGetAvatarStateV2(sellerAgentAddress, sellerAvatarAddress, out var sellerAvatarState))
+                if (!states.TryGetAvatarStateV2(sellerAgentAddress, sellerAvatarAddress, out var sellerAvatarState, out _))
                 {
                     errors.Add((orderId, ErrorCodeFailedLoadingState));
                     continue;

--- a/Lib9c/Action/Buy9.cs
+++ b/Lib9c/Action/Buy9.cs
@@ -106,7 +106,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}Buy exec started", addressesHex);
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, buyerAvatarAddress, out var buyerAvatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, buyerAvatarAddress, out var buyerAvatarState, out _))
             {
                 throw new FailedLoadStateException(
                     $"{addressesHex}Aborted as the avatar state of the buyer was failed to load.");
@@ -182,7 +182,7 @@ namespace Nekoyume.Action
                     sellerAvatarAddress);
 
 
-                if (!states.TryGetAvatarStateV2(sellerAgentAddress, sellerAvatarAddress, out var sellerAvatarState))
+                if (!states.TryGetAvatarStateV2(sellerAgentAddress, sellerAvatarAddress, out var sellerAvatarState, out _))
                 {
                     errors.Add((orderId, ErrorCodeFailedLoadingState));
                     continue;

--- a/Lib9c/Action/ChargeActionPoint.cs
+++ b/Lib9c/Action/ChargeActionPoint.cs
@@ -36,7 +36,7 @@ namespace Nekoyume.Action
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
 
-            if (!states.TryGetAvatarStateV2(context.Signer, avatarAddress, out var avatarState))
+            if (!states.TryGetAvatarStateV2(context.Signer, avatarAddress, out var avatarState, out _))
             {
                 throw new FailedLoadStateException(
                     $"{addressesHex}Aborted as the avatar state of the signer was failed to load.");

--- a/Lib9c/Action/CombinationConsumable.cs
+++ b/Lib9c/Action/CombinationConsumable.cs
@@ -70,7 +70,7 @@ namespace Nekoyume.Action
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
 
-            if (!states.TryGetAvatarStateV2(context.Signer, avatarAddress, out var avatarState))
+            if (!states.TryGetAvatarStateV2(context.Signer, avatarAddress, out var avatarState, out _))
             {
                 throw new FailedLoadStateException(
                     $"{addressesHex}Aborted as the avatar state of the signer was failed to load.");

--- a/Lib9c/Action/CombinationConsumable6.cs
+++ b/Lib9c/Action/CombinationConsumable6.cs
@@ -90,7 +90,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}Combination exec started", addressesHex);
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, AvatarAddress, out AvatarState avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, AvatarAddress, out AvatarState avatarState, out _))
             {
                 throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/CombinationConsumable7.cs
+++ b/Lib9c/Action/CombinationConsumable7.cs
@@ -91,7 +91,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}Combination exec started", addressesHex);
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, AvatarAddress, out AvatarState avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, AvatarAddress, out AvatarState avatarState, out _))
             {
                 throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/HackAndSlash.cs
+++ b/Lib9c/Action/HackAndSlash.cs
@@ -75,7 +75,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}HAS exec started", addressesHex);
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState, out _))
             {
                 throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/HackAndSlash10.cs
+++ b/Lib9c/Action/HackAndSlash10.cs
@@ -80,7 +80,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}HAS exec started", addressesHex);
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState, out _))
             {
                 throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/HackAndSlash6.cs
+++ b/Lib9c/Action/HackAndSlash6.cs
@@ -85,7 +85,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}HAS exec started", addressesHex);
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState, out _))
             {
                 throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/HackAndSlash7.cs
+++ b/Lib9c/Action/HackAndSlash7.cs
@@ -84,7 +84,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}HAS exec started", addressesHex);
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState, out _))
             {
                 throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/HackAndSlash8.cs
+++ b/Lib9c/Action/HackAndSlash8.cs
@@ -80,7 +80,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}HAS exec started", addressesHex);
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState, out _))
             {
                 throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/HackAndSlash9.cs
+++ b/Lib9c/Action/HackAndSlash9.cs
@@ -83,7 +83,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}HAS exec started", addressesHex);
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState, out _))
             {
                 throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/MimisbrunnrBattle.cs
+++ b/Lib9c/Action/MimisbrunnrBattle.cs
@@ -74,7 +74,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}Mimisbrunnr exec started", addressesHex);
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState, out _))
             {
                 throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/MimisbrunnrBattle4.cs
+++ b/Lib9c/Action/MimisbrunnrBattle4.cs
@@ -83,7 +83,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}Mimisbrunnr exec started", addressesHex);
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState, out _))
             {
                 throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/MimisbrunnrBattle5.cs
+++ b/Lib9c/Action/MimisbrunnrBattle5.cs
@@ -78,7 +78,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}Mimisbrunnr exec started", addressesHex);
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState, out _))
             {
                 throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/MimisbrunnrBattle6.cs
+++ b/Lib9c/Action/MimisbrunnrBattle6.cs
@@ -81,7 +81,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}Mimisbrunnr exec started", addressesHex);
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState, out _))
             {
                 throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/MimisbrunnrBattle7.cs
+++ b/Lib9c/Action/MimisbrunnrBattle7.cs
@@ -78,7 +78,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}Mimisbrunnr exec started", addressesHex);
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out AvatarState avatarState, out _))
             {
                 throw new FailedLoadStateException("Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/RankingBattle.cs
+++ b/Lib9c/Action/RankingBattle.cs
@@ -73,7 +73,7 @@ namespace Nekoyume.Action
                 throw new InvalidAddressException($"{addressesHex}Aborted as the signer tried to battle for themselves.");
             }
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out var avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out var avatarState, out bool migrationRequired))
             {
                 throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/RankingBattle.cs
+++ b/Lib9c/Action/RankingBattle.cs
@@ -269,9 +269,14 @@ namespace Nekoyume.Action
 
             states = states
                 .SetState(inventoryAddress, avatarState.inventory.Serialize())
-                .SetState(worldInformationAddress, avatarState.worldInformation.Serialize())
-                .SetState(questListAddress, avatarState.questList.Serialize())
-                .SetState(avatarAddress, avatarState.SerializeV2());
+                .SetState(questListAddress, avatarState.questList.Serialize());
+
+            if (migrationRequired)
+            {
+                states = states
+                    .SetState(worldInformationAddress, avatarState.worldInformation.Serialize())
+                    .SetState(avatarAddress, avatarState.SerializeV2());
+            }
 
             sw.Stop();
             Log.Verbose("{AddressesHex}RankingBattle Serialize AvatarState: {Elapsed}", addressesHex, sw.Elapsed);

--- a/Lib9c/Action/RankingBattle5.cs
+++ b/Lib9c/Action/RankingBattle5.cs
@@ -74,7 +74,7 @@ namespace Nekoyume.Action
                 throw new InvalidAddressException($"{addressesHex}Aborted as the signer tried to battle for themselves.");
             }
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, AvatarAddress, out var avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, AvatarAddress, out var avatarState, out _))
             {
                 throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/RankingBattle6.cs
+++ b/Lib9c/Action/RankingBattle6.cs
@@ -48,7 +48,7 @@ namespace Nekoyume.Action
                     .SetState(worldInformationAddress, MarkChanged)
                     .SetState(questListAddress, MarkChanged);
             }
-            
+
             CheckObsolete(BlockChain.Policy.BlockPolicySource.V100080ObsoleteIndex, ctx);
 
             // Avoid InvalidBlockStateRootHashException
@@ -74,7 +74,7 @@ namespace Nekoyume.Action
                 throw new InvalidAddressException($"{addressesHex}Aborted as the signer tried to battle for themselves.");
             }
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out var avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out var avatarState, out _))
             {
                 throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/RankingBattle7.cs
+++ b/Lib9c/Action/RankingBattle7.cs
@@ -74,7 +74,7 @@ namespace Nekoyume.Action
                 throw new InvalidAddressException($"{addressesHex}Aborted as the signer tried to battle for themselves.");
             }
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out var avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out var avatarState, out _))
             {
                 throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/RankingBattle8.cs
+++ b/Lib9c/Action/RankingBattle8.cs
@@ -77,7 +77,7 @@ namespace Nekoyume.Action
                 throw new InvalidAddressException($"{addressesHex}Aborted as the signer tried to battle for themselves.");
             }
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out var avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out var avatarState, out _))
             {
                 throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/RankingBattle9.cs
+++ b/Lib9c/Action/RankingBattle9.cs
@@ -78,7 +78,7 @@ namespace Nekoyume.Action
                 throw new InvalidAddressException($"{addressesHex}Aborted as the signer tried to battle for themselves.");
             }
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out var avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out var avatarState, out _))
             {
                 throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }

--- a/Lib9c/Action/RedeemCode.cs
+++ b/Lib9c/Action/RedeemCode.cs
@@ -52,7 +52,7 @@ namespace Nekoyume.Action
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
 
-            if (!states.TryGetAvatarStateV2(context.Signer, AvatarAddress, out AvatarState avatarState))
+            if (!states.TryGetAvatarStateV2(context.Signer, AvatarAddress, out AvatarState avatarState, out _))
             {
                 return states;
             }

--- a/Lib9c/Action/RedeemCode2.cs
+++ b/Lib9c/Action/RedeemCode2.cs
@@ -55,7 +55,7 @@ namespace Nekoyume.Action
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
 
-            if (!states.TryGetAvatarStateV2(context.Signer, AvatarAddress, out AvatarState avatarState))
+            if (!states.TryGetAvatarStateV2(context.Signer, AvatarAddress, out AvatarState avatarState, out _))
             {
                 return states;
             }

--- a/Lib9c/Action/SellCancellation.cs
+++ b/Lib9c/Action/SellCancellation.cs
@@ -100,7 +100,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}Sell Cancel exec started", addressesHex);
 
-            if (!states.TryGetAvatarStateV2(context.Signer, sellerAvatarAddress, out var avatarState))
+            if (!states.TryGetAvatarStateV2(context.Signer, sellerAvatarAddress, out var avatarState, out _))
             {
                 throw new FailedLoadStateException(
                     $"{addressesHex}Aborted as the avatar state of the seller failed to load.");

--- a/Lib9c/Action/SellCancellation7.cs
+++ b/Lib9c/Action/SellCancellation7.cs
@@ -103,7 +103,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}Sell Cancel exec started", addressesHex);
 
-            if (!states.TryGetAvatarStateV2(context.Signer, sellerAvatarAddress, out var avatarState))
+            if (!states.TryGetAvatarStateV2(context.Signer, sellerAvatarAddress, out var avatarState, out _))
             {
                 throw new FailedLoadStateException(
                     $"{addressesHex}Aborted as the avatar state of the seller failed to load.");

--- a/Lib9c/Action/SellCancellation8.cs
+++ b/Lib9c/Action/SellCancellation8.cs
@@ -103,7 +103,7 @@ namespace Nekoyume.Action
             var started = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}Sell Cancel exec started", addressesHex);
 
-            if (!states.TryGetAvatarStateV2(context.Signer, sellerAvatarAddress, out var avatarState))
+            if (!states.TryGetAvatarStateV2(context.Signer, sellerAvatarAddress, out var avatarState, out _))
             {
                 throw new FailedLoadStateException(
                     $"{addressesHex}Aborted as the avatar state of the seller failed to load.");

--- a/Lib9c/Action/UpdateSell.cs
+++ b/Lib9c/Action/UpdateSell.cs
@@ -93,7 +93,7 @@ namespace Nekoyume.Action
                     $"{addressesHex} Aborted as the price is less than zero: {price}.");
             }
 
-            if (!states.TryGetAvatarStateV2(context.Signer, sellerAvatarAddress, out var avatarState))
+            if (!states.TryGetAvatarStateV2(context.Signer, sellerAvatarAddress, out var avatarState, out _))
             {
                 throw new FailedLoadStateException(
                     $"{addressesHex} Aborted as the avatar state of the signer was failed to load.");

--- a/Lib9c/Action/UpdateSell0.cs
+++ b/Lib9c/Action/UpdateSell0.cs
@@ -96,7 +96,7 @@ namespace Nekoyume.Action
                     $"{addressesHex} Aborted as the price is less than zero: {price}.");
             }
 
-            if (!states.TryGetAvatarStateV2(context.Signer, sellerAvatarAddress, out var avatarState))
+            if (!states.TryGetAvatarStateV2(context.Signer, sellerAvatarAddress, out var avatarState, out _))
             {
                 throw new FailedLoadStateException(
                     $"{addressesHex} Aborted as the avatar state of the signer was failed to load.");


### PR DESCRIPTION
reduce RankingBattle evaluation time

AS-IS
```
[20:15:55 VRB] [6AA4c36889d37b4D77A5F855b9d62A2a021F3626, 8a63DD63B7fd3A7f785cc4Eb07ba904d19111F0c, 2Ba4885Add520498c144320D85Ac8039088117a6]RankingBattle Serialize AvatarState: 00:00:00.0297747
```

TO-BE
```
[20:11:10 VRB] [6AA4c36889d37b4D77A5F855b9d62A2a021F3626, 8a63DD63B7fd3A7f785cc4Eb07ba904d19111F0c, 2Ba4885Add520498c144320D85Ac8039088117a6]RankingBattle Serialize AvatarState: 00:00:00.0130076
```