### PR TITLE
Obsolete monster collection

### DIFF
--- a/.Lib9c.Tests/Action/ClaimMonsterCollectionRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimMonsterCollectionRewardTest.cs
@@ -12,7 +12,6 @@ namespace Lib9c.Tests.Action
     using Libplanet.Crypto;
     using Nekoyume;
     using Nekoyume.Action;
-    using Nekoyume.BlockChain.Policy;
     using Nekoyume.Model.Mail;
     using Nekoyume.Model.State;
     using Serilog;
@@ -357,8 +356,9 @@ namespace Lib9c.Tests.Action
                 new object[]
                 {
                     1,
-                    BlockPolicySource.V100220ObsoleteIndex,
-                    BlockPolicySource.V100220ObsoleteIndex - MonsterCollectionState.RewardInterval,
+                    ClaimMonsterCollectionReward.MonsterCollectionRewardEndBlockIndex,
+                    ClaimMonsterCollectionReward.MonsterCollectionRewardEndBlockIndex -
+                    MonsterCollectionState.RewardInterval,
                     new (int, int)[]
                     {
                         (400000, 80),
@@ -369,8 +369,10 @@ namespace Lib9c.Tests.Action
                 new object[]
                 {
                     1,
-                    BlockPolicySource.V100220ObsoleteIndex + MonsterCollectionState.RewardInterval * 3,
-                    BlockPolicySource.V100220ObsoleteIndex - MonsterCollectionState.RewardInterval,
+                    ClaimMonsterCollectionReward.MonsterCollectionRewardEndBlockIndex +
+                    MonsterCollectionState.RewardInterval * 3,
+                    ClaimMonsterCollectionReward.MonsterCollectionRewardEndBlockIndex -
+                    MonsterCollectionState.RewardInterval,
                     new (int, int)[]
                     {
                         (400000, 80),

--- a/.Lib9c.Tests/Action/ClaimMonsterCollectionRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimMonsterCollectionRewardTest.cs
@@ -12,6 +12,7 @@ namespace Lib9c.Tests.Action
     using Libplanet.Crypto;
     using Nekoyume;
     using Nekoyume.Action;
+    using Nekoyume.BlockChain.Policy;
     using Nekoyume.Model.Mail;
     using Nekoyume.Model.State;
     using Serilog;
@@ -346,6 +347,30 @@ namespace Lib9c.Tests.Action
                     1,
                     MonsterCollectionState.RewardInterval * 2,
                     MonsterCollectionState.RewardInterval * 2 - 1,
+                    new (int, int)[]
+                    {
+                        (400000, 80),
+                        (500000, 1),
+                    },
+                    null,
+                },
+                new object[]
+                {
+                    1,
+                    BlockPolicySource.V100220ObsoleteIndex,
+                    BlockPolicySource.V100220ObsoleteIndex - MonsterCollectionState.RewardInterval,
+                    new (int, int)[]
+                    {
+                        (400000, 80),
+                        (500000, 1),
+                    },
+                    null,
+                },
+                new object[]
+                {
+                    1,
+                    BlockPolicySource.V100220ObsoleteIndex + MonsterCollectionState.RewardInterval * 3,
+                    BlockPolicySource.V100220ObsoleteIndex - MonsterCollectionState.RewardInterval,
                     new (int, int)[]
                     {
                         (400000, 80),

--- a/.Lib9c.Tests/Action/MonsterCollectTest.cs
+++ b/.Lib9c.Tests/Action/MonsterCollectTest.cs
@@ -153,6 +153,26 @@ namespace Lib9c.Tests.Action
         }
 
         [Fact]
+        public void Execute_Throw_InvalidOperationException()
+        {
+            var stakeAddress = StakeState.DeriveAddress(_signer);
+            var states = _initialState.SetState(
+                stakeAddress,
+                new StakeState(stakeAddress, 0).SerializeV2());
+            MonsterCollect action = new MonsterCollect
+            {
+                level = 1,
+            };
+
+            Assert.Throws<InvalidOperationException>(() => action.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _signer,
+                BlockIndex = 1,
+            }));
+        }
+
+        [Fact]
         public void Rehearsal()
         {
             MonsterCollect action = new MonsterCollect

--- a/Lib9c/Action/ClaimMonsterCollectionReward.cs
+++ b/Lib9c/Action/ClaimMonsterCollectionReward.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Bencodex.Types;
 using Libplanet;
 using Libplanet.Action;
+using Nekoyume.BlockChain.Policy;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.Mail;
 using Nekoyume.Model.State;
@@ -19,7 +20,7 @@ namespace Nekoyume.Action
     /// </summary>
     [Serializable]
     [ActionType("claim_monster_collection_reward3")]
-    // FIXME: This action should be obsoleted.
+    [ActionObsolete(BlockPolicySource.V100220ObsoleteIndex)]
     public class ClaimMonsterCollectionReward : GameAction
     {
         public Address avatarAddress;

--- a/Lib9c/Action/ClaimMonsterCollectionReward.cs
+++ b/Lib9c/Action/ClaimMonsterCollectionReward.cs
@@ -60,7 +60,7 @@ namespace Nekoyume.Action
             List<MonsterCollectionRewardSheet.RewardInfo> rewards =
                 monsterCollectionState.CalculateRewards(
                     states.GetSheet<MonsterCollectionRewardSheet>(),
-                    context.BlockIndex
+                    Math.Min(BlockPolicySource.V100220ObsoleteIndex, context.BlockIndex)
                 );
 
             if (rewards.Count == 0)

--- a/Lib9c/Action/ClaimMonsterCollectionReward.cs
+++ b/Lib9c/Action/ClaimMonsterCollectionReward.cs
@@ -23,6 +23,7 @@ namespace Nekoyume.Action
     [ActionObsolete(BlockPolicySource.V100220ObsoleteIndex)]
     public class ClaimMonsterCollectionReward : GameAction
     {
+        public const long MonsterCollectionRewardEndBlockIndex = 4_481_909;
         public Address avatarAddress;
         public override IAccountStateDelta Execute(IActionContext context)
         {
@@ -60,7 +61,7 @@ namespace Nekoyume.Action
             List<MonsterCollectionRewardSheet.RewardInfo> rewards =
                 monsterCollectionState.CalculateRewards(
                     states.GetSheet<MonsterCollectionRewardSheet>(),
-                    Math.Min(BlockPolicySource.V100220ObsoleteIndex, context.BlockIndex)
+                    Math.Min(MonsterCollectionRewardEndBlockIndex, context.BlockIndex)
                 );
 
             if (rewards.Count == 0)

--- a/Lib9c/Action/MonsterCollect.cs
+++ b/Lib9c/Action/MonsterCollect.cs
@@ -39,6 +39,12 @@ namespace Nekoyume.Action
                     .MarkBalanceChanged(GoldCurrencyMock, context.Signer, MonsterCollectionState.DeriveAddress(context.Signer, 3));
             }
 
+            if (states.TryGetStakeState(context.Signer, out StakeState _))
+            {
+                throw new InvalidOperationException(
+                    "The user has staked. You cannot stake and monster-collect at the same time.");
+            }
+
             MonsterCollectionSheet monsterCollectionSheet = states.GetSheet<MonsterCollectionSheet>();
 
             AgentState agentState = states.GetAgentState(context.Signer);

--- a/Lib9c/Action/MonsterCollect.cs
+++ b/Lib9c/Action/MonsterCollect.cs
@@ -5,6 +5,7 @@ using Bencodex.Types;
 using Libplanet;
 using Libplanet.Action;
 using Libplanet.Assets;
+using Nekoyume.BlockChain.Policy;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
@@ -17,7 +18,7 @@ namespace Nekoyume.Action
     /// </summary>
     [Serializable]
     [ActionType("monster_collect3")]
-    // FIXME: This action should be obsoleted.
+    [ActionObsolete(BlockPolicySource.V100220ObsoleteIndex)]
     public class MonsterCollect : GameAction
     {
         public int level;

--- a/Lib9c/Policy/BlockPolicySource.cs
+++ b/Lib9c/Policy/BlockPolicySource.cs
@@ -70,7 +70,7 @@ namespace Nekoyume.BlockChain.Policy
 
         public const long V100210ObsoleteIndex = 4_366_622;
 
-        public const long V100220ObsoleteIndex = 4_378_478;
+        public const long V100220ObsoleteIndex = 4_390_272;
 
         public const long PermissionedMiningStartIndex = 2_225_500;
 


### PR DESCRIPTION
> I wrote this pull request by the insider request from @jaeho0103. Maybe it is a proposal yet. With these changes, it expects monster collection users to move to the stake because it makes users not able to accumulate more monster collection rewards since specific block index. To understand the full context, you should look `features/stake` branch.

This pull request does:

 - Obsolete `ClaimMonsterCollectionReward`, `MonsterCollect`.
 - Limit monster collection rewards since the `ClaimMonsterCollectionReward.MonsterCollectionEndBlockIndex`. Since the index, rewards will not be accumulated.
 - Update `BlockPolicySource.V100220ObsoleteIndex` to 2 weeks later from the v100220 target date, June 15 KST. (calculation formula: `((2 * 7 + 2) * 24 * 60 * 60 / 11) + 4264600`)
 - Prevent doing monster collection and staking at the same time.
