### PR TITLE
Fix up Git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "Libplanet"]
+[submodule ".Libplanet"]
 	path = .Libplanet
-	url = git@github.com:planetarium/libplanet.git
+	url = https://github.com/planetarium/libplanet.git


### PR DESCRIPTION
- The submodule name and its path did not match.  Now it shares the same identifier.
- The submodule URL changed from SSH URL to HTTPS URL.  GitHub's SSH clone URLs require contributors to have permission to push commits to the repository.  HTTPS clone URLs, however, require only permission to clone/pull.