### PR TITLE
fix zero division inconsistency between amd and arm architecture

### DIFF
--- a/Lib9c/Helper/AvatarStateExtensions.cs
+++ b/Lib9c/Helper/AvatarStateExtensions.cs
@@ -60,7 +60,12 @@ namespace Nekoyume.Helper
                 var maxExp = row.Exp + row.ExpNeed;
                 var remainExp = maxExp - currentExp;
                 var stageExp = StageRewardExpHelper.GetExp(currentLevel, stageId);
-                var requiredCount = (int)Math.Ceiling(remainExp / (double)stageExp);
+                if (stageExp == 0)
+                {
+                    break;
+                }
+
+                var requiredCount = (int)DecimalMath.DecimalEx.Ceiling(remainExp / (decimal)stageExp);
                 if (remainCount - requiredCount > 0) // level up
                 {
                     currentExp += stageExp * requiredCount;


### PR DESCRIPTION
Ever since the addition of `HackAndSlashSweep`, the action execution result between `amd` and `arm` architectures have shown some inconsistency. 

After some research, this issue appears to have been caused by the different results of `dividing by zero` between two architectures. 

This fix ensures that the calculation results are consistent in both `amd` and `arm`.