### PR TITLE
Make `MigrateMonsterCollection` action as polymorphic

### DIFF
--- a/.Lib9c.Tests/Action/MigrateMonsterCollectionTest.cs
+++ b/.Lib9c.Tests/Action/MigrateMonsterCollectionTest.cs
@@ -134,15 +134,6 @@ namespace Lib9c.Tests.Action
             Assert.Equal(action.PlainValue, deserialized.PlainValue);
         }
 
-        [Fact]
-        public void CannotBePolymorphicAction()
-        {
-            Assert.Throws<MissingActionTypeException>(() =>
-            {
-                PolymorphicAction<ActionBase> action = new MigrateMonsterCollection();
-            });
-        }
-
         private class ExecuteFixture : IEnumerable<object[]>
         {
             private readonly List<object[]> _data = new List<object[]>

--- a/Lib9c/Action/MigrateMonsterCollection.cs
+++ b/Lib9c/Action/MigrateMonsterCollection.cs
@@ -12,6 +12,7 @@ namespace Nekoyume.Action
     /// <see cref="MonsterCollectionState"/> into <see cref="StakeState"/> without cancellation, to
     /// keep its staked period.
     /// </summary>
+    [ActionType("migrate_monster_collection")]
     public class MigrateMonsterCollection : ActionBase
     {
         public Address AvatarAddress { get; private set; }


### PR DESCRIPTION
Since #1010, `Stake` and `ClaimStakeReward` became `PolymorphicAction<T>` but `MigrateMonsterCollection` was missed. This pull request does it.