### PR TITLE
Avoid DivideByZeroException in calculate combination cost

### DIFF
--- a/.Lib9c.Tests/CrystalCalculatorTest.cs
+++ b/.Lib9c.Tests/CrystalCalculatorTest.cs
@@ -74,20 +74,34 @@ namespace Lib9c.Tests
         }
 
         [Theory]
-        [InlineData(2, 1, 200)]
-        [InlineData(9, 10, 90)]
+        [InlineData(200, 100, 200, true, true)]
+        [InlineData(900, 1000, 90, true, true)]
         // Minimum
-        [InlineData(1, 2, 50)]
+        [InlineData(100, 200, 50, true, true)]
         // Maximum
-        [InlineData(3, 1, 300)]
-        public void CalculateCombinationCost(int psCount, int bpsCount, int expected)
+        [InlineData(300, 100, 300, true, true)]
+        // Avoid DivideByZeroException
+        [InlineData(0, 100, 100, true, true)]
+        [InlineData(100, 0, 100, true, true)]
+        [InlineData(0, 0, 100, true, true)]
+        [InlineData(100, 0, 100, true, false)]
+        [InlineData(0, 0, 100, false, true)]
+        [InlineData(0, 0, 100, false, false)]
+        public void CalculateCombinationCost(int psCrystal, int bpsCrystal, int expected, bool psExist, bool bpsExist)
         {
             var crystal = 100 * CrystalCalculator.CRYSTAL;
-            var ps = new CrystalCostState(default, crystal * psCount);
-            var bps = new CrystalCostState(default, crystal * bpsCount);
+            var ps = psExist
+                ? new CrystalCostState(default, psCrystal * CrystalCalculator.CRYSTAL)
+                : null;
+            var bps = bpsExist
+                ? new CrystalCostState(default, bpsCrystal * CrystalCalculator.CRYSTAL)
+                : null;
             var row = _tableSheets.CrystalFluctuationSheet.Values.First(r =>
                 r.Type == CrystalFluctuationSheet.ServiceType.Combination);
-            Assert.Equal(expected * CrystalCalculator.CRYSTAL, CrystalCalculator.CalculateCombinationCost(crystal, row, prevWeeklyCostState: ps, beforePrevWeeklyCostState: bps));
+            Assert.Equal(
+                expected * CrystalCalculator.CRYSTAL,
+                CrystalCalculator.CalculateCombinationCost(crystal, row, prevWeeklyCostState: ps, bps)
+            );
         }
 
         [Fact]

--- a/Lib9c/Helper/CrystalCalculator.cs
+++ b/Lib9c/Helper/CrystalCalculator.cs
@@ -110,7 +110,7 @@ namespace Nekoyume.Helper
             CrystalCostState prevWeeklyCostState = null,
             CrystalCostState beforePrevWeeklyCostState = null)
         {
-            if (!(prevWeeklyCostState is null) && !(beforePrevWeeklyCostState is null))
+            if (prevWeeklyCostState?.CRYSTAL > 0 * CRYSTAL && beforePrevWeeklyCostState?.CRYSTAL > 0 * CRYSTAL)
             {
                 int multiplier = (int) (prevWeeklyCostState.CRYSTAL.RawValue * 100 /
                                         beforePrevWeeklyCostState.CRYSTAL.RawValue);


### PR DESCRIPTION
```
Libplanet.Action.PolymorphicAction<Nekoyume.Action.CombinationEquipment> execution failed.
Libplanet.Action.UnexpectedlyTerminatedActionException: The action Libplanet.Action.PolymorphicAction<Nekoyume.Action.CombinationEquipment> (block #1044347, pre-evaluation hash 1878559e66cd33fca1262b7e38a5184bae4c00a3dea2345c2d0c8cc403000000, tx d97bce941ceefd0d05e6c8d71027da359b9e1bc030fcdd7761698b775d1ba398, previous state root hash be9fe55de5724ba7a19f98cdabe7d7424e011e4f4c4ab1f057effb3be4d24690) threw an exception during execution.  See also this exception's InnerException property.
 ---> System.DivideByZeroException: Attempted to divide by zero.
   at System.Numerics.BigInteger.op_Division(BigInteger dividend, BigInteger divisor)
   at Nekoyume.Helper.CrystalCalculator.CalculateCombinationCost(FungibleAssetValue crystal, Row row, CrystalCostState prevWeeklyCostState, CrystalCostState beforePrevWeeklyCostState) in /app/Lib9c/Lib9c/Helper/CrystalCalculator.cs:line 99
   at Nekoyume.Action.CombinationEquipment.Execute(IActionContext context)
   at Libplanet.Action.PolymorphicAction`1.Execute(IActionContext context) in /app/Lib9c/.Libplanet/Libplanet/Action/PolymorphicAction.cs:line 251
   at Libplanet.Action.ActionEvaluator`1.EvaluateActions(ImmutableArray`1 preEvaluationHash, Int64 blockIndex, Nullable`1 txid, IAccountStateDelta previousStates, Address miner, Address signer, Byte[] signature, IImmutableList`1 actions, Boolean rehearsal, ITrie previousBlockStatesTrie, Boolean blockAction, ILogger logger)+MoveNext() in /app/Lib9c/.Libplanet/Libplanet/Action/ActionEvaluator.cs:line 280
```

Avoid exception in previewnet test.