### PR TITLE
Avoid to add items with zero count

### DIFF
--- a/.Lib9c.Tests/Action/ClaimStakeRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimStakeRewardTest.cs
@@ -93,7 +93,8 @@ namespace Lib9c.Tests.Action
             // regular (100 / 8) * 4
             Assert.Equal(48, avatarState.inventory.Items.First(x => x.item.Id == 400000).count);
             // regular (100 / 200) * 4
-            Assert.Equal(0, avatarState.inventory.Items.First(x => x.item.Id == 500000).count);
+            // It must be never added into the inventory if the amount is 0.
+            Assert.Null(avatarState.inventory.Items.FirstOrDefault(x => x.item.Id == 500000));
 
             Assert.True(states.TryGetStakeState(_signerAddress, out StakeState stakeState));
             Assert.Equal(StakeState.LockupInterval, stakeState.ReceivedBlockIndex);

--- a/Lib9c/Action/ClaimStakeReward.cs
+++ b/Lib9c/Action/ClaimStakeReward.cs
@@ -60,6 +60,12 @@ namespace Nekoyume.Action
             foreach (var reward in rewards)
             {
                 var (quantity, _) = stakedAmount.DivRem(currency * reward.Rate);
+                if (quantity < 1)
+                {
+                    // If the quantity is zero, it doesn't add the item into inventory.
+                    continue;
+                }
+
                 ItemSheet.Row row = itemSheet[reward.ItemId];
                 ItemBase item = row is MaterialItemSheet.Row materialRow
                     ? ItemFactory.CreateTradableMaterial(materialRow)


### PR DESCRIPTION
This pull request makes `ClaimStakeReward` avoid to add items with zero count.