### PR TITLE
Add contidional value change `ActionsInMimisbrunnr`

### DIFF
--- a/Lib9c/GameConfig.cs
+++ b/Lib9c/GameConfig.cs
@@ -93,7 +93,7 @@ namespace Nekoyume
             public const int ItemEnhancementAction = IsEditor ? 1 : 9;
             public const int ActionsInShop = IsEditor ? 1 : 17;
             public const int ActionsInRankingBoard = IsEditor ? 1 : 25;
-            public const int ActionsInMimisbrunnr = 100;
+            public const int ActionsInMimisbrunnr = IsEditor ? 1 : 100;
 
             #endregion
 


### PR DESCRIPTION
### Description

For the debug, the editor conditionally changed the value so that the action could be used in Mimir even at level 1. The condition that controls this is `GameConfig.IsEditor`.

In Editor 🔽
![image](https://user-images.githubusercontent.com/48484989/161205616-4dcc55e5-1521-4142-a02d-008fd8003c08.png)
