### PR TITLE
Avoid InvalidStateRootHashException in genesis

### DIFF
--- a/Lib9c/Action/RewardGold.cs
+++ b/Lib9c/Action/RewardGold.cs
@@ -37,7 +37,8 @@ namespace Nekoyume.Action
             states = GenesisGoldDistribution(context, states);
 
             var arenaSheet = states.GetSheet<ArenaSheet>();
-            if (arenaSheet == null)
+            // Avoid InvalidBlockStateRootHashException in unit test genesis block evaluate.
+            if (arenaSheet == null || context.BlockIndex == 0)
             {
                 states = WeeklyArenaRankingBoard2(context, states);
             }


### PR DESCRIPTION
This issue occurs from the state calculated by `BlockChain.MakeGenesisBlock` and the result of actual block evaluation are different. maybe we fix [BlockChain.MakeGenesisBlock](https://github.com/planetarium/libplanet/blob/a3bfb32eaabe31a5c221dcf6918725e6f50e963c/Libplanet/Blockchain/BlockChain.cs#L362) /cc @libplanet 