### PR TITLE
Introduce `MigrateMonsterCollection` action

### DIFF
--- a/.Lib9c.Tests/Action/MigrateMonsterCollectionTest.cs
+++ b/.Lib9c.Tests/Action/MigrateMonsterCollectionTest.cs
@@ -1,8 +1,8 @@
 namespace Lib9c.Tests.Action
 {
+    using System;
     using System.Collections;
     using System.Collections.Generic;
-    using Bencodex.Types;
     using Libplanet;
     using Libplanet.Action;
     using Libplanet.Assets;
@@ -63,7 +63,7 @@ namespace Lib9c.Tests.Action
         }
 
         [Fact]
-        public void Execute_SkipIfAlreadyStakeStateExists()
+        public void Execute_ThrowsIfAlreadyStakeStateExists()
         {
             Address monsterCollectionAddress = MonsterCollectionState.DeriveAddress(_signer, 0);
             var monsterCollectionState = new MonsterCollectionState(
@@ -72,18 +72,14 @@ namespace Lib9c.Tests.Action
             var states = _state.SetState(
                     stakeStateAddress, new StakeState(stakeStateAddress, 0).SerializeV2())
                 .SetState(monsterCollectionAddress, monsterCollectionState.SerializeV2());
-            Assert.IsType<Dictionary>(states.GetState(monsterCollectionAddress));
             MigrateMonsterCollection action = new MigrateMonsterCollection(_avatarAddress);
-            states = action.Execute(new ActionContext
+            Assert.Throws<InvalidOperationException>(() => action.Execute(new ActionContext
             {
                 PreviousStates = states,
                 Signer = _signer,
                 BlockIndex = 0,
                 Random = new TestRandom(),
-            });
-
-            // If the migration proceeded, the monster collection state should be filled with Null.
-            Assert.IsType<Dictionary>(states.GetState(monsterCollectionAddress));
+            }));
         }
 
         [Theory]

--- a/.Lib9c.Tests/Action/MigrateMonsterCollectionTest.cs
+++ b/.Lib9c.Tests/Action/MigrateMonsterCollectionTest.cs
@@ -1,0 +1,167 @@
+namespace Lib9c.Tests.Action
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Assets;
+    using Libplanet.Crypto;
+    using Nekoyume;
+    using Nekoyume.Action;
+    using Nekoyume.Model.State;
+    using Serilog;
+    using Xunit;
+    using Xunit.Abstractions;
+    using static SerializeKeys;
+
+    public class MigrateMonsterCollectionTest
+    {
+        private readonly Address _signer;
+        private readonly IAccountStateDelta _state;
+
+        public MigrateMonsterCollectionTest(ITestOutputHelper outputHelper)
+        {
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.TestOutput(outputHelper)
+                .CreateLogger();
+
+            _signer = default;
+            var avatarAddress = _signer.Derive("avatar");
+            _state = new State();
+            Dictionary<string, string> sheets = TableSheetsImporter.ImportSheets();
+            var tableSheets = new TableSheets(sheets);
+            var rankingMapAddress = new PrivateKey().ToAddress();
+            var agentState = new AgentState(_signer);
+            var avatarState = new AvatarState(
+                avatarAddress,
+                _signer,
+                0,
+                tableSheets.GetAvatarSheets(),
+                new GameConfigState(),
+                rankingMapAddress);
+            agentState.avatarAddresses[0] = avatarAddress;
+
+            var currency = new Currency("NCG", 2, minters: null);
+            var goldCurrencyState = new GoldCurrencyState(currency);
+
+            _state = _state
+                .SetState(_signer, agentState.Serialize())
+                .SetState(avatarAddress.Derive(LegacyInventoryKey), avatarState.inventory.Serialize())
+                .SetState(avatarAddress.Derive(LegacyWorldInformationKey), avatarState.worldInformation.Serialize())
+                .SetState(avatarAddress.Derive(LegacyQuestListKey), avatarState.questList.Serialize())
+                .SetState(avatarAddress, avatarState.SerializeV2())
+                .SetState(Addresses.GoldCurrency, goldCurrencyState.Serialize());
+
+            foreach ((string key, string value) in sheets)
+            {
+                _state = _state
+                    .SetState(Addresses.TableSheet.Derive(key), value.Serialize());
+            }
+        }
+
+        [Theory]
+        [ClassData(typeof(ExecuteFixture))]
+        public void Execute(int collectionLevel, long claimBlockIndex, long stakedAmount)
+        {
+            Address collectionAddress = MonsterCollectionState.DeriveAddress(_signer, 0);
+            var monsterCollectionState = new MonsterCollectionState(collectionAddress, collectionLevel, 0);
+            Currency currency = _state.GetGoldCurrency();
+
+            var states = _state
+                .SetState(collectionAddress, monsterCollectionState.Serialize())
+                .MintAsset(monsterCollectionState.address, stakedAmount * currency);
+
+            Assert.Equal(0, states.GetAgentState(_signer).MonsterCollectionRound);
+            Assert.Equal(0 * currency, states.GetBalance(_signer, currency));
+            Assert.Equal(stakedAmount * currency, states.GetBalance(collectionAddress, currency));
+
+            MigrateMonsterCollection action = new MigrateMonsterCollection();
+            states = action.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _signer,
+                BlockIndex = claimBlockIndex,
+                Random = new TestRandom(),
+            });
+
+            Assert.True(states.TryGetStakeState(_signer, out StakeState stakeState));
+            Assert.Equal(
+                0 * currency,
+                states.GetBalance(monsterCollectionState.address, currency));
+            Assert.Equal(stakedAmount * currency, states.GetBalance(stakeState.address, currency));
+            Assert.Equal(monsterCollectionState.ReceivedBlockIndex, stakeState.ReceivedBlockIndex);
+        }
+
+        [Fact]
+        public void Serialization()
+        {
+            var action = new MigrateMonsterCollection();
+            var deserialized = new MigrateMonsterCollection();
+            deserialized.LoadPlainValue(action.PlainValue);
+            Assert.Equal(action.PlainValue, deserialized.PlainValue);
+        }
+
+        [Fact]
+        public void CannotBePolymorphicAction()
+        {
+            Assert.Throws<MissingActionTypeException>(() =>
+            {
+                PolymorphicAction<ActionBase> action = new MigrateMonsterCollection();
+            });
+        }
+
+        private class ExecuteFixture : IEnumerable<object[]>
+        {
+            private readonly List<object[]> _data = new List<object[]>
+            {
+                new object[]
+                {
+                    1,
+                    MonsterCollectionState.RewardInterval,
+                    500,
+                },
+                new object[]
+                {
+                    2,
+                    MonsterCollectionState.RewardInterval,
+                    2300,
+                },
+                new object[]
+                {
+                    3,
+                    MonsterCollectionState.RewardInterval,
+                    9500,
+                },
+                new object[]
+                {
+                    4,
+                    MonsterCollectionState.RewardInterval,
+                    63500,
+                },
+                new object[]
+                {
+                    5,
+                    MonsterCollectionState.RewardInterval,
+                    333500,
+                },
+                new object[]
+                {
+                    6,
+                    MonsterCollectionState.RewardInterval,
+                    813500,
+                },
+                new object[]
+                {
+                    7,
+                    MonsterCollectionState.RewardInterval,
+                    2313500,
+                },
+            };
+
+            public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => _data.GetEnumerator();
+        }
+    }
+}

--- a/Lib9c/Action/MigrateMonsterCollection.cs
+++ b/Lib9c/Action/MigrateMonsterCollection.cs
@@ -1,3 +1,4 @@
+using System;
 using Bencodex.Types;
 using Libplanet;
 using Libplanet.Action;
@@ -38,7 +39,7 @@ namespace Nekoyume.Action
             var states = context.PreviousStates;
             if (states.TryGetStakeState(context.Signer, out StakeState _))
             {
-                return states;
+                throw new InvalidOperationException("The user has already staked.");
             }
 
             var claimMonsterCollectionReward = new ClaimMonsterCollectionReward

--- a/Lib9c/Action/MigrateMonsterCollection.cs
+++ b/Lib9c/Action/MigrateMonsterCollection.cs
@@ -1,0 +1,42 @@
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Action;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Action
+{
+    /// <summary>
+    /// An action to migrate <see cref="MonsterCollectionState"/> into <see cref="StakeState"/>
+    /// without cancellation, to keep its staked period.
+    /// </summary>
+    public class MigrateMonsterCollection : ActionBase
+    {
+        public override IValue PlainValue => Null.Value;
+        public override void LoadPlainValue(IValue plainValue)
+        {
+        }
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            var states = context.PreviousStates;
+            var agentState = states.GetAgentState(context.Signer);
+            var currency = states.GetGoldCurrency();
+            Address collectionAddress = MonsterCollectionState.DeriveAddress(context.Signer, agentState.MonsterCollectionRound);
+            if (!states.TryGetState(collectionAddress, out Dictionary stateDict))
+            {
+                throw new FailedLoadStateException($"Aborted as the monster collection state failed to load.");
+            }
+
+            var monsterCollectionState = new MonsterCollectionState(stateDict);
+            var migratedStakeStateAddress = StakeState.DeriveAddress(context.Signer);
+            var migratedStakeState = new StakeState(migratedStakeStateAddress, monsterCollectionState.ReceivedBlockIndex);
+
+            return states.SetState(monsterCollectionState.address, Null.Value)
+                .SetState(migratedStakeStateAddress, migratedStakeState.SerializeV2())
+                .TransferAsset(
+                    monsterCollectionState.address,
+                    migratedStakeStateAddress,
+                    states.GetBalance(monsterCollectionState.address, currency));
+        }
+    }
+}

--- a/Lib9c/Action/MigrateMonsterCollection.cs
+++ b/Lib9c/Action/MigrateMonsterCollection.cs
@@ -2,25 +2,49 @@ using Bencodex.Types;
 using Libplanet;
 using Libplanet.Action;
 using Nekoyume.Model.State;
+using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Action
 {
     /// <summary>
-    /// An action to migrate <see cref="MonsterCollectionState"/> into <see cref="StakeState"/>
-    /// without cancellation, to keep its staked period.
+    /// An action to claim remained monster collection rewards and to migrate
+    /// <see cref="MonsterCollectionState"/> into <see cref="StakeState"/> without cancellation, to
+    /// keep its staked period.
     /// </summary>
     public class MigrateMonsterCollection : ActionBase
     {
-        public override IValue PlainValue => Null.Value;
+        public Address AvatarAddress { get; private set; }
+
+        public MigrateMonsterCollection(Address avatarAddress)
+        {
+            AvatarAddress = avatarAddress;
+        }
+
+        public MigrateMonsterCollection()
+        {
+        }
+
+        public override IValue PlainValue =>
+            Dictionary.Empty.Add(AvatarAddressKey, AvatarAddress.Serialize());
+
         public override void LoadPlainValue(IValue plainValue)
         {
+            var dictionary = (Dictionary)plainValue;
+            AvatarAddress = dictionary[AvatarAddressKey].ToAddress();
         }
 
         public override IAccountStateDelta Execute(IActionContext context)
         {
             var states = context.PreviousStates;
+            var claimMonsterCollectionReward = new ClaimMonsterCollectionReward
+            {
+                avatarAddress = AvatarAddress,
+            };
+            states = claimMonsterCollectionReward.Execute(context);
+
             var agentState = states.GetAgentState(context.Signer);
             var currency = states.GetGoldCurrency();
+
             Address collectionAddress = MonsterCollectionState.DeriveAddress(context.Signer, agentState.MonsterCollectionRound);
             if (!states.TryGetState(collectionAddress, out Dictionary stateDict))
             {

--- a/Lib9c/Action/MigrateMonsterCollection.cs
+++ b/Lib9c/Action/MigrateMonsterCollection.cs
@@ -36,6 +36,11 @@ namespace Nekoyume.Action
         public override IAccountStateDelta Execute(IActionContext context)
         {
             var states = context.PreviousStates;
+            if (states.TryGetStakeState(context.Signer, out StakeState _))
+            {
+                return states;
+            }
+
             var claimMonsterCollectionReward = new ClaimMonsterCollectionReward
             {
                 avatarAddress = AvatarAddress,


### PR DESCRIPTION
This pull request introduces `MigrationMonsterCollection` action to migrate `MonsterCollectionState` to `StakeState` for keeping staking period.