### PR TITLE
Move to .NET 6

### DIFF
--- a/.Lib9c.Benchmarks/Lib9c.Benchmarks.csproj
+++ b/.Lib9c.Benchmarks/Lib9c.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <PropertyGroup Condition="

--- a/.Lib9c.DevExtensions.Tests/Lib9c.DevExtensions.Tests.csproj
+++ b/.Lib9c.DevExtensions.Tests/Lib9c.DevExtensions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFramework>netcoreapp3.1</TargetFramework>
+      <TargetFramework>net6.0</TargetFramework>
       <LangVersion>8.0</LangVersion>
       <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/.Lib9c.Tests/Lib9c.Tests.csproj
+++ b/.Lib9c.Tests/Lib9c.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>

--- a/.Lib9c.Tools.Tests/Lib9c.Tools.Tests.csproj
+++ b/.Lib9c.Tools.Tests/Lib9c.Tools.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/.Lib9c.Tools/Lib9c.Tools.csproj
+++ b/.Lib9c.Tools/Lib9c.Tools.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <AssemblyName>9c-tools</AssemblyName>
     </PropertyGroup>
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.403
+        dotnet-version: 6.0.100
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
         submodules: true
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.403
+        dotnet-version: 6.0.100
     - name: bulid
       run: |
         dotnet_args="-c Release -p:NoPackageAnalysis=true"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.400",
+    "version": "6.0.100",
     "rollForward": "major"
   }
 }


### PR DESCRIPTION
[Because .NET 3.1 LTS support will be stopped on December 3, 2022][dotnet-lifecycle], we should move to .NET 6 LTS before it.
This pull request does it and the project contributors should install .NET 6 if you didn't install it yet.

[dotnet-lifecycle]: https://docs.microsoft.com/ko-kr/lifecycle/products/microsoft-net-and-net-core