### PR TITLE
Introduce CRYSTAL price fluctuation MVP

### DIFF
--- a/.Lib9c.Tests/Action/CombinationEquipmentTest.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipmentTest.cs
@@ -88,39 +88,42 @@ namespace Lib9c.Tests.Action
 
         [Theory]
         // Tutorial recipe.
-        [InlineData(false, false, true, true, false, 3, 0, true, 0, 1, null, true, false, false, false, null)]
+        [InlineData(null, false, false, true, true, false, 3, 0, true, 0L, 1, null, true, false, false, false, false)]
         // Migration AvatarState.
-        [InlineData(false, false, true, true, true, 3, 0, true, 0, 1, null, true, false, false, false, null)]
+        [InlineData(null, false, false, true, true, true, 3, 0, true, 0L, 1, null, true, false, false, false, false)]
         // SubRecipe
-        [InlineData(true, true, true, true, false, 11, 0, true, 0, 2, 1, true, false, false, false, null)]
+        [InlineData(null, true, true, true, true, false, 11, 0, true, 0L, 2, 1, true, false, false, false, false)]
         // Mimisbrunnr Equipment.
-        [InlineData(true, true, true, true, false, 11, 0, true, 0, 2, 3, true, true, true, false, null)]
+        [InlineData(null, true, true, true, true, false, 11, 0, true, 0L, 2, 3, true, true, true, false, false)]
         // Purchase CRYSTAL.
-        [InlineData(true, true, true, true, false, 3, 0, true, 0, 1, null, false, false, false, true, null)]
+        [InlineData(null, true, true, true, true, false, 3, 0, true, 0L, 1, null, false, false, false, true, false)]
+        // Purchase CRYSTAL with calculate previous cost.
+        [InlineData(null, true, true, true, true, false, 3, 0, true, 100_800L, 1, null, false, false, true, true, true)]
         // UnlockEquipmentRecipe not executed.
-        [InlineData(false, true, true, true, false, 11, 0, true, 0, 2, 1, true, false, false, false, typeof(FailedLoadStateException))]
+        [InlineData(typeof(FailedLoadStateException), false, true, true, true, false, 11, 0, true, 0L, 2, 1, true, false, false, false, false)]
         // CRYSTAL not paid.
-        [InlineData(true, false, true, true, false, 11, 0, true, 0, 2, 1, true, false, false, false, typeof(InvalidRecipeIdException))]
+        [InlineData(typeof(InvalidRecipeIdException), true, false, true, true, false, 11, 0, true, 0L, 2, 1, true, false, false, false, false)]
         // AgentState not exist.
-        [InlineData(true, true, false, true, false, 3, 0, true, 0, 1, null, true, false, false, false, typeof(FailedLoadStateException))]
+        [InlineData(typeof(FailedLoadStateException), true, true, false, true, false, 3, 0, true, 0L, 1, null, true, false, false, false, false)]
         // AvatarState not exist.
-        [InlineData(true, true, true, false, false, 3, 0, true, 0, 1, null, true, false, false, false, typeof(FailedLoadStateException))]
-        [InlineData(true, true, true, false, true, 3, 0, true, 0, 1, null, true, false, false, false, typeof(FailedLoadStateException))]
+        [InlineData(typeof(FailedLoadStateException), true, true, true, false, false, 3, 0, true, 0L, 1, null, true, false, false, false, false)]
+        [InlineData(typeof(FailedLoadStateException), true, true, true, false, true, 3, 0, true, 0L, 1, null, true, false, false, false, false)]
         // Tutorial not cleared.
-        [InlineData(true, true, true, true, false, 1, 0, true, 0, 1, null, true, false, false, false, typeof(NotEnoughClearedStageLevelException))]
+        [InlineData(typeof(NotEnoughClearedStageLevelException), true, true, true, true, false, 1, 0, true, 0L, 1, null, true, false, false, false, false)]
         // CombinationSlotState not exist.
-        [InlineData(true, true, true, true, false, 3, 5, true, 0, 1, null, true, false, false, false, typeof(FailedLoadStateException))]
+        [InlineData(typeof(FailedLoadStateException), true, true, true, true, false, 3, 5, true, 0L, 1, null, true, false, false, false, false)]
         // CombinationSlotState locked.
-        [InlineData(true, true, true, true, false, 3, 0, false, 0, 1, null, true, false, false, false, typeof(CombinationSlotUnlockException))]
+        [InlineData(typeof(CombinationSlotUnlockException), true, true, true, true, false, 3, 0, false, 0L, 1, null, true, false, false, false, false)]
         // Stage not cleared.
-        [InlineData(true, true, true, true, false, 3, 0, true, 0, 2, null, true, false, false, false, typeof(NotEnoughClearedStageLevelException))]
+        [InlineData(typeof(NotEnoughClearedStageLevelException), true, true, true, true, false, 3, 0, true, 0L, 2, null, true, false, false, false, false)]
         // Not enough material.
-        [InlineData(true, true, true, true, false, 3, 0, true, 0, 1, null, false, false, false, false, typeof(NotEnoughMaterialException))]
+        [InlineData(typeof(NotEnoughMaterialException), true, true, true, true, false, 3, 0, true, 0L, 1, null, false, false, false, false, false)]
         // Purchase CRYSTAL failed by Mimisbrunnr material.
-        [InlineData(true, true, true, true, false, 11, 0, true, 0, 2, 3, false, false, true, true, typeof(NotEnoughMaterialException))]
+        [InlineData(typeof(NotEnoughMaterialException), true, true, true, true, false, 11, 0, true, 0L, 2, 3, false, false, true, true, false)]
         // Insufficient NCG.
-        [InlineData(true, true, true, true, false, 11, 0, true, 0, 2, 3, true, false, true, false, typeof(InsufficientBalanceException))]
+        [InlineData(typeof(InsufficientBalanceException), true, true, true, true, false, 11, 0, true, 0L, 2, 3, true, false, true, false, false)]
         public void Execute(
+            Type exc,
             bool unlockIdsExist,
             bool crystalUnlock,
             bool agentExist,
@@ -136,7 +139,7 @@ namespace Lib9c.Tests.Action
             bool ncgBalanceExist,
             bool mimisbrunnr,
             bool payByCrystal,
-            Type exc
+            bool previousCostStateExist
         )
         {
             IAccountStateDelta state = _initialState;
@@ -244,9 +247,28 @@ namespace Lib9c.Tests.Action
                     }
                 }
 
-                expectedCrystal = crystalBalance;
-                state = state.MintAsset(_agentAddress, crystalBalance * CrystalCalculator.CRYSTAL);
+                if (previousCostStateExist)
+                {
+                    var previousCostAddress = Addresses.GetWeeklyCrystalCostAddress(1);
+                    var previousCostState = new CrystalCostState(previousCostAddress, crystalBalance * CrystalCalculator.CRYSTAL * 2);
+                    var beforePreviousCostAddress = Addresses.GetWeeklyCrystalCostAddress(0);
+                    var beforePreviousCostState = new CrystalCostState(beforePreviousCostAddress, crystalBalance * CrystalCalculator.CRYSTAL);
+
+                    state = state
+                        .SetState(previousCostAddress, previousCostState.Serialize())
+                        .SetState(beforePreviousCostAddress, beforePreviousCostState.Serialize());
+                }
+
+                expectedCrystal = previousCostStateExist ? crystalBalance * 2 : crystalBalance;
+                state = state.MintAsset(_agentAddress, expectedCrystal * CrystalCalculator.CRYSTAL);
             }
+
+            var dailyCostAddress =
+                Addresses.GetDailyCrystalCostAddress((int)(blockIndex / CrystalCostState.DailyIntervalIndex));
+            var weeklyCostAddress = Addresses.GetWeeklyCrystalCostAddress((int)(blockIndex / CrystalCostState.WeeklyIntervalIndex));
+
+            Assert.Null(state.GetState(dailyCostAddress));
+            Assert.Null(state.GetState(weeklyCostAddress));
 
             var action = new CombinationEquipment
             {
@@ -306,11 +328,21 @@ namespace Lib9c.Tests.Action
 
                 var nextAvatarState = nextState.GetAvatarStateV2(_avatarAddress);
                 var mail = nextAvatarState.mailBox.OfType<CombinationMail>().First();
+
                 Assert.Equal(equipment, mail.attachment.itemUsable);
+                Assert.Equal(payByCrystal, !(nextState.GetState(dailyCostAddress) is null));
+                Assert.Equal(payByCrystal, !(nextState.GetState(weeklyCostAddress) is null));
 
                 if (payByCrystal)
                 {
+                    var dailyCostState = nextState.GetCrystalCostState(dailyCostAddress);
+                    var weeklyCostState = nextState.GetCrystalCostState(weeklyCostAddress);
+
                     Assert.Equal(0 * CrystalCalculator.CRYSTAL, nextState.GetBalance(_agentAddress, CrystalCalculator.CRYSTAL));
+                    Assert.Equal(1, dailyCostState.Count);
+                    Assert.Equal(expectedCrystal * CrystalCalculator.CRYSTAL, dailyCostState.CRYSTAL);
+                    Assert.Equal(1, weeklyCostState.Count);
+                    Assert.Equal(expectedCrystal * CrystalCalculator.CRYSTAL, weeklyCostState.CRYSTAL);
                 }
 
                 Assert.Equal(expectedCrystal * CrystalCalculator.CRYSTAL, nextState.GetBalance(Addresses.MaterialCost, CrystalCalculator.CRYSTAL));

--- a/.Lib9c.Tests/CrystalCalculatorTest.cs
+++ b/.Lib9c.Tests/CrystalCalculatorTest.cs
@@ -4,6 +4,7 @@ namespace Lib9c.Tests
     using System.Collections.Generic;
     using Nekoyume.Helper;
     using Nekoyume.Model.Item;
+    using Nekoyume.Model.State;
     using Nekoyume.TableData;
     using Xunit;
 
@@ -60,6 +61,18 @@ namespace Lib9c.Tests
             Assert.Equal(
                 expected * CrystalCalculator.CRYSTAL,
                 actual);
+        }
+
+        [Theory]
+        [InlineData(2, 1, 200)]
+        [InlineData(1, 2, 50)]
+        public void CalculateCombinationCost(int psCount, int bpsCount, int expected)
+        {
+            var crystal = 100 * CrystalCalculator.CRYSTAL;
+            var ps = new CrystalCostState(default, crystal * psCount);
+            var bps = new CrystalCostState(default, crystal * bpsCount);
+
+            Assert.Equal(expected * CrystalCalculator.CRYSTAL, CrystalCalculator.CalculateCombinationCost(crystal, ps, bps));
         }
 
         private class CalculateCrystalData : IEnumerable<object[]>

--- a/.Lib9c.Tests/Model/State/CrystalCostStateTest.cs
+++ b/.Lib9c.Tests/Model/State/CrystalCostStateTest.cs
@@ -1,0 +1,27 @@
+namespace Lib9c.Tests.Model.State
+{
+    using Bencodex.Types;
+    using Libplanet;
+    using Libplanet.Crypto;
+    using Nekoyume.Helper;
+    using Nekoyume.Model.State;
+    using Xunit;
+
+    public class CrystalCostStateTest
+    {
+        [Fact]
+        public void Serialize()
+        {
+            var crystal = 100 * CrystalCalculator.CRYSTAL;
+            var address = new PrivateKey().ToAddress();
+            var state = new CrystalCostState(address, crystal);
+            state.Count++;
+            var serialized = state.Serialize();
+            var deserialized = new CrystalCostState(address, (List)serialized);
+
+            Assert.Equal(state.Address, deserialized.Address);
+            Assert.Equal(state.CRYSTAL, deserialized.CRYSTAL);
+            Assert.Equal(state.Count, deserialized.Count);
+        }
+    }
+}

--- a/Lib9c/Addresses.cs
+++ b/Lib9c/Addresses.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Globalization;
 using Libplanet;
 using Nekoyume.Action;
+using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
 namespace Nekoyume
@@ -30,5 +32,15 @@ namespace Nekoyume
         public static Address GetSheetAddress(string sheetName) => TableSheet.Derive(sheetName);
 
         public static Address GetItemAddress(Guid itemId) => Blacksmith.Derive(itemId.ToString());
+
+        public static Address GetDailyCrystalCostAddress(int index)
+        {
+            return MaterialCost.Derive($"daily_{index.ToString(CultureInfo.InvariantCulture)}");
+        }
+
+        public static Address GetWeeklyCrystalCostAddress(int index)
+        {
+            return MaterialCost.Derive($"weekly_{index.ToString(CultureInfo.InvariantCulture)}");
+        }
     }
 }

--- a/Lib9c/Helper/CrystalCalculator.cs
+++ b/Lib9c/Helper/CrystalCalculator.cs
@@ -1,9 +1,9 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using Libplanet.Assets;
 using Nekoyume.Model.Item;
+using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Nekoyume.TableData.Crystal;
 
@@ -59,6 +59,22 @@ namespace Nekoyume.Helper
                 crystalMonsterCollectionMultiplierSheet[monsterCollectionLevel];
             var extra = crystal.DivRem(100, out _) * multiplierRow.Multiplier;
             return crystal + extra;
+        }
+
+        public static FungibleAssetValue CalculateCombinationCost(
+            FungibleAssetValue crystal,
+            CrystalCostState prevWeeklyCostState = null,
+            CrystalCostState beforePrevWeeklyCostState = null
+        )
+        {
+            if (!(prevWeeklyCostState is null) && !(beforePrevWeeklyCostState is null))
+            {
+                var multiplier = prevWeeklyCostState.CRYSTAL.RawValue * 100 /
+                                 beforePrevWeeklyCostState.CRYSTAL.RawValue;
+                crystal = crystal.DivRem(100, out _) * multiplier;
+            }
+
+            return crystal;
         }
     }
 }

--- a/Lib9c/Model/State/CrystalCostState.cs
+++ b/Lib9c/Model/State/CrystalCostState.cs
@@ -1,0 +1,38 @@
+using System;
+using Bencodex.Types;
+using JetBrains.Annotations;
+using Libplanet;
+using Libplanet.Assets;
+
+namespace Nekoyume.Model.State
+{
+    [Serializable]
+    public class CrystalCostState : IState
+    {
+        public const long DailyIntervalIndex = 7200L;
+        public const long WeeklyIntervalIndex = 7200L * 7;
+        public Address Address;
+        public FungibleAssetValue CRYSTAL;
+        public int Count;
+
+        public CrystalCostState(Address address, FungibleAssetValue crystal)
+        {
+            Address = address;
+            CRYSTAL = crystal;
+        }
+
+        public CrystalCostState(Address address, List serialized)
+        {
+            Address = address;
+            CRYSTAL = serialized[0].ToFungibleAssetValue();
+            Count = serialized[1].ToInteger();
+        }
+
+        public IValue Serialize()
+        {
+            return List.Empty
+                .Add(CRYSTAL.Serialize())
+                .Add(Count.Serialize());
+        }
+    }
+}


### PR DESCRIPTION
- MVP for CRYSTAL price.
- Calculate the crystal cost by the ratio of the previous week's and before previous week's crystal costs.
- Add cost history by day & week.