### PR TITLE
Change RankingSimulator Constructor Parameters

### DIFF
--- a/.Lib9c.Tests/Action/RankingBattle10Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle10Test.cs
@@ -245,6 +245,9 @@ namespace Lib9c.Tests.Action
             Assert.Equal(result.score, log.score);
             Assert.Equal(result.Count, log.Count);
             Assert.Equal(result.result, log.result);
+
+            Assert.Equal(previousAvatar1State.SerializeV2(), nextAvatar1State.SerializeV2());
+            Assert.Equal(previousAvatar1State.worldInformation.Serialize(), nextAvatar1State.worldInformation.Serialize());
         }
 
         [Fact]

--- a/.Lib9c.Tests/Action/RankingBattle10Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle10Test.cs
@@ -1,12 +1,16 @@
-﻿namespace Lib9c.Tests.Action
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
+    using System.IO;
     using System.Linq;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using Bencodex.Types;
     using Libplanet;
     using Libplanet.Action;
     using Libplanet.Crypto;
+    using MessagePack;
     using Nekoyume;
     using Nekoyume.Action;
     using Nekoyume.Battle;
@@ -21,7 +25,7 @@
     using Xunit.Abstractions;
     using static SerializeKeys;
 
-    public class RankingBattleTest
+    public class RankingBattle10Test
     {
         private readonly TableSheets _tableSheets;
         private readonly Address _agent1Address;
@@ -30,7 +34,7 @@
         private readonly Address _weeklyArenaAddress;
         private readonly IAccountStateDelta _initialState;
 
-        public RankingBattleTest(ITestOutputHelper outputHelper)
+        public RankingBattle10Test(ITestOutputHelper outputHelper)
         {
             _initialState = new State();
 
@@ -152,7 +156,6 @@
             var enemyAvatarState = _initialState.GetAvatarState(_avatar2Address);
             enemyAvatarState.inventory.AddItem(enemyCostume);
 
-            Address worldInformationAddress = _avatar1Address.Derive(LegacyWorldInformationKey);
             if (avatarBackward)
             {
                 previousState =
@@ -165,7 +168,7 @@
                         _avatar1Address.Derive(LegacyInventoryKey),
                         previousAvatar1State.inventory.Serialize())
                     .SetState(
-                        worldInformationAddress,
+                        _avatar1Address.Derive(LegacyWorldInformationKey),
                         previousAvatar1State.worldInformation.Serialize())
                     .SetState(
                         _avatar1Address.Derive(LegacyQuestListKey),
@@ -193,7 +196,7 @@
                     .SetState(_avatar2Address, enemyAvatarState.SerializeV2());
             }
 
-            var action = new RankingBattle
+            var action = new RankingBattle10
             {
                 avatarAddress = _avatar1Address,
                 enemyAddress = _avatar2Address,
@@ -231,7 +234,7 @@
                 action.EnemyAvatarState,
                 new List<Guid>(),
                 _tableSheets.GetRankingSimulatorSheets(),
-                RankingBattle.StageId,
+                RankingBattle10.StageId,
                 action.ArenaInfo,
                 action.EnemyArenaInfo,
                 _tableSheets.CostumeStatSheet);
@@ -242,15 +245,12 @@
             Assert.Equal(result.score, log.score);
             Assert.Equal(result.Count, log.Count);
             Assert.Equal(result.result, log.result);
-
-            Assert.Equal(previousAvatar1State.SerializeV2(), nextAvatar1State.SerializeV2());
-            Assert.Equal(previousAvatar1State.worldInformation.Serialize(), nextAvatar1State.worldInformation.Serialize());
         }
 
         [Fact]
         public void ExecuteThrowInvalidAddressException()
         {
-            var action = new RankingBattle
+            var action = new RankingBattle10
             {
                 avatarAddress = _avatar1Address,
                 enemyAddress = _avatar1Address,
@@ -294,7 +294,7 @@
                     break;
             }
 
-            var action = new RankingBattle
+            var action = new RankingBattle10
             {
                 avatarAddress = avatarAddress,
                 enemyAddress = enemyAddress,
@@ -328,7 +328,7 @@
                 _avatar1Address,
                 previousAvatar1State.Serialize());
 
-            var action = new RankingBattle
+            var action = new RankingBattle10
             {
                 avatarAddress = _avatar1Address,
                 enemyAddress = _avatar2Address,
@@ -359,7 +359,7 @@
                 _weeklyArenaAddress,
                 previousWeeklyArenaState.Serialize());
 
-            var action = new RankingBattle
+            var action = new RankingBattle10
             {
                 avatarAddress = _avatar1Address,
                 enemyAddress = _avatar2Address,
@@ -392,7 +392,7 @@
                 _weeklyArenaAddress,
                 previousWeeklyArenaState.Serialize());
 
-            var action = new RankingBattle
+            var action = new RankingBattle10
             {
                 avatarAddress = _avatar1Address,
                 enemyAddress = _avatar2Address,
@@ -432,7 +432,7 @@
                 _weeklyArenaAddress,
                 previousWeeklyArenaState.Serialize());
 
-            var action = new RankingBattle
+            var action = new RankingBattle10
             {
                 avatarAddress = _avatar1Address,
                 enemyAddress = _avatar2Address,
@@ -456,7 +456,7 @@
         [Fact]
         public void Rehearsal()
         {
-            var action = new RankingBattle
+            var action = new RankingBattle10
             {
                 avatarAddress = _avatar1Address,
                 enemyAddress = _avatar2Address,
@@ -523,7 +523,7 @@
 
             var state = _initialState.SetState(_avatar1Address, previousAvatarState.Serialize());
 
-            var action = new RankingBattle
+            var action = new RankingBattle10
             {
                 avatarAddress = _avatar1Address,
                 enemyAddress = _avatar2Address,

--- a/.Lib9c.Tests/Action/RankingBattle2Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle2Test.cs
@@ -47,14 +47,14 @@ namespace Lib9c.Tests.Action
 
             var rankingMapAddress = new PrivateKey().ToAddress();
 
-            var (agent1State, avatar1State) = RankingBattleTest.GetAgentStateWithAvatarState(
+            var (agent1State, avatar1State) = RankingBattle10Test.GetAgentStateWithAvatarState(
                 sheets,
                 _tableSheets,
                 rankingMapAddress);
             _agent1Address = agent1State.address;
             _avatar1Address = avatar1State.address;
 
-            var (agent2State, avatar2State) = RankingBattleTest.GetAgentStateWithAvatarState(
+            var (agent2State, avatar2State) = RankingBattle10Test.GetAgentStateWithAvatarState(
                 sheets,
                 _tableSheets,
                 rankingMapAddress);

--- a/.Lib9c.Tests/Action/RankingBattle3Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle3Test.cs
@@ -47,14 +47,14 @@ namespace Lib9c.Tests.Action
 
             var rankingMapAddress = new PrivateKey().ToAddress();
 
-            var (agent1State, avatar1State) = RankingBattleTest.GetAgentStateWithAvatarState(
+            var (agent1State, avatar1State) = RankingBattle10Test.GetAgentStateWithAvatarState(
                 sheets,
                 _tableSheets,
                 rankingMapAddress);
             _agent1Address = agent1State.address;
             _avatar1Address = avatar1State.address;
 
-            var (agent2State, avatar2State) = RankingBattleTest.GetAgentStateWithAvatarState(
+            var (agent2State, avatar2State) = RankingBattle10Test.GetAgentStateWithAvatarState(
                 sheets,
                 _tableSheets,
                 rankingMapAddress);

--- a/.Lib9c.Tests/Action/RankingBattle8Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle8Test.cs
@@ -229,7 +229,7 @@
             Assert.True(nextWeeklyState[_avatar1Address].Score > prevScore);
 
             // Check simulation result equal.
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 new TestRandom(),
                 previousAvatar1State,
                 action.EnemyAvatarState,

--- a/.Lib9c.Tests/Action/RankingBattle9Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle9Test.cs
@@ -229,7 +229,7 @@ namespace Lib9c.Tests.Action
             Assert.True(nextWeeklyState[_avatar1Address].Score > prevScore);
 
             // Check simulation result equal.
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 new TestRandom(),
                 previousAvatar1State,
                 action.EnemyAvatarState,

--- a/.Lib9c.Tests/Action/RankingBattleTest.cs
+++ b/.Lib9c.Tests/Action/RankingBattleTest.cs
@@ -61,9 +61,13 @@
             _avatar2Address = avatar2State.address;
 
             var weeklyArenaState = new WeeklyArenaState(0);
-            weeklyArenaState.SetV2(avatar1State, _tableSheets.CharacterSheet, _tableSheets.CostumeStatSheet);
-            weeklyArenaState[_avatar1Address].Activate();
-            weeklyArenaState.SetV2(avatar2State, _tableSheets.CharacterSheet, _tableSheets.CostumeStatSheet);
+            if (_tableSheets.CostumeStatSheet != null)
+            {
+                weeklyArenaState.SetV2(avatar1State, _tableSheets.CharacterSheet, _tableSheets.CostumeStatSheet);
+                weeklyArenaState[_avatar1Address].Activate();
+                weeklyArenaState.SetV2(avatar2State, _tableSheets.CharacterSheet, _tableSheets.CostumeStatSheet);
+            }
+
             weeklyArenaState[_avatar2Address].Activate();
             _weeklyArenaAddress = weeklyArenaState.address;
 
@@ -224,17 +228,28 @@
             Assert.Equal(BattleLog.Result.Win, action.Result.result);
             Assert.True(nextWeeklyState[_avatar1Address].Score > prevScore);
 
-            // Check simulation result equal.
-            var simulator = new RankingSimulatorV1(
-                new TestRandom(),
+            var player = new Player(
                 previousAvatar1State,
+                _tableSheets.CharacterSheet,
+                _tableSheets.CharacterLevelSheet,
+                _tableSheets.EquipmentItemSetEffectSheet);
+            var enemyPlayer = new EnemyPlayer(
                 action.EnemyAvatarState,
+                _tableSheets.CharacterSheet,
+                _tableSheets.CharacterLevelSheet,
+                _tableSheets.EquipmentItemSetEffectSheet);
+            var simulator = new RankingSimulator(
+                new TestRandom(),
+                player,
+                enemyPlayer,
                 new List<Guid>(),
                 _tableSheets.GetRankingSimulatorSheets(),
                 RankingBattle.StageId,
                 action.ArenaInfo,
                 action.EnemyArenaInfo,
                 _tableSheets.CostumeStatSheet);
+            player.Simulator = simulator;
+            enemyPlayer.Simulator = simulator;
             simulator.Simulate();
 
             BattleLog log = simulator.Log;

--- a/.Lib9c.Tests/Action/RankingBattleTest.cs
+++ b/.Lib9c.Tests/Action/RankingBattleTest.cs
@@ -223,7 +223,6 @@
             Assert.NotNull(action.Result);
             Assert.NotNull(action.ArenaInfo);
             Assert.NotNull(action.EnemyArenaInfo);
-            Assert.NotNull(action.EnemyAvatarState);
             Assert.Contains(typeof(GetReward), action.Result.Select(e => e.GetType()));
             Assert.Equal(BattleLog.Result.Win, action.Result.result);
             Assert.True(nextWeeklyState[_avatar1Address].Score > prevScore);
@@ -234,7 +233,7 @@
                 _tableSheets.CharacterLevelSheet,
                 _tableSheets.EquipmentItemSetEffectSheet);
             var enemyPlayer = new EnemyPlayer(
-                action.EnemyAvatarState,
+                action.EnemyPlayer,
                 _tableSheets.CharacterSheet,
                 _tableSheets.CharacterLevelSheet,
                 _tableSheets.EquipmentItemSetEffectSheet);

--- a/.Lib9c.Tests/Action/RankingBattleTest.cs
+++ b/.Lib9c.Tests/Action/RankingBattleTest.cs
@@ -225,7 +225,7 @@ namespace Lib9c.Tests.Action
             Assert.True(nextWeeklyState[_avatar1Address].Score > prevScore);
 
             // Check simulation result equal.
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 new TestRandom(),
                 previousAvatar1State,
                 action.EnemyAvatarState,

--- a/.Lib9c.Tests/Battle/SimulationEnemyPlayerTest.cs
+++ b/.Lib9c.Tests/Battle/SimulationEnemyPlayerTest.cs
@@ -1,0 +1,61 @@
+namespace Lib9c.Tests
+{
+    using System.Linq;
+    using Bencodex.Types;
+    using Lib9c.Tests.Action;
+    using Libplanet;
+    using Libplanet.Crypto;
+    using Nekoyume.Battle;
+    using Nekoyume.Model;
+    using Nekoyume.Model.Item;
+    using Nekoyume.Model.Stat;
+    using Nekoyume.Model.State;
+    using Xunit;
+
+    public class SimulationEnemyPlayerTest
+    {
+        private readonly AvatarState _avatarState;
+        private readonly EnemyPlayer _enemyPlayer;
+
+        public SimulationEnemyPlayerTest()
+        {
+            var tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
+            var avatarState = new AvatarState(
+                new PrivateKey().ToAddress(),
+                new PrivateKey().ToAddress(),
+                1234,
+                tableSheets.GetAvatarSheets(),
+                new GameConfigState(),
+                new PrivateKey().ToAddress(),
+                "test"
+            );
+
+            var costumeRow = tableSheets.CostumeStatSheet.Values.First(r => r.StatType == StatType.ATK);
+            var costume = (Costume)ItemFactory.CreateItem(tableSheets.ItemSheet[costumeRow.CostumeId], new TestRandom());
+            costume.equipped = true;
+            avatarState.inventory.AddItem(costume);
+
+            var weaponRow = tableSheets.EquipmentItemSheet.Values.First(r => r.ItemSubType == ItemSubType.Weapon);
+            var weapon = (Weapon)ItemFactory.CreateItem(tableSheets.ItemSheet[weaponRow.Id], new TestRandom());
+            weapon.equipped = true;
+            avatarState.inventory.AddItem(weapon);
+            _avatarState = avatarState;
+            _enemyPlayer = new EnemyPlayer(avatarState, tableSheets.CharacterSheet, tableSheets.CharacterLevelSheet, tableSheets.EquipmentItemSetEffectSheet);
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            var simulationPlayer = new SimulationEnemyPlayer(_enemyPlayer);
+
+            Assert.Single(simulationPlayer.Costumes);
+            Assert.Single(simulationPlayer.Equipments);
+
+            var serialized = simulationPlayer.Serialize();
+            var deserialized = new SimulationEnemyPlayer((List)serialized);
+
+            Assert.Single(deserialized.Costumes);
+            Assert.Single(deserialized.Equipments);
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/RankingSimulatorTest.cs
+++ b/.Lib9c.Tests/Model/RankingSimulatorTest.cs
@@ -55,7 +55,7 @@ namespace Lib9c.Tests.Model
                 _tableSheets.WorldUnlockSheet
             );
 
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 _random,
                 avatarState,
                 avatarState,
@@ -99,7 +99,7 @@ namespace Lib9c.Tests.Model
             serialized = serialized.SetItem("score", score.Serialize());
             var info = new ArenaInfo(serialized);
 
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 _random,
                 avatarState,
                 avatarState,
@@ -145,7 +145,7 @@ namespace Lib9c.Tests.Model
             enemyCostume.equipped = true;
             enemyAvatarState.inventory.AddItem(enemyCostume);
 
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 _random,
                 avatarState,
                 enemyAvatarState,
@@ -193,7 +193,7 @@ namespace Lib9c.Tests.Model
                 _tableSheets.WorldSheet,
                 GameConfig.RequireClearedStageLevel.ActionsInRankingBoard);
 
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 _random,
                 avatarState,
                 avatarState,

--- a/.Lib9c.Tests/Model/RankingSimulatorV1Test.cs
+++ b/.Lib9c.Tests/Model/RankingSimulatorV1Test.cs
@@ -1,4 +1,4 @@
-﻿namespace Lib9c.Tests.Model
+namespace Lib9c.Tests.Model
 {
     using System;
     using System.Collections.Generic;
@@ -16,12 +16,12 @@
     using Nekoyume.TableData;
     using Xunit;
 
-    public class RankingSimulatorTest
+    public class RankingSimulatorV1Test
     {
         private readonly TableSheets _tableSheets;
         private readonly IRandom _random;
 
-        public RankingSimulatorTest()
+        public RankingSimulatorV1Test()
         {
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
             _random = new TestRandom();
@@ -34,8 +34,7 @@
         public void SimulateRequiredLevel(int level, int requiredLevel, bool expected)
         {
             var rewardSheet = new WeeklyArenaRewardSheet();
-            rewardSheet.Set(
-                $"id,item_id,ratio,min,max,required_level\n1,302000,0.1,1,1,{requiredLevel}");
+            rewardSheet.Set($"id,item_id,ratio,min,max,required_level\n1,302000,0.1,1,1,{requiredLevel}");
             _tableSheets.WeeklyArenaRewardSheet = rewardSheet;
             var avatarState = new AvatarState(
                 default,
@@ -56,31 +55,17 @@
                 _tableSheets.WorldUnlockSheet
             );
 
-            var player = new Player(
-                avatarState,
-                _tableSheets.CharacterSheet,
-                _tableSheets.CharacterLevelSheet,
-                _tableSheets.EquipmentItemSetEffectSheet);
-
-            var enemyPlayer = new EnemyPlayer(
-                avatarState,
-                _tableSheets.CharacterSheet,
-                _tableSheets.CharacterLevelSheet,
-                _tableSheets.EquipmentItemSetEffectSheet);
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 _random,
-                player,
-                enemyPlayer,
+                avatarState,
+                avatarState,
                 new List<Guid>(),
                 _tableSheets.GetRankingSimulatorSheets(),
                 1,
                 new ArenaInfo(avatarState, _tableSheets.CharacterSheet, false),
                 new ArenaInfo(avatarState, _tableSheets.CharacterSheet, false)
             );
-
-            player.Simulator = simulator;
-            enemyPlayer.Simulator = simulator;
-            simulator.Simulate();
+            simulator.SimulateV2();
 
             Assert.Equal(expected, simulator.Reward.Any());
         }
@@ -110,35 +95,21 @@
                 _tableSheets.WorldUnlockSheet
             );
 
-            var serialized =
-                (Dictionary)new ArenaInfo(avatarState, _tableSheets.CharacterSheet, false)
-                    .Serialize();
+            var serialized = (Dictionary)new ArenaInfo(avatarState, _tableSheets.CharacterSheet, false).Serialize();
             serialized = serialized.SetItem("score", score.Serialize());
             var info = new ArenaInfo(serialized);
 
-            var player = new Player(
-                avatarState,
-                _tableSheets.CharacterSheet,
-                _tableSheets.CharacterLevelSheet,
-                _tableSheets.EquipmentItemSetEffectSheet);
-            var enemyPlayer = new EnemyPlayer(
-                avatarState,
-                _tableSheets.CharacterSheet,
-                _tableSheets.CharacterLevelSheet,
-                _tableSheets.EquipmentItemSetEffectSheet);
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 _random,
-                player,
-                enemyPlayer,
+                avatarState,
+                avatarState,
                 new List<Guid>(),
                 _tableSheets.GetRankingSimulatorSheets(),
                 1,
                 info,
                 new ArenaInfo(avatarState, _tableSheets.CharacterSheet, false)
             );
-            player.Simulator = simulator;
-            enemyPlayer.Simulator = simulator;
-            simulator.Simulate();
+            simulator.SimulateV2();
 
             Assert.Equal(expected, simulator.Reward.Count());
         }
@@ -165,33 +136,19 @@
             var enemyAvatarState = new AvatarState(avatarState);
 
             var row = _tableSheets.CostumeStatSheet.Values.First(r => r.StatType == StatType.ATK);
-            var costume =
-                (Costume)ItemFactory.CreateItem(_tableSheets.ItemSheet[row.CostumeId], _random);
+            var costume = (Costume)ItemFactory.CreateItem(_tableSheets.ItemSheet[row.CostumeId], _random);
             costume.equipped = true;
             avatarState.inventory.AddItem(costume);
 
             var row2 = _tableSheets.CostumeStatSheet.Values.First(r => r.StatType == StatType.DEF);
-            var enemyCostume =
-                (Costume)ItemFactory.CreateItem(_tableSheets.ItemSheet[row2.CostumeId], _random);
+            var enemyCostume = (Costume)ItemFactory.CreateItem(_tableSheets.ItemSheet[row2.CostumeId], _random);
             enemyCostume.equipped = true;
             enemyAvatarState.inventory.AddItem(enemyCostume);
 
-            var player = new Player(
-                avatarState,
-                _tableSheets.CharacterSheet,
-                _tableSheets.CharacterLevelSheet,
-                _tableSheets.EquipmentItemSetEffectSheet);
-
-            var enemy = new EnemyPlayer(
-                avatarState,
-                _tableSheets.CharacterSheet,
-                _tableSheets.CharacterLevelSheet,
-                _tableSheets.EquipmentItemSetEffectSheet);
-
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 _random,
-                player,
-                enemy,
+                avatarState,
+                enemyAvatarState,
                 new List<Guid>(),
                 _tableSheets.GetRankingSimulatorSheets(),
                 1,
@@ -199,14 +156,12 @@
                 new ArenaInfo(enemyAvatarState, _tableSheets.CharacterSheet, false),
                 _tableSheets.CostumeStatSheet
             );
-            player.Simulator = simulator;
-            enemy.Simulator = simulator;
 
-            var simulatorPlayer = simulator.Player;
-            Assert.Equal(row.Stat, simulatorPlayer.Stats.OptionalStats.ATK);
+            var player = simulator.Player;
+            Assert.Equal(row.Stat, player.Stats.OptionalStats.ATK);
 
-            var simulatorPlayer2 = simulator.Simulate();
-            Assert.Equal(row.Stat, simulatorPlayer2.Stats.OptionalStats.ATK);
+            var player2 = simulator.SimulateV2();
+            Assert.Equal(row.Stat, player2.Stats.OptionalStats.ATK);
 
             var e = simulator.Log.OfType<SpawnEnemyPlayer>().First();
             var enemyPlayer = (EnemyPlayer)e.Character;
@@ -238,32 +193,20 @@
                 _tableSheets.WorldSheet,
                 GameConfig.RequireClearedStageLevel.ActionsInRankingBoard);
 
-            var player = new Player(
-                avatarState,
-                _tableSheets.CharacterSheet,
-                _tableSheets.CharacterLevelSheet,
-                _tableSheets.EquipmentItemSetEffectSheet);
-            var enemyPlayer = new EnemyPlayer(
-                avatarState,
-                _tableSheets.CharacterSheet,
-                _tableSheets.CharacterLevelSheet,
-                _tableSheets.EquipmentItemSetEffectSheet);
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 _random,
-                player,
-                enemyPlayer,
+                avatarState,
+                avatarState,
                 new List<Guid>(),
                 _tableSheets.GetRankingSimulatorSheets(),
                 1,
                 new ArenaInfo(avatarState, _tableSheets.CharacterSheet, false),
                 new ArenaInfo(avatarState, _tableSheets.CharacterSheet, false));
-            player.Simulator = simulator;
-            enemyPlayer.Simulator = simulator;
 
             var rewardIds = new HashSet<int>();
             for (int i = 0; i < simulationCount; ++i)
             {
-                simulator.Simulate();
+                simulator.SimulateV2();
                 foreach (var itemBase in simulator.Reward)
                 {
                     if (!rewardIds.Contains(itemBase.Id))
@@ -281,8 +224,7 @@
                 sheetIds.Add(sheet.Reward.ItemId);
             }
 
-            foreach (var id in rewardIds.TakeWhile(id => sheetIds.Count != 0)
-                         .Where(id => sheetIds.Contains(id)))
+            foreach (var id in rewardIds.TakeWhile(id => sheetIds.Count != 0).Where(id => sheetIds.Contains(id)))
             {
                 sheetIds.Remove(id);
             }

--- a/Lib9c/Action/RankingBattle.cs
+++ b/Lib9c/Action/RankingBattle.cs
@@ -192,7 +192,7 @@ namespace Nekoyume.Action
 
             ArenaInfo = new ArenaInfo((Dictionary)weeklyArenaMap[arenaKey]);
             EnemyArenaInfo = new ArenaInfo((Dictionary)weeklyArenaMap[enemyKey]);
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 ctx.Random,
                 avatarState,
                 enemyAvatarState,

--- a/Lib9c/Action/RankingBattle.cs
+++ b/Lib9c/Action/RankingBattle.cs
@@ -30,7 +30,7 @@ namespace Nekoyume.Action
         public List<Guid> costumeIds;
         public List<Guid> equipmentIds;
         public BattleLog Result { get; private set; }
-        public AvatarState EnemyAvatarState;
+        public SimulationEnemyPlayer EnemyPlayer;
         public ArenaInfo ArenaInfo;
         public ArenaInfo EnemyArenaInfo;
 
@@ -311,7 +311,7 @@ namespace Nekoyume.Action
             var ended = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}RankingBattle Total Executed Time: {Elapsed}", addressesHex,
                 ended - started);
-            EnemyAvatarState = enemyAvatarState;
+            EnemyPlayer = new SimulationEnemyPlayer(enemyPlayer);
             return states;
         }
 

--- a/Lib9c/Action/RankingBattle0.cs
+++ b/Lib9c/Action/RankingBattle0.cs
@@ -146,7 +146,7 @@ namespace Nekoyume.Action
 
             Log.Verbose("{WeeklyArenaStateAddress}", weeklyArenaState.address.ToHex());
 
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 ctx.Random,
                 avatarState,
                 enemyAvatarState,

--- a/Lib9c/Action/RankingBattle10.cs
+++ b/Lib9c/Action/RankingBattle10.cs
@@ -75,7 +75,7 @@ namespace Nekoyume.Action
                     $"{addressesHex}Aborted as the signer tried to battle for themselves.");
             }
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out var avatarState))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out var avatarState, out bool migrationRequired))
             {
                 throw new FailedLoadStateException(
                     $"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
@@ -285,9 +285,14 @@ namespace Nekoyume.Action
 
             states = states
                 .SetState(inventoryAddress, avatarState.inventory.Serialize())
-                .SetState(worldInformationAddress, avatarState.worldInformation.Serialize())
-                .SetState(questListAddress, avatarState.questList.Serialize())
-                .SetState(avatarAddress, avatarState.SerializeV2());
+                .SetState(questListAddress, avatarState.questList.Serialize());
+
+            if (migrationRequired)
+            {
+                states = states
+                    .SetState(worldInformationAddress, avatarState.worldInformation.Serialize())
+                    .SetState(avatarAddress, avatarState.SerializeV2());
+            }
 
             sw.Stop();
             Log.Verbose("{AddressesHex}RankingBattle Serialize AvatarState: {Elapsed}",

--- a/Lib9c/Action/RankingBattle2.cs
+++ b/Lib9c/Action/RankingBattle2.cs
@@ -151,7 +151,7 @@ namespace Nekoyume.Action
             Log.Verbose("{AddressesHex}RankingBattle Get CostumeStatSheet: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 ctx.Random,
                 avatarState,
                 enemyAvatarState,

--- a/Lib9c/Action/RankingBattle3.cs
+++ b/Lib9c/Action/RankingBattle3.cs
@@ -154,7 +154,7 @@ namespace Nekoyume.Action
             Log.Verbose("{AddressesHex}RankingBattle Get CostumeStatSheet: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 ctx.Random,
                 avatarState,
                 enemyAvatarState,

--- a/Lib9c/Action/RankingBattle4.cs
+++ b/Lib9c/Action/RankingBattle4.cs
@@ -163,7 +163,7 @@ namespace Nekoyume.Action
             Log.Verbose("{AddressesHex}RankingBattle Validate ArenaInfo: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 ctx.Random,
                 avatarState,
                 enemyAvatarState,

--- a/Lib9c/Action/RankingBattle5.cs
+++ b/Lib9c/Action/RankingBattle5.cs
@@ -177,7 +177,7 @@ namespace Nekoyume.Action
             Log.Verbose("{AddressesHex}RankingBattle Validate ArenaInfo: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 ctx.Random,
                 avatarState,
                 enemyAvatarState,

--- a/Lib9c/Action/RankingBattle6.cs
+++ b/Lib9c/Action/RankingBattle6.cs
@@ -183,7 +183,7 @@ namespace Nekoyume.Action
             Log.Verbose("{AddressesHex}RankingBattle Validate ArenaInfo: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 ctx.Random,
                 avatarState,
                 enemyAvatarState,

--- a/Lib9c/Action/RankingBattle7.cs
+++ b/Lib9c/Action/RankingBattle7.cs
@@ -183,7 +183,7 @@ namespace Nekoyume.Action
             Log.Verbose("{AddressesHex}RankingBattle Validate ArenaInfo: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 ctx.Random,
                 avatarState,
                 enemyAvatarState,

--- a/Lib9c/Action/RankingBattle8.cs
+++ b/Lib9c/Action/RankingBattle8.cs
@@ -188,7 +188,7 @@ namespace Nekoyume.Action
 
             ArenaInfo = new ArenaInfo((Dictionary)weeklyArenaState[avatarAddress].Serialize());
             EnemyArenaInfo = new ArenaInfo((Dictionary)weeklyArenaState[enemyAddress].Serialize());
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 ctx.Random,
                 avatarState,
                 enemyAvatarState,

--- a/Lib9c/Action/RankingBattle9.cs
+++ b/Lib9c/Action/RankingBattle9.cs
@@ -189,7 +189,7 @@ namespace Nekoyume.Action
 
             ArenaInfo = new ArenaInfo((Dictionary)weeklyArenaState[avatarAddress].Serialize());
             EnemyArenaInfo = new ArenaInfo((Dictionary)weeklyArenaState[enemyAddress].Serialize());
-            var simulator = new RankingSimulator(
+            var simulator = new RankingSimulatorV1(
                 ctx.Random,
                 avatarState,
                 enemyAvatarState,

--- a/Lib9c/Battle/RankingSimulator.cs
+++ b/Lib9c/Battle/RankingSimulator.cs
@@ -1,10 +1,7 @@
-// #define TEST_LOG
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Libplanet.Action;
-using Libplanet.Crypto;
 using Nekoyume.Model;
 using Nekoyume.Model.BattleStatus;
 using Nekoyume.Model.Item;
@@ -21,15 +18,14 @@ namespace Nekoyume.Battle
         private List<ItemBase> _reward;
         private readonly ArenaInfo _arenaInfo;
         private readonly ArenaInfo _enemyInfo;
-        private readonly AvatarState _avatarState;
 
         public readonly WeeklyArenaRewardSheet WeeklyArenaRewardSheet;
         public override IEnumerable<ItemBase> Reward => _reward;
 
         public RankingSimulator(
             IRandom random,
-            AvatarState avatarState,
-            AvatarState enemyAvatarState,
+            Player player,
+            EnemyPlayer enemyPlayer,
             List<Guid> foods,
             RankingSimulatorSheets rankingSimulatorSheets,
             int stageId,
@@ -37,24 +33,23 @@ namespace Nekoyume.Battle
             ArenaInfo enemyInfo
         ) : base(
             random,
-            avatarState,
+            player,
             foods,
             rankingSimulatorSheets
         )
         {
-            _enemyPlayer = new EnemyPlayer(enemyAvatarState, this);
+            _enemyPlayer = enemyPlayer;
             _enemyPlayer.Stats.EqualizeCurrentHPWithHP();
             _stageId = stageId;
             _arenaInfo = arenaInfo;
             _enemyInfo = enemyInfo;
-            _avatarState = avatarState;
             WeeklyArenaRewardSheet = rankingSimulatorSheets.WeeklyArenaRewardSheet;
         }
 
         public RankingSimulator(
             IRandom random,
-            AvatarState avatarState,
-            AvatarState enemyAvatarState,
+            Player player,
+            EnemyPlayer enemyPlayer,
             List<Guid> foods,
             RankingSimulatorSheets rankingSimulatorSheets,
             int stageId,
@@ -63,8 +58,8 @@ namespace Nekoyume.Battle
             CostumeStatSheet costumeStatSheet
         ) : this(
             random,
-            avatarState,
-            enemyAvatarState,
+            player,
+            enemyPlayer,
             foods,
             rankingSimulatorSheets,
             stageId,
@@ -186,472 +181,10 @@ namespace Nekoyume.Battle
             return Player;
         }
 
-        [Obsolete("Use Simulate")]
-        public Player SimulateV1()
-        {
-#if TEST_LOG
-            var sb = new System.Text.StringBuilder();
-#endif
-            Log.stageId = _stageId;
-            SpawnV1();
-            Characters = new SimplePriorityQueue<CharacterBase, decimal>();
-            Characters.Enqueue(Player, TurnPriority / Player.SPD);
-            Characters.Enqueue(_enemyPlayer, TurnPriority / _enemyPlayer.SPD);
-            TurnNumber = 1;
-            WaveNumber = 1;
-            WaveTurn = 1;
-#if TEST_LOG
-            sb.Clear();
-            sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
-            sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
-            sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
-            sb.Append($" / {nameof(WaveNumber)} Start");
-            UnityEngine.Debug.LogWarning(sb.ToString());
-#endif
-            while (true)
-            {
-                if (TurnNumber > MaxTurn)
-                {
-                    Result = BattleLog.Result.TimeOver;
-#if TEST_LOG
-                    sb.Clear();
-                    sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
-                    sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
-                    sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
-                    sb.Append($" / {nameof(MaxTurn)}: {MaxTurn}");
-                    sb.Append($" / {nameof(Result)}: {Result.ToString()}");
-                    UnityEngine.Debug.LogWarning(sb.ToString());
-#endif
-                    break;
-                }
-
-                // 캐릭터 큐가 비어 있는 경우 break.
-                if (!Characters.TryDequeue(out var character))
-                    break;
-
-                character.Tick();
-
-                // 플레이어가 죽은 경우 break;
-                if (Player.IsDead)
-                {
-                    Result = BattleLog.Result.Lose;
-#if TEST_LOG
-                    sb.Clear();
-                    sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
-                    sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
-                    sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
-                    sb.Append($" / {nameof(Player)} Dead");
-                    sb.Append($" / {nameof(Result)}: {Result.ToString()}");
-                    UnityEngine.Debug.LogWarning(sb.ToString());
-#endif
-                    break;
-                }
-
-                // 플레이어의 타겟(적)이 없는 경우 break.
-                if (!Player.Targets.Any())
-                {
-                    Result = BattleLog.Result.Win;
-                    Log.clearedWaveNumber = WaveNumber;
-
-                    break;
-                }
-
-                foreach (var other in Characters)
-                {
-                    var current = Characters.GetPriority(other);
-                    var speed = current * 0.6m;
-                    Characters.UpdatePriority(other, speed);
-                }
-
-                Characters.Enqueue(character, TurnPriority / character.SPD);
-            }
-
-            Log.diffScore = _arenaInfo.UpdateV3(_avatarState, _enemyInfo, Result);
-            Log.score = _arenaInfo.Score;
-
-            var itemSelector = new WeightedSelector<StageSheet.RewardData>(Random);
-            var rewardSheet = WeeklyArenaRewardSheet;
-            foreach (var row in rewardSheet.OrderedList)
-            {
-                var reward = row.Reward;
-                if (reward.RequiredLevel <= Player.Level)
-                {
-                    itemSelector.Add(reward, reward.Ratio);
-                }
-            }
-
-            var max = _arenaInfo.GetRewardCount();
-            _reward = SetReward(itemSelector, max, Random, MaterialItemSheet);
-            var getReward = new GetReward(null, _reward);
-            Log.Add(getReward);
-            Log.result = Result;
-#if TEST_LOG
-            sb.Clear();
-            sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
-            sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
-            sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
-            sb.Append($" / {nameof(Simulate)} End");
-            sb.Append($" / {nameof(Result)}: {Result.ToString()}");
-            UnityEngine.Debug.LogWarning(sb.ToString());
-#endif
-            return Player;
-        }
-
-        [Obsolete("Use Simulate")]
-        public Player SimulateV2()
-        {
-#if TEST_LOG
-            var sb = new System.Text.StringBuilder();
-#endif
-            Log.stageId = _stageId;
-            SpawnV2();
-            Characters = new SimplePriorityQueue<CharacterBase, decimal>();
-            Characters.Enqueue(Player, TurnPriority / Player.SPD);
-            Characters.Enqueue(_enemyPlayer, TurnPriority / _enemyPlayer.SPD);
-            TurnNumber = 1;
-            WaveNumber = 1;
-            WaveTurn = 1;
-#if TEST_LOG
-            sb.Clear();
-            sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
-            sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
-            sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
-            sb.Append($" / {nameof(WaveNumber)} Start");
-            UnityEngine.Debug.LogWarning(sb.ToString());
-#endif
-            while (true)
-            {
-                if (TurnNumber > MaxTurn)
-                {
-                    Result = BattleLog.Result.TimeOver;
-#if TEST_LOG
-                    sb.Clear();
-                    sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
-                    sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
-                    sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
-                    sb.Append($" / {nameof(MaxTurn)}: {MaxTurn}");
-                    sb.Append($" / {nameof(Result)}: {Result.ToString()}");
-                    UnityEngine.Debug.LogWarning(sb.ToString());
-#endif
-                    break;
-                }
-
-                // 캐릭터 큐가 비어 있는 경우 break.
-                if (!Characters.TryDequeue(out var character))
-                    break;
-
-                character.Tick();
-
-                // 플레이어가 죽은 경우 break;
-                if (Player.IsDead)
-                {
-                    Result = BattleLog.Result.Lose;
-#if TEST_LOG
-                    sb.Clear();
-                    sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
-                    sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
-                    sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
-                    sb.Append($" / {nameof(Player)} Dead");
-                    sb.Append($" / {nameof(Result)}: {Result.ToString()}");
-                    UnityEngine.Debug.LogWarning(sb.ToString());
-#endif
-                    break;
-                }
-
-                // 플레이어의 타겟(적)이 없는 경우 break.
-                if (!Player.Targets.Any())
-                {
-                    Result = BattleLog.Result.Win;
-                    Log.clearedWaveNumber = WaveNumber;
-
-                    break;
-                }
-
-                foreach (var other in Characters)
-                {
-                    var current = Characters.GetPriority(other);
-                    var speed = current * 0.6m;
-                    Characters.UpdatePriority(other, speed);
-                }
-
-                Characters.Enqueue(character, TurnPriority / character.SPD);
-            }
-
-            Log.diffScore = _arenaInfo.UpdateV3(_avatarState, _enemyInfo, Result);
-            Log.score = _arenaInfo.Score;
-
-            var itemSelector = new WeightedSelector<StageSheet.RewardData>(Random);
-            var rewardSheet = WeeklyArenaRewardSheet;
-            foreach (var row in rewardSheet.OrderedList)
-            {
-                var reward = row.Reward;
-                if (reward.RequiredLevel <= Player.Level)
-                {
-                    itemSelector.Add(reward, reward.Ratio);
-                }
-            }
-
-            var max = _arenaInfo.GetRewardCount();
-            _reward = SetRewardV2(itemSelector, max, Random, MaterialItemSheet);
-            var getReward = new GetReward(null, _reward);
-            Log.Add(getReward);
-            Log.result = Result;
-#if TEST_LOG
-            sb.Clear();
-            sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
-            sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
-            sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
-            sb.Append($" / {nameof(Simulate)} End");
-            sb.Append($" / {nameof(Result)}: {Result.ToString()}");
-            UnityEngine.Debug.LogWarning(sb.ToString());
-#endif
-            return Player;
-        }
-
-        [Obsolete("Use Simulate")]
-        public Player SimulateV3()
-        {
-#if TEST_LOG
-            var sb = new System.Text.StringBuilder();
-#endif
-            Log.stageId = _stageId;
-            SpawnV2(); // v2
-            Characters = new SimplePriorityQueue<CharacterBase, decimal>();
-            Characters.Enqueue(Player, TurnPriority / Player.SPD);
-            Characters.Enqueue(_enemyPlayer, TurnPriority / _enemyPlayer.SPD);
-            TurnNumber = 1;
-            WaveNumber = 1;
-            WaveTurn = 1;
-#if TEST_LOG
-            sb.Clear();
-            sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
-            sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
-            sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
-            sb.Append($" / {nameof(WaveNumber)} Start");
-            UnityEngine.Debug.LogWarning(sb.ToString());
-#endif
-            while (true)
-            {
-                if (TurnNumber > MaxTurn)
-                {
-                    Result = BattleLog.Result.TimeOver;
-#if TEST_LOG
-                    sb.Clear();
-                    sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
-                    sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
-                    sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
-                    sb.Append($" / {nameof(MaxTurn)}: {MaxTurn}");
-                    sb.Append($" / {nameof(Result)}: {Result.ToString()}");
-                    UnityEngine.Debug.LogWarning(sb.ToString());
-#endif
-                    break;
-                }
-
-                // 캐릭터 큐가 비어 있는 경우 break.
-                if (!Characters.TryDequeue(out var character))
-                    break;
-
-                character.Tick();
-
-                // 플레이어가 죽은 경우 break;
-                if (Player.IsDead)
-                {
-                    Result = BattleLog.Result.Lose;
-#if TEST_LOG
-                    sb.Clear();
-                    sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
-                    sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
-                    sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
-                    sb.Append($" / {nameof(Player)} Dead");
-                    sb.Append($" / {nameof(Result)}: {Result.ToString()}");
-                    UnityEngine.Debug.LogWarning(sb.ToString());
-#endif
-                    break;
-                }
-
-                // 플레이어의 타겟(적)이 없는 경우 break.
-                if (!Player.Targets.Any())
-                {
-                    Result = BattleLog.Result.Win;
-                    Log.clearedWaveNumber = WaveNumber;
-
-                    break;
-                }
-
-                foreach (var other in Characters)
-                {
-                    var current = Characters.GetPriority(other);
-                    var speed = current * 0.6m;
-                    Characters.UpdatePriority(other, speed);
-                }
-
-                Characters.Enqueue(character, TurnPriority / character.SPD);
-            }
-
-            Log.diffScore = _arenaInfo.UpdateV4(_enemyInfo, Result);
-            Log.score = _arenaInfo.Score;
-
-            var itemSelector = new WeightedSelector<StageSheet.RewardData>(Random);
-            var rewardSheet = WeeklyArenaRewardSheet;
-            foreach (var row in rewardSheet.OrderedList)
-            {
-                var reward = row.Reward;
-                if (reward.RequiredLevel <= Player.Level)
-                {
-                    itemSelector.Add(reward, reward.Ratio);
-                }
-            }
-
-            var max = _arenaInfo.GetRewardCount();
-            _reward = SetRewardV2(itemSelector, max, Random, MaterialItemSheet);
-            var getReward = new GetReward(null, _reward);
-            Log.Add(getReward);
-            Log.result = Result;
-#if TEST_LOG
-            sb.Clear();
-            sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
-            sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
-            sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
-            sb.Append($" / {nameof(Simulate)} End");
-            sb.Append($" / {nameof(Result)}: {Result.ToString()}");
-            UnityEngine.Debug.LogWarning(sb.ToString());
-#endif
-            return Player;
-        }
-
-        [Obsolete("use Simulate")]
-        public Player SimulateV4()
-        {
-#if TEST_LOG
-            var sb = new System.Text.StringBuilder();
-#endif
-            Log.stageId = _stageId;
-            Spawn();
-            Characters = new SimplePriorityQueue<CharacterBase, decimal>();
-            Characters.Enqueue(Player, TurnPriority / Player.SPD);
-            Characters.Enqueue(_enemyPlayer, TurnPriority / _enemyPlayer.SPD);
-            TurnNumber = 1;
-            WaveNumber = 1;
-            WaveTurn = 1;
-#if TEST_LOG
-            sb.Clear();
-            sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
-            sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
-            sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
-            sb.Append($" / {nameof(WaveNumber)} Start");
-            UnityEngine.Debug.LogWarning(sb.ToString());
-#endif
-            while (true)
-            {
-                if (TurnNumber > MaxTurn)
-                {
-                    Result = BattleLog.Result.TimeOver;
-#if TEST_LOG
-                    sb.Clear();
-                    sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
-                    sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
-                    sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
-                    sb.Append($" / {nameof(MaxTurn)}: {MaxTurn}");
-                    sb.Append($" / {nameof(Result)}: {Result.ToString()}");
-                    UnityEngine.Debug.LogWarning(sb.ToString());
-#endif
-                    break;
-                }
-
-                // 캐릭터 큐가 비어 있는 경우 break.
-                if (!Characters.TryDequeue(out var character))
-                    break;
-
-                character.Tick();
-
-                // 플레이어가 죽은 경우 break;
-                if (Player.IsDead)
-                {
-                    Result = BattleLog.Result.Lose;
-#if TEST_LOG
-                    sb.Clear();
-                    sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
-                    sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
-                    sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
-                    sb.Append($" / {nameof(Player)} Dead");
-                    sb.Append($" / {nameof(Result)}: {Result.ToString()}");
-                    UnityEngine.Debug.LogWarning(sb.ToString());
-#endif
-                    break;
-                }
-
-                // 플레이어의 타겟(적)이 없는 경우 break.
-                if (!Player.Targets.Any())
-                {
-                    Result = BattleLog.Result.Win;
-                    Log.clearedWaveNumber = WaveNumber;
-
-                    break;
-                }
-
-                foreach (var other in Characters)
-                {
-                    var current = Characters.GetPriority(other);
-                    var speed = current * 0.6m;
-                    Characters.UpdatePriority(other, speed);
-                }
-
-                Characters.Enqueue(character, TurnPriority / character.SPD);
-            }
-
-            Log.diffScore = _arenaInfo.UpdateV4(_enemyInfo, Result);
-            Log.score = _arenaInfo.Score;
-
-            var itemSelector = new WeightedSelector<StageSheet.RewardData>(Random);
-            var rewardSheet = WeeklyArenaRewardSheet;
-            foreach (var row in rewardSheet.OrderedList)
-            {
-                var reward = row.Reward;
-                if (reward.RequiredLevel <= Player.Level)
-                {
-                    itemSelector.Add(reward, reward.Ratio);
-                }
-            }
-
-            var max = _arenaInfo.GetRewardCount();
-            _reward = SetRewardV2(itemSelector, max, Random, MaterialItemSheet);
-            var getReward = new GetReward(null, _reward);
-            Log.Add(getReward);
-            Log.result = Result;
-#if TEST_LOG
-            sb.Clear();
-            sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
-            sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
-            sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
-            sb.Append($" / {nameof(Simulate)} End");
-            sb.Append($" / {nameof(Result)}: {Result.ToString()}");
-            UnityEngine.Debug.LogWarning(sb.ToString());
-#endif
-            return Player;
-        }
-
         private void Spawn()
         {
             Player.Spawn();
             _enemyPlayer.Spawn();
-            Player.Targets.Add(_enemyPlayer);
-            _enemyPlayer.Targets.Add(Player);
-        }
-
-        [Obsolete("Use Spawn")]
-        private void SpawnV1()
-        {
-            Player.SpawnV1();
-            _enemyPlayer.SpawnV1();
-            Player.Targets.Add(_enemyPlayer);
-            _enemyPlayer.Targets.Add(Player);
-        }
-
-        [Obsolete("Use Spawn")]
-        private void SpawnV2()
-        {
-            Player.SpawnV2();
-            _enemyPlayer.SpawnV2();
             Player.Targets.Add(_enemyPlayer);
             _enemyPlayer.Targets.Add(Player);
         }

--- a/Lib9c/Battle/RankingSimulatorV1.cs
+++ b/Lib9c/Battle/RankingSimulatorV1.cs
@@ -1,0 +1,659 @@
+// #define TEST_LOG
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Libplanet.Action;
+using Libplanet.Crypto;
+using Nekoyume.Model;
+using Nekoyume.Model.BattleStatus;
+using Nekoyume.Model.Item;
+using Nekoyume.Model.State;
+using Nekoyume.TableData;
+using Priority_Queue;
+
+namespace Nekoyume.Battle
+{
+    public class RankingSimulatorV1 : Simulator
+    {
+        private readonly EnemyPlayer _enemyPlayer;
+        private readonly int _stageId;
+        private List<ItemBase> _reward;
+        private readonly ArenaInfo _arenaInfo;
+        private readonly ArenaInfo _enemyInfo;
+        private readonly AvatarState _avatarState;
+
+        public readonly WeeklyArenaRewardSheet WeeklyArenaRewardSheet;
+        public override IEnumerable<ItemBase> Reward => _reward;
+
+        public RankingSimulatorV1(
+            IRandom random,
+            AvatarState avatarState,
+            AvatarState enemyAvatarState,
+            List<Guid> foods,
+            RankingSimulatorSheets rankingSimulatorSheets,
+            int stageId,
+            ArenaInfo arenaInfo,
+            ArenaInfo enemyInfo
+        ) : base(
+            random,
+            avatarState,
+            foods,
+            rankingSimulatorSheets
+        )
+        {
+            _enemyPlayer = new EnemyPlayer(enemyAvatarState, this);
+            _enemyPlayer.Stats.EqualizeCurrentHPWithHP();
+            _stageId = stageId;
+            _arenaInfo = arenaInfo;
+            _enemyInfo = enemyInfo;
+            _avatarState = avatarState;
+            WeeklyArenaRewardSheet = rankingSimulatorSheets.WeeklyArenaRewardSheet;
+        }
+
+        public RankingSimulatorV1(
+            IRandom random,
+            AvatarState avatarState,
+            AvatarState enemyAvatarState,
+            List<Guid> foods,
+            RankingSimulatorSheets rankingSimulatorSheets,
+            int stageId,
+            ArenaInfo arenaInfo,
+            ArenaInfo enemyInfo,
+            CostumeStatSheet costumeStatSheet
+        ) : this(
+            random,
+            avatarState,
+            enemyAvatarState,
+            foods,
+            rankingSimulatorSheets,
+            stageId,
+            arenaInfo,
+            enemyInfo
+        )
+        {
+            Player.SetCostumeStat(costumeStatSheet);
+            _enemyPlayer.SetCostumeStat(costumeStatSheet);
+        }
+
+        public Player Simulate()
+        {
+#if TEST_LOG
+            var sb = new System.Text.StringBuilder();
+#endif
+            Log.stageId = _stageId;
+            Spawn();
+            Characters = new SimplePriorityQueue<CharacterBase, decimal>();
+            Characters.Enqueue(Player, TurnPriority / Player.SPD);
+            Characters.Enqueue(_enemyPlayer, TurnPriority / _enemyPlayer.SPD);
+            TurnNumber = 1;
+            WaveNumber = 1;
+            WaveTurn = 1;
+#if TEST_LOG
+            sb.Clear();
+            sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+            sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+            sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+            sb.Append($" / {nameof(WaveNumber)} Start");
+            UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+            while (true)
+            {
+                if (TurnNumber > MaxTurn)
+                {
+                    Result = BattleLog.Result.TimeOver;
+#if TEST_LOG
+                    sb.Clear();
+                    sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+                    sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+                    sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+                    sb.Append($" / {nameof(MaxTurn)}: {MaxTurn}");
+                    sb.Append($" / {nameof(Result)}: {Result.ToString()}");
+                    UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+                    break;
+                }
+
+                // 캐릭터 큐가 비어 있는 경우 break.
+                if (!Characters.TryDequeue(out var character))
+                    break;
+
+                character.Tick();
+
+                // 플레이어가 죽은 경우 break;
+                if (Player.IsDead)
+                {
+                    Result = BattleLog.Result.Lose;
+#if TEST_LOG
+                    sb.Clear();
+                    sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+                    sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+                    sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+                    sb.Append($" / {nameof(Player)} Dead");
+                    sb.Append($" / {nameof(Result)}: {Result.ToString()}");
+                    UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+                    break;
+                }
+
+                // 플레이어의 타겟(적)이 없는 경우 break.
+                if (!Player.Targets.Any())
+                {
+                    Result = BattleLog.Result.Win;
+                    Log.clearedWaveNumber = WaveNumber;
+
+                    break;
+                }
+
+                foreach (var other in Characters)
+                {
+                    var current = Characters.GetPriority(other);
+                    var speed = current * 0.6m;
+                    Characters.UpdatePriority(other, speed);
+                }
+
+                Characters.Enqueue(character, TurnPriority / character.SPD);
+            }
+
+            Log.diffScore = _arenaInfo.Update(_enemyInfo, Result);
+            Log.score = _arenaInfo.Score;
+
+            var itemSelector = new WeightedSelector<StageSheet.RewardData>(Random);
+            var rewardSheet = WeeklyArenaRewardSheet;
+            foreach (var row in rewardSheet.OrderedList)
+            {
+                var reward = row.Reward;
+                if (reward.RequiredLevel <= Player.Level)
+                {
+                    itemSelector.Add(reward, reward.Ratio);
+                }
+            }
+
+            var max = _arenaInfo.GetRewardCount();
+            _reward = SetRewardV2(itemSelector, max, Random, MaterialItemSheet);
+            var getReward = new GetReward(null, _reward);
+            Log.Add(getReward);
+            Log.result = Result;
+#if TEST_LOG
+            sb.Clear();
+            sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+            sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+            sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+            sb.Append($" / {nameof(Simulate)} End");
+            sb.Append($" / {nameof(Result)}: {Result.ToString()}");
+            UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+            return Player;
+        }
+
+        [Obsolete("Use Simulate")]
+        public Player SimulateV1()
+        {
+#if TEST_LOG
+            var sb = new System.Text.StringBuilder();
+#endif
+            Log.stageId = _stageId;
+            SpawnV1();
+            Characters = new SimplePriorityQueue<CharacterBase, decimal>();
+            Characters.Enqueue(Player, TurnPriority / Player.SPD);
+            Characters.Enqueue(_enemyPlayer, TurnPriority / _enemyPlayer.SPD);
+            TurnNumber = 1;
+            WaveNumber = 1;
+            WaveTurn = 1;
+#if TEST_LOG
+            sb.Clear();
+            sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+            sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+            sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+            sb.Append($" / {nameof(WaveNumber)} Start");
+            UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+            while (true)
+            {
+                if (TurnNumber > MaxTurn)
+                {
+                    Result = BattleLog.Result.TimeOver;
+#if TEST_LOG
+                    sb.Clear();
+                    sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+                    sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+                    sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+                    sb.Append($" / {nameof(MaxTurn)}: {MaxTurn}");
+                    sb.Append($" / {nameof(Result)}: {Result.ToString()}");
+                    UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+                    break;
+                }
+
+                // 캐릭터 큐가 비어 있는 경우 break.
+                if (!Characters.TryDequeue(out var character))
+                    break;
+
+                character.Tick();
+
+                // 플레이어가 죽은 경우 break;
+                if (Player.IsDead)
+                {
+                    Result = BattleLog.Result.Lose;
+#if TEST_LOG
+                    sb.Clear();
+                    sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+                    sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+                    sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+                    sb.Append($" / {nameof(Player)} Dead");
+                    sb.Append($" / {nameof(Result)}: {Result.ToString()}");
+                    UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+                    break;
+                }
+
+                // 플레이어의 타겟(적)이 없는 경우 break.
+                if (!Player.Targets.Any())
+                {
+                    Result = BattleLog.Result.Win;
+                    Log.clearedWaveNumber = WaveNumber;
+
+                    break;
+                }
+
+                foreach (var other in Characters)
+                {
+                    var current = Characters.GetPriority(other);
+                    var speed = current * 0.6m;
+                    Characters.UpdatePriority(other, speed);
+                }
+
+                Characters.Enqueue(character, TurnPriority / character.SPD);
+            }
+
+            Log.diffScore = _arenaInfo.UpdateV3(_avatarState, _enemyInfo, Result);
+            Log.score = _arenaInfo.Score;
+
+            var itemSelector = new WeightedSelector<StageSheet.RewardData>(Random);
+            var rewardSheet = WeeklyArenaRewardSheet;
+            foreach (var row in rewardSheet.OrderedList)
+            {
+                var reward = row.Reward;
+                if (reward.RequiredLevel <= Player.Level)
+                {
+                    itemSelector.Add(reward, reward.Ratio);
+                }
+            }
+
+            var max = _arenaInfo.GetRewardCount();
+            _reward = SetReward(itemSelector, max, Random, MaterialItemSheet);
+            var getReward = new GetReward(null, _reward);
+            Log.Add(getReward);
+            Log.result = Result;
+#if TEST_LOG
+            sb.Clear();
+            sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+            sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+            sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+            sb.Append($" / {nameof(Simulate)} End");
+            sb.Append($" / {nameof(Result)}: {Result.ToString()}");
+            UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+            return Player;
+        }
+
+        [Obsolete("Use Simulate")]
+        public Player SimulateV2()
+        {
+#if TEST_LOG
+            var sb = new System.Text.StringBuilder();
+#endif
+            Log.stageId = _stageId;
+            SpawnV2();
+            Characters = new SimplePriorityQueue<CharacterBase, decimal>();
+            Characters.Enqueue(Player, TurnPriority / Player.SPD);
+            Characters.Enqueue(_enemyPlayer, TurnPriority / _enemyPlayer.SPD);
+            TurnNumber = 1;
+            WaveNumber = 1;
+            WaveTurn = 1;
+#if TEST_LOG
+            sb.Clear();
+            sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+            sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+            sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+            sb.Append($" / {nameof(WaveNumber)} Start");
+            UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+            while (true)
+            {
+                if (TurnNumber > MaxTurn)
+                {
+                    Result = BattleLog.Result.TimeOver;
+#if TEST_LOG
+                    sb.Clear();
+                    sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+                    sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+                    sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+                    sb.Append($" / {nameof(MaxTurn)}: {MaxTurn}");
+                    sb.Append($" / {nameof(Result)}: {Result.ToString()}");
+                    UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+                    break;
+                }
+
+                // 캐릭터 큐가 비어 있는 경우 break.
+                if (!Characters.TryDequeue(out var character))
+                    break;
+
+                character.Tick();
+
+                // 플레이어가 죽은 경우 break;
+                if (Player.IsDead)
+                {
+                    Result = BattleLog.Result.Lose;
+#if TEST_LOG
+                    sb.Clear();
+                    sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+                    sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+                    sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+                    sb.Append($" / {nameof(Player)} Dead");
+                    sb.Append($" / {nameof(Result)}: {Result.ToString()}");
+                    UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+                    break;
+                }
+
+                // 플레이어의 타겟(적)이 없는 경우 break.
+                if (!Player.Targets.Any())
+                {
+                    Result = BattleLog.Result.Win;
+                    Log.clearedWaveNumber = WaveNumber;
+
+                    break;
+                }
+
+                foreach (var other in Characters)
+                {
+                    var current = Characters.GetPriority(other);
+                    var speed = current * 0.6m;
+                    Characters.UpdatePriority(other, speed);
+                }
+
+                Characters.Enqueue(character, TurnPriority / character.SPD);
+            }
+
+            Log.diffScore = _arenaInfo.UpdateV3(_avatarState, _enemyInfo, Result);
+            Log.score = _arenaInfo.Score;
+
+            var itemSelector = new WeightedSelector<StageSheet.RewardData>(Random);
+            var rewardSheet = WeeklyArenaRewardSheet;
+            foreach (var row in rewardSheet.OrderedList)
+            {
+                var reward = row.Reward;
+                if (reward.RequiredLevel <= Player.Level)
+                {
+                    itemSelector.Add(reward, reward.Ratio);
+                }
+            }
+
+            var max = _arenaInfo.GetRewardCount();
+            _reward = SetRewardV2(itemSelector, max, Random, MaterialItemSheet);
+            var getReward = new GetReward(null, _reward);
+            Log.Add(getReward);
+            Log.result = Result;
+#if TEST_LOG
+            sb.Clear();
+            sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+            sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+            sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+            sb.Append($" / {nameof(Simulate)} End");
+            sb.Append($" / {nameof(Result)}: {Result.ToString()}");
+            UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+            return Player;
+        }
+
+        [Obsolete("Use Simulate")]
+        public Player SimulateV3()
+        {
+#if TEST_LOG
+            var sb = new System.Text.StringBuilder();
+#endif
+            Log.stageId = _stageId;
+            SpawnV2(); // v2
+            Characters = new SimplePriorityQueue<CharacterBase, decimal>();
+            Characters.Enqueue(Player, TurnPriority / Player.SPD);
+            Characters.Enqueue(_enemyPlayer, TurnPriority / _enemyPlayer.SPD);
+            TurnNumber = 1;
+            WaveNumber = 1;
+            WaveTurn = 1;
+#if TEST_LOG
+            sb.Clear();
+            sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+            sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+            sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+            sb.Append($" / {nameof(WaveNumber)} Start");
+            UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+            while (true)
+            {
+                if (TurnNumber > MaxTurn)
+                {
+                    Result = BattleLog.Result.TimeOver;
+#if TEST_LOG
+                    sb.Clear();
+                    sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+                    sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+                    sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+                    sb.Append($" / {nameof(MaxTurn)}: {MaxTurn}");
+                    sb.Append($" / {nameof(Result)}: {Result.ToString()}");
+                    UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+                    break;
+                }
+
+                // 캐릭터 큐가 비어 있는 경우 break.
+                if (!Characters.TryDequeue(out var character))
+                    break;
+
+                character.Tick();
+
+                // 플레이어가 죽은 경우 break;
+                if (Player.IsDead)
+                {
+                    Result = BattleLog.Result.Lose;
+#if TEST_LOG
+                    sb.Clear();
+                    sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+                    sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+                    sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+                    sb.Append($" / {nameof(Player)} Dead");
+                    sb.Append($" / {nameof(Result)}: {Result.ToString()}");
+                    UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+                    break;
+                }
+
+                // 플레이어의 타겟(적)이 없는 경우 break.
+                if (!Player.Targets.Any())
+                {
+                    Result = BattleLog.Result.Win;
+                    Log.clearedWaveNumber = WaveNumber;
+
+                    break;
+                }
+
+                foreach (var other in Characters)
+                {
+                    var current = Characters.GetPriority(other);
+                    var speed = current * 0.6m;
+                    Characters.UpdatePriority(other, speed);
+                }
+
+                Characters.Enqueue(character, TurnPriority / character.SPD);
+            }
+
+            Log.diffScore = _arenaInfo.UpdateV4(_enemyInfo, Result);
+            Log.score = _arenaInfo.Score;
+
+            var itemSelector = new WeightedSelector<StageSheet.RewardData>(Random);
+            var rewardSheet = WeeklyArenaRewardSheet;
+            foreach (var row in rewardSheet.OrderedList)
+            {
+                var reward = row.Reward;
+                if (reward.RequiredLevel <= Player.Level)
+                {
+                    itemSelector.Add(reward, reward.Ratio);
+                }
+            }
+
+            var max = _arenaInfo.GetRewardCount();
+            _reward = SetRewardV2(itemSelector, max, Random, MaterialItemSheet);
+            var getReward = new GetReward(null, _reward);
+            Log.Add(getReward);
+            Log.result = Result;
+#if TEST_LOG
+            sb.Clear();
+            sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+            sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+            sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+            sb.Append($" / {nameof(Simulate)} End");
+            sb.Append($" / {nameof(Result)}: {Result.ToString()}");
+            UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+            return Player;
+        }
+
+        [Obsolete("use Simulate")]
+        public Player SimulateV4()
+        {
+#if TEST_LOG
+            var sb = new System.Text.StringBuilder();
+#endif
+            Log.stageId = _stageId;
+            Spawn();
+            Characters = new SimplePriorityQueue<CharacterBase, decimal>();
+            Characters.Enqueue(Player, TurnPriority / Player.SPD);
+            Characters.Enqueue(_enemyPlayer, TurnPriority / _enemyPlayer.SPD);
+            TurnNumber = 1;
+            WaveNumber = 1;
+            WaveTurn = 1;
+#if TEST_LOG
+            sb.Clear();
+            sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+            sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+            sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+            sb.Append($" / {nameof(WaveNumber)} Start");
+            UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+            while (true)
+            {
+                if (TurnNumber > MaxTurn)
+                {
+                    Result = BattleLog.Result.TimeOver;
+#if TEST_LOG
+                    sb.Clear();
+                    sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+                    sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+                    sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+                    sb.Append($" / {nameof(MaxTurn)}: {MaxTurn}");
+                    sb.Append($" / {nameof(Result)}: {Result.ToString()}");
+                    UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+                    break;
+                }
+
+                // 캐릭터 큐가 비어 있는 경우 break.
+                if (!Characters.TryDequeue(out var character))
+                    break;
+
+                character.Tick();
+
+                // 플레이어가 죽은 경우 break;
+                if (Player.IsDead)
+                {
+                    Result = BattleLog.Result.Lose;
+#if TEST_LOG
+                    sb.Clear();
+                    sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+                    sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+                    sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+                    sb.Append($" / {nameof(Player)} Dead");
+                    sb.Append($" / {nameof(Result)}: {Result.ToString()}");
+                    UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+                    break;
+                }
+
+                // 플레이어의 타겟(적)이 없는 경우 break.
+                if (!Player.Targets.Any())
+                {
+                    Result = BattleLog.Result.Win;
+                    Log.clearedWaveNumber = WaveNumber;
+
+                    break;
+                }
+
+                foreach (var other in Characters)
+                {
+                    var current = Characters.GetPriority(other);
+                    var speed = current * 0.6m;
+                    Characters.UpdatePriority(other, speed);
+                }
+
+                Characters.Enqueue(character, TurnPriority / character.SPD);
+            }
+
+            Log.diffScore = _arenaInfo.UpdateV4(_enemyInfo, Result);
+            Log.score = _arenaInfo.Score;
+
+            var itemSelector = new WeightedSelector<StageSheet.RewardData>(Random);
+            var rewardSheet = WeeklyArenaRewardSheet;
+            foreach (var row in rewardSheet.OrderedList)
+            {
+                var reward = row.Reward;
+                if (reward.RequiredLevel <= Player.Level)
+                {
+                    itemSelector.Add(reward, reward.Ratio);
+                }
+            }
+
+            var max = _arenaInfo.GetRewardCount();
+            _reward = SetRewardV2(itemSelector, max, Random, MaterialItemSheet);
+            var getReward = new GetReward(null, _reward);
+            Log.Add(getReward);
+            Log.result = Result;
+#if TEST_LOG
+            sb.Clear();
+            sb.Append($"{nameof(TurnNumber)}: {TurnNumber}");
+            sb.Append($" / {nameof(WaveNumber)}: {WaveNumber}");
+            sb.Append($" / {nameof(WaveTurn)}: {WaveTurn}");
+            sb.Append($" / {nameof(Simulate)} End");
+            sb.Append($" / {nameof(Result)}: {Result.ToString()}");
+            UnityEngine.Debug.LogWarning(sb.ToString());
+#endif
+            return Player;
+        }
+
+        private void Spawn()
+        {
+            Player.Spawn();
+            _enemyPlayer.Spawn();
+            Player.Targets.Add(_enemyPlayer);
+            _enemyPlayer.Targets.Add(Player);
+        }
+
+        [Obsolete("Use Spawn")]
+        private void SpawnV1()
+        {
+            Player.SpawnV1();
+            _enemyPlayer.SpawnV1();
+            Player.Targets.Add(_enemyPlayer);
+            _enemyPlayer.Targets.Add(Player);
+        }
+
+        [Obsolete("Use Spawn")]
+        private void SpawnV2()
+        {
+            Player.SpawnV2();
+            _enemyPlayer.SpawnV2();
+            Player.Targets.Add(_enemyPlayer);
+            _enemyPlayer.Targets.Add(Player);
+        }
+    }
+}

--- a/Lib9c/Battle/SimulationEnemyPlayer.cs
+++ b/Lib9c/Battle/SimulationEnemyPlayer.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using Nekoyume.Model;
+using Nekoyume.Model.Item;
+
+namespace Nekoyume.Battle
+{
+    public readonly struct SimulationEnemyPlayer
+    {
+        public readonly string NameWithHash;
+        public readonly int CharacterId;
+        public readonly int Level;
+        public readonly int HairIndex;
+        public readonly int LensIndex;
+        public readonly int EarIndex;
+        public readonly int TailIndex;
+
+        public readonly IReadOnlyList<Costume> Costumes;
+        public readonly IReadOnlyList<Equipment> Equipments;
+
+        public SimulationEnemyPlayer(EnemyPlayer enemyPlayer)
+        {
+            NameWithHash = enemyPlayer.NameWithHash;
+            CharacterId = enemyPlayer.CharacterId;
+            Level = enemyPlayer.Level;
+            HairIndex = enemyPlayer.hairIndex;
+            LensIndex = enemyPlayer.hairIndex;
+            EarIndex = enemyPlayer.earIndex;
+            TailIndex = enemyPlayer.tailIndex;
+            Costumes = enemyPlayer.Costumes;
+            Equipments = enemyPlayer.Equipments;
+        }
+    }
+}

--- a/Lib9c/Battle/SimulationEnemyPlayer.cs
+++ b/Lib9c/Battle/SimulationEnemyPlayer.cs
@@ -1,10 +1,13 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
+using Bencodex.Types;
 using Nekoyume.Model;
 using Nekoyume.Model.Item;
+using Nekoyume.Model.State;
 
 namespace Nekoyume.Battle
 {
-    public readonly struct SimulationEnemyPlayer
+    public readonly struct SimulationEnemyPlayer: IState
     {
         public readonly string NameWithHash;
         public readonly int CharacterId;
@@ -28,6 +31,35 @@ namespace Nekoyume.Battle
             TailIndex = enemyPlayer.tailIndex;
             Costumes = enemyPlayer.Costumes;
             Equipments = enemyPlayer.Equipments;
+        }
+
+        public SimulationEnemyPlayer(List serialized)
+        {
+            NameWithHash = serialized[0].ToDotnetString();
+            CharacterId = serialized[1].ToInteger();
+            Level = serialized[2].ToInteger();
+            HairIndex = serialized[3].ToInteger();
+            LensIndex = serialized[4].ToInteger();
+            EarIndex = serialized[5].ToInteger();
+            TailIndex = serialized[6].ToInteger();
+            Costumes = ((List) serialized[7]).Select(c =>
+                (Costume) ItemFactory.Deserialize((Dictionary) c)).ToList();
+            Equipments = ((List) serialized[8]).Select(e =>
+                (Equipment) ItemFactory.Deserialize((Dictionary) e)).ToList();
+        }
+
+        public IValue Serialize()
+        {
+            return List.Empty
+                .Add(NameWithHash.Serialize())
+                .Add(CharacterId.Serialize())
+                .Add(Level.Serialize())
+                .Add(HairIndex.Serialize())
+                .Add(LensIndex.Serialize())
+                .Add(EarIndex.Serialize())
+                .Add(TailIndex.Serialize())
+                .Add(Costumes.Aggregate(List.Empty, (current, costume) => current.Add(costume.Serialize())))
+                .Add(Equipments.Aggregate(List.Empty, (current, equipment) => current.Add(equipment.Serialize())));
         }
     }
 }

--- a/Lib9c/Battle/Simulator.cs
+++ b/Lib9c/Battle/Simulator.cs
@@ -53,6 +53,27 @@ namespace Nekoyume.Battle
             Player.Stats.EqualizeCurrentHPWithHP();
         }
 
+        protected Simulator(
+            IRandom random,
+            Player player,
+            List<Guid> foods,
+            SimulatorSheets simulatorSheets
+        )
+        {
+            Random = random;
+            MaterialItemSheet = simulatorSheets.MaterialItemSheet;
+            SkillSheet = simulatorSheets.SkillSheet;
+            SkillBuffSheet = simulatorSheets.SkillBuffSheet;
+            BuffSheet = simulatorSheets.BuffSheet;
+            CharacterSheet = simulatorSheets.CharacterSheet;
+            CharacterLevelSheet = simulatorSheets.CharacterLevelSheet;
+            EquipmentItemSetEffectSheet = simulatorSheets.EquipmentItemSetEffectSheet;
+            Log = new BattleLog();
+            Player = player;
+            Player.Use(foods);
+            Player.Stats.EqualizeCurrentHPWithHP();
+        }
+
         public static List<ItemBase> SetReward(
             WeightedSelector<StageSheet.RewardData> itemSelector,
             int maxCount,

--- a/Lib9c/Model/Character/EnemyPlayer.cs
+++ b/Lib9c/Model/Character/EnemyPlayer.cs
@@ -7,7 +7,7 @@ using Nekoyume.TableData;
 namespace Nekoyume.Model
 {
     [Serializable]
-    public class EnemyPlayer: Player
+    public class EnemyPlayer : Player
     {
         public readonly string NameWithHash;
         public EnemyPlayer(AvatarState avatarState, Simulator simulator) : base(avatarState, simulator)
@@ -27,6 +27,21 @@ namespace Nekoyume.Model
             equipmentItemSetEffectSheet
         )
         {
+            NameWithHash = avatarState.NameWithHash;
+        }
+
+        public EnemyPlayer(SimulationEnemyPlayer enemyPlayer,
+            CharacterSheet characterSheet,
+            CharacterLevelSheet characterLevelSheet,
+            EquipmentItemSetEffectSheet equipmentItemSetEffectSheet
+        ) : base(
+            enemyPlayer,
+            characterSheet,
+            characterLevelSheet,
+            equipmentItemSetEffectSheet
+        )
+        {
+            NameWithHash = enemyPlayer.NameWithHash;
         }
 
         public EnemyPlayer(

--- a/Lib9c/Model/Character/Player.cs
+++ b/Lib9c/Model/Character/Player.cs
@@ -100,6 +100,34 @@ namespace Nekoyume.Model
             PostConstruction(simulator.CharacterLevelSheet, simulator.EquipmentItemSetEffectSheet);
         }
 
+        protected Player(SimulationEnemyPlayer enemyPlayer,
+            CharacterSheet characterSheet,
+            CharacterLevelSheet levelSheet,
+            EquipmentItemSetEffectSheet equipmentItemSetEffectSheet
+        ) : base(
+            null,
+            characterSheet,
+            enemyPlayer.CharacterId,
+            enemyPlayer.Level)
+        {
+            weapon = null;
+            armor = null;
+            belt = null;
+            necklace = null;
+            ring = null;
+            monsterMap = new CollectionMap();
+            eventMap = new CollectionMap();
+            hairIndex = enemyPlayer.HairIndex;
+            lensIndex = enemyPlayer.LensIndex;
+            earIndex = enemyPlayer.EarIndex;
+            tailIndex = enemyPlayer.TailIndex;
+            _equipments = enemyPlayer.Equipments as List<Equipment>;
+            _costumes = enemyPlayer.Costumes as List<Costume>;
+            characterLevelSheet = levelSheet;
+            AttackCountMax = AttackCountHelper.GetCountMax(Level);
+            SetEquipmentStat(equipmentItemSetEffectSheet);
+        }
+
         public Player(
             AvatarState avatarState,
             CharacterSheet characterSheet,
@@ -231,6 +259,11 @@ namespace Nekoyume.Model
                 .OfType<Equipment>()
                 .Where(e => e.equipped)
                 .ToList();
+            SetEquipmentStat(sheet);
+        }
+
+        private void SetEquipmentStat(EquipmentItemSetEffectSheet sheet)
+        {
             foreach (var equipment in _equipments)
             {
                 switch (equipment.ItemSubType)


### PR DESCRIPTION
- In the `RankingSimulator` constructor, inject `Player` instead of `AvatarState`

- Version up list
   - ranking_battle10 -> ranking_battle11
   - RankingSimulator ->RankingSimulatorV1
   - New RankingSimulator
   
- Related Link
   - https://github.com/planetarium/NineChronicles/pull/1220
   -  [RankingBattle 등에서 AvatarState 를 풀로 쓰는 대신 전투에 필요한 중간 상태만 사용하게끔](https://app.asana.com/0/958521740385861/1201869821990665/f)