### PR TITLE
More tests to check `Stake` & `ClaimStakeReward` not registered yet

### DIFF
--- a/.Lib9c.Tests/Action/ClaimStakeRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimStakeRewardTest.cs
@@ -114,5 +114,14 @@ namespace Lib9c.Tests.Action
             deserialized.LoadPlainValue(action.PlainValue);
             Assert.Equal(action.AvatarAddress, deserialized.AvatarAddress);
         }
+
+        [Fact]
+        public void CannotBePolymorphicAction()
+        {
+            Assert.Throws<MissingActionTypeException>(() =>
+            {
+                PolymorphicAction<ActionBase> action = new ClaimStakeReward(_avatarAddress);
+            });
+        }
     }
 }

--- a/.Lib9c.Tests/Action/StakeTest.cs
+++ b/.Lib9c.Tests/Action/StakeTest.cs
@@ -149,5 +149,14 @@ namespace Lib9c.Tests.Action
 
             Assert.Equal(action.Amount, deserialized.Amount);
         }
+
+        [Fact]
+        public void CannotBePolymorphicAction()
+        {
+            Assert.Throws<MissingActionTypeException>(() =>
+            {
+                PolymorphicAction<ActionBase> action = new Stake(100);
+            });
+        }
     }
 }


### PR DESCRIPTION
Currently, there are `Stake` & `ClaimStakeReward` actions and they aren't registered to `PolymorphicAction<ActionBase>` because they don't have `ActionTypeAttribute`. And it is intended.

So this pull request adds more tests to check `Stake` & `ClaimStakeReward` not registered yet explicitly.