### PR TITLE
Correct `MigrateMonsterCollection` action

### DIFF
--- a/.Lib9c.Tests/Action/MigrateMonsterCollectionTest.cs
+++ b/.Lib9c.Tests/Action/MigrateMonsterCollectionTest.cs
@@ -112,7 +112,8 @@ namespace Lib9c.Tests.Action
                 0 * currency,
                 states.GetBalance(monsterCollectionState.address, currency));
             Assert.Equal(stakedAmount * currency, states.GetBalance(stakeState.address, currency));
-            Assert.Equal(monsterCollectionState.ReceivedBlockIndex, stakeState.ReceivedBlockIndex);
+            Assert.Equal(claimBlockIndex, stakeState.ReceivedBlockIndex);
+            Assert.Equal(monsterCollectionState.StartedBlockIndex, stakeState.StartedBlockIndex);
             Assert.True(
                 states.TryGetAvatarStateV2(
                     _signer,

--- a/Lib9c/Action/MigrateMonsterCollection.cs
+++ b/Lib9c/Action/MigrateMonsterCollection.cs
@@ -60,7 +60,12 @@ namespace Nekoyume.Action
 
             var monsterCollectionState = new MonsterCollectionState(stateDict);
             var migratedStakeStateAddress = StakeState.DeriveAddress(context.Signer);
-            var migratedStakeState = new StakeState(migratedStakeStateAddress, monsterCollectionState.ReceivedBlockIndex);
+            var migratedStakeState = new StakeState(
+                migratedStakeStateAddress,
+                monsterCollectionState.StartedBlockIndex,
+                monsterCollectionState.ReceivedBlockIndex,
+                monsterCollectionState.ExpiredBlockIndex,
+                new StakeState.StakeAchievements());
 
             return states.SetState(monsterCollectionState.address, Null.Value)
                 .SetState(migratedStakeStateAddress, migratedStakeState.SerializeV2())

--- a/Lib9c/Model/State/StakeState.cs
+++ b/Lib9c/Model/State/StakeState.cs
@@ -68,6 +68,20 @@ namespace Nekoyume.Model.State
             Achievements = new StakeAchievements();
         }
 
+        public StakeState(
+            Address address,
+            long startedBlockIndex,
+            long receivedBlockIndex,
+            long cancellableBlockIndex,
+            StakeAchievements achievements
+        ) : base(address)
+        {
+            StartedBlockIndex = startedBlockIndex;
+            ReceivedBlockIndex = receivedBlockIndex;
+            CancellableBlockIndex = cancellableBlockIndex;
+            Achievements = achievements;
+        }
+
         public StakeState(Dictionary serialized) : base(serialized)
         {
             CancellableBlockIndex = (long)serialized[CancellableBlockIndexKey].ToBigInteger();


### PR DESCRIPTION
Originally the action migrated and made halt stake state. This pull request fixes it.