### PR TITLE
Add zero item for chain consistency, in the condition

### DIFF
--- a/.Lib9c.Tests/Action/ClaimStakeRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimStakeRewardTest.cs
@@ -1,5 +1,6 @@
 namespace Lib9c.Tests.Action
 {
+    using System.Collections.Immutable;
     using System.Linq;
     using Libplanet;
     using Libplanet.Action;
@@ -41,7 +42,11 @@ namespace Lib9c.Tests.Action
 
             _tableSheets = new TableSheets(sheets);
 
-            _currency = new Currency("NCG", 2, minters: null);
+            _currency = new Currency(
+                "NCG",
+                2,
+                minters: ImmutableHashSet<Address>.Empty.Add(
+                    new Address("47d082a115c63e7b58b1532d20e631538eafadde")));
             _goldCurrencyState = new GoldCurrencyState(_currency);
 
             _signerAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/Scenario/StakeAndClaimStakeRewardScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/StakeAndClaimStakeRewardScenarioTest.cs
@@ -1,6 +1,7 @@
 namespace Lib9c.Tests.Action.Scenario
 {
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Linq;
     using Libplanet;
     using Libplanet.Action;
@@ -43,7 +44,8 @@ namespace Lib9c.Tests.Action.Scenario
 
             _tableSheets = new TableSheets(sheets);
 
-            _currency = new Currency("NCG", 2, minters: null);
+            _currency = new Currency("NCG", 2, minters: ImmutableHashSet<Address>.Empty.Add(
+                new Address("47d082a115c63e7b58b1532d20e631538eafadde")));
             _goldCurrencyState = new GoldCurrencyState(_currency);
 
             _signerAddress = new PrivateKey().ToAddress();

--- a/Lib9c/Action/ClaimStakeReward.cs
+++ b/Lib9c/Action/ClaimStakeReward.cs
@@ -52,6 +52,13 @@ namespace Nekoyume.Action
                 throw new RequiredBlockIndexException();
             }
 
+            // Assume previewnet from the NCG's minter address.
+            bool isPreviewNet = context.PreviousStates.GetGoldCurrency().Minters
+                .Contains(new Address("340f110b91d0577a9ae0ea69ce15269436f217da"));
+
+            // https://github.com/planetarium/lib9c/pull/1073
+            bool addZeroItemForChainConsistency = isPreviewNet && context.BlockIndex < 1_200_000;
+
             var avatarState = states.GetAvatarStateV2(AvatarAddress);
             int level = stakeRegularRewardSheet.FindLevelByStakedAmount(stakedAmount);
             var rewards = stakeRegularRewardSheet[level].Rewards;
@@ -60,7 +67,7 @@ namespace Nekoyume.Action
             foreach (var reward in rewards)
             {
                 var (quantity, _) = stakedAmount.DivRem(currency * reward.Rate);
-                if (quantity < 1)
+                if (!addZeroItemForChainConsistency && quantity < 1)
                 {
                     // If the quantity is zero, it doesn't add the item into inventory.
                     continue;


### PR DESCRIPTION
This pull request is continued from #1073. The #1073 PR will break the chain consistency on the `previewnet` network because it was changed to update states differently. So this pull request makes the action execute like the original action if it's `previewnet` and the block index is under 1,200,000.