### PR TITLE
Fix first stage sweep bug

### DIFF
--- a/.Lib9c.Tests/Action/HackAndSlashSweepTest.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweepTest.cs
@@ -134,8 +134,15 @@ namespace Lib9c.Tests.Action
         public void Execute(int apStoneCount, int worldId, int stageId, bool challenge, bool backward)
         {
             var gameConfigState = _initialState.GetGameConfigState();
-
             var prevStageId = stageId - 1;
+            var worldInformation = new WorldInformation(
+                    0, _initialState.GetSheet<WorldSheet>(), challenge ? prevStageId : stageId);
+
+            if (challenge)
+            {
+                worldInformation.UnlockWorld(worldId, 0,  _tableSheets.WorldSheet);
+            }
+
             var avatarState = new AvatarState(
                 _avatarAddress,
                 _agentAddress,
@@ -144,8 +151,7 @@ namespace Lib9c.Tests.Action
                 gameConfigState,
                 _rankingMapAddress)
             {
-                worldInformation = new WorldInformation(
-                    0, _initialState.GetSheet<WorldSheet>(), challenge ? prevStageId : stageId),
+                worldInformation = worldInformation,
                 level = 400,
             };
 
@@ -289,27 +295,6 @@ namespace Lib9c.Tests.Action
             };
 
             Assert.Throws<SheetRowColumnException>(() => action.Execute(new ActionContext()
-            {
-                PreviousStates = _initialState,
-                Signer = _agentAddress,
-                Random = new TestRandom(),
-            }));
-        }
-
-        [Theory]
-        [InlineData(1, 50)]
-        [InlineData(2, 51)]
-        public void Execute_StageClearedException(int worldId, int stageId)
-        {
-            var action = new HackAndSlashSweep
-            {
-                apStoneCount = 1,
-                avatarAddress = _avatarAddress,
-                worldId = worldId,
-                stageId = stageId,
-            };
-
-            Assert.Throws<StageNotClearedException>(() => action.Execute(new ActionContext()
             {
                 PreviousStates = _initialState,
                 Signer = _agentAddress,

--- a/.Lib9c.Tests/Action/HackAndSlashSweepTest.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweepTest.cs
@@ -123,6 +123,8 @@ namespace Lib9c.Tests.Action
         [InlineData(2, 2, 51, false, false)]
         [InlineData(2, 2, 52, false, true)]
         [InlineData(2, 2, 52, false, false)]
+        [InlineData(2, 1, 1, true, true)]
+        [InlineData(2, 1, 1, true, false)]
         [InlineData(2, 1, 2, true, true)]
         [InlineData(2, 1, 2, true, false)]
         [InlineData(2, 2, 51, true, true)]
@@ -133,6 +135,7 @@ namespace Lib9c.Tests.Action
         {
             var gameConfigState = _initialState.GetGameConfigState();
 
+            var prevStageId = stageId - 1;
             var avatarState = new AvatarState(
                 _avatarAddress,
                 _agentAddress,
@@ -142,7 +145,7 @@ namespace Lib9c.Tests.Action
                 _rankingMapAddress)
             {
                 worldInformation = new WorldInformation(
-                    0, _initialState.GetSheet<WorldSheet>(), challenge ? stageId - 1 : stageId),
+                    0, _initialState.GetSheet<WorldSheet>(), challenge ? prevStageId : stageId),
                 level = 400,
             };
 

--- a/.Lib9c.Tests/Action/HackAndSlashSweepTest3.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweepTest3.cs
@@ -16,7 +16,7 @@ namespace Lib9c.Tests.Action
     using Xunit;
     using static SerializeKeys;
 
-    public class HackAndSlashSweepTest3
+    public class HackAndSlashSweep3Test3
     {
         private readonly Dictionary<string, string> _sheets;
         private readonly TableSheets _tableSheets;
@@ -36,7 +36,7 @@ namespace Lib9c.Tests.Action
         private readonly IAccountStateDelta _initialState;
         private readonly IRandom _random;
 
-        public HackAndSlashSweepTest3()
+        public HackAndSlashSweep3Test3()
         {
             _random = new TestRandom();
             _sheets = TableSheetsImporter.ImportSheets();
@@ -174,10 +174,10 @@ namespace Lib9c.Tests.Action
 
                 var random = new TestRandom(_random.Seed);
                 var expectedRewardItems =
-                    HackAndSlashSweep.GetRewardItems(random, playCount, stageRow, _tableSheets.MaterialItemSheet);
+                    HackAndSlashSweep3.GetRewardItems(random, playCount, stageRow, _tableSheets.MaterialItemSheet);
 
                 var (equipments, costumes) = GetDummyItems(avatarState);
-                var action = new HackAndSlashSweep
+                var action = new HackAndSlashSweep3
                 {
                     actionPoint = avatarState.actionPoint,
                     costumes = costumes,
@@ -215,7 +215,7 @@ namespace Lib9c.Tests.Action
         [InlineData(false)]
         public void Execute_FailedLoadStateException(bool backward)
         {
-            var action = new HackAndSlashSweep
+            var action = new HackAndSlashSweep3
             {
                 apStoneCount = 1,
                 avatarAddress = _avatarAddress,
@@ -245,7 +245,7 @@ namespace Lib9c.Tests.Action
         [InlineData(100, 1)]
         public void Execute_SheetRowNotFoundException(int worldId, int stageId)
         {
-            var action = new HackAndSlashSweep
+            var action = new HackAndSlashSweep3
             {
                 apStoneCount = 1,
                 avatarAddress = _avatarAddress,
@@ -265,7 +265,7 @@ namespace Lib9c.Tests.Action
         [InlineData(1, 999)]
         public void Execute_SheetRowColumnException(int worldId, int stageId)
         {
-            var action = new HackAndSlashSweep
+            var action = new HackAndSlashSweep3
             {
                 apStoneCount = 1,
                 avatarAddress = _avatarAddress,
@@ -284,7 +284,7 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Execute_StageClearedException()
         {
-            var action = new HackAndSlashSweep
+            var action = new HackAndSlashSweep3
             {
                 apStoneCount = 1,
                 avatarAddress = _avatarAddress,
@@ -305,7 +305,7 @@ namespace Lib9c.Tests.Action
         [InlineData(false)]
         public void Execute_InvalidStageException(bool backward)
         {
-            var action = new HackAndSlashSweep
+            var action = new HackAndSlashSweep3
             {
                 apStoneCount = 1,
                 avatarAddress = _avatarAddress,
@@ -376,7 +376,7 @@ namespace Lib9c.Tests.Action
                         avatarState.questList.Serialize());
             }
 
-            var action = new HackAndSlashSweep
+            var action = new HackAndSlashSweep3
             {
                 apStoneCount = 1,
                 avatarAddress = _avatarAddress,
@@ -430,7 +430,7 @@ namespace Lib9c.Tests.Action
                         avatarState.questList.Serialize());
             }
 
-            var action = new HackAndSlashSweep
+            var action = new HackAndSlashSweep3
             {
                 apStoneCount = apStoneCount,
                 avatarAddress = _avatarAddress,
@@ -505,7 +505,7 @@ namespace Lib9c.Tests.Action
 
                 var (equipments, costumes) = GetDummyItems(avatarState);
 
-                var action = new HackAndSlashSweep
+                var action = new HackAndSlashSweep3
                 {
                     equipments = equipments,
                     costumes = costumes,
@@ -579,7 +579,7 @@ namespace Lib9c.Tests.Action
                     playCount);
 
                 var (equipments, costumes) = GetDummyItems(avatarState);
-                var action = new HackAndSlashSweep
+                var action = new HackAndSlashSweep3
                 {
                     costumes = costumes,
                     equipments = equipments,
@@ -654,7 +654,7 @@ namespace Lib9c.Tests.Action
                     playCount);
 
                 var (equipments, costumes) = GetDummyItems(avatarState);
-                var action = new HackAndSlashSweep
+                var action = new HackAndSlashSweep3
                 {
                     costumes = costumes,
                     equipments = equipments,
@@ -728,7 +728,7 @@ namespace Lib9c.Tests.Action
                     stageId,
                     playCount);
 
-                var action = new HackAndSlashSweep
+                var action = new HackAndSlashSweep3
                 {
                     costumes = new List<Guid>(),
                     equipments = new List<Guid>(),

--- a/.Lib9c.Tests/Action/HackAndSlashSweepTest3.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweepTest3.cs
@@ -16,7 +16,7 @@ namespace Lib9c.Tests.Action
     using Xunit;
     using static SerializeKeys;
 
-    public class HackAndSlashSweep3Test3
+    public class HackAndSlashSweepTest3
     {
         private readonly Dictionary<string, string> _sheets;
         private readonly TableSheets _tableSheets;
@@ -36,7 +36,7 @@ namespace Lib9c.Tests.Action
         private readonly IAccountStateDelta _initialState;
         private readonly IRandom _random;
 
-        public HackAndSlashSweep3Test3()
+        public HackAndSlashSweepTest3()
         {
             _random = new TestRandom();
             _sheets = TableSheetsImporter.ImportSheets();

--- a/Lib9c/Action/HackAndSlashSweep.cs
+++ b/Lib9c/Action/HackAndSlashSweep.cs
@@ -135,16 +135,17 @@ namespace Nekoyume.Action
             }
 
             var prevStageId = Math.Max(stageId - 1, 1);
+            var firstStage = prevStageId == 1;
             worldInformation.TryGetWorldByStageId(prevStageId, out var prevStageWorld);
 
-            if (!prevStageWorld.IsStageCleared)
+            if (!prevStageWorld.IsStageCleared && !firstStage)
             {
                 throw new StageNotClearedException(
                     $"{addressesHex}There is no stage cleared in that world (worldId:{prevStageWorld.Id})"
                 );
             }
 
-            if (stageId > prevStageWorld.StageClearedId + 1)
+            if (stageId > prevStageWorld.StageClearedId + 1 && !firstStage)
             {
                 throw new InvalidStageException(
                     $"{addressesHex}Aborted as the stage ({prevStageWorld.Id}/{prevStageId}) is not cleared; " +

--- a/Lib9c/Action/HackAndSlashSweep.cs
+++ b/Lib9c/Action/HackAndSlashSweep.cs
@@ -78,7 +78,7 @@ namespace Nekoyume.Action
                                                     $"apStoneCount : {apStoneCount} > UsableApStoneCount : {UsableApStoneCount}");
             }
 
-            if (worldId == GameConfig.MimisbrunnrWorldId)
+            if (worldId >= GameConfig.MimisbrunnrWorldId)
             {
                 throw new InvalidWorldException(
                     $"{addressesHex} [{worldId}] can't execute HackAndSlashSweep action.");
@@ -132,24 +132,17 @@ namespace Nekoyume.Action
             {
                 // NOTE: Add new World from WorldSheet
                 worldInformation.AddAndUnlockNewWorld(worldRow, context.BlockIndex, worldSheet);
+                if (!worldInformation.TryGetWorld(worldId, out world))
+                {
+                    // Do nothing.
+                }
             }
 
-            var prevStageId = Math.Max(stageId - 1, 1);
-            var isFirstStage = prevStageId == 1;
-            worldInformation.TryGetWorldByStageId(prevStageId, out var prevStageWorld);
-
-            if (!prevStageWorld.IsStageCleared && !isFirstStage)
-            {
-                throw new StageNotClearedException(
-                    $"{addressesHex}There is no stage cleared in that world (worldId:{prevStageWorld.Id})"
-                );
-            }
-
-            if (stageId > prevStageWorld.StageClearedId + 1 && !isFirstStage)
+            if (!world.IsPlayable(stageId))
             {
                 throw new InvalidStageException(
-                    $"{addressesHex}Aborted as the stage ({prevStageWorld.Id}/{prevStageId}) is not cleared; " +
-                    $"cleared stage: {prevStageWorld.StageClearedId}"
+                    $"{addressesHex}Aborted as the stage isn't playable;" +
+                    $"StageClearedId: {world.StageClearedId}"
                 );
             }
 

--- a/Lib9c/Action/HackAndSlashSweep.cs
+++ b/Lib9c/Action/HackAndSlashSweep.cs
@@ -135,17 +135,17 @@ namespace Nekoyume.Action
             }
 
             var prevStageId = Math.Max(stageId - 1, 1);
-            var firstStage = prevStageId == 1;
+            var isFirstStage = prevStageId == 1;
             worldInformation.TryGetWorldByStageId(prevStageId, out var prevStageWorld);
 
-            if (!prevStageWorld.IsStageCleared && !firstStage)
+            if (!prevStageWorld.IsStageCleared && !isFirstStage)
             {
                 throw new StageNotClearedException(
                     $"{addressesHex}There is no stage cleared in that world (worldId:{prevStageWorld.Id})"
                 );
             }
 
-            if (stageId > prevStageWorld.StageClearedId + 1 && !firstStage)
+            if (stageId > prevStageWorld.StageClearedId + 1 && !isFirstStage)
             {
                 throw new InvalidStageException(
                     $"{addressesHex}Aborted as the stage ({prevStageWorld.Id}/{prevStageId}) is not cleared; " +


### PR DESCRIPTION
Related to https://github.com/planetarium/lib9c/pull/1017

Add first stage sweep test case & Fix stage check rule

----
And... I'm add below code
```csharp
...
# check first world, first stage
var firstStage = prevStageId == 1;
...
if (!prevStageWorld.IsStageCleared && !firstStage)
...
```

I don't think it's best to do hardcoding like this
Is there any way to get information about the first stage of the first world?
