### PR TITLE
Introduce JoinArena action

### DIFF
--- a/.Lib9c.Tests/Action/JoinArenaTest.cs
+++ b/.Lib9c.Tests/Action/JoinArenaTest.cs
@@ -1,0 +1,449 @@
+namespace Lib9c.Tests.Action
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Bencodex.Types;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Assets;
+    using Libplanet.Crypto;
+    using Nekoyume;
+    using Nekoyume.Action;
+    using Nekoyume.Arena;
+    using Nekoyume.Model.Arena;
+    using Nekoyume.Model.EnumType;
+    using Nekoyume.Model.Item;
+    using Nekoyume.Model.State;
+    using Nekoyume.TableData;
+    using Serilog;
+    using Xunit;
+    using Xunit.Abstractions;
+    using static SerializeKeys;
+
+    public class JoinArenaTest
+    {
+        private readonly Dictionary<string, string> _sheets;
+        private readonly TableSheets _tableSheets;
+        private readonly Address _signer;
+        private readonly Address _avatarAddress;
+        private readonly IRandom _random;
+        private readonly Currency _currency;
+        private IAccountStateDelta _state;
+
+        public JoinArenaTest(ITestOutputHelper outputHelper)
+        {
+            _random = new TestRandom();
+            _sheets = TableSheetsImporter.ImportSheets();
+            _tableSheets = new TableSheets(_sheets);
+
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.TestOutput(outputHelper)
+                .CreateLogger();
+
+            _signer = default;
+            _avatarAddress = _signer.Derive("avatar");
+            _state = new State();
+            var sheets = TableSheetsImporter.ImportSheets();
+            var tableSheets = new TableSheets(sheets);
+            var rankingMapAddress = new PrivateKey().ToAddress();
+            var agentState = new AgentState(_signer);
+            var avatarState = new AvatarState(
+                _avatarAddress,
+                _signer,
+                0,
+                tableSheets.GetAvatarSheets(),
+                new GameConfigState(),
+                rankingMapAddress);
+            agentState.avatarAddresses[0] = _avatarAddress;
+
+            var currency = new Currency("NCG", 2, minters: null);
+            var goldCurrencyState = new GoldCurrencyState(currency);
+            _currency = new Currency("CRYSTAL", 18, minters: null);
+
+            _state = _state
+                .SetState(_signer, agentState.Serialize())
+                .SetState(_avatarAddress.Derive(LegacyInventoryKey), avatarState.inventory.Serialize())
+                .SetState(_avatarAddress.Derive(LegacyWorldInformationKey), avatarState.worldInformation.Serialize())
+                .SetState(_avatarAddress.Derive(LegacyQuestListKey), avatarState.questList.Serialize())
+                .SetState(_avatarAddress, avatarState.SerializeV2())
+                .SetState(Addresses.GoldCurrency, goldCurrencyState.Serialize());
+
+            foreach ((string key, string value) in sheets)
+            {
+                _state = _state
+                    .SetState(Addresses.TableSheet.Derive(key), value.Serialize());
+            }
+        }
+
+        public (List<Guid> Equipments, List<Guid> Costumes) GetDummyItems(AvatarState avatarState)
+        {
+            var items = Doomfist.GetAllParts(_tableSheets, avatarState.level);
+            foreach (var equipment in items)
+            {
+                avatarState.inventory.AddItem(equipment);
+            }
+
+            var equipments = items.Select(e => e.NonFungibleId).ToList();
+
+            var random = new TestRandom();
+            var costumes = new List<Guid>();
+            if (avatarState.level >= GameConfig.RequireCharacterLevel.CharacterFullCostumeSlot)
+            {
+                var costumeId = _tableSheets
+                    .CostumeItemSheet
+                    .Values
+                    .First(r => r.ItemSubType == ItemSubType.FullCostume)
+                    .Id;
+
+                var costume = (Costume)ItemFactory.CreateItem(
+                    _tableSheets.ItemSheet[costumeId], random);
+                avatarState.inventory.AddItem(costume);
+                costumes.Add(costume.ItemId);
+            }
+
+            return (equipments, costumes);
+        }
+
+        public AvatarState GetAvatarState(AvatarState avatarState, out List<Guid> equipments, out List<Guid> costumes)
+        {
+            avatarState.level = 999;
+            (equipments, costumes) = GetDummyItems(avatarState);
+
+            _state = _state
+                .SetState(_avatarAddress, avatarState.SerializeV2())
+                .SetState(_avatarAddress.Derive(LegacyInventoryKey), avatarState.inventory.Serialize())
+                .SetState(_avatarAddress.Derive(LegacyWorldInformationKey), avatarState.worldInformation.Serialize())
+                .SetState(_avatarAddress.Derive(LegacyQuestListKey), avatarState.questList.Serialize());
+
+            return avatarState;
+        }
+
+        public AvatarState AddMedal(AvatarState avatarState, ArenaSheet.Row row)
+        {
+            var materialSheet = _state.GetSheet<MaterialItemSheet>();
+            foreach (var data in row.Round)
+            {
+                if (!data.ArenaType.Equals(ArenaType.Season))
+                {
+                    continue;
+                }
+
+                var itemId = ArenaHelper.GetMedalItemId(data.Id, data.Round);
+                var material = ItemFactory.CreateMaterial(materialSheet, itemId);
+                avatarState.inventory.AddItem(material);
+            }
+
+            _state = _state
+                .SetState(_avatarAddress, avatarState.SerializeV2())
+                .SetState(_avatarAddress.Derive(LegacyInventoryKey), avatarState.inventory.Serialize())
+                .SetState(_avatarAddress.Derive(LegacyWorldInformationKey), avatarState.worldInformation.Serialize())
+                .SetState(_avatarAddress.Derive(LegacyQuestListKey), avatarState.questList.Serialize());
+
+            return avatarState;
+        }
+
+        [Theory]
+        [InlineData(0, 1, 1)]
+        [InlineData(0, 1, 2)]
+        [InlineData(7, 1, 2)]
+        [InlineData(100, 1, 8)]
+        public void Execute(long blockIndex, int championshipId, int round)
+        {
+            var arenaSheet = _state.GetSheet<ArenaSheet>();
+            if (!arenaSheet.TryGetValue(championshipId, out var row))
+            {
+                throw new SheetRowNotFoundException(
+                    nameof(ArenaSheet), $"championship Id : {championshipId}");
+            }
+
+            var avatarState = _state.GetAvatarStateV2(_avatarAddress);
+            avatarState = GetAvatarState(avatarState, out var equipments, out var costumes);
+            avatarState = AddMedal(avatarState, row);
+            var preCurrency = 1000 * _currency;
+            var state = _state.MintAsset(_signer, preCurrency);
+
+            var action = new JoinArena()
+            {
+                championshipId = championshipId,
+                round = round,
+                costumes = costumes,
+                equipments = equipments,
+                avatarAddress = _avatarAddress,
+            };
+
+            state = action.Execute(new ActionContext
+            {
+                PreviousStates = state,
+                Signer = _signer,
+                Random = _random,
+                Rehearsal = false,
+                BlockIndex = blockIndex,
+            });
+
+            // ArenaParticipants
+            var arenaParticipantsAdr = ArenaParticipants.DeriveAddress(championshipId, round);
+            var serializedArenaParticipants = (List)state.GetState(arenaParticipantsAdr);
+            var arenaParticipants = new ArenaParticipants(serializedArenaParticipants);
+
+            Assert.Equal(arenaParticipantsAdr, arenaParticipants.Address);
+            Assert.Equal(_avatarAddress, arenaParticipants.AvatarAddresses.First());
+
+            // ArenaAvatarState
+            var arenaAvatarStateAdr = ArenaAvatarState.DeriveAddress(_avatarAddress);
+            var serializedArenaAvatarState = (List)state.GetState(arenaAvatarStateAdr);
+            var arenaAvatarState = new ArenaAvatarState(serializedArenaAvatarState);
+
+            foreach (var guid in arenaAvatarState.Equipments)
+            {
+                Assert.Contains(avatarState.inventory.Equipments, x => x.ItemId.Equals(guid));
+            }
+
+            foreach (var guid in arenaAvatarState.Costumes)
+            {
+                Assert.Contains(avatarState.inventory.Costumes, x => x.ItemId.Equals(guid));
+            }
+
+            Assert.Equal(arenaAvatarStateAdr, arenaAvatarState.Address);
+            Assert.Equal(avatarState.level, arenaAvatarState.Level);
+
+            // ArenaScore
+            var arenaScoreAdr = ArenaScore.DeriveAddress(_avatarAddress, championshipId, round);
+            var serializedArenaScore = (List)state.GetState(arenaScoreAdr);
+            var arenaScore = new ArenaScore(serializedArenaScore);
+
+            Assert.Equal(arenaScoreAdr, arenaScore.Address);
+            Assert.Equal(GameConfig.ArenaScoreDefault, arenaScore.Score);
+
+            // ArenaInformation
+            var arenaInformationAdr = ArenaInformation.DeriveAddress(_avatarAddress, championshipId, round);
+            var serializedArenaInformation = (List)state.GetState(arenaInformationAdr);
+            var arenaInformation = new ArenaInformation(serializedArenaInformation);
+
+            Assert.Equal(arenaInformationAdr, arenaInformation.Address);
+            Assert.Equal(0, arenaInformation.Win);
+            Assert.Equal(0, arenaInformation.Lose);
+            Assert.Equal(ArenaInformation.MaxTicketCount, arenaInformation.Ticket);
+
+            if (!row.TryGetRound(round, out var roundData))
+            {
+                throw new RoundNotFoundException($"{nameof(JoinArena)} : {row.Id} / {round}");
+            }
+
+            if (roundData.IsTheRoundOpened(blockIndex))
+            {
+                var curCurrency = preCurrency - (roundData.EntranceFee * _currency);
+                Assert.Equal(curCurrency, state.GetBalance(_signer, _currency));
+            }
+            else
+            {
+                var curCurrency = preCurrency - (roundData.DiscountedEntranceFee * _currency);
+                Assert.Equal(curCurrency, state.GetBalance(_signer, _currency));
+            }
+        }
+
+        [Theory]
+        [InlineData(9999)]
+        public void Execute_SheetRowNotFoundException(int championshipId)
+        {
+            var avatarState = _state.GetAvatarStateV2(_avatarAddress);
+            avatarState = GetAvatarState(avatarState, out var equipments, out var costumes);
+            var state = _state.SetState(_avatarAddress, avatarState.SerializeV2());
+
+            var action = new JoinArena()
+            {
+                championshipId = championshipId,
+                round = 1,
+                costumes = costumes,
+                equipments = equipments,
+                avatarAddress = _avatarAddress,
+            };
+
+            Assert.Throws<SheetRowNotFoundException>(() => action.Execute(new ActionContext()
+            {
+                PreviousStates = state,
+                Signer = _signer,
+                Random = new TestRandom(),
+            }));
+        }
+
+        [Theory]
+        [InlineData(123)]
+        public void Execute_RoundNotFoundByIdsException(int round)
+        {
+            var avatarState = _state.GetAvatarStateV2(_avatarAddress);
+            avatarState = GetAvatarState(avatarState, out var equipments, out var costumes);
+            var state = _state.SetState(_avatarAddress, avatarState.SerializeV2());
+
+            var action = new JoinArena()
+            {
+                championshipId = 1,
+                round = round,
+                costumes = costumes,
+                equipments = equipments,
+                avatarAddress = _avatarAddress,
+            };
+
+            Assert.Throws<RoundNotFoundException>(() => action.Execute(new ActionContext()
+            {
+                PreviousStates = state,
+                Signer = _signer,
+                Random = new TestRandom(),
+                BlockIndex = 1,
+            }));
+        }
+
+        [Theory]
+        [InlineData(8)]
+        public void Execute_NotEnoughMedalException(int round)
+        {
+            var avatarState = _state.GetAvatarStateV2(_avatarAddress);
+            GetAvatarState(avatarState, out var equipments, out var costumes);
+            var preCurrency = 1000 * _currency;
+            var state = _state.MintAsset(_signer, preCurrency);
+
+            var action = new JoinArena()
+            {
+                championshipId = 1,
+                round = round,
+                costumes = costumes,
+                equipments = equipments,
+                avatarAddress = _avatarAddress,
+            };
+
+            Assert.Throws<NotEnoughMedalException>(() => action.Execute(new ActionContext()
+            {
+                PreviousStates = state,
+                Signer = _signer,
+                Random = new TestRandom(),
+                BlockIndex = 100,
+            }));
+        }
+
+        [Theory]
+        [InlineData(6, 0)] // discounted_entrance_fee
+        [InlineData(8, 100)] // entrance_fee
+        public void Execute_NotEnoughFungibleAssetValueException(int round, long blockIndex)
+        {
+            var avatarState = _state.GetAvatarStateV2(_avatarAddress);
+            GetAvatarState(avatarState, out var equipments, out var costumes);
+            var state = _state.SetState(_avatarAddress, avatarState.SerializeV2());
+
+            var action = new JoinArena()
+            {
+                championshipId = 1,
+                round = round,
+                costumes = costumes,
+                equipments = equipments,
+                avatarAddress = _avatarAddress,
+            };
+
+            Assert.Throws<NotEnoughFungibleAssetValueException>(() => action.Execute(new ActionContext()
+            {
+                PreviousStates = state,
+                Signer = _signer,
+                Random = new TestRandom(),
+                BlockIndex = blockIndex,
+            }));
+        }
+
+        [Fact]
+        public void Execute_ArenaScoreAlreadyContainsException()
+        {
+            var avatarState = _state.GetAvatarStateV2(_avatarAddress);
+            avatarState = GetAvatarState(avatarState, out var equipments, out var costumes);
+            var state = _state.SetState(_avatarAddress, avatarState.SerializeV2());
+
+            var action = new JoinArena()
+            {
+                championshipId = 1,
+                round = 1,
+                costumes = costumes,
+                equipments = equipments,
+                avatarAddress = _avatarAddress,
+            };
+
+            state = action.Execute(new ActionContext
+            {
+                PreviousStates = state,
+                Signer = _signer,
+                Random = _random,
+                Rehearsal = false,
+                BlockIndex = 1,
+            });
+
+            Assert.Throws<ArenaScoreAlreadyContainsException>(() => action.Execute(new ActionContext()
+            {
+                PreviousStates = state,
+                Signer = _signer,
+                Random = new TestRandom(),
+                BlockIndex = 2,
+            }));
+        }
+
+        [Fact]
+        public void Execute_ArenaScoreAlreadyContainsException2()
+        {
+            const int championshipId = 1;
+            const int round = 1;
+
+            var avatarState = _state.GetAvatarStateV2(_avatarAddress);
+            avatarState = GetAvatarState(avatarState, out var equipments, out var costumes);
+            var state = _state.SetState(_avatarAddress, avatarState.SerializeV2());
+
+            var arenaScoreAdr = ArenaScore.DeriveAddress(_avatarAddress, championshipId, round);
+            var arenaScore = new ArenaScore(_avatarAddress, championshipId, round);
+            state = state.SetState(arenaScoreAdr, arenaScore.Serialize());
+
+            var action = new JoinArena()
+            {
+                championshipId = championshipId,
+                round = round,
+                costumes = costumes,
+                equipments = equipments,
+                avatarAddress = _avatarAddress,
+            };
+
+            Assert.Throws<ArenaScoreAlreadyContainsException>(() => action.Execute(new ActionContext()
+            {
+                PreviousStates = state,
+                Signer = _signer,
+                Random = new TestRandom(),
+                BlockIndex = 1,
+            }));
+        }
+
+        [Fact]
+        public void Execute_ArenaInformationAlreadyContainsException()
+        {
+            const int championshipId = 1;
+            const int round = 1;
+
+            var avatarState = _state.GetAvatarStateV2(_avatarAddress);
+            avatarState = GetAvatarState(avatarState, out var equipments, out var costumes);
+            var state = _state.SetState(_avatarAddress, avatarState.SerializeV2());
+
+            var arenaInformationAdr = ArenaInformation.DeriveAddress(_avatarAddress, championshipId, round);
+            var arenaInformation = new ArenaInformation(_avatarAddress, championshipId, round);
+            state = state.SetState(arenaInformationAdr, arenaInformation.Serialize());
+
+            var action = new JoinArena()
+            {
+                championshipId = championshipId,
+                round = round,
+                costumes = costumes,
+                equipments = equipments,
+                avatarAddress = _avatarAddress,
+            };
+
+            Assert.Throws<ArenaInformationAlreadyContainsException>(() => action.Execute(new ActionContext()
+            {
+                PreviousStates = state,
+                Signer = _signer,
+                Random = new TestRandom(),
+                BlockIndex = 1,
+            }));
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/Arena/ArenaAvatarStateTest.cs
+++ b/.Lib9c.Tests/Model/Arena/ArenaAvatarStateTest.cs
@@ -1,0 +1,47 @@
+namespace Lib9c.Tests.Model.Arena
+{
+    using Bencodex.Types;
+    using Libplanet;
+    using Libplanet.Crypto;
+    using Nekoyume.Model.State;
+    using Xunit;
+
+    public class ArenaAvatarStateTest
+    {
+        private readonly TableSheets _tableSheets;
+
+        public ArenaAvatarStateTest()
+        {
+            var sheets = TableSheetsImporter.ImportSheets();
+            _tableSheets = new TableSheets(sheets);
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            var avatarAddress = new PrivateKey().ToAddress();
+            var agentAddress = new PrivateKey().ToAddress();
+            var avatarState = GetNewAvatarState(avatarAddress, agentAddress);
+            var state = new ArenaAvatarState(avatarState);
+
+            var serialized = (List)state.Serialize();
+            var deserialized = new ArenaAvatarState(serialized);
+
+            Assert.Equal(state.Costumes, deserialized.Costumes);
+            Assert.Equal(state.Equipments, deserialized.Equipments);
+            Assert.Equal(state.Level, deserialized.Level);
+        }
+
+        private AvatarState GetNewAvatarState(Address avatarAddress, Address agentAddress)
+        {
+            var rankingState = new RankingState1();
+            return new AvatarState(
+                avatarAddress,
+                agentAddress,
+                0,
+                _tableSheets.GetAvatarSheets(),
+                new GameConfigState(),
+                rankingState.UpdateRankingMap(avatarAddress));
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/Arena/ArenaInformationTest.cs
+++ b/.Lib9c.Tests/Model/Arena/ArenaInformationTest.cs
@@ -1,0 +1,25 @@
+namespace Lib9c.Tests.Model.Arena
+{
+    using Bencodex.Types;
+    using Libplanet;
+    using Libplanet.Crypto;
+    using Nekoyume.Model.Arena;
+    using Xunit;
+
+    public class ArenaInformationTest
+    {
+        [Fact]
+        public void Serialize()
+        {
+            var avatarAddress = new PrivateKey().ToAddress();
+            var state = new ArenaInformation(avatarAddress, 1, 1);
+            var serialized = (List)state.Serialize();
+            var deserialized = new ArenaInformation(serialized);
+
+            Assert.Equal(state.Address, deserialized.Address);
+            Assert.Equal(state.Win, deserialized.Win);
+            Assert.Equal(state.Lose, deserialized.Lose);
+            Assert.Equal(state.Ticket, deserialized.Ticket);
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/Arena/ArenaParticipantsTest.cs
+++ b/.Lib9c.Tests/Model/Arena/ArenaParticipantsTest.cs
@@ -1,0 +1,20 @@
+namespace Lib9c.Tests.Model.Arena
+{
+    using Bencodex.Types;
+    using Nekoyume.Model.Arena;
+    using Xunit;
+
+    public class ArenaParticipantsTest
+    {
+        [Fact]
+        public void Serialize()
+        {
+            var state = new ArenaParticipants(1, 1);
+            var serialized = (List)state.Serialize();
+            var deserialized = new ArenaParticipants(serialized);
+
+            Assert.Equal(state.Address, deserialized.Address);
+            Assert.Equal(state.AvatarAddresses, deserialized.AvatarAddresses);
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/Arena/ArenaScoreTest.cs
+++ b/.Lib9c.Tests/Model/Arena/ArenaScoreTest.cs
@@ -1,0 +1,23 @@
+namespace Lib9c.Tests.Model.Arena
+{
+    using Bencodex.Types;
+    using Libplanet;
+    using Libplanet.Crypto;
+    using Nekoyume.Model.Arena;
+    using Xunit;
+
+    public class ArenaScoreTest
+    {
+        [Fact]
+        public void Serialize()
+        {
+            var avatarAddress = new PrivateKey().ToAddress();
+            var state = new ArenaScore(avatarAddress, 1, 1);
+            var serialized = (List)state.Serialize();
+            var deserialized = new ArenaScore(serialized);
+
+            Assert.Equal(state.Address, deserialized.Address);
+            Assert.Equal(state.Score, deserialized.Score);
+        }
+    }
+}

--- a/.Lib9c.Tests/TableData/ArenaSheetTest.cs
+++ b/.Lib9c.Tests/TableData/ArenaSheetTest.cs
@@ -1,0 +1,34 @@
+namespace Lib9c.Tests.TableData
+{
+    using System.Linq;
+    using Nekoyume.Model.EnumType;
+    using Nekoyume.TableData;
+    using Xunit;
+
+    public class ArenaSheetTest
+    {
+        [Fact]
+        public void SetToSheet()
+        {
+            const string content = @"id,round,arena_type,start_block_index,end_block_index,required_medal_count,entrance_fee,discounted_entrance_fee,ticket_price,additional_ticket_price
+1,1,OffSeason,0,5,0,0,0,5,2
+1,2,Season,6,10,0,0,0,5,2
+1,3,Championship,11,20000,1,0,0,5,2";
+
+            var sheet = new ArenaSheet();
+            sheet.Set(content);
+
+            Assert.Single(sheet);
+            Assert.Equal(3, sheet.First.Round.Count);
+            Assert.Equal(1, sheet.First.Round.First().Id);
+            Assert.Equal(1, sheet.First.Round.First().Round);
+            Assert.Equal(ArenaType.OffSeason, sheet.First.Round.First().ArenaType);
+            Assert.Equal(0, sheet.First.Round.First().StartBlockIndex);
+            Assert.Equal(5, sheet.First.Round.First().EndBlockIndex);
+            Assert.Equal(0, sheet.First.Round.First().RequiredMedalCount);
+            Assert.Equal(0, sheet.First.Round.First().EntranceFee);
+            Assert.Equal(5, sheet.First.Round.First().TicketPrice);
+            Assert.Equal(2, sheet.First.Round.First().AdditionalTicketPrice);
+        }
+    }
+}

--- a/.Lib9c.Tests/TableSheets.cs
+++ b/.Lib9c.Tests/TableSheets.cs
@@ -147,6 +147,8 @@ namespace Lib9c.Tests
 
         public CrystalMaterialCostSheet CrystalMaterialCostSheet { get; private set; }
 
+        public ArenaSheet ArenaSheet { get; private set; }
+
         public void ItemSheetInitialize()
         {
             ItemSheet ??= new ItemSheet();
@@ -198,6 +200,21 @@ namespace Lib9c.Tests
                 CharacterSheet,
                 CharacterLevelSheet,
                 EquipmentItemSetEffectSheet,
+                WeeklyArenaRewardSheet
+            );
+        }
+
+        public ArenaSimulatorSheets GetArenaSimulatorSheets()
+        {
+            return new ArenaSimulatorSheets(
+                MaterialItemSheet,
+                SkillSheet,
+                SkillBuffSheet,
+                BuffSheet,
+                CharacterSheet,
+                CharacterLevelSheet,
+                EquipmentItemSetEffectSheet,
+                CostumeStatSheet,
                 WeeklyArenaRewardSheet
             );
         }

--- a/Lib9c/Action/AccountStateDeltaExtensions.cs
+++ b/Lib9c/Action/AccountStateDeltaExtensions.cs
@@ -5,11 +5,11 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using Bencodex.Types;
-using JetBrains.Annotations;
 using Libplanet;
 using Libplanet.Action;
 using Libplanet.Assets;
 using LruCacheNet;
+using Nekoyume.Model.Arena;
 using Nekoyume.Helper;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
@@ -514,6 +514,7 @@ namespace Nekoyume.Action
             bool containQuestSheet = false,
             bool containStageSimulatorSheets = false,
             bool containRankingSimulatorSheets = false,
+            bool containArenaSimulatorSheets = false,
             IEnumerable<Type> sheetTypes = null)
         {
             var sheetTypeList = sheetTypes?.ToList() ?? new List<Type>();
@@ -575,6 +576,19 @@ namespace Nekoyume.Action
                 sheetTypeList.Add(typeof(CharacterLevelSheet));
                 sheetTypeList.Add(typeof(EquipmentItemSetEffectSheet));
                 sheetTypeList.Add(typeof(WeeklyArenaRewardSheet));
+            }
+
+            if (containArenaSimulatorSheets)
+            {
+                sheetTypeList.Add(typeof(MaterialItemSheet));
+                sheetTypeList.Add(typeof(SkillSheet));
+                sheetTypeList.Add(typeof(SkillBuffSheet));
+                sheetTypeList.Add(typeof(BuffSheet));
+                sheetTypeList.Add(typeof(CharacterSheet));
+                sheetTypeList.Add(typeof(CharacterLevelSheet));
+                sheetTypeList.Add(typeof(EquipmentItemSetEffectSheet));
+                sheetTypeList.Add(typeof(WeeklyArenaRewardSheet));
+                sheetTypeList.Add(typeof(CostumeStatSheet));
             }
 
             return states.GetSheets(sheetTypeList.Distinct().ToArray());
@@ -764,7 +778,7 @@ namespace Nekoyume.Action
 
             return new ShopState((Dictionary)value);
         }
-        
+
         public static (Address arenaInfoAddress, ArenaInfo arenaInfo, bool isNewArenaInfo) GetArenaInfo(
             this IAccountStateDelta states,
             Address weeklyArenaAddress,
@@ -800,6 +814,96 @@ namespace Nekoyume.Action
             return false;
         }
 
+        public static ArenaParticipants GetArenaParticipants(this IAccountStateDelta states,
+            Address arenaParticipantsAddress, int id, int round)
+        {
+            return states.TryGetState(arenaParticipantsAddress, out List list)
+                ? new ArenaParticipants(list)
+                : new ArenaParticipants(id, round);
+        }
+
+        public static ArenaAvatarState GetArenaAvatarState(this IAccountStateDelta states,
+            Address arenaAvatarStateAddress, AvatarState avatarState)
+        {
+            return states.TryGetState(arenaAvatarStateAddress, out List list)
+                ? new ArenaAvatarState(list)
+                : new ArenaAvatarState(avatarState);
+        }
+
+        public static bool TryGetArenaParticipants(this IAccountStateDelta states,
+            Address arenaParticipantsAddress, out ArenaParticipants arenaParticipants)
+        {
+            if (states.TryGetState(arenaParticipantsAddress, out List list))
+            {
+                arenaParticipants = new ArenaParticipants(list);
+                return true;
+            }
+
+            arenaParticipants = null;
+            return false;
+        }
+
+        public static bool TryGetArenaAvatarState(this IAccountStateDelta states,
+            Address arenaAvatarStateAddress, out ArenaAvatarState arenaAvatarState)
+        {
+            if (states.TryGetState(arenaAvatarStateAddress, out List list))
+            {
+                arenaAvatarState = new ArenaAvatarState(list);
+                return true;
+            }
+
+            arenaAvatarState = null;
+            return false;
+        }
+
+        public static bool TryGetArenaScore(this IAccountStateDelta states,
+            Address arenaScoreAddress, out ArenaScore arenaScore)
+        {
+            if (states.TryGetState(arenaScoreAddress, out List list))
+            {
+                arenaScore = new ArenaScore(list);
+                return true;
+            }
+
+            arenaScore = null;
+            return false;
+        }
+
+        public static bool TryGetArenaInformation(this IAccountStateDelta states,
+            Address arenaInformationAddress, out ArenaInformation arenaInformation)
+        {
+            if (states.TryGetState(arenaInformationAddress, out List list))
+            {
+                arenaInformation = new ArenaInformation(list);
+                return true;
+            }
+
+            arenaInformation = null;
+            return false;
+        }
+
+        public static AvatarState GetEnemyAvatarState(this IAccountStateDelta states, Address avatarAddress)
+        {
+            AvatarState enemyAvatarState;
+            try
+            {
+                enemyAvatarState = states.GetAvatarStateV2(avatarAddress);
+            }
+            // BackWard compatible.
+            catch (FailedLoadStateException)
+            {
+                enemyAvatarState = states.GetAvatarState(avatarAddress);
+            }
+
+            if (enemyAvatarState is null)
+            {
+                throw new FailedLoadStateException(
+                    $"Aborted as the avatar state of the opponent ({avatarAddress}) was failed to load.");
+            }
+
+            return enemyAvatarState;
+        }
+
         public static CrystalCostState GetCrystalCostState(this IAccountStateDelta states,
             Address address)
         {
@@ -833,6 +937,5 @@ namespace Nekoyume.Action
 
             return (dailyCostState, weeklyCostState, prevWeeklyCostState, beforePrevWeeklyCostState);
         }
-
     }
 }

--- a/Lib9c/Action/JoinArena.cs
+++ b/Lib9c/Action/JoinArena.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Action;
+using Nekoyume.Arena;
+using Nekoyume.Extensions;
+using Nekoyume.Helper;
+using Nekoyume.Model.Arena;
+using Nekoyume.Model.EnumType;
+using Nekoyume.Model.State;
+using Nekoyume.TableData;
+
+namespace Nekoyume.Action
+{
+    /// <summary>
+    /// Introduced at https://github.com/planetarium/lib9c/pull/1006
+    /// </summary>
+    [Serializable]
+    [ActionType("join_arena")]
+    public class JoinArena : GameAction
+    {
+        public Address avatarAddress;
+        public int championshipId;
+        public int round;
+        public List<Guid> costumes;
+        public List<Guid> equipments;
+
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            new Dictionary<string, IValue>()
+            {
+                ["avatarAddress"] = avatarAddress.Serialize(),
+                ["championshipId"] = championshipId.Serialize(),
+                ["round"] = round.Serialize(),
+                ["costumes"] = new List(costumes
+                    .OrderBy(element => element).Select(e => e.Serialize())),
+                ["equipments"] = new List(equipments
+                    .OrderBy(element => element).Select(e => e.Serialize())),
+            }.ToImmutableDictionary();
+
+        protected override void LoadPlainValueInternal(
+            IImmutableDictionary<string, IValue> plainValue)
+        {
+            avatarAddress = plainValue["avatarAddress"].ToAddress();
+            championshipId = plainValue["championshipId"].ToInteger();
+            round = plainValue["round"].ToInteger();
+            costumes = ((List)plainValue["costumes"]).Select(e => e.ToGuid()).ToList();
+            equipments = ((List)plainValue["equipments"]).Select(e => e.ToGuid()).ToList();
+        }
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            var states = context.PreviousStates;
+            if (context.Rehearsal)
+            {
+                return states;
+            }
+
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
+
+            if (!states.TryGetAgentAvatarStatesV2(context.Signer, avatarAddress,
+                    out var agentState, out var avatarState, out _))
+            {
+                throw new FailedLoadStateException(
+                    $"[{nameof(JoinArena)}] Aborted as the avatar state of the signer failed to load.");
+            }
+
+            var sheets = states.GetSheets(
+                sheetTypes: new[]
+                {
+                    typeof(ItemRequirementSheet),
+                    typeof(EquipmentItemRecipeSheet),
+                    typeof(EquipmentItemSubRecipeSheetV2),
+                    typeof(EquipmentItemOptionSheet),
+                    typeof(ArenaSheet),
+                });
+
+            avatarState.ValidEquipmentAndCostume(costumes, equipments,
+                sheets.GetSheet<ItemRequirementSheet>(),
+                sheets.GetSheet<EquipmentItemRecipeSheet>(),
+                sheets.GetSheet<EquipmentItemSubRecipeSheetV2>(),
+                sheets.GetSheet<EquipmentItemOptionSheet>(),
+                context.BlockIndex, addressesHex);
+
+            var sheet = sheets.GetSheet<ArenaSheet>();
+            if (!sheet.TryGetValue(championshipId, out var row))
+            {
+                throw new SheetRowNotFoundException(
+                    nameof(ArenaSheet), $"championship Id : {championshipId}");
+            }
+
+            if (!row.TryGetRound(round, out var roundData))
+            {
+                throw new RoundNotFoundException(
+                    $"[{nameof(JoinArena)}] ChampionshipId({row.Id}) - round({round})");
+            }
+
+            // check fee
+            var costCrystal = ArenaHelper.GetEntranceFee(roundData, context.BlockIndex);
+            if (costCrystal > 0 * CrystalCalculator.CRYSTAL)
+            {
+                var crystalBalance = states.GetBalance(context.Signer, CrystalCalculator.CRYSTAL);
+                if (costCrystal > crystalBalance)
+                {
+                    throw new NotEnoughFungibleAssetValueException(
+                        $"required {costCrystal}, but balance is {crystalBalance}");
+                }
+
+                var arenaAdr = ArenaHelper.DeriveArenaAddress(roundData.Id, roundData.Round);
+                states = states.TransferAsset(context.Signer, arenaAdr, costCrystal);
+            }
+
+            // check medal
+            if (roundData.ArenaType.Equals(ArenaType.Championship))
+            {
+                var medalCount = ArenaHelper.GetMedalTotalCount(row, avatarState);
+                if (medalCount < roundData.RequiredMedalCount)
+                {
+                    throw new NotEnoughMedalException(
+                        $"[{nameof(JoinArena)}] have({medalCount}) < Required Medal Count({roundData.RequiredMedalCount}) ");
+                }
+            }
+
+            // create ArenaScore
+            var arenaScoreAdr =
+                ArenaScore.DeriveAddress(avatarAddress, roundData.Id, roundData.Round);
+            if (states.TryGetState(arenaScoreAdr, out List _))
+            {
+                throw new ArenaScoreAlreadyContainsException(
+                    $"[{nameof(JoinArena)}] id({roundData.Id}) / round({roundData.Round})");
+            }
+
+            var arenaScore = new ArenaScore(avatarAddress, roundData.Id, roundData.Round);
+
+            // create ArenaInformation
+            var arenaInformationAdr =
+                ArenaInformation.DeriveAddress(avatarAddress, roundData.Id, roundData.Round);
+            if (states.TryGetState(arenaInformationAdr, out List _))
+            {
+                throw new ArenaInformationAlreadyContainsException(
+                    $"[{nameof(JoinArena)}] id({roundData.Id}) / round({roundData.Round})");
+            }
+
+            var arenaInformation =
+                new ArenaInformation(avatarAddress, roundData.Id, roundData.Round);
+
+            // update ArenaParticipants
+            var arenaParticipantsAdr = ArenaParticipants.DeriveAddress(roundData.Id, roundData.Round);
+            var arenaParticipants = states.GetArenaParticipants(arenaParticipantsAdr, roundData.Id, roundData.Round);
+            arenaParticipants.Add(avatarAddress);
+
+            // update ArenaAvatarState
+            var arenaAvatarStateAdr = ArenaAvatarState.DeriveAddress(avatarAddress);
+            var arenaAvatarState = states.GetArenaAvatarState(arenaAvatarStateAdr, avatarState);
+            arenaAvatarState.UpdateCostumes(costumes);
+            arenaAvatarState.UpdateEquipment(equipments);
+            arenaAvatarState.UpdateLevel(avatarState.level);
+
+            return states
+                .SetState(arenaScoreAdr, arenaScore.Serialize())
+                .SetState(arenaInformationAdr, arenaInformation.Serialize())
+                .SetState(arenaParticipantsAdr, arenaParticipants.Serialize())
+                .SetState(arenaAvatarStateAdr, arenaAvatarState.Serialize())
+                .SetState(context.Signer, agentState.Serialize());
+        }
+    }
+}

--- a/Lib9c/Action/NotEnoughMedalException.cs
+++ b/Lib9c/Action/NotEnoughMedalException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Nekoyume.Action
+{
+    [Serializable]
+    public class NotEnoughMedalException : Exception
+    {
+        public NotEnoughMedalException(string msg) : base(msg)
+        {
+        }
+
+        public NotEnoughMedalException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Lib9c/Addresses.cs
+++ b/Lib9c/Addresses.cs
@@ -26,6 +26,7 @@ namespace Nekoyume
         public static readonly Address UnlockWorld           = new Address("000000000000000000000000000000000000000e");
         public static readonly Address UnlockEquipmentRecipe = new Address("000000000000000000000000000000000000000f");
         public static readonly Address MaterialCost          = new Address("0000000000000000000000000000000000000010");
+        public static readonly Address Arena                 = new Address("0000000000000000000000000000000000000011");
 
         public static Address GetSheetAddress<T>() where T : ISheet => GetSheetAddress(typeof(T).Name);
         

--- a/Lib9c/Arena/ArenaHelper.cs
+++ b/Lib9c/Arena/ArenaHelper.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using Libplanet;
+using Libplanet.Assets;
+using Nekoyume.Action;
+using Nekoyume.Helper;
+using Nekoyume.Model.EnumType;
+using Nekoyume.Model.Item;
+using Nekoyume.Model.State;
+using Nekoyume.TableData;
+
+namespace Nekoyume.Arena
+{
+    /// <summary>
+    /// There are only things that don't change
+    /// </summary>
+    public static class ArenaHelper
+    {
+        public static Address DeriveArenaAddress(int championshipId, int round) =>
+            Addresses.Arena.Derive($"_{championshipId}_{round}");
+
+        public static int GetMedalItemId(int championshipId, int round) =>
+            700_000 + (championshipId * 100) + round;
+
+        public static Material GetMedal(int championshipId, int round,
+            MaterialItemSheet materialItemSheet)
+        {
+            var itemId = GetMedalItemId(championshipId, round);
+            var medal = ItemFactory.CreateMaterial(materialItemSheet, itemId);
+            return medal;
+        }
+
+        public static int GetMedalTotalCount(ArenaSheet.Row row, AvatarState avatarState)
+        {
+            var count = 0;
+            foreach (var data in row.Round)
+            {
+                if (!data.ArenaType.Equals(ArenaType.Season))
+                {
+                    continue;
+                }
+
+                var itemId = GetMedalItemId(data.Id, data.Round);
+                if (avatarState.inventory.TryGetItem(itemId, out var item))
+                {
+                    count += item.count;
+                }
+            }
+
+            return count;
+        }
+
+        public static FungibleAssetValue GetEntranceFee(ArenaSheet.RoundData roundData, long currentBlockIndex)
+        {
+            var fee = roundData.IsTheRoundOpened(currentBlockIndex)
+                ? roundData.EntranceFee
+                : roundData.DiscountedEntranceFee;
+            return fee * CrystalCalculator.CRYSTAL;
+        }
+
+        public static bool ValidateScoreDifference(IReadOnlyDictionary<ArenaType, (int, int)> scoreLimits,
+            ArenaType arenaType, int myScore, int enemyScore)
+        {
+            if (arenaType.Equals(ArenaType.OffSeason))
+            {
+                return true;
+            }
+
+            var (upper, lower) = scoreLimits[arenaType];
+            var diff = enemyScore - myScore;
+            return lower <= diff && diff <= upper;
+        }
+    }
+}

--- a/Lib9c/Extensions/SheetsExtensions.cs
+++ b/Lib9c/Extensions/SheetsExtensions.cs
@@ -190,5 +190,21 @@ namespace Nekoyume.Extensions
                 sheets.GetSheet<WeeklyArenaRewardSheet>()
             );
         }
+
+        public static ArenaSimulatorSheets GetArenaSimulatorSheets(
+            this Dictionary<Type, (Address address, ISheet sheet)> sheets)
+        {
+            return new ArenaSimulatorSheets(
+                sheets.GetSheet<MaterialItemSheet>(),
+                sheets.GetSheet<SkillSheet>(),
+                sheets.GetSheet<SkillBuffSheet>(),
+                sheets.GetSheet<BuffSheet>(),
+                sheets.GetSheet<CharacterSheet>(),
+                sheets.GetSheet<CharacterLevelSheet>(),
+                sheets.GetSheet<EquipmentItemSetEffectSheet>(),
+                sheets.GetSheet<CostumeStatSheet>(),
+                sheets.GetSheet<WeeklyArenaRewardSheet>()
+            );
+        }
     }
 }

--- a/Lib9c/Helper/AvatarStateExtensions.cs
+++ b/Lib9c/Helper/AvatarStateExtensions.cs
@@ -76,5 +76,27 @@ namespace Nekoyume.Helper
 
             return (currentLevel, currentExp);
         }
+
+        public static void ValidEquipmentAndCostume(this AvatarState avatarState,
+            IEnumerable<Guid> costumeIds,
+            List<Guid> equipmentIds,
+            ItemRequirementSheet itemRequirementSheet,
+            EquipmentItemRecipeSheet equipmentItemRecipeSheet,
+            EquipmentItemSubRecipeSheetV2 equipmentItemSubRecipeSheetV2,
+            EquipmentItemOptionSheet equipmentItemOptionSheet,
+            long blockIndex,
+            string addressesHex)
+        {
+            var equipments = avatarState.ValidateEquipmentsV2(equipmentIds, blockIndex);
+            var costumeItemIds = avatarState.ValidateCostume(costumeIds);
+            avatarState.ValidateItemRequirement(
+                costumeItemIds.ToList(),
+                equipments,
+                itemRequirementSheet,
+                equipmentItemRecipeSheet,
+                equipmentItemSubRecipeSheetV2,
+                equipmentItemOptionSheet,
+                addressesHex);
+        }
     }
 }

--- a/Lib9c/Model/Arena/ArenaExceptions.cs
+++ b/Lib9c/Model/Arena/ArenaExceptions.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Nekoyume.Model.Arena
+{
+    [Serializable]
+    public class RoundNotFoundException : Exception
+    {
+        public RoundNotFoundException(string message) : base(message)
+        {
+        }
+
+        protected RoundNotFoundException(SerializationInfo info, StreamingContext context) :
+            base(info, context)
+        {
+        }
+    }
+
+    [Serializable]
+    public class ArenaScoreAlreadyContainsException : Exception
+    {
+        public ArenaScoreAlreadyContainsException(string message) : base(message)
+        {
+        }
+
+        protected ArenaScoreAlreadyContainsException(SerializationInfo info,
+            StreamingContext context) : base(info, context)
+        {
+        }
+    }
+
+    [Serializable]
+    public class ArenaInformationAlreadyContainsException : Exception
+    {
+        public ArenaInformationAlreadyContainsException(string message) : base(message)
+        {
+        }
+
+        protected ArenaInformationAlreadyContainsException(SerializationInfo info,
+            StreamingContext context) : base(info, context)
+        {
+        }
+    }
+
+    [Serializable]
+    public class ArenaParticipantsNotFoundException : Exception
+    {
+        public ArenaParticipantsNotFoundException(string message) : base(message)
+        {
+        }
+
+        protected ArenaParticipantsNotFoundException(SerializationInfo info,
+            StreamingContext context) :
+            base(info, context)
+        {
+        }
+    }
+
+    [Serializable]
+    public class ArenaAvatarStateNotFoundException : Exception
+    {
+        public ArenaAvatarStateNotFoundException(string message) : base(message)
+        {
+        }
+
+        protected ArenaAvatarStateNotFoundException(SerializationInfo info,
+            StreamingContext context) :
+            base(info, context)
+        {
+        }
+    }
+
+    [Serializable]
+    public class ArenaScoreNotFoundException : Exception
+    {
+        public ArenaScoreNotFoundException(string message) : base(message)
+        {
+        }
+
+        protected ArenaScoreNotFoundException(SerializationInfo info, StreamingContext context) :
+            base(info, context)
+        {
+        }
+    }
+
+    [Serializable]
+    public class ArenaInformationNotFoundException : Exception
+    {
+        public ArenaInformationNotFoundException(string message) : base(message)
+        {
+        }
+
+        protected ArenaInformationNotFoundException(SerializationInfo info,
+            StreamingContext context) :
+            base(info, context)
+        {
+        }
+    }
+
+    [Serializable]
+    public class AddressNotFoundInArenaParticipantsException : Exception
+    {
+        public AddressNotFoundInArenaParticipantsException(string message) : base(message)
+        {
+        }
+
+        protected AddressNotFoundInArenaParticipantsException(SerializationInfo info,
+            StreamingContext context) :
+            base(info, context)
+        {
+        }
+    }
+
+    [Serializable]
+    public class NotEnoughTicketException : Exception
+    {
+        public NotEnoughTicketException(string message) : base(message)
+        {
+        }
+
+        protected NotEnoughTicketException(SerializationInfo info,
+            StreamingContext context) :
+            base(info, context)
+        {
+        }
+    }
+
+    [Serializable]
+    public class ValidateScoreDifferenceException : Exception
+    {
+        public ValidateScoreDifferenceException(string message) : base(message)
+        {
+        }
+
+        protected ValidateScoreDifferenceException(SerializationInfo info,
+            StreamingContext context) :
+            base(info, context)
+        {
+        }
+    }
+
+    [Serializable]
+    public class ThisArenaIsClosedException : Exception
+    {
+        public ThisArenaIsClosedException(string message) : base(message)
+        {
+        }
+
+        protected ThisArenaIsClosedException(SerializationInfo info,
+            StreamingContext context) :
+            base(info, context)
+        {
+        }
+    }
+
+}

--- a/Lib9c/Model/Arena/ArenaInformation.cs
+++ b/Lib9c/Model/Arena/ArenaInformation.cs
@@ -1,0 +1,68 @@
+using Bencodex.Types;
+using Libplanet;
+using Nekoyume.Action;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Model.Arena
+{
+    /// <summary>
+    /// Introduced at https://github.com/planetarium/lib9c/pull/1006
+    /// </summary>
+    public class ArenaInformation : IState
+    {
+        public static Address DeriveAddress(Address avatarAddress, int championshipId, int round) =>
+            avatarAddress.Derive($"arena_information_{championshipId}_{round}");
+
+        public const int MaxTicketCount = 8;
+
+        public Address Address;
+        public int Win { get; private set; }
+        public int Lose { get; private set; }
+        public int Ticket { get; private set; }
+
+        public ArenaInformation(Address avatarAddress, int championshipId, int round)
+        {
+            Address = DeriveAddress(avatarAddress, championshipId, round);
+            Ticket = MaxTicketCount;
+        }
+
+        public ArenaInformation(List serialized)
+        {
+            Address = serialized[0].ToAddress();
+            Win = (Integer)serialized[1];
+            Lose = (Integer)serialized[2];
+            Ticket = (Integer)serialized[3];
+        }
+
+        public IValue Serialize()
+        {
+            return List.Empty
+                .Add(Address.Serialize())
+                .Add(Win)
+                .Add(Lose)
+                .Add(Ticket);
+        }
+
+        public void RefillTicket()
+        {
+            Ticket = MaxTicketCount;
+        }
+
+        public void UseTicket(int value)
+        {
+            if (Ticket < value)
+            {
+                throw new NotEnoughTicketException(
+                    $"[{nameof(ArenaInformation)}] have({Ticket}) < use({value})");
+            }
+
+            Ticket -= value;
+        }
+
+        public void UpdateRecord(int win, int lose)
+        {
+            Win += win;
+            Lose += lose;
+        }
+    }
+}

--- a/Lib9c/Model/Arena/ArenaParticipants.cs
+++ b/Lib9c/Model/Arena/ArenaParticipants.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+using Bencodex.Types;
+using Libplanet;
+using Nekoyume.Action;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Model.Arena
+{
+    /// <summary>
+    /// Introduced at https://github.com/planetarium/lib9c/pull/1006
+    /// </summary>
+    public class ArenaParticipants : IState
+    {
+        public static Address DeriveAddress(int championshipId, int round) =>
+            Addresses.Arena.Derive($"arena_participants_{championshipId}_{round}");
+
+        public Address Address;
+        public readonly List<Address> AvatarAddresses;
+
+        public ArenaParticipants(int championshipId, int round)
+        {
+            Address = DeriveAddress(championshipId, round);
+            AvatarAddresses = new List<Address>();
+        }
+
+        public ArenaParticipants(List serialized)
+        {
+            Address = serialized[0].ToAddress();
+            AvatarAddresses = ((List)serialized[1]).Select(c => c.ToAddress()).ToList();
+        }
+
+        public IValue Serialize()
+        {
+            return List.Empty
+                .Add(Address.Serialize())
+                .Add(AvatarAddresses.Aggregate(List.Empty,
+                    (list, address) => list.Add(address.Serialize())));
+        }
+
+        public void Add(Address address)
+        {
+            AvatarAddresses.Add(address);
+        }
+    }
+}

--- a/Lib9c/Model/Arena/ArenaScore.cs
+++ b/Lib9c/Model/Arena/ArenaScore.cs
@@ -1,0 +1,46 @@
+using System;
+using Bencodex.Types;
+using Nekoyume.Model.State;
+using Libplanet;
+using Nekoyume.Action;
+
+namespace Nekoyume.Model.Arena
+{
+    /// <summary>
+    /// Introduced at https://github.com/planetarium/lib9c/pull/1006
+    /// </summary>
+    public class ArenaScore : IState
+    {
+        public static Address DeriveAddress(Address avatarAddress, int championshipId, int round) =>
+            avatarAddress.Derive($"arena_score_{championshipId}_{round}");
+
+        public const int ArenaScoreDefault = 1000;
+
+        public Address Address;
+        public int Score { get; private set; }
+
+        public ArenaScore(Address avatarAddress, int championshipId, int round)
+        {
+            Address = DeriveAddress(avatarAddress, championshipId, round);
+            Score = ArenaScoreDefault;
+        }
+
+        public ArenaScore(List serialized)
+        {
+            Address = serialized[0].ToAddress();
+            Score = (Integer)serialized[1];
+        }
+
+        public IValue Serialize()
+        {
+            return List.Empty
+                .Add(Address.Serialize())
+                .Add(Score);
+        }
+
+        public void AddScore(int score)
+        {
+            Score = Math.Max(Score + score, ArenaScoreDefault);
+        }
+    }
+}

--- a/Lib9c/Model/EnumType/ArenaType.cs
+++ b/Lib9c/Model/EnumType/ArenaType.cs
@@ -1,0 +1,9 @@
+namespace Nekoyume.Model.EnumType
+{
+    public enum ArenaType
+    {
+        OffSeason,
+        Season,
+        Championship,
+    }
+}

--- a/Lib9c/Model/State/ArenaAvatarState.cs
+++ b/Lib9c/Model/State/ArenaAvatarState.cs
@@ -1,0 +1,76 @@
+using System;
+using Bencodex.Types;
+using Libplanet;
+using Nekoyume.Action;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+
+namespace Nekoyume.Model.State
+{
+    /// <summary>
+    /// Introduced at https://github.com/planetarium/lib9c/pull/1006
+    /// </summary>
+    public class ArenaAvatarState : IState
+    {
+        public static Address DeriveAddress(Address avatarAddress) =>
+            avatarAddress.Derive("arena_avatar");
+
+        public Address Address;
+        public List<Guid> Costumes { get; }
+        public List<Guid> Equipments { get; }
+        public int Level { get; private set; }
+
+        public ArenaAvatarState(AvatarState avatarState)
+        {
+            Address = DeriveAddress(avatarState.address);
+            Costumes = new List<Guid>();
+            Equipments = new List<Guid>();
+            Level = avatarState.level;
+        }
+
+        public ArenaAvatarState(List serialized)
+        {
+            Address = serialized[0].ToAddress();
+            Costumes = serialized[1].ToList(StateExtensions.ToGuid);
+            Equipments = serialized[2].ToList(StateExtensions.ToGuid);
+            Level = (Integer)serialized[3];
+        }
+
+        public IValue Serialize()
+        {
+            return List.Empty
+                .Add(Address.Serialize())
+                .Add(Costumes.OrderBy(x => x).Select(x => x.Serialize()).Serialize())
+                .Add(Equipments.OrderBy(x => x).Select(x => x.Serialize()).Serialize())
+                .Add(Level);
+        }
+
+        public void UpdateCostumes([NotNull] List<Guid> costumes)
+        {
+            if (costumes == null)
+            {
+                throw new ArgumentNullException(nameof(costumes));
+            }
+
+            Costumes.Clear();
+            Costumes.AddRange(costumes);
+        }
+
+        public void UpdateEquipment([NotNull] List<Guid> equipments)
+        {
+            if (equipments == null)
+            {
+                throw new ArgumentNullException(nameof(equipments));
+            }
+
+            Equipments.Clear();
+            Equipments.AddRange(equipments);
+        }
+
+        public void UpdateLevel(int level)
+        {
+            Level = level;
+        }
+    }
+}

--- a/Lib9c/TableCSV/Arena.meta
+++ b/Lib9c/TableCSV/Arena.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0023b4ee123379f489d8ea266203d4a7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lib9c/TableCSV/Arena/ArenaSheet.csv
+++ b/Lib9c/TableCSV/Arena/ArenaSheet.csv
@@ -1,0 +1,9 @@
+id,round,arena_type,start_block_index,end_block_index,required_medal_count,entrance_fee,discounted_entrance_fee,ticket_price,additional_ticket_price
+1,1,OffSeason,0,5,0,0,0,5,2
+1,2,Season,6,10,0,100,50,5,2
+1,3,OffSeason,11,20,0,0,0,5,2
+1,4,Season,21,30,0,100,50,5,2
+1,5,OffSeason,31,40,0,0,0,5,2
+1,6,Season,41,50,0,100,50,5,2
+1,7,OffSeason,51,60,0,0,0,5,2
+1,8,Championship,61,20000,3,1000,500,5,2

--- a/Lib9c/TableCSV/Arena/ArenaSheet.csv.meta
+++ b/Lib9c/TableCSV/Arena/ArenaSheet.csv.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d976e6f264d5cc14b924245f5f0c7408
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Lib9c/TableCSV/Item/MaterialItemSheet.csv
+++ b/Lib9c/TableCSV/Item/MaterialItemSheet.csv
@@ -137,3 +137,6 @@ id,_name,item_sub_type,grade,elemental_type
 700008,아레나 시즌8 메달,NormalMaterial,5,Normal
 700009,아레나 시즌9 메달,NormalMaterial,5,Normal
 700010,아레나 시즌10 메달,NormalMaterial,5,Normal
+700102,1-1 메달,NormalMaterial,5,Normal
+700104,1-2 메달,NormalMaterial,5,Normal
+700106,1-3 메달,NormalMaterial,5,Normal

--- a/Lib9c/TableData/ArenaSheet.cs
+++ b/Lib9c/TableData/ArenaSheet.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Nekoyume.Model.Arena;
+using Nekoyume.Model.EnumType;
+
+namespace Nekoyume.TableData
+{
+    using static TableExtensions;
+
+    [Serializable]
+    public class ArenaSheet : Sheet<int, ArenaSheet.Row>
+    {
+        public class RoundData
+        {
+            public int Id { get; }
+            public int Round { get; }
+            public ArenaType ArenaType { get; }
+            public long StartBlockIndex { get; }
+            public long EndBlockIndex { get; }
+            public int RequiredMedalCount { get; }
+            public long EntranceFee { get; }
+            public long DiscountedEntranceFee { get; }
+            public decimal TicketPrice { get; }
+            public decimal AdditionalTicketPrice { get; }
+
+            public RoundData(int id, int round, ArenaType arenaType,
+                long startBlockIndex, long endBlockIndex,
+                int requiredMedalCount,
+                long entranceFee, long discountedEntranceFee,
+                decimal ticketPrice, decimal additionalTicketPrice)
+            {
+                Id = id;
+                Round = round;
+                ArenaType = arenaType;
+                StartBlockIndex = startBlockIndex;
+                EndBlockIndex = endBlockIndex;
+                RequiredMedalCount = requiredMedalCount;
+                EntranceFee = entranceFee;
+                DiscountedEntranceFee = discountedEntranceFee;
+                TicketPrice = ticketPrice;
+                AdditionalTicketPrice = additionalTicketPrice;
+            }
+
+            public bool IsTheRoundOpened(long blockIndex)
+            {
+                return StartBlockIndex <= blockIndex && blockIndex <= EndBlockIndex;
+            }
+        }
+
+        [Serializable]
+        public class Row : SheetRow<int>
+        {
+            public override int Key => Id;
+            public int Id { get; private set; }
+            public List<RoundData> Round { get; private set; }
+
+            public override void Set(IReadOnlyList<string> fields)
+            {
+                Id = ParseInt(fields[0]);
+                var round = ParseInt(fields[1]);
+                var arenaType = (ArenaType)Enum.Parse(typeof(ArenaType), fields[2]);
+                var startIndex = ParseLong(fields[3]);
+                var endIndex = ParseLong(fields[4]);
+                var requiredWins = ParseInt(fields[5]);
+                var entranceFee = ParseLong(fields[6]);
+                var discountedEntranceFee = ParseLong(fields[7]);
+                var ticketPrice = ParseDecimal(fields[8]);
+                var additionalTicketPrice = ParseDecimal(fields[9]);
+                Round = new List<RoundData>
+                {
+                    new RoundData(Id, round, arenaType, startIndex, endIndex,
+                        requiredWins, entranceFee, discountedEntranceFee,
+                        ticketPrice, additionalTicketPrice)
+                };
+            }
+
+            public bool TryGetRound(int round, out RoundData roundData)
+            {
+                roundData = Round.FirstOrDefault(x => x.Round.Equals(round));
+                return !(roundData is null);
+            }
+
+            public bool TryGetChampionshipRound(out RoundData roundData)
+            {
+                roundData = Round.FirstOrDefault(x => x.ArenaType.Equals(ArenaType.Championship));
+                return !(roundData is null);
+            }
+        }
+
+        public ArenaSheet() : base(nameof(ArenaSheet))
+        {
+        }
+
+        protected override void AddRow(int key, Row value)
+        {
+            if (!TryGetValue(key, out var row))
+            {
+                Add(key, value);
+
+                return;
+            }
+
+            if (!value.Round.Any())
+            {
+                return;
+            }
+
+            row.Round.Add(value.Round[0]);
+        }
+    }
+}

--- a/Lib9c/TableData/Exceptions.cs
+++ b/Lib9c/TableData/Exceptions.cs
@@ -36,6 +36,11 @@ namespace Nekoyume.TableData
         {
         }
 
+        public SheetRowNotFoundException(string sheetName, long longKey)
+            : this(sheetName, longKey.ToString(CultureInfo.InvariantCulture))
+        {
+        }
+
         public SheetRowNotFoundException(string sheetName, string key) : this(sheetName, "Key", key)
         {
         }
@@ -44,7 +49,7 @@ namespace Nekoyume.TableData
             base($"{sheetName}: {condition} - {value}")
         {
         }
-        
+
         public SheetRowNotFoundException(string addressesHex, string sheetName, int intKey)
             : base($"{addressesHex}{sheetName}: Key - {intKey.ToString(CultureInfo.InvariantCulture)}")
         {

--- a/Lib9c/TableData/SimulatorSheets.cs
+++ b/Lib9c/TableData/SimulatorSheets.cs
@@ -89,4 +89,33 @@ namespace Nekoyume.TableData
             WeeklyArenaRewardSheet = weeklyArenaRewardSheet;
         }
     }
+
+    public class ArenaSimulatorSheets : SimulatorSheets
+    {
+        public CostumeStatSheet CostumeStatSheet { get; }
+        public WeeklyArenaRewardSheet WeeklyArenaRewardSheet { get; }
+
+        public ArenaSimulatorSheets(
+            MaterialItemSheet materialItemSheet,
+            SkillSheet skillSheet,
+            SkillBuffSheet skillBuffSheet,
+            BuffSheet buffSheet,
+            CharacterSheet characterSheet,
+            CharacterLevelSheet characterLevelSheet,
+            EquipmentItemSetEffectSheet equipmentItemSetEffectSheet,
+            CostumeStatSheet costumeStatSheet,
+            WeeklyArenaRewardSheet weeklyArenaRewardSheet
+        ) : base(materialItemSheet,
+            skillSheet,
+            skillBuffSheet,
+            buffSheet,
+            characterSheet,
+            characterLevelSheet,
+            equipmentItemSetEffectSheet)
+        {
+            CostumeStatSheet = costumeStatSheet;
+            WeeklyArenaRewardSheet = weeklyArenaRewardSheet;
+
+        }
+    }
 }


### PR DESCRIPTION
Only parts related to the Join Arena action were taken from https://github.com/planetarium/lib9c/pull/1006

---

- Create `JoinArena` action 
- Create `ArenaAvatar` state
   - This state has the avatar information you need in the arena. (equipment, costumes, avatar level)
- Create `ArenaParticipants` 
   - ArenaParticipants has a list of participants for the arena
- Create `ArenaScore`
    -  ArenaScore only has a score.
- Create `ArenaInformation` 
   - ArenaInformation has win, lose, ticket
 - Create  `Arena` Sheet
   - This sheet contains arena related information
 - Update `RewardGold`
   - Add RefillArenaTicket function