### PR TITLE
Support lastcommit

### DIFF
--- a/Lib9c/Miner.cs
+++ b/Lib9c/Miner.cs
@@ -42,6 +42,7 @@ namespace Nekoyume.BlockChain
         public Address Address => _privateKey.ToAddress();
 
         public async Task<Block<T>> MineBlockAsync(
+            BlockCommit? lastCommit,
             CancellationToken cancellationToken)
         {
             var txs = new HashSet<Transaction<T>>();
@@ -61,8 +62,8 @@ namespace Nekoyume.BlockChain
                 block = await _chain.MineBlock(
                     _privateKey,
                     DateTimeOffset.UtcNow,
-                    cancellationToken: cancellationToken,
-                    append: true);
+                    lastCommit: lastCommit,
+                    cancellationToken: cancellationToken);
 
                 if (_swarm is Swarm<T> s && s.Running)
                 {


### PR DESCRIPTION
This patch adds a nullable `BlockCommit` typed `lastCommit` argument to `Miner.MineBlockAsync()`.