### PR TITLE
Fix arena score formula

### DIFF
--- a/.Lib9c.Tests/Action/RankingBattle10Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle10Test.cs
@@ -235,7 +235,7 @@ namespace Lib9c.Tests.Action
                 action.ArenaInfo,
                 action.EnemyArenaInfo,
                 _tableSheets.CostumeStatSheet);
-            simulator.Simulate();
+            simulator.SimulateV5();
 
             Assert.Equal(nextArenaInfo.Score, simulator.Log.score);
             Assert.Equal(previousAvatar1State.SerializeV2(), nextAvatar1State.SerializeV2());

--- a/.Lib9c.Tests/Action/RankingBattle11Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle11Test.cs
@@ -1,0 +1,736 @@
+namespace Lib9c.Tests.Action
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using Bencodex.Types;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Crypto;
+    using Nekoyume;
+    using Nekoyume.Action;
+    using Nekoyume.Battle;
+    using Nekoyume.Model;
+    using Nekoyume.Model.BattleStatus;
+    using Nekoyume.Model.Item;
+    using Nekoyume.Model.Stat;
+    using Nekoyume.Model.State;
+    using Nekoyume.TableData;
+    using Serilog;
+    using Xunit;
+    using Xunit.Abstractions;
+    using static SerializeKeys;
+
+    public class RankingBattle11Test
+    {
+        private const int ArenaIndex = RankingBattle11.UpdateTargetWeeklyArenaIndex - 1;
+        private readonly TableSheets _tableSheets;
+        private readonly Address _agent1Address;
+        private readonly Address _avatar1Address;
+        private readonly Address _avatar2Address;
+        private readonly Address _weeklyArenaAddress;
+        private readonly IAccountStateDelta _initialState;
+
+        public RankingBattle11Test(ITestOutputHelper outputHelper)
+        {
+            _initialState = new State();
+
+            var sheets = TableSheetsImporter.ImportSheets();
+            foreach (var (key, value) in sheets)
+            {
+                _initialState = _initialState.SetState(
+                    Addresses.TableSheet.Derive(key),
+                    value.Serialize());
+            }
+
+            _tableSheets = new TableSheets(sheets);
+
+            var rankingMapAddress = new PrivateKey().ToAddress();
+
+            var (agent1State, avatar1State) = GetAgentStateWithAvatarState(
+                sheets,
+                _tableSheets,
+                rankingMapAddress);
+            _agent1Address = agent1State.address;
+            _avatar1Address = avatar1State.address;
+
+            var (agent2State, avatar2State) = GetAgentStateWithAvatarState(
+                sheets,
+                _tableSheets,
+                rankingMapAddress);
+            var agent2Address = agent2State.address;
+            _avatar2Address = avatar2State.address;
+
+            var weeklyArenaState = new WeeklyArenaState(ArenaIndex);
+            weeklyArenaState.SetV2(avatar1State, _tableSheets.CharacterSheet, _tableSheets.CostumeStatSheet);
+            weeklyArenaState[_avatar1Address].Activate();
+            weeklyArenaState.SetV2(avatar2State, _tableSheets.CharacterSheet, _tableSheets.CostumeStatSheet);
+            weeklyArenaState[_avatar2Address].Activate();
+            _weeklyArenaAddress = weeklyArenaState.address;
+
+            _initialState = _initialState
+                .SetState(_agent1Address, agent1State.Serialize())
+                .SetState(_avatar1Address, avatar1State.Serialize())
+                .SetState(agent2Address, agent2State.Serialize())
+                .SetState(_avatar2Address, avatar2State.Serialize())
+                .SetState(Addresses.GameConfig, new GameConfigState(sheets[nameof(GameConfigSheet)]).Serialize())
+                .SetState(_weeklyArenaAddress, weeklyArenaState.Serialize());
+
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.TestOutput(outputHelper)
+                .CreateLogger();
+        }
+
+        public static (AgentState, AvatarState) GetAgentStateWithAvatarState(
+            IReadOnlyDictionary<string, string> sheets,
+            TableSheets tableSheets,
+            Address rankingMapAddress)
+        {
+            var agentAddress = new PrivateKey().ToAddress();
+            var agentState = new AgentState(agentAddress);
+
+            var avatarAddress = agentAddress.Derive("avatar");
+            var avatarState = new AvatarState(
+                avatarAddress,
+                agentAddress,
+                0,
+                tableSheets.GetAvatarSheets(),
+                new GameConfigState(sheets[nameof(GameConfigSheet)]),
+                rankingMapAddress)
+            {
+                worldInformation = new WorldInformation(
+                    0,
+                    tableSheets.WorldSheet,
+                    Math.Max(
+                        tableSheets.StageSheet.First?.Id ?? 1,
+                        GameConfig.RequireClearedStageLevel.ActionsInRankingBoard)),
+            };
+            agentState.avatarAddresses.Add(0, avatarAddress);
+
+            return (agentState, avatarState);
+        }
+
+        [Fact]
+        public void Execute()
+        {
+            var previousWeeklyState = _initialState.GetWeeklyArenaState(ArenaIndex);
+            var previousAvatar1State = _initialState.GetAvatarState(_avatar1Address);
+            previousAvatar1State.level = 10;
+            var prevScore = previousWeeklyState[_avatar1Address].Score;
+
+            var previousState = _initialState.SetState(
+                _avatar1Address,
+                previousAvatar1State.Serialize());
+
+            var itemIds = _tableSheets.WeeklyArenaRewardSheet.Values
+                .Select(r => r.Reward.ItemId)
+                .ToList();
+
+            Assert.All(itemIds, id => Assert.False(previousAvatar1State.inventory.HasItem(id)));
+
+            var row = _tableSheets.CostumeStatSheet.Values.First(r => r.StatType == StatType.ATK);
+            var costume = (Costume)ItemFactory.CreateItem(
+                _tableSheets.ItemSheet[row.CostumeId], new TestRandom());
+            costume.equipped = true;
+            previousAvatar1State.inventory.AddItem(costume);
+
+            var row2 = _tableSheets.CostumeStatSheet.Values.First(r => r.StatType == StatType.DEF);
+            var enemyCostume = (Costume)ItemFactory.CreateItem(
+                _tableSheets.ItemSheet[row2.CostumeId], new TestRandom());
+            enemyCostume.equipped = true;
+            var enemyAvatarState = _initialState.GetAvatarState(_avatar2Address);
+            enemyAvatarState.inventory.AddItem(enemyCostume);
+
+            Address worldInformationAddress = _avatar1Address.Derive(LegacyWorldInformationKey);
+            var weeklyArenaAddress =
+                WeeklyArenaState.DeriveAddress(RankingBattle11.UpdateTargetWeeklyArenaIndex);
+            previousState = previousState
+                .SetState(
+                    _avatar1Address.Derive(LegacyInventoryKey),
+                    previousAvatar1State.inventory.Serialize())
+                .SetState(
+                    worldInformationAddress,
+                    previousAvatar1State.worldInformation.Serialize())
+                .SetState(
+                    _avatar1Address.Derive(LegacyQuestListKey),
+                    previousAvatar1State.questList.Serialize())
+                .SetState(_avatar1Address, previousAvatar1State.SerializeV2())
+                .SetState(
+                    _avatar2Address.Derive(LegacyInventoryKey),
+                    enemyAvatarState.inventory.Serialize())
+                .SetState(
+                    _avatar2Address.Derive(LegacyWorldInformationKey),
+                    enemyAvatarState.worldInformation.Serialize())
+                .SetState(
+                    _avatar2Address.Derive(LegacyQuestListKey),
+                    enemyAvatarState.questList.Serialize())
+                .SetState(_avatar2Address, enemyAvatarState.SerializeV2())
+                .SetState(
+                    weeklyArenaAddress,
+                    new WeeklyArenaState(RankingBattle11.UpdateTargetWeeklyArenaIndex).Serialize());
+
+            var action = new RankingBattle11
+            {
+                avatarAddress = _avatar1Address,
+                enemyAddress = _avatar2Address,
+                weeklyArenaAddress = weeklyArenaAddress,
+                costumeIds = new List<Guid> { costume.ItemId },
+                equipmentIds = new List<Guid>(),
+            };
+
+            var nextState = action.Execute(new ActionContext
+            {
+                PreviousStates = previousState,
+                Signer = _agent1Address,
+                Random = new TestRandom(),
+                Rehearsal = false,
+                BlockIndex = RankingBattle11.UpdateTargetBlockIndex,
+            });
+
+            Assert.True(nextState.TryGetState(weeklyArenaAddress.Derive(_avatar1Address.ToByteArray()), out Dictionary rawArenaInfo));
+            Assert.True(nextState.TryGetState(weeklyArenaAddress.Derive(_avatar2Address.ToByteArray()), out Dictionary rawEnemyInfo));
+            Assert.True(nextState.TryGetState(weeklyArenaAddress.Derive("address_list"), out List rawAddressList));
+            var nextWeekly = nextState.GetWeeklyArenaState(weeklyArenaAddress);
+            Assert.Empty(nextWeekly.Map);
+
+            var nextAvatar1State = nextState.GetAvatarStateV2(_avatar1Address);
+            var nextArenaInfo = new ArenaInfo(rawArenaInfo);
+            var addressList = rawAddressList.ToList(StateExtensions.ToAddress);
+
+            Assert.Contains(_avatar1Address, addressList);
+            Assert.Contains(_avatar2Address, addressList);
+            Assert.Contains(nextAvatar1State.inventory.Materials, i => itemIds.Contains(i.Id));
+            Assert.NotNull(action.ArenaInfo);
+            Assert.NotNull(action.EnemyArenaInfo);
+            Assert.True(nextArenaInfo.Score > prevScore);
+
+            // Check simulation result equal.
+            var player = new Player(
+                previousAvatar1State,
+                _tableSheets.CharacterSheet,
+                _tableSheets.CharacterLevelSheet,
+                _tableSheets.EquipmentItemSetEffectSheet);
+            var simulator = new RankingSimulator(
+                new TestRandom(),
+                player,
+                action.EnemyPlayerDigest,
+                new List<Guid>(),
+                _tableSheets.GetRankingSimulatorSheets(),
+                RankingBattle11.StageId,
+                action.ArenaInfo,
+                action.EnemyArenaInfo,
+                _tableSheets.CostumeStatSheet);
+            simulator.SimulateV5();
+
+            Assert.Equal(nextArenaInfo.Score, simulator.Log.score);
+            Assert.Equal(previousAvatar1State.SerializeV2(), nextAvatar1State.SerializeV2());
+            Assert.Equal(previousAvatar1State.worldInformation.Serialize(), nextAvatar1State.worldInformation.Serialize());
+        }
+
+        [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(true, true, false)]
+        [InlineData(true, false, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, true)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, true)]
+        [InlineData(false, false, false)]
+        public void Execute_Backward_Compatible(bool isNew, bool avatarBackward, bool enemyBackward)
+        {
+            var previousWeeklyState = _initialState.GetWeeklyArenaState(ArenaIndex);
+            var previousAvatar1State = _initialState.GetAvatarState(_avatar1Address);
+            previousAvatar1State.level = 10;
+            var prevScore = previousWeeklyState[_avatar1Address].Score;
+            if (isNew)
+            {
+                previousWeeklyState.Remove(_avatar1Address);
+            }
+
+            var previousState = _initialState.SetState(
+                _avatar1Address,
+                previousAvatar1State.Serialize());
+
+            var itemIds = _tableSheets.WeeklyArenaRewardSheet.Values
+                .Select(r => r.Reward.ItemId)
+                .ToList();
+
+            Assert.All(itemIds, id => Assert.False(previousAvatar1State.inventory.HasItem(id)));
+
+            var row = _tableSheets.CostumeStatSheet.Values.First(r => r.StatType == StatType.ATK);
+            var costume = (Costume)ItemFactory.CreateItem(
+                _tableSheets.ItemSheet[row.CostumeId], new TestRandom());
+            costume.equipped = true;
+            previousAvatar1State.inventory.AddItem(costume);
+
+            var row2 = _tableSheets.CostumeStatSheet.Values.First(r => r.StatType == StatType.DEF);
+            var enemyCostume = (Costume)ItemFactory.CreateItem(
+                _tableSheets.ItemSheet[row2.CostumeId], new TestRandom());
+            enemyCostume.equipped = true;
+            var enemyAvatarState = _initialState.GetAvatarState(_avatar2Address);
+            enemyAvatarState.inventory.AddItem(enemyCostume);
+
+            Address worldInformationAddress = _avatar1Address.Derive(LegacyWorldInformationKey);
+            if (avatarBackward)
+            {
+                previousState =
+                    previousState.SetState(_avatar1Address, previousAvatar1State.Serialize());
+            }
+            else
+            {
+                previousState = previousState
+                    .SetState(
+                        _avatar1Address.Derive(LegacyInventoryKey),
+                        previousAvatar1State.inventory.Serialize())
+                    .SetState(
+                        worldInformationAddress,
+                        previousAvatar1State.worldInformation.Serialize())
+                    .SetState(
+                        _avatar1Address.Derive(LegacyQuestListKey),
+                        previousAvatar1State.questList.Serialize())
+                    .SetState(_avatar1Address, previousAvatar1State.SerializeV2());
+            }
+
+            if (enemyBackward)
+            {
+                previousState =
+                    previousState.SetState(_avatar2Address, enemyAvatarState.Serialize());
+            }
+            else
+            {
+                previousState = previousState
+                    .SetState(
+                        _avatar2Address.Derive(LegacyInventoryKey),
+                        enemyAvatarState.inventory.Serialize())
+                    .SetState(
+                        _avatar2Address.Derive(LegacyWorldInformationKey),
+                        enemyAvatarState.worldInformation.Serialize())
+                    .SetState(
+                        _avatar2Address.Derive(LegacyQuestListKey),
+                        enemyAvatarState.questList.Serialize())
+                    .SetState(_avatar2Address, enemyAvatarState.SerializeV2());
+            }
+
+            var action = new RankingBattle11
+            {
+                avatarAddress = _avatar1Address,
+                enemyAddress = _avatar2Address,
+                weeklyArenaAddress = _weeklyArenaAddress,
+                costumeIds = new List<Guid> { costume.ItemId },
+                equipmentIds = new List<Guid>(),
+            };
+
+            var nextState = action.Execute(new ActionContext
+            {
+                PreviousStates = previousState,
+                Signer = _agent1Address,
+                Random = new TestRandom(),
+                Rehearsal = false,
+                BlockIndex = RankingBattle11.UpdateTargetBlockIndex - 1,
+            });
+
+            var nextAvatar1State = nextState.GetAvatarStateV2(_avatar1Address);
+            var nextWeeklyState = nextState.GetWeeklyArenaState(ArenaIndex);
+            var nextArenaInfo = nextWeeklyState[_avatar1Address];
+
+            Assert.Contains(nextAvatar1State.inventory.Materials, i => itemIds.Contains(i.Id));
+            Assert.NotNull(action.ArenaInfo);
+            Assert.NotNull(action.EnemyArenaInfo);
+            Assert.True(nextArenaInfo.Score > prevScore);
+
+            // Check simulation result equal.
+            var player = new Player(
+                previousAvatar1State,
+                _tableSheets.CharacterSheet,
+                _tableSheets.CharacterLevelSheet,
+                _tableSheets.EquipmentItemSetEffectSheet);
+            var simulator = new RankingSimulator(
+                new TestRandom(),
+                player,
+                action.EnemyPlayerDigest,
+                new List<Guid>(),
+                _tableSheets.GetRankingSimulatorSheets(),
+                RankingBattle11.StageId,
+                action.ArenaInfo,
+                action.EnemyArenaInfo,
+                _tableSheets.CostumeStatSheet);
+            simulator.SimulateV5();
+
+            Assert.Equal(nextArenaInfo.Score, simulator.Log.score);
+            Assert.Equal(previousAvatar1State.SerializeV2(), nextAvatar1State.SerializeV2());
+            Assert.Equal(previousAvatar1State.worldInformation.Serialize(), nextAvatar1State.worldInformation.Serialize());
+        }
+
+        [Fact]
+        public void ExecuteThrowInvalidAddressException()
+        {
+            var action = new RankingBattle11
+            {
+                avatarAddress = _avatar1Address,
+                enemyAddress = _avatar1Address,
+                weeklyArenaAddress = _weeklyArenaAddress,
+                costumeIds = new List<Guid>(),
+                equipmentIds = new List<Guid>(),
+            };
+
+            Assert.Throws<InvalidAddressException>(() =>
+            {
+                action.Execute(new ActionContext
+                {
+                    PreviousStates = _initialState,
+                    Signer = _agent1Address,
+                    Random = new TestRandom(),
+                    Rehearsal = false,
+                });
+            });
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void ExecuteThrowFailedLoadStateException(int caseIndex)
+        {
+            Address signer = default;
+            Address avatarAddress = default;
+            Address enemyAddress = default;
+
+            switch (caseIndex)
+            {
+                case 0:
+                    signer = new PrivateKey().ToAddress();
+                    avatarAddress = _avatar1Address;
+                    enemyAddress = _avatar2Address;
+                    break;
+                case 1:
+                    signer = _agent1Address;
+                    avatarAddress = _avatar1Address;
+                    enemyAddress = new PrivateKey().ToAddress();
+                    break;
+            }
+
+            var action = new RankingBattle11
+            {
+                avatarAddress = avatarAddress,
+                enemyAddress = enemyAddress,
+                weeklyArenaAddress = _weeklyArenaAddress,
+                costumeIds = new List<Guid>(),
+                equipmentIds = new List<Guid>(),
+            };
+
+            Assert.Throws<FailedLoadStateException>(() =>
+            {
+                action.Execute(new ActionContext
+                {
+                    PreviousStates = _initialState,
+                    Signer = signer,
+                    Random = new TestRandom(),
+                    Rehearsal = false,
+                });
+            });
+        }
+
+        [Fact]
+        public void ExecuteThrowNotEnoughClearedStageLevelException()
+        {
+            var previousAvatar1State = _initialState.GetAvatarState(_avatar1Address);
+            previousAvatar1State.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                false
+            );
+            var previousState = _initialState.SetState(
+                _avatar1Address,
+                previousAvatar1State.Serialize());
+
+            var action = new RankingBattle11
+            {
+                avatarAddress = _avatar1Address,
+                enemyAddress = _avatar2Address,
+                weeklyArenaAddress = _weeklyArenaAddress,
+                costumeIds = new List<Guid>(),
+                equipmentIds = new List<Guid>(),
+            };
+
+            Assert.Throws<NotEnoughClearedStageLevelException>(() =>
+            {
+                action.Execute(new ActionContext
+                {
+                    PreviousStates = previousState,
+                    Signer = _agent1Address,
+                    Random = new TestRandom(),
+                    Rehearsal = false,
+                });
+            });
+        }
+
+        [Fact]
+        public void ExecuteThrowWeeklyArenaStateAlreadyEndedException()
+        {
+            var previousWeeklyArenaState = _initialState.GetWeeklyArenaState(_weeklyArenaAddress);
+            previousWeeklyArenaState.Ended = true;
+
+            var previousState = _initialState.SetState(
+                _weeklyArenaAddress,
+                previousWeeklyArenaState.Serialize());
+
+            var action = new RankingBattle11
+            {
+                avatarAddress = _avatar1Address,
+                enemyAddress = _avatar2Address,
+                weeklyArenaAddress = _weeklyArenaAddress,
+                costumeIds = new List<Guid>(),
+                equipmentIds = new List<Guid>(),
+            };
+
+            Assert.Throws<WeeklyArenaStateAlreadyEndedException>(() =>
+            {
+                action.Execute(new ActionContext
+                {
+                    PreviousStates = previousState,
+                    Signer = _agent1Address,
+                    Random = new TestRandom(),
+                    Rehearsal = false,
+                });
+            });
+        }
+
+        [Fact]
+        public void ExecuteThrowWeeklyArenaStateNotContainsAvatarAddressException()
+        {
+            var targetAddress = _avatar2Address;
+
+            var previousWeeklyArenaState = _initialState.GetWeeklyArenaState(_weeklyArenaAddress);
+            previousWeeklyArenaState.Remove(targetAddress);
+
+            var previousState = _initialState.SetState(
+                _weeklyArenaAddress,
+                previousWeeklyArenaState.Serialize());
+
+            var action = new RankingBattle11
+            {
+                avatarAddress = _avatar1Address,
+                enemyAddress = _avatar2Address,
+                weeklyArenaAddress = _weeklyArenaAddress,
+                costumeIds = new List<Guid>(),
+                equipmentIds = new List<Guid>(),
+            };
+
+            Assert.Throws<WeeklyArenaStateNotContainsAvatarAddressException>(() =>
+            {
+                action.Execute(new ActionContext
+                {
+                    PreviousStates = previousState,
+                    Signer = _agent1Address,
+                    Random = new TestRandom(),
+                    Rehearsal = false,
+                });
+            });
+        }
+
+        [Fact]
+        public void ExecuteThrowNotEnoughWeeklyArenaChallengeCountException()
+        {
+            var previousAvatarState = _initialState.GetAvatarState(_avatar1Address);
+            var previousWeeklyArenaState = _initialState.GetWeeklyArenaState(_weeklyArenaAddress);
+            while (true)
+            {
+                var arenaInfo = previousWeeklyArenaState.GetArenaInfo(_avatar1Address);
+                arenaInfo.UpdateV3(previousAvatarState, arenaInfo, BattleLog.Result.Lose);
+                if (arenaInfo.DailyChallengeCount == 0)
+                {
+                    break;
+                }
+            }
+
+            var previousState = _initialState.SetState(
+                _weeklyArenaAddress,
+                previousWeeklyArenaState.Serialize());
+
+            var action = new RankingBattle11
+            {
+                avatarAddress = _avatar1Address,
+                enemyAddress = _avatar2Address,
+                weeklyArenaAddress = _weeklyArenaAddress,
+                costumeIds = new List<Guid>(),
+                equipmentIds = new List<Guid>(),
+            };
+
+            Assert.Throws<NotEnoughWeeklyArenaChallengeCountException>(() =>
+            {
+                action.Execute(new ActionContext
+                {
+                    PreviousStates = previousState,
+                    Signer = _agent1Address,
+                    Random = new TestRandom(),
+                    Rehearsal = false,
+                });
+            });
+        }
+
+        [Theory]
+        [InlineData(15)]
+        [InlineData(30)]
+        [InlineData(50)]
+        [InlineData(75)]
+        [InlineData(100)]
+        [InlineData(120)]
+        [InlineData(150)]
+        [InlineData(200)]
+        public void Execute_Throw_NotEnoughAvatarLevelException(int avatarLevel)
+        {
+            var state = _initialState;
+            var avatarState = state.GetAvatarState(_avatar1Address);
+            avatarState.level = avatarLevel;
+            var enemyAddress = _avatar2Address;
+
+            var previousWeeklyArenaState = state.GetWeeklyArenaState(_weeklyArenaAddress);
+
+            state = state.SetState(
+                _weeklyArenaAddress,
+                previousWeeklyArenaState.Serialize());
+
+            var itemIds = new[] { GameConfig.DefaultAvatarWeaponId, 40100000 };
+            foreach (var itemId in itemIds)
+            {
+                foreach (var requirementRow in _tableSheets.ItemRequirementSheet.OrderedList
+                    .Where(e => e.ItemId >= itemId && e.Level > avatarState.level)
+                    .Take(3))
+                {
+                    var costumes = new List<Guid>();
+                    var equipments = new List<Guid>();
+                    var random = new TestRandom(DateTimeOffset.Now.Millisecond);
+                    if (_tableSheets.EquipmentItemSheet.TryGetValue(requirementRow.ItemId, out var row))
+                    {
+                        var equipment = ItemFactory.CreateItem(row, random);
+                        avatarState.inventory.AddItem(equipment);
+                        equipments.Add(((INonFungibleItem)equipment).NonFungibleId);
+                    }
+                    else if (_tableSheets.CostumeItemSheet.TryGetValue(requirementRow.ItemId, out var row2))
+                    {
+                        var costume = ItemFactory.CreateItem(row2, random);
+                        avatarState.inventory.AddItem(costume);
+                        costumes.Add(((INonFungibleItem)costume).NonFungibleId);
+                    }
+
+                    state = state.SetState(avatarState.address, avatarState.SerializeV2())
+                        .SetState(
+                            avatarState.address.Derive(LegacyInventoryKey),
+                            avatarState.inventory.Serialize())
+                        .SetState(
+                            avatarState.address.Derive(LegacyWorldInformationKey),
+                            avatarState.worldInformation.Serialize())
+                        .SetState(
+                            avatarState.address.Derive(LegacyQuestListKey),
+                            avatarState.questList.Serialize());
+
+                    var action = new RankingBattle11
+                    {
+                        avatarAddress = avatarState.address,
+                        enemyAddress = enemyAddress,
+                        weeklyArenaAddress = _weeklyArenaAddress,
+                        costumeIds = costumes,
+                        equipmentIds = equipments,
+                    };
+
+                    Assert.Throws<NotEnoughAvatarLevelException>(() => action.Execute(new ActionContext
+                    {
+                        PreviousStates = state,
+                        Signer = _agent1Address,
+                        Random = random,
+                        BlockIndex = 3806324 + 1, // Ranking Battle Action throws NotEnoughAvatarLevelException when BlockIndex is higher than 3806324.
+                    }));
+                }
+            }
+        }
+
+        [Fact]
+        public void Rehearsal()
+        {
+            var action = new RankingBattle11
+            {
+                avatarAddress = _avatar1Address,
+                enemyAddress = _avatar2Address,
+                weeklyArenaAddress = _weeklyArenaAddress,
+                costumeIds = new List<Guid>(),
+                equipmentIds = new List<Guid>(),
+            };
+
+            var updatedAddresses = new List<Address>
+            {
+                _avatar1Address,
+                _weeklyArenaAddress,
+                _avatar1Address.Derive(LegacyInventoryKey),
+                _avatar1Address.Derive(LegacyWorldInformationKey),
+                _avatar1Address.Derive(LegacyQuestListKey),
+            };
+
+            var state = new State();
+
+            var nextState = action.Execute(new ActionContext
+            {
+                PreviousStates = state,
+                Signer = _agent1Address,
+                BlockIndex = 0,
+                Rehearsal = true,
+            });
+
+            Assert.Equal(updatedAddresses.ToImmutableHashSet(), nextState.UpdatedAddresses);
+        }
+
+        [Theory]
+        [InlineData(ItemSubType.Weapon, GameConfig.MaxEquipmentSlotCount.Weapon)]
+        [InlineData(ItemSubType.Armor, GameConfig.MaxEquipmentSlotCount.Armor)]
+        [InlineData(ItemSubType.Belt, GameConfig.MaxEquipmentSlotCount.Belt)]
+        [InlineData(ItemSubType.Necklace, GameConfig.MaxEquipmentSlotCount.Necklace)]
+        [InlineData(ItemSubType.Ring, GameConfig.MaxEquipmentSlotCount.Ring)]
+        public void MultipleEquipmentTest(ItemSubType type, int maxCount)
+        {
+            var previousAvatarState = _initialState.GetAvatarState(_avatar1Address);
+            var maxLevel = _tableSheets.CharacterLevelSheet.Max(row => row.Value.Level);
+            var expRow = _tableSheets.CharacterLevelSheet[maxLevel];
+            var maxLevelExp = expRow.Exp;
+
+            previousAvatarState.level = maxLevel;
+            previousAvatarState.exp = maxLevelExp;
+
+            var weaponRows = _tableSheets
+                .EquipmentItemSheet
+                .Values
+                .Where(r => r.ItemSubType == type)
+                .Take(maxCount + 1);
+
+            var equipments = new List<Guid>();
+            foreach (var row in weaponRows)
+            {
+                var equipment = ItemFactory.CreateItem(
+                        _tableSheets.EquipmentItemSheet[row.Id],
+                        new TestRandom())
+                    as Equipment;
+
+                equipments.Add(equipment.ItemId);
+                previousAvatarState.inventory.AddItem(equipment);
+            }
+
+            var state = _initialState.SetState(_avatar1Address, previousAvatarState.Serialize());
+
+            var action = new RankingBattle11
+            {
+                avatarAddress = _avatar1Address,
+                enemyAddress = _avatar2Address,
+                weeklyArenaAddress = _weeklyArenaAddress,
+                costumeIds = new List<Guid>(),
+                equipmentIds = equipments,
+            };
+
+            Assert.Throws<DuplicateEquipmentException>(() => action.Execute(new ActionContext
+            {
+                PreviousStates = state,
+                Signer = _agent1Address,
+                Random = new TestRandom(),
+                Rehearsal = false,
+            }));
+        }
+    }
+}

--- a/.Lib9c.Tests/Action/RankingBattle8Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle8Test.cs
@@ -239,7 +239,7 @@
                 action.ArenaInfo,
                 action.EnemyArenaInfo,
                 _tableSheets.CostumeStatSheet);
-            simulator.Simulate();
+            simulator.SimulateV5();
 
             BattleLog log = simulator.Log;
             BattleLog result = action.Result;

--- a/.Lib9c.Tests/Action/RankingBattle9Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle9Test.cs
@@ -239,7 +239,7 @@ namespace Lib9c.Tests.Action
                 action.ArenaInfo,
                 action.EnemyArenaInfo,
                 _tableSheets.CostumeStatSheet);
-            simulator.Simulate();
+            simulator.SimulateV5();
 
             BattleLog log = simulator.Log;
             BattleLog result = action.Result;

--- a/.Lib9c.Tests/Action/RankingBattleTest.cs
+++ b/.Lib9c.Tests/Action/RankingBattleTest.cs
@@ -24,7 +24,6 @@ namespace Lib9c.Tests.Action
 
     public class RankingBattleTest
     {
-        private const int ArenaIndex = RankingBattle.UpdateTargetWeeklyArenaIndex - 1;
         private readonly TableSheets _tableSheets;
         private readonly Address _agent1Address;
         private readonly Address _avatar1Address;
@@ -62,11 +61,25 @@ namespace Lib9c.Tests.Action
             var agent2Address = agent2State.address;
             _avatar2Address = avatar2State.address;
 
-            var weeklyArenaState = new WeeklyArenaState(ArenaIndex);
-            weeklyArenaState.SetV2(avatar1State, _tableSheets.CharacterSheet, _tableSheets.CostumeStatSheet);
-            weeklyArenaState[_avatar1Address].Activate();
-            weeklyArenaState.SetV2(avatar2State, _tableSheets.CharacterSheet, _tableSheets.CostumeStatSheet);
-            weeklyArenaState[_avatar2Address].Activate();
+            var weeklyArenaState = new WeeklyArenaState(0);
+            var weeklyAddressListAddress = weeklyArenaState.address.Derive("address_list");
+            var weeklyAddressList = new List<Address>
+            {
+                _avatar1Address,
+                _avatar2Address,
+            };
+            var arenaInfo1Address = weeklyArenaState.address.Derive(_avatar1Address.ToByteArray());
+            var arenaInfo1 = new ArenaInfo(
+                avatar1State,
+                _tableSheets.CharacterSheet,
+                _tableSheets.CostumeStatSheet,
+                true);
+            var arenaInfo2Address = weeklyArenaState.address.Derive(_avatar2Address.ToByteArray());
+            var arenaInfo2 = new ArenaInfo(
+                avatar2State,
+                _tableSheets.CharacterSheet,
+                _tableSheets.CostumeStatSheet,
+                true);
             _weeklyArenaAddress = weeklyArenaState.address;
 
             _initialState = _initialState
@@ -75,7 +88,12 @@ namespace Lib9c.Tests.Action
                 .SetState(agent2Address, agent2State.Serialize())
                 .SetState(_avatar2Address, avatar2State.Serialize())
                 .SetState(Addresses.GameConfig, new GameConfigState(sheets[nameof(GameConfigSheet)]).Serialize())
-                .SetState(_weeklyArenaAddress, weeklyArenaState.Serialize());
+                .SetState(_weeklyArenaAddress, weeklyArenaState.Serialize())
+                .SetState(
+                    weeklyAddressListAddress,
+                    weeklyAddressList.Aggregate(List.Empty, (list, address) => list.Add(address.Serialize())))
+                .SetState(arenaInfo1Address, arenaInfo1.Serialize())
+                .SetState(arenaInfo2Address, arenaInfo2.Serialize());
 
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
@@ -115,14 +133,18 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Execute()
         {
-            var previousWeeklyState = _initialState.GetWeeklyArenaState(ArenaIndex);
-            var previousAvatar1State = _initialState.GetAvatarState(_avatar1Address);
+            var previousState = _initialState;
+            var previousWeeklyState = previousState.GetWeeklyArenaState(0);
+            var previousAvatar1State = previousState.GetAvatarState(_avatar1Address);
             previousAvatar1State.level = 10;
-            var prevScore = previousWeeklyState[_avatar1Address].Score;
-
-            var previousState = _initialState.SetState(
+            previousState = previousState.SetState(
                 _avatar1Address,
                 previousAvatar1State.Serialize());
+
+            var previousArenaInfo1Address = previousWeeklyState.address.Derive(_avatar1Address.ToByteArray());
+            var previousArenaInfo1 =
+                new ArenaInfo((Dictionary)previousState.GetState(previousArenaInfo1Address));
+            var previousScore = previousArenaInfo1.Score;
 
             var itemIds = _tableSheets.WeeklyArenaRewardSheet.Values
                 .Select(r => r.Reward.ItemId)
@@ -130,53 +152,22 @@ namespace Lib9c.Tests.Action
 
             Assert.All(itemIds, id => Assert.False(previousAvatar1State.inventory.HasItem(id)));
 
-            var row = _tableSheets.CostumeStatSheet.Values.First(r => r.StatType == StatType.ATK);
-            var costume = (Costume)ItemFactory.CreateItem(
-                _tableSheets.ItemSheet[row.CostumeId], new TestRandom());
-            costume.equipped = true;
-            previousAvatar1State.inventory.AddItem(costume);
-
-            var row2 = _tableSheets.CostumeStatSheet.Values.First(r => r.StatType == StatType.DEF);
-            var enemyCostume = (Costume)ItemFactory.CreateItem(
-                _tableSheets.ItemSheet[row2.CostumeId], new TestRandom());
-            enemyCostume.equipped = true;
-            var enemyAvatarState = _initialState.GetAvatarState(_avatar2Address);
-            enemyAvatarState.inventory.AddItem(enemyCostume);
-
-            Address worldInformationAddress = _avatar1Address.Derive(LegacyWorldInformationKey);
-            var weeklyArenaAddress =
-                WeeklyArenaState.DeriveAddress(RankingBattle.UpdateTargetWeeklyArenaIndex);
-            previousState = previousState
-                .SetState(
-                    _avatar1Address.Derive(LegacyInventoryKey),
-                    previousAvatar1State.inventory.Serialize())
-                .SetState(
-                    worldInformationAddress,
-                    previousAvatar1State.worldInformation.Serialize())
-                .SetState(
-                    _avatar1Address.Derive(LegacyQuestListKey),
-                    previousAvatar1State.questList.Serialize())
-                .SetState(_avatar1Address, previousAvatar1State.SerializeV2())
-                .SetState(
-                    _avatar2Address.Derive(LegacyInventoryKey),
-                    enemyAvatarState.inventory.Serialize())
-                .SetState(
-                    _avatar2Address.Derive(LegacyWorldInformationKey),
-                    enemyAvatarState.worldInformation.Serialize())
-                .SetState(
-                    _avatar2Address.Derive(LegacyQuestListKey),
-                    enemyAvatarState.questList.Serialize())
-                .SetState(_avatar2Address, enemyAvatarState.SerializeV2())
-                .SetState(
-                    weeklyArenaAddress,
-                    new WeeklyArenaState(RankingBattle.UpdateTargetWeeklyArenaIndex).Serialize());
+            var enemyAvatarState = previousState.GetAvatarState(_avatar2Address);
+            previousState = SetState(
+                previousState,
+                _tableSheets,
+                previousAvatar1State,
+                false,
+                enemyAvatarState,
+                false,
+                out var costumeNonFungibleId);
 
             var action = new RankingBattle
             {
                 avatarAddress = _avatar1Address,
                 enemyAddress = _avatar2Address,
-                weeklyArenaAddress = weeklyArenaAddress,
-                costumeIds = new List<Guid> { costume.ItemId },
+                weeklyArenaAddress = _weeklyArenaAddress,
+                costumeIds = new List<Guid> { costumeNonFungibleId },
                 equipmentIds = new List<Guid>(),
             };
 
@@ -186,25 +177,30 @@ namespace Lib9c.Tests.Action
                 Signer = _agent1Address,
                 Random = new TestRandom(),
                 Rehearsal = false,
-                BlockIndex = RankingBattle.UpdateTargetBlockIndex,
             });
-
-            Assert.True(nextState.TryGetState(weeklyArenaAddress.Derive(_avatar1Address.ToByteArray()), out Dictionary rawArenaInfo));
-            Assert.True(nextState.TryGetState(weeklyArenaAddress.Derive(_avatar2Address.ToByteArray()), out Dictionary rawEnemyInfo));
-            Assert.True(nextState.TryGetState(weeklyArenaAddress.Derive("address_list"), out List rawAddressList));
-            var nextWeekly = nextState.GetWeeklyArenaState(weeklyArenaAddress);
-            Assert.Empty(nextWeekly.Map);
-
-            var nextAvatar1State = nextState.GetAvatarStateV2(_avatar1Address);
-            var nextArenaInfo = new ArenaInfo(rawArenaInfo);
-            var addressList = rawAddressList.ToList(StateExtensions.ToAddress);
-
-            Assert.Contains(_avatar1Address, addressList);
-            Assert.Contains(_avatar2Address, addressList);
-            Assert.Contains(nextAvatar1State.inventory.Materials, i => itemIds.Contains(i.Id));
             Assert.NotNull(action.ArenaInfo);
             Assert.NotNull(action.EnemyArenaInfo);
-            Assert.True(nextArenaInfo.Score > prevScore);
+
+            var nextWeeklyArenaState = nextState.GetWeeklyArenaState(0);
+            Assert.True(nextState.TryGetState(
+                nextWeeklyArenaState.address.Derive(_avatar1Address.ToByteArray()),
+                out Dictionary rawArenaInfo));
+            var nextArenaInfo = new ArenaInfo(rawArenaInfo);
+            Assert.True(nextArenaInfo.Score > previousScore);
+
+            Assert.True(nextState.TryGetState(
+                nextWeeklyArenaState.address.Derive(_avatar2Address.ToByteArray()),
+                out Dictionary _));
+
+            Assert.True(nextState.TryGetState(nextWeeklyArenaState.address.Derive("address_list"), out List rawAddressList));
+            var addressList = rawAddressList.ToList(StateExtensions.ToAddress);
+            Assert.Contains(_avatar1Address, addressList);
+            Assert.Contains(_avatar2Address, addressList);
+
+            Assert.Empty(nextWeeklyArenaState.Map);
+
+            var nextAvatar1State = nextState.GetAvatarStateV2(_avatar1Address);
+            Assert.Contains(nextAvatar1State.inventory.Materials, i => itemIds.Contains(i.Id));
 
             // Check simulation result equal.
             var player = new Player(
@@ -222,7 +218,7 @@ namespace Lib9c.Tests.Action
                 action.ArenaInfo,
                 action.EnemyArenaInfo,
                 _tableSheets.CostumeStatSheet);
-            simulator.SimulateV5();
+            simulator.Simulate(ArenaScoreHelper.GetScore);
 
             Assert.Equal(nextArenaInfo.Score, simulator.Log.score);
             Assert.Equal(previousAvatar1State.SerializeV2(), nextAvatar1State.SerializeV2());
@@ -240,18 +236,27 @@ namespace Lib9c.Tests.Action
         [InlineData(false, false, false)]
         public void Execute_Backward_Compatible(bool isNew, bool avatarBackward, bool enemyBackward)
         {
-            var previousWeeklyState = _initialState.GetWeeklyArenaState(ArenaIndex);
-            var previousAvatar1State = _initialState.GetAvatarState(_avatar1Address);
+            var previousState = _initialState;
+            var previousWeeklyState = previousState.GetWeeklyArenaState(0);
+            var previousAvatar1State = previousState.GetAvatarState(_avatar1Address);
             previousAvatar1State.level = 10;
-            var prevScore = previousWeeklyState[_avatar1Address].Score;
-            if (isNew)
-            {
-                previousWeeklyState.Remove(_avatar1Address);
-            }
-
-            var previousState = _initialState.SetState(
+            previousState = previousState.SetState(
                 _avatar1Address,
                 previousAvatar1State.Serialize());
+
+            var previousArenaInfo1Address = previousWeeklyState.address.Derive(_avatar1Address.ToByteArray());
+            var previousArenaInfo1 =
+                new ArenaInfo((Dictionary)previousState.GetState(previousArenaInfo1Address));
+            var previousScore = previousArenaInfo1.Score;
+            if (isNew)
+            {
+                var addressListAddress = previousWeeklyState.address.Derive("address_list");
+                if (previousState.TryGetState(addressListAddress, out List rawAddressList))
+                {
+                    rawAddressList = new List(rawAddressList.Remove(_avatar1Address.Serialize()));
+                    previousState = previousState.SetState(addressListAddress, rawAddressList);
+                }
+            }
 
             var itemIds = _tableSheets.WeeklyArenaRewardSheet.Values
                 .Select(r => r.Reward.ItemId)
@@ -259,66 +264,22 @@ namespace Lib9c.Tests.Action
 
             Assert.All(itemIds, id => Assert.False(previousAvatar1State.inventory.HasItem(id)));
 
-            var row = _tableSheets.CostumeStatSheet.Values.First(r => r.StatType == StatType.ATK);
-            var costume = (Costume)ItemFactory.CreateItem(
-                _tableSheets.ItemSheet[row.CostumeId], new TestRandom());
-            costume.equipped = true;
-            previousAvatar1State.inventory.AddItem(costume);
-
-            var row2 = _tableSheets.CostumeStatSheet.Values.First(r => r.StatType == StatType.DEF);
-            var enemyCostume = (Costume)ItemFactory.CreateItem(
-                _tableSheets.ItemSheet[row2.CostumeId], new TestRandom());
-            enemyCostume.equipped = true;
-            var enemyAvatarState = _initialState.GetAvatarState(_avatar2Address);
-            enemyAvatarState.inventory.AddItem(enemyCostume);
-
-            Address worldInformationAddress = _avatar1Address.Derive(LegacyWorldInformationKey);
-            if (avatarBackward)
-            {
-                previousState =
-                    previousState.SetState(_avatar1Address, previousAvatar1State.Serialize());
-            }
-            else
-            {
-                previousState = previousState
-                    .SetState(
-                        _avatar1Address.Derive(LegacyInventoryKey),
-                        previousAvatar1State.inventory.Serialize())
-                    .SetState(
-                        worldInformationAddress,
-                        previousAvatar1State.worldInformation.Serialize())
-                    .SetState(
-                        _avatar1Address.Derive(LegacyQuestListKey),
-                        previousAvatar1State.questList.Serialize())
-                    .SetState(_avatar1Address, previousAvatar1State.SerializeV2());
-            }
-
-            if (enemyBackward)
-            {
-                previousState =
-                    previousState.SetState(_avatar2Address, enemyAvatarState.Serialize());
-            }
-            else
-            {
-                previousState = previousState
-                    .SetState(
-                        _avatar2Address.Derive(LegacyInventoryKey),
-                        enemyAvatarState.inventory.Serialize())
-                    .SetState(
-                        _avatar2Address.Derive(LegacyWorldInformationKey),
-                        enemyAvatarState.worldInformation.Serialize())
-                    .SetState(
-                        _avatar2Address.Derive(LegacyQuestListKey),
-                        enemyAvatarState.questList.Serialize())
-                    .SetState(_avatar2Address, enemyAvatarState.SerializeV2());
-            }
+            var enemyAvatarState = previousState.GetAvatarState(_avatar2Address);
+            previousState = SetState(
+                previousState,
+                _tableSheets,
+                previousAvatar1State,
+                avatarBackward,
+                enemyAvatarState,
+                enemyBackward,
+                out var costumeNonFungibleId);
 
             var action = new RankingBattle
             {
                 avatarAddress = _avatar1Address,
                 enemyAddress = _avatar2Address,
                 weeklyArenaAddress = _weeklyArenaAddress,
-                costumeIds = new List<Guid> { costume.ItemId },
+                costumeIds = new List<Guid> { costumeNonFungibleId },
                 equipmentIds = new List<Guid>(),
             };
 
@@ -328,17 +289,18 @@ namespace Lib9c.Tests.Action
                 Signer = _agent1Address,
                 Random = new TestRandom(),
                 Rehearsal = false,
-                BlockIndex = RankingBattle.UpdateTargetBlockIndex - 1,
             });
-
-            var nextAvatar1State = nextState.GetAvatarStateV2(_avatar1Address);
-            var nextWeeklyState = nextState.GetWeeklyArenaState(ArenaIndex);
-            var nextArenaInfo = nextWeeklyState[_avatar1Address];
-
-            Assert.Contains(nextAvatar1State.inventory.Materials, i => itemIds.Contains(i.Id));
             Assert.NotNull(action.ArenaInfo);
             Assert.NotNull(action.EnemyArenaInfo);
-            Assert.True(nextArenaInfo.Score > prevScore);
+
+            var nextAvatar1State = nextState.GetAvatarStateV2(_avatar1Address);
+            Assert.Contains(nextAvatar1State.inventory.Materials, i => itemIds.Contains(i.Id));
+
+            var nextWeeklyArenaState = nextState.GetWeeklyArenaState(0);
+            var nextArenaInfo1Address = nextWeeklyArenaState.address.Derive(_avatar1Address.ToByteArray());
+            var nextArenaInfo1 =
+                new ArenaInfo((Dictionary)nextState.GetState(nextArenaInfo1Address));
+            Assert.True(nextArenaInfo1.Score > previousScore);
 
             // Check simulation result equal.
             var player = new Player(
@@ -356,9 +318,9 @@ namespace Lib9c.Tests.Action
                 action.ArenaInfo,
                 action.EnemyArenaInfo,
                 _tableSheets.CostumeStatSheet);
-            simulator.SimulateV5();
+            simulator.Simulate(ArenaScoreHelper.GetScore);
 
-            Assert.Equal(nextArenaInfo.Score, simulator.Log.score);
+            Assert.Equal(nextArenaInfo1.Score, simulator.Log.score);
             Assert.Equal(previousAvatar1State.SerializeV2(), nextAvatar1State.SerializeV2());
             Assert.Equal(previousAvatar1State.worldInformation.Serialize(), nextAvatar1State.worldInformation.Serialize());
         }
@@ -497,56 +459,23 @@ namespace Lib9c.Tests.Action
         }
 
         [Fact]
-        public void ExecuteThrowWeeklyArenaStateNotContainsAvatarAddressException()
-        {
-            var targetAddress = _avatar2Address;
-
-            var previousWeeklyArenaState = _initialState.GetWeeklyArenaState(_weeklyArenaAddress);
-            previousWeeklyArenaState.Remove(targetAddress);
-
-            var previousState = _initialState.SetState(
-                _weeklyArenaAddress,
-                previousWeeklyArenaState.Serialize());
-
-            var action = new RankingBattle
-            {
-                avatarAddress = _avatar1Address,
-                enemyAddress = _avatar2Address,
-                weeklyArenaAddress = _weeklyArenaAddress,
-                costumeIds = new List<Guid>(),
-                equipmentIds = new List<Guid>(),
-            };
-
-            Assert.Throws<WeeklyArenaStateNotContainsAvatarAddressException>(() =>
-            {
-                action.Execute(new ActionContext
-                {
-                    PreviousStates = previousState,
-                    Signer = _agent1Address,
-                    Random = new TestRandom(),
-                    Rehearsal = false,
-                });
-            });
-        }
-
-        [Fact]
         public void ExecuteThrowNotEnoughWeeklyArenaChallengeCountException()
         {
+            var previousArenaInfoAddress = _weeklyArenaAddress.Derive(_avatar1Address.ToByteArray());
+            var previousArenaInfo = new ArenaInfo((Dictionary)_initialState.GetState(previousArenaInfoAddress));
             var previousAvatarState = _initialState.GetAvatarState(_avatar1Address);
-            var previousWeeklyArenaState = _initialState.GetWeeklyArenaState(_weeklyArenaAddress);
             while (true)
             {
-                var arenaInfo = previousWeeklyArenaState.GetArenaInfo(_avatar1Address);
-                arenaInfo.UpdateV3(previousAvatarState, arenaInfo, BattleLog.Result.Lose);
-                if (arenaInfo.DailyChallengeCount == 0)
+                previousArenaInfo.UpdateV3(previousAvatarState, previousArenaInfo, BattleLog.Result.Lose);
+                if (previousArenaInfo.DailyChallengeCount == 0)
                 {
                     break;
                 }
             }
 
             var previousState = _initialState.SetState(
-                _weeklyArenaAddress,
-                previousWeeklyArenaState.Serialize());
+                previousArenaInfoAddress,
+                previousArenaInfo.Serialize());
 
             var action = new RankingBattle
             {
@@ -639,44 +568,9 @@ namespace Lib9c.Tests.Action
                         PreviousStates = state,
                         Signer = _agent1Address,
                         Random = random,
-                        BlockIndex = 3806324 + 1, // Ranking Battle Action throws NotEnoughAvatarLevelException when BlockIndex is higher than 3806324.
                     }));
                 }
             }
-        }
-
-        [Fact]
-        public void Rehearsal()
-        {
-            var action = new RankingBattle
-            {
-                avatarAddress = _avatar1Address,
-                enemyAddress = _avatar2Address,
-                weeklyArenaAddress = _weeklyArenaAddress,
-                costumeIds = new List<Guid>(),
-                equipmentIds = new List<Guid>(),
-            };
-
-            var updatedAddresses = new List<Address>
-            {
-                _avatar1Address,
-                _weeklyArenaAddress,
-                _avatar1Address.Derive(LegacyInventoryKey),
-                _avatar1Address.Derive(LegacyWorldInformationKey),
-                _avatar1Address.Derive(LegacyQuestListKey),
-            };
-
-            var state = new State();
-
-            var nextState = action.Execute(new ActionContext
-            {
-                PreviousStates = state,
-                Signer = _agent1Address,
-                BlockIndex = 0,
-                Rehearsal = true,
-            });
-
-            Assert.Equal(updatedAddresses.ToImmutableHashSet(), nextState.UpdatedAddresses);
         }
 
         [Theory]
@@ -731,6 +625,57 @@ namespace Lib9c.Tests.Action
                 Random = new TestRandom(),
                 Rehearsal = false,
             }));
+        }
+
+        private static IAccountStateDelta SetState(
+            IAccountStateDelta states,
+            TableSheets tableSheets,
+            AvatarState avatarState,
+            bool avatarStateBackward,
+            AvatarState enemyAvatarState,
+            bool enemyAvatarStateBackward,
+            out Guid costumeNonFungibleId)
+        {
+            var row = tableSheets.CostumeStatSheet.Values.First(r => r.StatType == StatType.ATK);
+            var costume = (Costume)ItemFactory.CreateItem(
+                tableSheets.ItemSheet[row.CostumeId],
+                new TestRandom());
+            costumeNonFungibleId = costume.NonFungibleId;
+            costume.equipped = true;
+            avatarState.inventory.AddItem(costume);
+            states = SetState(states, avatarState, avatarStateBackward);
+
+            var row2 = tableSheets.CostumeStatSheet.Values.First(r => r.StatType == StatType.DEF);
+            var enemyCostume = (Costume)ItemFactory.CreateItem(
+                tableSheets.ItemSheet[row2.CostumeId],
+                new TestRandom());
+            enemyCostume.equipped = true;
+            enemyAvatarState.inventory.AddItem(enemyCostume);
+            return SetState(states, enemyAvatarState, enemyAvatarStateBackward);
+        }
+
+        private static IAccountStateDelta SetState(
+            IAccountStateDelta states,
+            AvatarState avatarState,
+            bool backward = false)
+        {
+            var avatarAddress = avatarState.address;
+            if (backward)
+            {
+                return states.SetState(avatarAddress, avatarState.Serialize());
+            }
+
+            return states
+                .SetState(
+                    avatarAddress.Derive(LegacyInventoryKey),
+                    avatarState.inventory.Serialize())
+                .SetState(
+                    avatarAddress.Derive(LegacyWorldInformationKey),
+                    avatarState.worldInformation.Serialize())
+                .SetState(
+                    avatarAddress.Derive(LegacyQuestListKey),
+                    avatarState.questList.Serialize())
+                .SetState(avatarAddress, avatarState.SerializeV2());
         }
     }
 }

--- a/.Lib9c.Tests/Action/RankingBattleTest.cs
+++ b/.Lib9c.Tests/Action/RankingBattleTest.cs
@@ -222,7 +222,7 @@ namespace Lib9c.Tests.Action
                 action.ArenaInfo,
                 action.EnemyArenaInfo,
                 _tableSheets.CostumeStatSheet);
-            simulator.Simulate();
+            simulator.SimulateV5();
 
             Assert.Equal(nextArenaInfo.Score, simulator.Log.score);
             Assert.Equal(previousAvatar1State.SerializeV2(), nextAvatar1State.SerializeV2());
@@ -356,7 +356,7 @@ namespace Lib9c.Tests.Action
                 action.ArenaInfo,
                 action.EnemyArenaInfo,
                 _tableSheets.CostumeStatSheet);
-            simulator.Simulate();
+            simulator.SimulateV5();
 
             Assert.Equal(nextArenaInfo.Score, simulator.Log.score);
             Assert.Equal(previousAvatar1State.SerializeV2(), nextAvatar1State.SerializeV2());

--- a/.Lib9c.Tests/Action/RewardGoldTest.cs
+++ b/.Lib9c.Tests/Action/RewardGoldTest.cs
@@ -10,6 +10,7 @@ namespace Lib9c.Tests.Action
     using Libplanet.Crypto;
     using Nekoyume;
     using Nekoyume.Action;
+    using Nekoyume.Battle;
     using Nekoyume.Model.BattleStatus;
     using Nekoyume.Model.State;
     using Nekoyume.TableData;
@@ -60,7 +61,10 @@ namespace Lib9c.Tests.Action
         {
             var weekly = new WeeklyArenaState(0);
             weekly.Set(_avatarState, _tableSheets.CharacterSheet);
-            weekly[_avatarState.address].Update(weekly[_avatarState.address], BattleLog.Result.Lose);
+            weekly[_avatarState.address].Update(
+                weekly[_avatarState.address],
+                BattleLog.Result.Lose,
+                ArenaScoreHelper.GetScore);
             var gameConfigState = new GameConfigState();
             gameConfigState.Set(_tableSheets.GameConfigSheet);
             var state = _baseState
@@ -146,7 +150,10 @@ namespace Lib9c.Tests.Action
             if (!afterUpdate)
             {
                 weekly.Set(_avatarState, _tableSheets.CharacterSheet);
-                weekly[avatarAddress].Update(weekly[avatarAddress], BattleLog.Result.Lose);
+                weekly[avatarAddress].Update(
+                    weekly[avatarAddress],
+                    BattleLog.Result.Lose,
+                    ArenaScoreHelper.GetScore);
 
                 Assert.Equal(4, weekly[avatarAddress].DailyChallengeCount);
             }
@@ -164,7 +171,10 @@ namespace Lib9c.Tests.Action
             if (afterUpdate)
             {
                 var prevInfo = new ArenaInfo(_avatarState, _tableSheets.CharacterSheet, true);
-                prevInfo.Update(prevInfo, BattleLog.Result.Lose);
+                prevInfo.Update(
+                    prevInfo,
+                    BattleLog.Result.Lose,
+                    ArenaScoreHelper.GetScore);
 
                 Assert.Equal(4, prevInfo.DailyChallengeCount);
 
@@ -226,7 +236,10 @@ namespace Lib9c.Tests.Action
             var legacyWeeklyIndex = RankingBattle.UpdateTargetWeeklyArenaIndex - 1;
             var legacyWeekly = new WeeklyArenaState(legacyWeeklyIndex);
             legacyWeekly.Set(_avatarState, _tableSheets.CharacterSheet);
-            legacyWeekly[_avatarState.address].Update(legacyWeekly[_avatarState.address], BattleLog.Result.Lose);
+            legacyWeekly[_avatarState.address].Update(
+                legacyWeekly[_avatarState.address],
+                BattleLog.Result.Lose,
+                ArenaScoreHelper.GetScore);
 
             Assert.Equal(4, legacyWeekly[_avatarState.address].DailyChallengeCount);
 
@@ -262,7 +275,10 @@ namespace Lib9c.Tests.Action
             Assert.True(state.TryGetState(addressListAddress, out List _));
 
             var prevInfo = new ArenaInfo(prevRawInfo);
-            prevInfo.Update(prevInfo, BattleLog.Result.Lose);
+            prevInfo.Update(
+                prevInfo,
+                BattleLog.Result.Lose,
+                ArenaScoreHelper.GetScore);
 
             Assert.Equal(4, prevInfo.DailyChallengeCount);
 

--- a/.Lib9c.Tests/Action/RewardGoldTest.cs
+++ b/.Lib9c.Tests/Action/RewardGoldTest.cs
@@ -96,7 +96,7 @@ namespace Lib9c.Tests.Action
             var ctx = new ActionContext()
             {
                 BlockIndex = blockIndex,
-                PreviousStates = _baseState,
+                PreviousStates = state,
                 Miner = default,
             };
 
@@ -135,11 +135,10 @@ namespace Lib9c.Tests.Action
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void PrepareNextArena(bool afterUpdate)
+        [InlineData(true, RankingBattle11.UpdateTargetWeeklyArenaIndex - 1, RankingBattle11.UpdateTargetBlockIndex)]
+        [InlineData(false, RankingBattle11.UpdateTargetWeeklyArenaIndex - 1, RankingBattle11.UpdateTargetBlockIndex)]
+        public void PrepareNextArena(bool afterUpdate, int weeklyIndex, int blockIndex)
         {
-            var weeklyIndex = RankingBattle.UpdateTargetWeeklyArenaIndex - 1;
             if (afterUpdate)
             {
                 weeklyIndex++;
@@ -165,8 +164,6 @@ namespace Lib9c.Tests.Action
                 .SetState(weekly.address, weekly.Serialize())
                 .SetState(nextWeekly.address, nextWeekly.Serialize())
                 .SetState(gameConfigState.address, gameConfigState.Serialize());
-
-            var blockIndex = RankingBattle.UpdateTargetBlockIndex;
 
             if (afterUpdate)
             {
@@ -196,7 +193,7 @@ namespace Lib9c.Tests.Action
             var ctx = new ActionContext()
             {
                 BlockIndex = blockIndex,
-                PreviousStates = _baseState,
+                PreviousStates = state,
                 Miner = default,
             };
 
@@ -230,10 +227,10 @@ namespace Lib9c.Tests.Action
             Assert.Equal(avatarAddress, addressList.First());
         }
 
-        [Fact]
-        public void ResetChallengeCount()
+        [Theory]
+        [InlineData(RankingBattle11.UpdateTargetWeeklyArenaIndex - 1, RankingBattle11.UpdateTargetBlockIndex)]
+        public void ResetChallengeCount(int legacyWeeklyIndex, int blockIndex)
         {
-            var legacyWeeklyIndex = RankingBattle.UpdateTargetWeeklyArenaIndex - 1;
             var legacyWeekly = new WeeklyArenaState(legacyWeeklyIndex);
             legacyWeekly.Set(_avatarState, _tableSheets.CharacterSheet);
             legacyWeekly[_avatarState.address].Update(
@@ -257,8 +254,8 @@ namespace Lib9c.Tests.Action
 
             var migrationCtx = new ActionContext
             {
-                BlockIndex = RankingBattle.UpdateTargetBlockIndex,
-                PreviousStates = _baseState,
+                BlockIndex = blockIndex,
+                PreviousStates = state,
                 Miner = default,
             };
 
@@ -282,7 +279,7 @@ namespace Lib9c.Tests.Action
 
             Assert.Equal(4, prevInfo.DailyChallengeCount);
 
-            var blockIndex = RankingBattle.UpdateTargetBlockIndex + gameConfigState.DailyArenaInterval;
+            blockIndex += gameConfigState.DailyArenaInterval;
 
             var ctx = new ActionContext
             {

--- a/.Lib9c.Tests/Action/Scenario/WeeklyArenaStateUpdateScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/WeeklyArenaStateUpdateScenarioTest.cs
@@ -109,13 +109,13 @@ namespace Lib9c.Tests.Action.Scenario
             };
             agent3State.avatarAddresses.Add(0, _avatar3Address);
 
-            var prevWeeklyArenaState = new WeeklyArenaState(RankingBattle.UpdateTargetWeeklyArenaIndex - 2);
-            var weeklyArenaState = new WeeklyArenaState(RankingBattle.UpdateTargetWeeklyArenaIndex - 1);
+            var prevWeeklyArenaState = new WeeklyArenaState(RankingBattle11.UpdateTargetWeeklyArenaIndex - 2);
+            var weeklyArenaState = new WeeklyArenaState(RankingBattle11.UpdateTargetWeeklyArenaIndex - 1);
             weeklyArenaState.SetV2(avatarState, tableSheets.CharacterSheet, tableSheets.CostumeStatSheet);
             weeklyArenaState[_avatar1Address].Activate();
             weeklyArenaState.SetV2(avatar2State, tableSheets.CharacterSheet, tableSheets.CostumeStatSheet);
             weeklyArenaState[_avatar2Address].Activate();
-            _weeklyArenaAddress = WeeklyArenaState.DeriveAddress(RankingBattle.UpdateTargetWeeklyArenaIndex);
+            _weeklyArenaAddress = WeeklyArenaState.DeriveAddress(RankingBattle11.UpdateTargetWeeklyArenaIndex);
 
             var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
 
@@ -129,7 +129,7 @@ namespace Lib9c.Tests.Action.Scenario
                 .SetState(Addresses.GameConfig, new GameConfigState(sheets[nameof(GameConfigSheet)]).Serialize())
                 .SetState(prevWeeklyArenaState.address, prevWeeklyArenaState.Serialize())
                 .SetState(weeklyArenaState.address, weeklyArenaState.Serialize())
-                .SetState(_weeklyArenaAddress, new WeeklyArenaState(RankingBattle.UpdateTargetWeeklyArenaIndex).Serialize())
+                .SetState(_weeklyArenaAddress, new WeeklyArenaState(RankingBattle11.UpdateTargetWeeklyArenaIndex).Serialize())
                 .SetState(GoldCurrencyState.Address, gold.Serialize())
                 .SetState(Addresses.GoldDistribution, GoldDistributionTest.Fixture.Select(v => v.Serialize()).Serialize())
                 .MintAsset(GoldCurrencyState.Address, gold.Currency * 100000000000);
@@ -158,7 +158,7 @@ namespace Lib9c.Tests.Action.Scenario
             Assert.False(_initialState.TryGetState(listAddress, out List _));
 
             var testRandom = new TestRandom();
-            var blockIndex = RankingBattle.UpdateTargetBlockIndex;
+            var blockIndex = RankingBattle11.UpdateTargetBlockIndex;
             var nextState = rb.Execute(new ActionContext
             {
                 PreviousStates = _initialState,

--- a/.Lib9c.Tests/Battle/ArenaScoreHelperTest.cs
+++ b/.Lib9c.Tests/Battle/ArenaScoreHelperTest.cs
@@ -50,11 +50,11 @@ namespace Lib9c.Tests
         [InlineData(1000, 500, 1, 0, -30)]
         [InlineData(1000, 0, 1, 0, -30)]
         [InlineData(1000, int.MinValue, 0, 0, 0)]
-        public void GetScoreV2(int challengerScore, int defenderScore, int win, int timeOver, int lose)
+        public void GetScoreV2(int challengerScore, int defenderScore, int winScore, int timeOver, int loseScore)
         {
-            Assert.Equal(win, ArenaScoreHelper.GetScoreV2(challengerScore, defenderScore, Result.Win));
+            Assert.Equal(winScore, ArenaScoreHelper.GetScoreV2(challengerScore, defenderScore, Result.Win));
             Assert.Equal(timeOver, ArenaScoreHelper.GetScoreV2(challengerScore, defenderScore, Result.TimeOver));
-            Assert.Equal(lose, ArenaScoreHelper.GetScoreV2(challengerScore, defenderScore, Result.Lose));
+            Assert.Equal(loseScore, ArenaScoreHelper.GetScoreV2(challengerScore, defenderScore, Result.Lose));
         }
 
         [Theory]
@@ -73,13 +73,41 @@ namespace Lib9c.Tests
         [InlineData(1000, 500, 1, 0, -5)]
         [InlineData(1000, 0, 1, 0, -5)]
         [InlineData(1000, int.MinValue, 0, 0, 0)]
-        public void GetScore(int challengerScore, int defenderScore, int win, int defenderLoseScore, int lose)
+        public void GetScoreV3(
+            int challengerScore,
+            int defenderScore,
+            int winScore,
+            int defenderLoseScore,
+            int loseScore)
         {
-            var result = ArenaScoreHelper.GetScore(challengerScore, defenderScore, Result.Win);
-            Assert.Equal(win, result.challengerScore);
+            var result = ArenaScoreHelper.GetScoreV3(challengerScore, defenderScore, Result.Win);
+            Assert.Equal(winScore, result.challengerScore);
             Assert.Equal(defenderLoseScore, result.defenderScore);
-            result = ArenaScoreHelper.GetScore(challengerScore, defenderScore, Result.Lose);
-            Assert.Equal(lose, result.challengerScore);
+            result = ArenaScoreHelper.GetScoreV3(challengerScore, defenderScore, Result.Lose);
+            Assert.Equal(loseScore, result.challengerScore);
+        }
+
+        [Theory]
+        [InlineData(1000, int.MaxValue, 24, -3, -1)]
+        [InlineData(1000, 1201, 24, -3, -1)]
+        [InlineData(1000, 1101, 22, -2, -1)]
+        [InlineData(1000, 1001, 20, -1, -1)]
+        [InlineData(1000, 1000, 18, -1, -1)]
+        [InlineData(1000, 901, 18, -1, -1)]
+        [InlineData(1000, 801, 16, -1, -1)]
+        [InlineData(1000, 800, 1, -1, 0)]
+        [InlineData(int.MaxValue, 0, 1, -1, 0)]
+        [InlineData(1000, int.MinValue, 0, 0, 0)]
+        [InlineData(int.MinValue, 1000, 0, 0, 0)]
+        [InlineData(int.MinValue, int.MinValue, 0, 0, 0)]
+        public void GetScore(int challengerScore, int defenderScore, int winPoint, int losePoint, int defenderLosePoint)
+        {
+            var (challengerScoreDelta, defenderScoreDelta) =
+                ArenaScoreHelper.GetScore(challengerScore, defenderScore, Result.Win);
+            Assert.Equal(winPoint, challengerScoreDelta);
+            Assert.Equal(defenderLosePoint, defenderScoreDelta);
+            (challengerScoreDelta, _) = ArenaScoreHelper.GetScore(challengerScore, defenderScore, Result.Lose);
+            Assert.Equal(losePoint, challengerScoreDelta);
         }
     }
 }

--- a/.Lib9c.Tests/Model/Item/ShopItemTest.cs
+++ b/.Lib9c.Tests/Model/Item/ShopItemTest.cs
@@ -24,21 +24,10 @@
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
         }
 
-        public static IEnumerable<object[]> GetShopItems() => new List<object[]>
+        [Fact]
+        public void Serialize()
         {
-            new object[]
-            {
-                GetShopItemWithFirstCostume(),
-                GetShopItemWithFirstEquipment(),
-                GetShopItemWithFirstMaterial(),
-            },
-        };
-
-        [Theory]
-        [MemberData(nameof(GetShopItems))]
-        public void Serialize(params ShopItem[] shopItems)
-        {
-            foreach (var shopItem in shopItems)
+            foreach (var shopItem in GetShopItems())
             {
                 var serialized = shopItem.Serialize();
                 var deserialized = new ShopItem((BxDictionary)serialized);
@@ -47,11 +36,10 @@
             }
         }
 
-        [Theory]
-        [MemberData(nameof(GetShopItems))]
-        public void Serialize_With_DotNet_Api(params ShopItem[] shopItems)
+        [Fact]
+        public void Serialize_With_DotNet_Api()
         {
-            foreach (var shopItem in shopItems)
+            foreach (var shopItem in GetShopItems())
             {
                 var formatter = new BinaryFormatter();
                 using var ms = new MemoryStream();
@@ -131,6 +119,13 @@
             serialized = serialized.SetItem(ShopItem.ExpiredBlockIndexKey, "-1");
             Assert.Throws<ArgumentOutOfRangeException>(() => new ShopItem(serialized));
         }
+
+        private static ShopItem[] GetShopItems() => new[]
+        {
+            GetShopItemWithFirstCostume(),
+            GetShopItemWithFirstEquipment(),
+            GetShopItemWithFirstMaterial(),
+        };
 
         private static ShopItem GetShopItemWithFirstCostume()
         {

--- a/Lib9c/Action/RankingBattle.cs
+++ b/Lib9c/Action/RankingBattle.cs
@@ -222,7 +222,7 @@ namespace Nekoyume.Action
                     enemyInfo,
                     costumeStatSheet);
 
-                simulator.Simulate();
+                simulator.SimulateV5();
 
                 sw.Stop();
                 Log.Verbose(
@@ -368,7 +368,7 @@ namespace Nekoyume.Action
                 enemyArenaInfo,
                 costumeStatSheet);
 
-            simulator.Simulate();
+            simulator.SimulateV5();
 
             sw.Stop();
             Log.Verbose(

--- a/Lib9c/Action/RankingBattle.cs
+++ b/Lib9c/Action/RankingBattle.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Numerics;
 using Bencodex.Types;
 using Libplanet;
 using Libplanet.Action;
@@ -18,48 +17,33 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionType("ranking_battle11")]
+    [ActionType("ranking_battle12")]
     public class RankingBattle : GameAction
     {
         public const int StageId = 999999;
-        public static readonly BigInteger EntranceFee = 100;
-        // BlockIndex for ArenaInfo separate from WeeklyArenaState.Map.
-        // https://github.com/planetarium/lib9c/issues/883
-        public const long UpdateTargetBlockIndex = 3_808_000L;
-        // WeeklyArenaIndex for ArenaInfo separate from WeeklyArenaState.Map.
-        public const int UpdateTargetWeeklyArenaIndex = 68;
 
         public Address avatarAddress;
         public Address enemyAddress;
         public Address weeklyArenaAddress;
         public List<Guid> costumeIds;
         public List<Guid> equipmentIds;
+
         public EnemyPlayerDigest EnemyPlayerDigest;
         public ArenaInfo ArenaInfo;
         public ArenaInfo EnemyArenaInfo;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {
-            IActionContext ctx = context;
+            var ctx = context;
             var states = ctx.PreviousStates;
-            var inventoryAddress = avatarAddress.Derive(LegacyInventoryKey);
-            var worldInformationAddress = avatarAddress.Derive(LegacyWorldInformationKey);
-            var questListAddress = avatarAddress.Derive(LegacyQuestListKey);
             if (ctx.Rehearsal)
-            {
-                return states
-                    .SetState(avatarAddress, MarkChanged)
-                    .SetState(weeklyArenaAddress, MarkChanged)
-                    .SetState(inventoryAddress, MarkChanged)
-                    .SetState(worldInformationAddress, MarkChanged)
-                    .SetState(questListAddress, MarkChanged);
-            }
-
-            // Avoid InvalidBlockStateRootHashException
-            if (ctx.BlockIndex == 680341 && Id.Equals(new Guid("df37dbd8-5703-4dff-918b-ad22ee4c34c6")))
             {
                 return states;
             }
+
+            var inventoryAddress = avatarAddress.Derive(LegacyInventoryKey);
+            var worldInformationAddress = avatarAddress.Derive(LegacyWorldInformationKey);
+            var questListAddress = avatarAddress.Derive(LegacyQuestListKey);
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress, enemyAddress);
 
@@ -75,12 +59,14 @@ namespace Nekoyume.Action
 
             if (avatarAddress.Equals(enemyAddress))
             {
-                throw new InvalidAddressException($"{addressesHex}Aborted as the signer tried to battle for themselves.");
+                throw new InvalidAddressException(
+                    $"{addressesHex}Aborted as the signer tried to battle for themselves.");
             }
 
-            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out var avatarState, out bool migrationRequired))
+            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out var avatarState, out var migrationRequired))
             {
-                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException(
+                    $"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
             }
 
             sw.Stop();
@@ -88,7 +74,7 @@ namespace Nekoyume.Action
 
             sw.Restart();
             var sheets = states.GetSheets(
-                containRankingSimulatorSheets:true,
+                containRankingSimulatorSheets: true,
                 sheetTypes: new[]
                 {
                     typeof(CharacterSheet),
@@ -107,17 +93,14 @@ namespace Nekoyume.Action
 
             var items = equipmentIds.Concat(costumeIds);
             avatarState.EquipItems(items);
-            if (context.BlockIndex > 3806324)
-            {
-                avatarState.ValidateItemRequirement(
-                    costumeItemIds.ToList(),
-                    equipments,
-                    states.GetSheet<ItemRequirementSheet>(),
-                    states.GetSheet<EquipmentItemRecipeSheet>(),
-                    states.GetSheet<EquipmentItemSubRecipeSheetV2>(),
-                    states.GetSheet<EquipmentItemOptionSheet>(),
-                    addressesHex);
-            }
+            avatarState.ValidateItemRequirement(
+                costumeItemIds.ToList(),
+                equipments,
+                states.GetSheet<ItemRequirementSheet>(),
+                states.GetSheet<EquipmentItemRecipeSheet>(),
+                states.GetSheet<EquipmentItemSubRecipeSheetV2>(),
+                states.GetSheet<EquipmentItemOptionSheet>(),
+                addressesHex);
 
             sw.Stop();
             Log.Verbose("{AddressesHex}RankingBattle Equip Equipments: {Elapsed}", addressesHex, sw.Elapsed);
@@ -142,9 +125,11 @@ namespace Nekoyume.Action
             {
                 enemyAvatarState = states.GetAvatarState(enemyAddress);
             }
+
             if (enemyAvatarState is null)
             {
-                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the opponent ({enemyAddress}) was failed to load.");
+                throw new FailedLoadStateException(
+                    $"{addressesHex}Aborted as the avatar state of the opponent ({enemyAddress}) was failed to load.");
             }
 
             sw.Stop();
@@ -158,170 +143,49 @@ namespace Nekoyume.Action
             }
 
             sw.Stop();
-            Log.Verbose("{AddressesHex}RankingBattle Get WeeklyArenaState ({Address}): {Elapsed}", addressesHex, weeklyArenaAddress, sw.Elapsed);
+            Log.Verbose(
+                "{AddressesHex}RankingBattle Get WeeklyArenaState ({Address}): {Elapsed}",
+                addressesHex,
+                weeklyArenaAddress,
+                sw.Elapsed);
             sw.Restart();
 
-            bool arenaEnded = rawWeeklyArenaState["ended"].ToBoolean();
+            var arenaEnded = rawWeeklyArenaState["ended"].ToBoolean();
             if (arenaEnded)
             {
                 throw new WeeklyArenaStateAlreadyEndedException();
             }
 
-            if (context.BlockIndex >= UpdateTargetBlockIndex)
+            // Run updated model
+            var arenaInfoAddress = weeklyArenaAddress.Derive(avatarAddress.ToByteArray());
+            ArenaInfo arenaInfo;
+            var characterSheet = sheets.GetSheet<CharacterSheet>();
+            var addressListAddress = weeklyArenaAddress.Derive("address_list");
+            var listCheck = false;
+            if (!states.TryGetState(arenaInfoAddress, out Dictionary rawArenaInfo))
             {
-                // Run updated model
-                var arenaInfoAddress = weeklyArenaAddress.Derive(avatarAddress.ToByteArray());
-                ArenaInfo arenaInfo;
-                var characterSheet = sheets.GetSheet<CharacterSheet>();
-                var addressListAddress = weeklyArenaAddress.Derive("address_list");
-                bool listCheck = false;
-                if (!states.TryGetState(arenaInfoAddress, out Dictionary rawArenaInfo))
-                {
-                    arenaInfo = new ArenaInfo(avatarState, characterSheet, costumeStatSheet, true);
-                    listCheck = true;
-                    rawArenaInfo = (Dictionary) arenaInfo.Serialize();
-                }
-                else
-                {
-                    arenaInfo = new ArenaInfo(rawArenaInfo);
-                }
-
-                var enemyInfoAddress = weeklyArenaAddress.Derive(enemyAddress.ToByteArray());
-                ArenaInfo enemyInfo;
-                if (!states.TryGetState(enemyInfoAddress, out Dictionary rawEnemyInfo))
-                {
-                    enemyInfo = new ArenaInfo(enemyAvatarState, characterSheet, costumeStatSheet,
-                        true);
-                    listCheck = true;
-                    rawEnemyInfo = (Dictionary) enemyInfo.Serialize();
-                }
-                else
-                {
-                    enemyInfo = new ArenaInfo(rawEnemyInfo);
-                }
-
-                if (arenaInfo.DailyChallengeCount <= 0)
-                {
-                    throw new NotEnoughWeeklyArenaChallengeCountException(
-                        addressesHex + NotEnoughWeeklyArenaChallengeCountException.BaseMessage);
-                }
-
-                ArenaInfo = new ArenaInfo(rawArenaInfo);
-                EnemyArenaInfo = new ArenaInfo(rawEnemyInfo);
-                var rankingSheets = sheets.GetRankingSimulatorSheets();
-                var player = new Player(avatarState, rankingSheets);
-                var enemyPlayerDigest = new EnemyPlayerDigest(enemyAvatarState);
-                var simulator = new RankingSimulator(
-                    ctx.Random,
-                    player,
-                    enemyPlayerDigest,
-                    new List<Guid>(),
-                    rankingSheets,
-                    StageId,
-                    arenaInfo,
-                    enemyInfo,
-                    costumeStatSheet);
-
-                simulator.SimulateV5();
-
-                sw.Stop();
-                Log.Verbose(
-                "{AddressesHex}RankingBattle Simulate() with equipment:({Equipment}), costume:({Costume}): {Elapsed}",
-                addressesHex,
-                string.Join(",", simulator.Player.Equipments.Select(r => r.ItemId)),
-                string.Join(",", simulator.Player.Costumes.Select(r => r.ItemId)),
-                sw.Elapsed
-                );
-
-                Log.Verbose(
-                    "{AddressesHex}Execute RankingBattle({AvatarAddress}); result: {Result} event count: {EventCount}",
-                    addressesHex,
-                    avatarAddress,
-                    simulator.Log.result,
-                    simulator.Log.Count
-                );
-                sw.Restart();
-
-                foreach (var itemBase in simulator.Reward.OrderBy(i => i.Id))
-                {
-                    Log.Verbose(
-                        "{AddressesHex}RankingBattle Add Reward Item({ItemBaseId}): {Elapsed}",
-                        addressesHex,
-                        itemBase.Id,
-                        sw.Elapsed);
-                    avatarState.inventory.AddItem(itemBase);
-                }
-
-                sw.Stop();
-                Log.Verbose("{AddressesHex}RankingBattle Serialize WeeklyArenaState: {Elapsed}", addressesHex, sw.Elapsed);
-                sw.Restart();
-
-                states = states
-                    .SetState(inventoryAddress, avatarState.inventory.Serialize())
-                    .SetState(arenaInfoAddress, arenaInfo.Serialize())
-                    .SetState(enemyInfoAddress, enemyInfo.Serialize())
-                    .SetState(questListAddress, avatarState.questList.Serialize());
-
-                if (migrationRequired)
-                {
-                    states = states
-                        .SetState(worldInformationAddress, avatarState.worldInformation.Serialize())
-                        .SetState(avatarAddress, avatarState.SerializeV2());
-                }
-
-                if (listCheck)
-                {
-                    var addressList = states.TryGetState(addressListAddress, out List rawAddressList)
-                        ? rawAddressList.ToList(StateExtensions.ToAddress)
-                        : new List<Address>();
-
-                    if (!addressList.Contains(avatarAddress))
-                    {
-                        addressList.Add(avatarAddress);
-                    }
-
-                    if (!addressList.Contains(enemyAddress))
-                    {
-                        addressList.Add(enemyAddress);
-                    }
-
-                    states = states.SetState(addressListAddress,
-                        addressList.Aggregate(List.Empty,
-                            (current, address) => current.Add(address.Serialize())));
-                }
-                sw.Stop();
-                Log.Verbose("{AddressesHex}RankingBattle Serialize AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
-                sw.Restart();
-
-                var ended = DateTimeOffset.UtcNow;
-                Log.Verbose("{AddressesHex}RankingBattle Total Executed Time: {Elapsed}", addressesHex, ended - started);
-                EnemyPlayerDigest = enemyPlayerDigest;
-                return states;
+                arenaInfo = new ArenaInfo(avatarState, characterSheet, costumeStatSheet, true);
+                listCheck = true;
+                rawArenaInfo = (Dictionary)arenaInfo.Serialize();
             }
-            // Run Backward compatible
-            return BackwardCompatibleExecute(rawWeeklyArenaState, sheets, avatarState, costumeStatSheet, sw, addressesHex, enemyAvatarState, ctx, states, inventoryAddress, questListAddress, migrationRequired, worldInformationAddress, started);
-        }
-
-        private IAccountStateDelta BackwardCompatibleExecute(Dictionary rawWeeklyArenaState, Dictionary<Type, (Address address, ISheet sheet)> sheets,
-            AvatarState avatarState, CostumeStatSheet costumeStatSheet, Stopwatch sw, string addressesHex,
-            AvatarState enemyAvatarState, IActionContext ctx, IAccountStateDelta states, Address inventoryAddress,
-            Address questListAddress, bool migrationRequired, Address worldInformationAddress, DateTimeOffset started)
-        {
-            Dictionary weeklyArenaMap = (Dictionary) rawWeeklyArenaState["map"];
-
-            IKey arenaKey = (IKey) avatarAddress.Serialize();
-            if (!weeklyArenaMap.ContainsKey(arenaKey))
+            else
             {
-                var characterSheet = sheets.GetSheet<CharacterSheet>();
-                var newInfo = new ArenaInfo(avatarState, characterSheet, costumeStatSheet, false);
-                weeklyArenaMap =
-                    (Dictionary) weeklyArenaMap.Add(arenaKey, newInfo.Serialize());
-                sw.Stop();
-                Log.Verbose("{AddressesHex}RankingBattle Set AvatarInfo: {Elapsed}", addressesHex, sw.Elapsed);
-                sw.Restart();
+                arenaInfo = new ArenaInfo(rawArenaInfo);
             }
 
-            var arenaInfo = new ArenaInfo((Dictionary) weeklyArenaMap[arenaKey]);
+            var enemyInfoAddress = weeklyArenaAddress.Derive(enemyAddress.ToByteArray());
+            ArenaInfo enemyArenaInfo;
+            if (!states.TryGetState(enemyInfoAddress, out Dictionary rawEnemyInfo))
+            {
+                enemyArenaInfo = new ArenaInfo(enemyAvatarState, characterSheet, costumeStatSheet,
+                    true);
+                listCheck = true;
+                rawEnemyInfo = (Dictionary)enemyArenaInfo.Serialize();
+            }
+            else
+            {
+                enemyArenaInfo = new ArenaInfo(rawEnemyInfo);
+            }
 
             if (arenaInfo.DailyChallengeCount <= 0)
             {
@@ -329,31 +193,8 @@ namespace Nekoyume.Action
                     addressesHex + NotEnoughWeeklyArenaChallengeCountException.BaseMessage);
             }
 
-            if (!arenaInfo.Active)
-            {
-                arenaInfo.Activate();
-            }
-
-            IKey enemyKey = (IKey) enemyAddress.Serialize();
-            if (!weeklyArenaMap.ContainsKey(enemyKey))
-            {
-                throw new WeeklyArenaStateNotContainsAvatarAddressException(addressesHex, enemyAddress);
-            }
-
-            var enemyArenaInfo = new ArenaInfo((Dictionary) weeklyArenaMap[enemyKey]);
-            if (!enemyArenaInfo.Active)
-            {
-                enemyArenaInfo.Activate();
-            }
-
-            Log.Verbose("{WeeklyArenaStateAddress}", weeklyArenaAddress.ToHex());
-
-            sw.Stop();
-            Log.Verbose("{AddressesHex}RankingBattle Validate ArenaInfo: {Elapsed}", addressesHex, sw.Elapsed);
-            sw.Restart();
-
-            ArenaInfo = new ArenaInfo((Dictionary) weeklyArenaMap[arenaKey]);
-            EnemyArenaInfo = new ArenaInfo((Dictionary) weeklyArenaMap[enemyKey]);
+            ArenaInfo = new ArenaInfo(rawArenaInfo);
+            EnemyArenaInfo = new ArenaInfo(rawEnemyInfo);
             var rankingSheets = sheets.GetRankingSimulatorSheets();
             var player = new Player(avatarState, rankingSheets);
             var enemyPlayerDigest = new EnemyPlayerDigest(enemyAvatarState);
@@ -368,7 +209,7 @@ namespace Nekoyume.Action
                 enemyArenaInfo,
                 costumeStatSheet);
 
-            simulator.SimulateV5();
+            simulator.Simulate(ArenaScoreHelper.GetScore);
 
             sw.Stop();
             Log.Verbose(
@@ -398,40 +239,14 @@ namespace Nekoyume.Action
                 avatarState.inventory.AddItem(itemBase);
             }
 
-            var arenaMapDict = new Dictionary<IKey, IValue>();
-            foreach (var kv in weeklyArenaMap)
-            {
-                var key = kv.Key;
-                var value = kv.Value;
-                if (key.Equals(arenaKey))
-                {
-                    value = arenaInfo.Serialize();
-                }
-
-                if (key.Equals(enemyKey))
-                {
-                    value = enemyArenaInfo.Serialize();
-                }
-
-                arenaMapDict[key] = value;
-            }
-
-            var weeklyArenaDict = new Dictionary<IKey, IValue>();
-            foreach (var kv in rawWeeklyArenaState)
-            {
-                weeklyArenaDict[kv.Key] = kv.Key.Equals((Text) "map")
-                    ? new Dictionary(arenaMapDict)
-                    : kv.Value;
-            }
-
-            states = states.SetState(weeklyArenaAddress, new Dictionary(weeklyArenaDict));
-
             sw.Stop();
             Log.Verbose("{AddressesHex}RankingBattle Serialize WeeklyArenaState: {Elapsed}", addressesHex, sw.Elapsed);
             sw.Restart();
 
             states = states
                 .SetState(inventoryAddress, avatarState.inventory.Serialize())
+                .SetState(arenaInfoAddress, arenaInfo.Serialize())
+                .SetState(enemyInfoAddress, enemyArenaInfo.Serialize())
                 .SetState(questListAddress, avatarState.questList.Serialize());
 
             if (migrationRequired)
@@ -439,6 +254,27 @@ namespace Nekoyume.Action
                 states = states
                     .SetState(worldInformationAddress, avatarState.worldInformation.Serialize())
                     .SetState(avatarAddress, avatarState.SerializeV2());
+            }
+
+            if (listCheck)
+            {
+                var addressList = states.TryGetState(addressListAddress, out List rawAddressList)
+                    ? rawAddressList.ToList(StateExtensions.ToAddress)
+                    : new List<Address>();
+
+                if (!addressList.Contains(avatarAddress))
+                {
+                    addressList.Add(avatarAddress);
+                }
+
+                if (!addressList.Contains(enemyAddress))
+                {
+                    addressList.Add(enemyAddress);
+                }
+
+                states = states.SetState(addressListAddress,
+                    addressList.Aggregate(List.Empty,
+                        (current, address) => current.Add(address.Serialize())));
             }
 
             sw.Stop();
@@ -470,10 +306,10 @@ namespace Nekoyume.Action
             avatarAddress = plainValue["avatarAddress"].ToAddress();
             enemyAddress = plainValue["enemyAddress"].ToAddress();
             weeklyArenaAddress = plainValue["weeklyArenaAddress"].ToAddress();
-            costumeIds = ((List) plainValue["costume_ids"])
+            costumeIds = ((List)plainValue["costume_ids"])
                 .Select(e => e.ToGuid())
                 .ToList();
-            equipmentIds = ((List) plainValue["equipment_ids"])
+            equipmentIds = ((List)plainValue["equipment_ids"])
                 .Select(e => e.ToGuid())
                 .ToList();
         }

--- a/Lib9c/Action/RankingBattle10.cs
+++ b/Lib9c/Action/RankingBattle10.cs
@@ -217,7 +217,7 @@ namespace Nekoyume.Action
                 enemyArenaInfo,
                 costumeStatSheet);
 
-            simulator.Simulate();
+            simulator.SimulateV5();
 
             sw.Stop();
             Log.Verbose(

--- a/Lib9c/Action/RankingBattle11.cs
+++ b/Lib9c/Action/RankingBattle11.cs
@@ -1,0 +1,481 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Numerics;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Action;
+using Nekoyume.Battle;
+using Nekoyume.Model;
+using Nekoyume.Extensions;
+using Nekoyume.Model.State;
+using Nekoyume.TableData;
+using Serilog;
+using static Lib9c.SerializeKeys;
+
+namespace Nekoyume.Action
+{
+    [Serializable]
+    [ActionType("ranking_battle11")]
+    public class RankingBattle11 : GameAction
+    {
+        public const int StageId = 999999;
+        public static readonly BigInteger EntranceFee = 100;
+        // BlockIndex for ArenaInfo separate from WeeklyArenaState.Map.
+        // https://github.com/planetarium/lib9c/issues/883
+        public const long UpdateTargetBlockIndex = 3_808_000L;
+        // WeeklyArenaIndex for ArenaInfo separate from WeeklyArenaState.Map.
+        public const int UpdateTargetWeeklyArenaIndex = 68;
+
+        public Address avatarAddress;
+        public Address enemyAddress;
+        public Address weeklyArenaAddress;
+        public List<Guid> costumeIds;
+        public List<Guid> equipmentIds;
+        public EnemyPlayerDigest EnemyPlayerDigest;
+        public ArenaInfo ArenaInfo;
+        public ArenaInfo EnemyArenaInfo;
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            IActionContext ctx = context;
+            var states = ctx.PreviousStates;
+            var inventoryAddress = avatarAddress.Derive(LegacyInventoryKey);
+            var worldInformationAddress = avatarAddress.Derive(LegacyWorldInformationKey);
+            var questListAddress = avatarAddress.Derive(LegacyQuestListKey);
+            if (ctx.Rehearsal)
+            {
+                return states
+                    .SetState(avatarAddress, MarkChanged)
+                    .SetState(weeklyArenaAddress, MarkChanged)
+                    .SetState(inventoryAddress, MarkChanged)
+                    .SetState(worldInformationAddress, MarkChanged)
+                    .SetState(questListAddress, MarkChanged);
+            }
+
+            // Avoid InvalidBlockStateRootHashException
+            if (ctx.BlockIndex == 680341 && Id.Equals(new Guid("df37dbd8-5703-4dff-918b-ad22ee4c34c6")))
+            {
+                return states;
+            }
+
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress, enemyAddress);
+
+            var sw = new Stopwatch();
+            sw.Start();
+            var started = DateTimeOffset.UtcNow;
+            Log.Verbose(
+                "{AddressesHex}RankingBattle exec started. costume: ({CostumeIds}), equipment: ({EquipmentIds})",
+                addressesHex,
+                string.Join(",", costumeIds),
+                string.Join(",", equipmentIds)
+            );
+
+            if (avatarAddress.Equals(enemyAddress))
+            {
+                throw new InvalidAddressException($"{addressesHex}Aborted as the signer tried to battle for themselves.");
+            }
+
+            if (!states.TryGetAvatarStateV2(ctx.Signer, avatarAddress, out var avatarState, out bool migrationRequired))
+            {
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
+            }
+
+            sw.Stop();
+            Log.Verbose("{AddressesHex}RankingBattle Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
+
+            sw.Restart();
+            var sheets = states.GetSheets(
+                containRankingSimulatorSheets:true,
+                sheetTypes: new[]
+                {
+                    typeof(CharacterSheet),
+                    typeof(CostumeStatSheet),
+                });
+            sw.Stop();
+            Log.Verbose("{AddressesHex}HAS Get Sheets: {Elapsed}", addressesHex, sw.Elapsed);
+            sw.Restart();
+
+            var equipments = avatarState.ValidateEquipmentsV2(equipmentIds, context.BlockIndex);
+            var costumeItemIds = avatarState.ValidateCostume(costumeIds);
+
+            sw.Stop();
+            Log.Verbose("{AddressesHex}RankingBattle Validate Equipments: {Elapsed}", addressesHex, sw.Elapsed);
+            sw.Restart();
+
+            var items = equipmentIds.Concat(costumeIds);
+            avatarState.EquipItems(items);
+            if (context.BlockIndex > 3806324)
+            {
+                avatarState.ValidateItemRequirement(
+                    costumeItemIds.ToList(),
+                    equipments,
+                    states.GetSheet<ItemRequirementSheet>(),
+                    states.GetSheet<EquipmentItemRecipeSheet>(),
+                    states.GetSheet<EquipmentItemSubRecipeSheetV2>(),
+                    states.GetSheet<EquipmentItemOptionSheet>(),
+                    addressesHex);
+            }
+
+            sw.Stop();
+            Log.Verbose("{AddressesHex}RankingBattle Equip Equipments: {Elapsed}", addressesHex, sw.Elapsed);
+            sw.Restart();
+
+            if (!avatarState.worldInformation.TryGetUnlockedWorldByStageClearedBlockIndex(out var world) ||
+                world.StageClearedId < GameConfig.RequireClearedStageLevel.ActionsInRankingBoard)
+            {
+                throw new NotEnoughClearedStageLevelException(
+                    addressesHex,
+                    GameConfig.RequireClearedStageLevel.ActionsInRankingBoard,
+                    world.StageClearedId);
+            }
+
+            AvatarState enemyAvatarState;
+            try
+            {
+                enemyAvatarState = states.GetAvatarStateV2(enemyAddress);
+            }
+            // BackWard compatible.
+            catch (FailedLoadStateException)
+            {
+                enemyAvatarState = states.GetAvatarState(enemyAddress);
+            }
+            if (enemyAvatarState is null)
+            {
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the opponent ({enemyAddress}) was failed to load.");
+            }
+
+            sw.Stop();
+            Log.Verbose("{AddressesHex}RankingBattle Get Enemy AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
+            sw.Restart();
+
+            var costumeStatSheet = sheets.GetSheet<CostumeStatSheet>();
+            if (!states.TryGetState(weeklyArenaAddress, out Dictionary rawWeeklyArenaState))
+            {
+                return states;
+            }
+
+            sw.Stop();
+            Log.Verbose("{AddressesHex}RankingBattle Get WeeklyArenaState ({Address}): {Elapsed}", addressesHex, weeklyArenaAddress, sw.Elapsed);
+            sw.Restart();
+
+            bool arenaEnded = rawWeeklyArenaState["ended"].ToBoolean();
+            if (arenaEnded)
+            {
+                throw new WeeklyArenaStateAlreadyEndedException();
+            }
+
+            if (context.BlockIndex >= UpdateTargetBlockIndex)
+            {
+                // Run updated model
+                var arenaInfoAddress = weeklyArenaAddress.Derive(avatarAddress.ToByteArray());
+                ArenaInfo arenaInfo;
+                var characterSheet = sheets.GetSheet<CharacterSheet>();
+                var addressListAddress = weeklyArenaAddress.Derive("address_list");
+                bool listCheck = false;
+                if (!states.TryGetState(arenaInfoAddress, out Dictionary rawArenaInfo))
+                {
+                    arenaInfo = new ArenaInfo(avatarState, characterSheet, costumeStatSheet, true);
+                    listCheck = true;
+                    rawArenaInfo = (Dictionary) arenaInfo.Serialize();
+                }
+                else
+                {
+                    arenaInfo = new ArenaInfo(rawArenaInfo);
+                }
+
+                var enemyInfoAddress = weeklyArenaAddress.Derive(enemyAddress.ToByteArray());
+                ArenaInfo enemyInfo;
+                if (!states.TryGetState(enemyInfoAddress, out Dictionary rawEnemyInfo))
+                {
+                    enemyInfo = new ArenaInfo(enemyAvatarState, characterSheet, costumeStatSheet,
+                        true);
+                    listCheck = true;
+                    rawEnemyInfo = (Dictionary) enemyInfo.Serialize();
+                }
+                else
+                {
+                    enemyInfo = new ArenaInfo(rawEnemyInfo);
+                }
+
+                if (arenaInfo.DailyChallengeCount <= 0)
+                {
+                    throw new NotEnoughWeeklyArenaChallengeCountException(
+                        addressesHex + NotEnoughWeeklyArenaChallengeCountException.BaseMessage);
+                }
+
+                ArenaInfo = new ArenaInfo(rawArenaInfo);
+                EnemyArenaInfo = new ArenaInfo(rawEnemyInfo);
+                var rankingSheets = sheets.GetRankingSimulatorSheets();
+                var player = new Player(avatarState, rankingSheets);
+                var enemyPlayerDigest = new EnemyPlayerDigest(enemyAvatarState);
+                var simulator = new RankingSimulator(
+                    ctx.Random,
+                    player,
+                    enemyPlayerDigest,
+                    new List<Guid>(),
+                    rankingSheets,
+                    StageId,
+                    arenaInfo,
+                    enemyInfo,
+                    costumeStatSheet);
+
+                simulator.SimulateV5();
+
+                sw.Stop();
+                Log.Verbose(
+                "{AddressesHex}RankingBattle Simulate() with equipment:({Equipment}), costume:({Costume}): {Elapsed}",
+                addressesHex,
+                string.Join(",", simulator.Player.Equipments.Select(r => r.ItemId)),
+                string.Join(",", simulator.Player.Costumes.Select(r => r.ItemId)),
+                sw.Elapsed
+                );
+
+                Log.Verbose(
+                    "{AddressesHex}Execute RankingBattle({AvatarAddress}); result: {Result} event count: {EventCount}",
+                    addressesHex,
+                    avatarAddress,
+                    simulator.Log.result,
+                    simulator.Log.Count
+                );
+                sw.Restart();
+
+                foreach (var itemBase in simulator.Reward.OrderBy(i => i.Id))
+                {
+                    Log.Verbose(
+                        "{AddressesHex}RankingBattle Add Reward Item({ItemBaseId}): {Elapsed}",
+                        addressesHex,
+                        itemBase.Id,
+                        sw.Elapsed);
+                    avatarState.inventory.AddItem(itemBase);
+                }
+
+                sw.Stop();
+                Log.Verbose("{AddressesHex}RankingBattle Serialize WeeklyArenaState: {Elapsed}", addressesHex, sw.Elapsed);
+                sw.Restart();
+
+                states = states
+                    .SetState(inventoryAddress, avatarState.inventory.Serialize())
+                    .SetState(arenaInfoAddress, arenaInfo.Serialize())
+                    .SetState(enemyInfoAddress, enemyInfo.Serialize())
+                    .SetState(questListAddress, avatarState.questList.Serialize());
+
+                if (migrationRequired)
+                {
+                    states = states
+                        .SetState(worldInformationAddress, avatarState.worldInformation.Serialize())
+                        .SetState(avatarAddress, avatarState.SerializeV2());
+                }
+
+                if (listCheck)
+                {
+                    var addressList = states.TryGetState(addressListAddress, out List rawAddressList)
+                        ? rawAddressList.ToList(StateExtensions.ToAddress)
+                        : new List<Address>();
+
+                    if (!addressList.Contains(avatarAddress))
+                    {
+                        addressList.Add(avatarAddress);
+                    }
+
+                    if (!addressList.Contains(enemyAddress))
+                    {
+                        addressList.Add(enemyAddress);
+                    }
+
+                    states = states.SetState(addressListAddress,
+                        addressList.Aggregate(List.Empty,
+                            (current, address) => current.Add(address.Serialize())));
+                }
+                sw.Stop();
+                Log.Verbose("{AddressesHex}RankingBattle Serialize AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
+                sw.Restart();
+
+                var ended = DateTimeOffset.UtcNow;
+                Log.Verbose("{AddressesHex}RankingBattle Total Executed Time: {Elapsed}", addressesHex, ended - started);
+                EnemyPlayerDigest = enemyPlayerDigest;
+                return states;
+            }
+            // Run Backward compatible
+            return BackwardCompatibleExecute(rawWeeklyArenaState, sheets, avatarState, costumeStatSheet, sw, addressesHex, enemyAvatarState, ctx, states, inventoryAddress, questListAddress, migrationRequired, worldInformationAddress, started);
+        }
+
+        private IAccountStateDelta BackwardCompatibleExecute(Dictionary rawWeeklyArenaState, Dictionary<Type, (Address address, ISheet sheet)> sheets,
+            AvatarState avatarState, CostumeStatSheet costumeStatSheet, Stopwatch sw, string addressesHex,
+            AvatarState enemyAvatarState, IActionContext ctx, IAccountStateDelta states, Address inventoryAddress,
+            Address questListAddress, bool migrationRequired, Address worldInformationAddress, DateTimeOffset started)
+        {
+            Dictionary weeklyArenaMap = (Dictionary) rawWeeklyArenaState["map"];
+
+            IKey arenaKey = (IKey) avatarAddress.Serialize();
+            if (!weeklyArenaMap.ContainsKey(arenaKey))
+            {
+                var characterSheet = sheets.GetSheet<CharacterSheet>();
+                var newInfo = new ArenaInfo(avatarState, characterSheet, costumeStatSheet, false);
+                weeklyArenaMap =
+                    (Dictionary) weeklyArenaMap.Add(arenaKey, newInfo.Serialize());
+                sw.Stop();
+                Log.Verbose("{AddressesHex}RankingBattle Set AvatarInfo: {Elapsed}", addressesHex, sw.Elapsed);
+                sw.Restart();
+            }
+
+            var arenaInfo = new ArenaInfo((Dictionary) weeklyArenaMap[arenaKey]);
+
+            if (arenaInfo.DailyChallengeCount <= 0)
+            {
+                throw new NotEnoughWeeklyArenaChallengeCountException(
+                    addressesHex + NotEnoughWeeklyArenaChallengeCountException.BaseMessage);
+            }
+
+            if (!arenaInfo.Active)
+            {
+                arenaInfo.Activate();
+            }
+
+            IKey enemyKey = (IKey) enemyAddress.Serialize();
+            if (!weeklyArenaMap.ContainsKey(enemyKey))
+            {
+                throw new WeeklyArenaStateNotContainsAvatarAddressException(addressesHex, enemyAddress);
+            }
+
+            var enemyArenaInfo = new ArenaInfo((Dictionary) weeklyArenaMap[enemyKey]);
+            if (!enemyArenaInfo.Active)
+            {
+                enemyArenaInfo.Activate();
+            }
+
+            Log.Verbose("{WeeklyArenaStateAddress}", weeklyArenaAddress.ToHex());
+
+            sw.Stop();
+            Log.Verbose("{AddressesHex}RankingBattle Validate ArenaInfo: {Elapsed}", addressesHex, sw.Elapsed);
+            sw.Restart();
+
+            ArenaInfo = new ArenaInfo((Dictionary) weeklyArenaMap[arenaKey]);
+            EnemyArenaInfo = new ArenaInfo((Dictionary) weeklyArenaMap[enemyKey]);
+            var rankingSheets = sheets.GetRankingSimulatorSheets();
+            var player = new Player(avatarState, rankingSheets);
+            var enemyPlayerDigest = new EnemyPlayerDigest(enemyAvatarState);
+            var simulator = new RankingSimulator(
+                ctx.Random,
+                player,
+                enemyPlayerDigest,
+                new List<Guid>(),
+                rankingSheets,
+                StageId,
+                arenaInfo,
+                enemyArenaInfo,
+                costumeStatSheet);
+
+            simulator.SimulateV5();
+
+            sw.Stop();
+            Log.Verbose(
+                "{AddressesHex}RankingBattle Simulate() with equipment:({Equipment}), costume:({Costume}): {Elapsed}",
+                addressesHex,
+                string.Join(",", simulator.Player.Equipments.Select(r => r.ItemId)),
+                string.Join(",", simulator.Player.Costumes.Select(r => r.ItemId)),
+                sw.Elapsed
+            );
+
+            Log.Verbose(
+                "{AddressesHex}Execute RankingBattle({AvatarAddress}); result: {Result} event count: {EventCount}",
+                addressesHex,
+                avatarAddress,
+                simulator.Log.result,
+                simulator.Log.Count
+            );
+            sw.Restart();
+
+            foreach (var itemBase in simulator.Reward.OrderBy(i => i.Id))
+            {
+                Log.Verbose(
+                    "{AddressesHex}RankingBattle Add Reward Item({ItemBaseId}): {Elapsed}",
+                    addressesHex,
+                    itemBase.Id,
+                    sw.Elapsed);
+                avatarState.inventory.AddItem(itemBase);
+            }
+
+            var arenaMapDict = new Dictionary<IKey, IValue>();
+            foreach (var kv in weeklyArenaMap)
+            {
+                var key = kv.Key;
+                var value = kv.Value;
+                if (key.Equals(arenaKey))
+                {
+                    value = arenaInfo.Serialize();
+                }
+
+                if (key.Equals(enemyKey))
+                {
+                    value = enemyArenaInfo.Serialize();
+                }
+
+                arenaMapDict[key] = value;
+            }
+
+            var weeklyArenaDict = new Dictionary<IKey, IValue>();
+            foreach (var kv in rawWeeklyArenaState)
+            {
+                weeklyArenaDict[kv.Key] = kv.Key.Equals((Text) "map")
+                    ? new Dictionary(arenaMapDict)
+                    : kv.Value;
+            }
+
+            states = states.SetState(weeklyArenaAddress, new Dictionary(weeklyArenaDict));
+
+            sw.Stop();
+            Log.Verbose("{AddressesHex}RankingBattle Serialize WeeklyArenaState: {Elapsed}", addressesHex, sw.Elapsed);
+            sw.Restart();
+
+            states = states
+                .SetState(inventoryAddress, avatarState.inventory.Serialize())
+                .SetState(questListAddress, avatarState.questList.Serialize());
+
+            if (migrationRequired)
+            {
+                states = states
+                    .SetState(worldInformationAddress, avatarState.worldInformation.Serialize())
+                    .SetState(avatarAddress, avatarState.SerializeV2());
+            }
+
+            sw.Stop();
+            Log.Verbose("{AddressesHex}RankingBattle Serialize AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
+            sw.Restart();
+
+            var ended = DateTimeOffset.UtcNow;
+            Log.Verbose("{AddressesHex}RankingBattle Total Executed Time: {Elapsed}", addressesHex, ended - started);
+            EnemyPlayerDigest = enemyPlayerDigest;
+            return states;
+        }
+
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            new Dictionary<string, IValue>
+            {
+                ["avatarAddress"] = avatarAddress.Serialize(),
+                ["enemyAddress"] = enemyAddress.Serialize(),
+                ["weeklyArenaAddress"] = weeklyArenaAddress.Serialize(),
+                ["costume_ids"] = new List(costumeIds
+                    .OrderBy(element => element)
+                    .Select(e => e.Serialize())),
+                ["equipment_ids"] = new List(equipmentIds
+                    .OrderBy(element => element)
+                    .Select(e => e.Serialize())),
+            }.ToImmutableDictionary();
+
+        protected override void LoadPlainValueInternal(IImmutableDictionary<string, IValue> plainValue)
+        {
+            avatarAddress = plainValue["avatarAddress"].ToAddress();
+            enemyAddress = plainValue["enemyAddress"].ToAddress();
+            weeklyArenaAddress = plainValue["weeklyArenaAddress"].ToAddress();
+            costumeIds = ((List) plainValue["costume_ids"])
+                .Select(e => e.ToGuid())
+                .ToList();
+            equipmentIds = ((List) plainValue["equipment_ids"])
+                .Select(e => e.ToGuid())
+                .ToList();
+        }
+    }
+}

--- a/Lib9c/Action/RankingBattle9.cs
+++ b/Lib9c/Action/RankingBattle9.cs
@@ -200,7 +200,7 @@ namespace Nekoyume.Action
                 enemyArenaInfo,
                 costumeStatSheet);
 
-            simulator.Simulate();
+            simulator.SimulateV5();
 
             sw.Stop();
             Log.Verbose(

--- a/Lib9c/Action/RewardGold.cs
+++ b/Lib9c/Action/RewardGold.cs
@@ -135,12 +135,12 @@ namespace Nekoyume.Action
                     var addressList = states.TryGetState(listAddress, out List rawList)
                         ? rawList.ToList(StateExtensions.ToAddress)
                         : new List<Address>();
-                    if (ctx.BlockIndex >= RankingBattle.UpdateTargetBlockIndex)
+                    if (ctx.BlockIndex >= RankingBattle11.UpdateTargetBlockIndex)
                     {
                         weekly.ResetIndex = ctx.BlockIndex;
 
                         // Copy Map to address list.
-                        if (ctx.BlockIndex == RankingBattle.UpdateTargetBlockIndex)
+                        if (ctx.BlockIndex == RankingBattle11.UpdateTargetBlockIndex)
                         {
                             foreach (var kv in prevWeekly.Map)
                             {
@@ -214,7 +214,7 @@ namespace Nekoyume.Action
             if (ctx.BlockIndex - resetIndex >= gameConfigState.DailyArenaInterval)
             {
                 var weekly = new WeeklyArenaState(rawWeekly);
-                if (resetIndex >= RankingBattle.UpdateTargetBlockIndex)
+                if (resetIndex >= RankingBattle11.UpdateTargetBlockIndex)
                 {
                     // Reset count each ArenaInfo.
                     weekly.ResetIndex = ctx.BlockIndex;

--- a/Lib9c/Battle/ArenaScoreHelper.cs
+++ b/Lib9c/Battle/ArenaScoreHelper.cs
@@ -123,7 +123,7 @@ namespace Nekoyume.Battle
             }
 
             var differ = challengerRating - defenderRating;
-            foreach (var (differ2, winScore, defenderLoseScore, loseScore) in CachedScoreV3)
+            foreach (var (differ2, winScore, defenderLoseScore, loseScore) in CachedScore)
             {
                 if (differ >= differ2)
                 {
@@ -214,6 +214,37 @@ namespace Nekoyume.Battle
             return result == BattleLog.Result.Win
                 ? 1
                 : -30;
+        }
+        
+        [Obsolete("Use GetScore()")]
+        public static (int challengerScore, int defenderScore) GetScoreV3(int challengerRating, int defenderRating, BattleLog.Result result)
+        {
+            if (challengerRating < 0 ||
+                defenderRating < 0 ||
+                result == BattleLog.Result.TimeOver)
+            {
+                return (0, 0);
+            }
+
+            var differ = challengerRating - defenderRating;
+            foreach (var (differ2, winScore, defenderLoseScore, loseScore) in CachedScoreV3)
+            {
+                if (differ >= differ2)
+                {
+                    continue;
+                }
+
+                if (result == BattleLog.Result.Win)
+                {
+                    return (winScore, defenderLoseScore);
+                }
+
+                return (loseScore, 0);
+            }
+
+            return result == BattleLog.Result.Win
+                ? (1, 0)
+                : (-5, 0);
         }
     }
 }

--- a/Lib9c/Battle/ArenaScoreHelper.cs
+++ b/Lib9c/Battle/ArenaScoreHelper.cs
@@ -32,37 +32,34 @@ namespace Nekoyume.Battle
         /// value: tuple (win score, lose score)
         /// </summary>
         [Obsolete("Use CachedScore")]
-        private static readonly IReadOnlyDictionary<int, (int, int)> CachedScoreV1 = new Dictionary<int, (int, int)>
-        {
-            {DifferLowerLimit, (WinScoreMax, LoseScoreMin)},
-            {-900, (WinScoreMax, LoseScoreMin)},
-            {-800, (WinScoreMax, LoseScoreMin)},
-            {-700, (WinScoreMax, LoseScoreMin)},
-            {-600, (WinScoreMax, LoseScoreMin)},
-            {-500, (50, LoseScoreMin)},
-            {-400, (40, -6)},
-            {-300, (30, -6)},
-            {-200, (25, -8)},
-            {-100, (20, -8)},
-            {99, (15, -10)},
-            {199, (8, -10)},
-            {299, (4, -20)},
-            {399, (2, -25)},
-            {499, (1, LoseScoreMax)},
-            {599, (WinScoreMin, LoseScoreMax)},
-            {699, (WinScoreMin, LoseScoreMax)},
-            {799, (WinScoreMin, LoseScoreMax)},
-            {899, (WinScoreMin, LoseScoreMax)},
-            {999, (WinScoreMin, LoseScoreMax)},
-            {DifferUpperLimit, (WinScoreMin, LoseScoreMax)},
-        };
-
-        #endregion
+        private static readonly IReadOnlyDictionary<int, (int, int)> CachedScoreV1 =
+            new Dictionary<int, (int, int)>
+            {
+                { DifferLowerLimit, (WinScoreMax, LoseScoreMin) },
+                { -900, (WinScoreMax, LoseScoreMin) },
+                { -800, (WinScoreMax, LoseScoreMin) },
+                { -700, (WinScoreMax, LoseScoreMin) },
+                { -600, (WinScoreMax, LoseScoreMin) },
+                { -500, (50, LoseScoreMin) },
+                { -400, (40, -6) },
+                { -300, (30, -6) },
+                { -200, (25, -8) },
+                { -100, (20, -8) },
+                { 99, (15, -10) },
+                { 199, (8, -10) },
+                { 299, (4, -20) },
+                { 399, (2, -25) },
+                { 499, (1, LoseScoreMax) },
+                { 599, (WinScoreMin, LoseScoreMax) },
+                { 699, (WinScoreMin, LoseScoreMax) },
+                { 799, (WinScoreMin, LoseScoreMax) },
+                { 899, (WinScoreMin, LoseScoreMax) },
+                { 999, (WinScoreMin, LoseScoreMax) },
+                { DifferUpperLimit, (WinScoreMin, LoseScoreMax) },
+            };
 
         /// <summary>
         /// differ: (challenger rate - defender rate)
-        /// winScore
-        /// loseScore
         /// </summary>
         [Obsolete("Use CachedScore")]
         private static readonly IOrderedEnumerable<(int differ, int winScore, int loseScore)> CachedScoreV2 =
@@ -81,14 +78,14 @@ namespace Nekoyume.Battle
                 (500, 2, -30),
             }.OrderBy(tuple => tuple.differ);
 
+        #endregion
+
         /// <summary>
         /// differ: (challenger rate - defender rate)
-        /// winScore
-        /// loseScore
-        /// defenderWinScore
         /// </summary>
+        [Obsolete("Use CachedScore")]
         private static readonly IOrderedEnumerable<(int differ, int winScore, int defenderLoseScore, int loseScore)>
-            CachedScore = new List<(int differ, int winScore, int defenderLoseScore, int loseScore)>
+            CachedScoreV3 = new List<(int differ, int winScore, int defenderLoseScore, int loseScore)>
             {
                 (-500, 60, -2, -5),
                 (-400, 45, -2, -5),
@@ -103,6 +100,19 @@ namespace Nekoyume.Battle
                 (500, 2, 0, -5),
             }.OrderBy(tuple => tuple.differ);
 
+        /// <summary>
+        /// differ: (challenger rate - defender rate)
+        /// </summary>
+        private static readonly IOrderedEnumerable<(int differ, int winScore, int defenderLoseScore, int loseScore)>
+            CachedScore = new List<(int differ, int winScore, int defenderLoseScore, int loseScore)>
+            {
+                (-200, 24, -1, -3),
+                (-100, 22, -1, -2),
+                (0, 20, -1, -1),
+                (100, 18, -1, -1),
+                (200, 16, -1, -1),
+            }.OrderBy(tuple => tuple.differ);
+
         public static (int challengerScore, int defenderScore) GetScore(int challengerRating, int defenderRating, BattleLog.Result result)
         {
             if (challengerRating < 0 ||
@@ -113,7 +123,7 @@ namespace Nekoyume.Battle
             }
 
             var differ = challengerRating - defenderRating;
-            foreach (var (differ2, winScore, defenderLoseScore, loseScore) in CachedScore)
+            foreach (var (differ2, winScore, defenderLoseScore, loseScore) in CachedScoreV3)
             {
                 if (differ >= differ2)
                 {

--- a/Lib9c/Battle/ArenaScoreHelper.cs
+++ b/Lib9c/Battle/ArenaScoreHelper.cs
@@ -7,6 +7,9 @@ namespace Nekoyume.Battle
 {
     public static class ArenaScoreHelper
     {
+        private const int DEFAULT_WIN_POINT = 1;
+        private const int DEFAULT_LOSE_POINT = -1;
+
         #region Obsolete
 
         [Obsolete("Only to used for V1")]
@@ -78,8 +81,6 @@ namespace Nekoyume.Battle
                 (500, 2, -30),
             }.OrderBy(tuple => tuple.differ);
 
-        #endregion
-
         /// <summary>
         /// differ: (challenger rate - defender rate)
         /// </summary>
@@ -99,21 +100,27 @@ namespace Nekoyume.Battle
                 (400, 4, 0, -5),
                 (500, 2, 0, -5),
             }.OrderBy(tuple => tuple.differ);
+        
+        #endregion
 
         /// <summary>
         /// differ: (challenger rate - defender rate)
         /// </summary>
-        private static readonly IOrderedEnumerable<(int differ, int winScore, int defenderLoseScore, int loseScore)>
-            CachedScore = new List<(int differ, int winScore, int defenderLoseScore, int loseScore)>
-            {
-                (-200, 24, -1, -3),
-                (-100, 22, -1, -2),
-                (0, 20, -1, -1),
-                (100, 18, -1, -1),
-                (200, 16, -1, -1),
-            }.OrderBy(tuple => tuple.differ);
+        private static readonly
+            IOrderedEnumerable<(int scoreDiffer, int winPoint, int losePoint, int defenderLosePoint)> CachedScore =
+                new List<(int scoreDiffer, int winPoint, int losePoint, int defenderLosePoint)>
+                {
+                    (-200, 24, -3, -1),
+                    (-100, 22, -2, -1),
+                    (0, 20, -1, -1),
+                    (100, 18, -1, -1),
+                    (200, 16, -1, -1),
+                }.OrderBy(tuple => tuple.scoreDiffer);
 
-        public static (int challengerScore, int defenderScore) GetScore(int challengerRating, int defenderRating, BattleLog.Result result)
+        public static (int challengerScoreDelta, int defenderScoreDelta) GetScore(
+            int challengerRating,
+            int defenderRating,
+            BattleLog.Result result)
         {
             if (challengerRating < 0 ||
                 defenderRating < 0 ||
@@ -122,25 +129,22 @@ namespace Nekoyume.Battle
                 return (0, 0);
             }
 
-            var differ = challengerRating - defenderRating;
-            foreach (var (differ2, winScore, defenderLoseScore, loseScore) in CachedScore)
+            var scoreDiffer = challengerRating - defenderRating;
+            foreach (var (cachedScoreDiffer, winPoint, losePoint, defenderLosePoint) in CachedScore)
             {
-                if (differ >= differ2)
+                if (scoreDiffer >= cachedScoreDiffer)
                 {
                     continue;
                 }
 
-                if (result == BattleLog.Result.Win)
-                {
-                    return (winScore, defenderLoseScore);
-                }
-
-                return (loseScore, 0);
+                return result == BattleLog.Result.Win
+                    ? (winPoint, defenderLosePoint)
+                    : (losePoint, 0);
             }
 
             return result == BattleLog.Result.Win
-                ? (1, 0)
-                : (-5, 0);
+                ? (DEFAULT_WIN_POINT, 0)
+                : (DEFAULT_LOSE_POINT, 0);
         }
 
         [Obsolete("Use GetScore()")]

--- a/Lib9c/Battle/RankingSimulator.cs
+++ b/Lib9c/Battle/RankingSimulator.cs
@@ -187,7 +187,7 @@ namespace Nekoyume.Battle
                 Characters.Enqueue(character, TurnPriority / character.SPD);
             }
 
-            Log.diffScore = _arenaInfo.Update(_enemyInfo, Result);
+            Log.diffScore = _arenaInfo.UpdateV5(_enemyInfo, Result);
             Log.score = _arenaInfo.Score;
 
             var itemSelector = new WeightedSelector<StageSheet.RewardData>(Random);

--- a/Lib9c/Battle/RankingSimulator.cs
+++ b/Lib9c/Battle/RankingSimulator.cs
@@ -108,7 +108,7 @@ namespace Nekoyume.Battle
             _enemyPlayer.SetCostumeStat(costumeStatSheet);
         }
 
-        public Player Simulate(Func<int, int, BattleLog.Result, (int challengerScore, int defenderScore)> scoreGetter)
+        public Player Simulate(Func<int, int, BattleLog.Result, (int challengerScoreDelta, int defenderScoreDelta)> scoreGetter)
         {
 #if TEST_LOG
             var sb = new System.Text.StringBuilder();

--- a/Lib9c/Model/State/ArenaInfo.cs
+++ b/Lib9c/Model/State/ArenaInfo.cs
@@ -213,7 +213,7 @@ namespace Nekoyume.Model.State
             }
 
             var score =
-                ArenaScoreHelper.GetScore(Score, enemyInfo.Score, result);
+                ArenaScoreHelper.GetScoreV3(Score, enemyInfo.Score, result);
             Score = Math.Max(1000, Score + score.challengerScore);
             enemyInfo.Score = Math.Max(1000, enemyInfo.Score + score.defenderScore);
             return score.challengerScore;

--- a/Lib9c/Model/State/ArenaInfo.cs
+++ b/Lib9c/Model/State/ArenaInfo.cs
@@ -194,7 +194,8 @@ namespace Nekoyume.Model.State
             return earnedScore;
         }
 
-        public int Update(ArenaInfo enemyInfo, BattleLog.Result result)
+        [Obsolete("Use Update()")]
+        public int UpdateV5(ArenaInfo enemyInfo, BattleLog.Result result)
         {
             DailyChallengeCount--;
             switch (result)
@@ -217,6 +218,33 @@ namespace Nekoyume.Model.State
             Score = Math.Max(1000, Score + score.challengerScore);
             enemyInfo.Score = Math.Max(1000, enemyInfo.Score + score.defenderScore);
             return score.challengerScore;
+        }
+
+        public int Update(
+            ArenaInfo enemyInfo,
+            BattleLog.Result result,
+            Func<int, int, BattleLog.Result, (int challengerScore, int defenderScore)> scoreGetter)
+        {
+            DailyChallengeCount--;
+            switch (result)
+            {
+                case BattleLog.Result.Win:
+                    ArenaRecord.Win++;
+                    break;
+                case BattleLog.Result.Lose:
+                    ArenaRecord.Lose++;
+                    break;
+                case BattleLog.Result.TimeOver:
+                    ArenaRecord.Draw++;
+                    return 0;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(result), result, null);
+            }
+
+            var (challengerScore, defenderScore) = scoreGetter(Score, enemyInfo.Score, result);
+            Score = Math.Max(1000, Score + challengerScore);
+            enemyInfo.Score = Math.Max(1000, enemyInfo.Score + defenderScore);
+            return challengerScore;
         }
 
         public void Activate()

--- a/Lib9c/Model/State/ArenaInfo.cs
+++ b/Lib9c/Model/State/ArenaInfo.cs
@@ -223,7 +223,7 @@ namespace Nekoyume.Model.State
         public int Update(
             ArenaInfo enemyInfo,
             BattleLog.Result result,
-            Func<int, int, BattleLog.Result, (int challengerScore, int defenderScore)> scoreGetter)
+            Func<int, int, BattleLog.Result, (int challengerScoreDelta, int defenderScoreDelta)> scoreGetter)
         {
             DailyChallengeCount--;
             switch (result)
@@ -241,10 +241,10 @@ namespace Nekoyume.Model.State
                     throw new ArgumentOutOfRangeException(nameof(result), result, null);
             }
 
-            var (challengerScore, defenderScore) = scoreGetter(Score, enemyInfo.Score, result);
-            Score = Math.Max(1000, Score + challengerScore);
-            enemyInfo.Score = Math.Max(1000, enemyInfo.Score + defenderScore);
-            return challengerScore;
+            var (challengerScoreDelta, defenderScoreDelta) = scoreGetter(Score, enemyInfo.Score, result);
+            Score = Math.Max(1000, Score + challengerScoreDelta);
+            enemyInfo.Score = Math.Max(1000, enemyInfo.Score + defenderScoreDelta);
+            return challengerScoreDelta;
         }
 
         public void Activate()


### PR DESCRIPTION
- Archive `RankingBattle11`
- Upgrade `RankingBattle`
- Upgrade `RankingSimulator.Simulate()`
- Upgrade `ArenaInfo.Update()`
- Upgrade `ArenaScoreHelper.GetScore()` and `ArenaScoreHelper.CachedScore`
- [[season3] 스코어 처리 방식 변경](https://app.asana.com/0/958521740385861/1202139879327858/f)