### PR TITLE
Prevent renew staking with same amount

### DIFF
--- a/.Lib9c.Tests/Action/StakeTest.cs
+++ b/.Lib9c.Tests/Action/StakeTest.cs
@@ -132,6 +132,31 @@ namespace Lib9c.Tests.Action
                 Signer = _signerAddress,
                 BlockIndex = 1,
             }));
+
+            // Same (since 4611070)
+            if (states.TryGetStakeState(_signerAddress, out StakeState stakeState))
+            {
+                states = states.SetState(
+                    stakeState.address,
+                    new StakeState(stakeState.address, 4611070 - 100).Serialize());
+            }
+
+            updateAction = new Stake(51);
+            Assert.Throws<RequiredBlockIndexException>(() => updateAction.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _signerAddress,
+                BlockIndex = 4611070,
+            }));
+
+            // At 4611070 - 99, it should be updated.
+            Assert.True(updateAction.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _signerAddress,
+                BlockIndex = 4611070 - 99,
+            }).TryGetStakeState(_signerAddress, out stakeState));
+            Assert.Equal(4611070 - 99, stakeState.StartedBlockIndex);
         }
 
         [Fact]

--- a/Lib9c/Action/Stake.cs
+++ b/Lib9c/Action/Stake.cs
@@ -100,7 +100,10 @@ namespace Nekoyume.Action
                 throw new StakeExistingClaimableException();
             }
 
-            if (!stakeState.IsCancellable(context.BlockIndex) && targetStakeBalance < stakedBalance)
+            if (!stakeState.IsCancellable(context.BlockIndex) &&
+                (context.BlockIndex >= 4611070
+                    ? targetStakeBalance <= stakedBalance
+                    : targetStakeBalance < stakedBalance))
             {
                 throw new RequiredBlockIndexException();
             }


### PR DESCRIPTION
Originally, it renewed staking with the same amount and set `startedBlockIndex` to 0 again. This pull request restricts a behavior like it since the specific block index, `4611070`.