### PR TITLE
Version up GetLevelAndExp()

### DIFF
--- a/.Lib9c.Tests/Action/HackAndSlashSweepTest1.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweepTest1.cs
@@ -146,7 +146,7 @@ namespace Lib9c.Tests.Action
                 var itemPlayCount = gameConfigState.ActionPointMax / stageRow.CostAP * apStoneCount;
                 var apPlayCount = avatarState.actionPoint / stageRow.CostAP;
                 var playCount = apPlayCount + itemPlayCount;
-                (expectedLevel, expectedExp) = avatarState.GetLevelAndExp(
+                (expectedLevel, expectedExp) = avatarState.GetLevelAndExpV1(
                     _tableSheets.CharacterLevelSheet,
                     stageId,
                     playCount);
@@ -432,7 +432,7 @@ namespace Lib9c.Tests.Action
                     gameConfigState.ActionPointMax / stageRow.CostAP * useApStoneCount;
                 var apPlayCount = avatarState.actionPoint / stageRow.CostAP;
                 var playCount = apPlayCount + itemPlayCount;
-                (expectedLevel, expectedExp) = avatarState.GetLevelAndExp(
+                (expectedLevel, expectedExp) = avatarState.GetLevelAndExpV1(
                     _tableSheets.CharacterLevelSheet,
                     25,
                     playCount);
@@ -501,7 +501,7 @@ namespace Lib9c.Tests.Action
                     gameConfigState.ActionPointMax / stageRow.CostAP * 1;
                 var apPlayCount = avatarState.actionPoint / stageRow.CostAP;
                 var playCount = apPlayCount + itemPlayCount;
-                (expectedLevel, expectedExp) = avatarState.GetLevelAndExp(
+                (expectedLevel, expectedExp) = avatarState.GetLevelAndExpV1(
                     _tableSheets.CharacterLevelSheet,
                     25,
                     playCount);

--- a/.Lib9c.Tests/Action/HackAndSlashSweepTest2.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweepTest2.cs
@@ -146,7 +146,7 @@ namespace Lib9c.Tests.Action
                 var itemPlayCount = gameConfigState.ActionPointMax / stageRow.CostAP * apStoneCount;
                 var apPlayCount = avatarState.actionPoint / stageRow.CostAP;
                 var playCount = apPlayCount + itemPlayCount;
-                (expectedLevel, expectedExp) = avatarState.GetLevelAndExp(
+                (expectedLevel, expectedExp) = avatarState.GetLevelAndExpV1(
                     _tableSheets.CharacterLevelSheet,
                     stageId,
                     playCount);
@@ -470,7 +470,7 @@ namespace Lib9c.Tests.Action
                     gameConfigState.ActionPointMax / stageRow.CostAP * useApStoneCount;
                 var apPlayCount = avatarState.actionPoint / stageRow.CostAP;
                 var playCount = apPlayCount + itemPlayCount;
-                (expectedLevel, expectedExp) = avatarState.GetLevelAndExp(
+                (expectedLevel, expectedExp) = avatarState.GetLevelAndExpV1(
                     _tableSheets.CharacterLevelSheet,
                     25,
                     playCount);
@@ -539,7 +539,7 @@ namespace Lib9c.Tests.Action
                     gameConfigState.ActionPointMax / stageRow.CostAP * 1;
                 var apPlayCount = avatarState.actionPoint / stageRow.CostAP;
                 var playCount = apPlayCount + itemPlayCount;
-                (expectedLevel, expectedExp) = avatarState.GetLevelAndExp(
+                (expectedLevel, expectedExp) = avatarState.GetLevelAndExpV1(
                     _tableSheets.CharacterLevelSheet,
                     25,
                     playCount);

--- a/.Lib9c.Tests/Action/HackAndSlashSweepTest3.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweepTest3.cs
@@ -167,7 +167,7 @@ namespace Lib9c.Tests.Action
                 var itemPlayCount = gameConfigState.ActionPointMax / stageRow.CostAP * apStoneCount;
                 var apPlayCount = avatarState.actionPoint / stageRow.CostAP;
                 var playCount = apPlayCount + itemPlayCount;
-                (expectedLevel, expectedExp) = avatarState.GetLevelAndExp(
+                (expectedLevel, expectedExp) = avatarState.GetLevelAndExpV1(
                     _tableSheets.CharacterLevelSheet,
                     stageId,
                     playCount);
@@ -498,7 +498,7 @@ namespace Lib9c.Tests.Action
                     gameConfigState.ActionPointMax / stageRow.CostAP * useApStoneCount;
                 var apPlayCount = avatarState.actionPoint / stageRow.CostAP;
                 var playCount = apPlayCount + itemPlayCount;
-                (expectedLevel, expectedExp) = avatarState.GetLevelAndExp(
+                (expectedLevel, expectedExp) = avatarState.GetLevelAndExpV1(
                     _tableSheets.CharacterLevelSheet,
                     2,
                     playCount);
@@ -573,7 +573,7 @@ namespace Lib9c.Tests.Action
                     gameConfigState.ActionPointMax / stageRow.CostAP * 1;
                 var apPlayCount = avatarState.actionPoint / stageRow.CostAP;
                 var playCount = apPlayCount + itemPlayCount;
-                (expectedLevel, expectedExp) = avatarState.GetLevelAndExp(
+                (expectedLevel, expectedExp) = avatarState.GetLevelAndExpV1(
                     _tableSheets.CharacterLevelSheet,
                     2,
                     playCount);
@@ -648,7 +648,7 @@ namespace Lib9c.Tests.Action
                     gameConfigState.ActionPointMax / stageRow.CostAP * 1;
                 var apPlayCount = avatarState.actionPoint / stageRow.CostAP;
                 var playCount = apPlayCount + itemPlayCount;
-                (expectedLevel, expectedExp) = avatarState.GetLevelAndExp(
+                (expectedLevel, expectedExp) = avatarState.GetLevelAndExpV1(
                     _tableSheets.CharacterLevelSheet,
                     2,
                     playCount);
@@ -723,7 +723,7 @@ namespace Lib9c.Tests.Action
                     gameConfigState.ActionPointMax / stageRow.CostAP * 1;
                 var apPlayCount = avatarState.actionPoint / stageRow.CostAP;
                 var playCount = apPlayCount + itemPlayCount;
-                (expectedLevel, expectedExp) = avatarState.GetLevelAndExp(
+                (expectedLevel, expectedExp) = avatarState.GetLevelAndExpV1(
                     _tableSheets.CharacterLevelSheet,
                     stageId,
                     playCount);

--- a/Lib9c/Action/HackAndSlashSweep1.cs
+++ b/Lib9c/Action/HackAndSlashSweep1.cs
@@ -167,7 +167,7 @@ namespace Nekoyume.Action
             avatarState.UpdateInventory(rewardItems);
 
             var levelSheet = sheets.GetSheet<CharacterLevelSheet>();
-            var (level, exp) = avatarState.GetLevelAndExp(levelSheet, stageId, playCount);
+            var (level, exp) = avatarState.GetLevelAndExpV1(levelSheet, stageId, playCount);
             avatarState.UpdateExp(level, exp);
 
             return states

--- a/Lib9c/Action/HackAndSlashSweep2.cs
+++ b/Lib9c/Action/HackAndSlashSweep2.cs
@@ -171,7 +171,7 @@ namespace Nekoyume.Action
             avatarState.UpdateInventory(rewardItems);
 
             var levelSheet = sheets.GetSheet<CharacterLevelSheet>();
-            var (level, exp) = avatarState.GetLevelAndExp(levelSheet, stageId, playCount);
+            var (level, exp) = avatarState.GetLevelAndExpV1(levelSheet, stageId, playCount);
             avatarState.UpdateExp(level, exp);
 
             return states

--- a/Lib9c/Action/HackAndSlashSweep3.cs
+++ b/Lib9c/Action/HackAndSlashSweep3.cs
@@ -223,7 +223,7 @@ namespace Nekoyume.Action
             avatarState.UpdateInventory(rewardItems);
 
             var levelSheet = sheets.GetSheet<CharacterLevelSheet>();
-            var (level, exp) = avatarState.GetLevelAndExp(levelSheet, stageId, playCount);
+            var (level, exp) = avatarState.GetLevelAndExpV1(levelSheet, stageId, playCount);
             avatarState.UpdateExp(level, exp);
 
             return states

--- a/Lib9c/Helper/AvatarStateExtensions.cs
+++ b/Lib9c/Helper/AvatarStateExtensions.cs
@@ -66,6 +66,41 @@ namespace Nekoyume.Helper
                 }
 
                 var requiredCount = (int)DecimalMath.DecimalEx.Ceiling(remainExp / (decimal)stageExp);
+                if (remainCount - requiredCount >= 0) // level up
+                {
+                    currentExp += stageExp * requiredCount;
+                    remainCount -= requiredCount;
+                    currentLevel += 1;
+                }
+                else
+                {
+                    currentExp += stageExp * remainCount;
+                    break;
+                }
+            }
+
+            return (currentLevel, currentExp);
+        }
+
+        [Obsolete("Use GetLevelAndExp")]
+        public static (int, long) GetLevelAndExpV1(this AvatarState avatarState,
+            CharacterLevelSheet characterLevelSheet, int stageId, int repeatCount)
+        {
+            var remainCount = repeatCount;
+            var currentLevel = avatarState.level;
+            var currentExp = avatarState.exp;
+            while (remainCount > 0)
+            {
+                characterLevelSheet.TryGetValue(currentLevel, out var row, true);
+                var maxExp = row.Exp + row.ExpNeed;
+                var remainExp = maxExp - currentExp;
+                var stageExp = StageRewardExpHelper.GetExp(currentLevel, stageId);
+                if (stageExp == 0)
+                {
+                    break;
+                }
+
+                var requiredCount = (int)DecimalMath.DecimalEx.Ceiling(remainExp / (decimal)stageExp);
                 if (remainCount - requiredCount > 0) // level up
                 {
                     currentExp += stageExp * requiredCount;


### PR DESCRIPTION
[[스윕] 스윕으로 EXP를 획득 시 보유 EXP가 100이 될 경우 레벨업을 하지 않는 현상](https://app.asana.com/0/1133453747809944/1202350473096109)