### PR TITLE
Restore IsAuthorizedMinerTransactionRaw

### DIFF
--- a/Lib9c/Policy/BlockPolicySource.Utils.cs
+++ b/Lib9c/Policy/BlockPolicySource.Utils.cs
@@ -51,6 +51,13 @@ namespace Nekoyume.BlockChain.Policy
             }
         }
 
+        private static bool IsAuthorizedMinerTransactionRaw(
+            Transaction<NCAction> transaction,
+            ImmutableHashSet<Address> allAuthorizedMiners)
+        {
+            return allAuthorizedMiners.Contains(transaction.Signer);
+        }
+
         private static InvalidBlockHashAlgorithmTypeException ValidateHashAlgorithmTypeRaw(
             Block<NCAction> block,
             IVariableSubPolicy<HashAlgorithmType> hashAlgorithmTypePolicy)

--- a/Lib9c/Policy/BlockPolicySource.cs
+++ b/Lib9c/Policy/BlockPolicySource.cs
@@ -59,7 +59,7 @@ namespace Nekoyume.BlockChain.Policy
         public const long V100095ObsoleteIndex = 3_317_632;
 
         public const long V100096ObsoleteIndex = 3_317_632;
-        
+
         public const long V100170ObsoleteIndex = 3_810_000;
 
         public const long V100190ObsoleteIndex = 4_204_863;
@@ -286,6 +286,20 @@ namespace Nekoyume.BlockChain.Policy
 
             try
             {
+                // Check if it is a no-op transaction to prove it's made by the authorized miner.
+                if (IsAuthorizedMinerTransactionRaw(transaction, allAuthorizedMiners))
+                {
+                    // FIXME: This works under a strong assumption that any miner that was ever
+                    // in a set of authorized miners can only create transactions without
+                    // any actions.
+                    return transaction.Actions.Any()
+                        ? new TxPolicyViolationException(
+                            transaction.Id,
+                            $"Transaction {transaction.Id} by an authorized miner should not " +
+                            $"have any action: {transaction.Actions.Count}")
+                        : null;
+                }
+
                 // Check ActivateAccount
                 if (transaction.Actions.Count == 1 &&
                     transaction.Actions.First().InnerAction is IActivateAction aa)


### PR DESCRIPTION
This PR restores `IsAuthorizedMinerTransactionRaw()` (see also #911) check due to process previous blocks already in the chain.