### PR TITLE
feat(#1087): introduce useful `IActionContext` extensions

### DIFF
--- a/.Lib9c.Tests/Action/ActionContextExtensionsTest.cs
+++ b/.Lib9c.Tests/Action/ActionContextExtensionsTest.cs
@@ -1,0 +1,137 @@
+namespace Lib9c.Tests.Action
+{
+    using System.Collections.Generic;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Assets;
+    using Libplanet.Crypto;
+    using Nekoyume;
+    using Nekoyume.Action;
+    using Nekoyume.Model.State;
+    using Xunit;
+
+    public class ActionContextExtensionsTest
+    {
+        public static IEnumerable<object[]> IsMainNetTestcases()
+        {
+            yield return new object[]
+            {
+                new GoldCurrencyState(
+                    new Currency("NCG", 2, new Address("47d082a115c63e7b58b1532d20e631538eafadde"))),
+                true,
+            };
+
+            yield return new object[]
+            {
+                new GoldCurrencyState(
+                    new Currency("NCG", 18, new Address("47d082a115c63e7b58b1532d20e631538eafadde"))),
+                false,
+            };
+
+            yield return new object[]
+            {
+                new GoldCurrencyState(
+                    new Currency("NCG", 2, new PrivateKey().ToAddress())),
+                false,
+            };
+
+            yield return new object[]
+            {
+                new GoldCurrencyState(
+                    new Currency("ETH", 2, new Address("47d082a115c63e7b58b1532d20e631538eafadde"))),
+                false,
+            };
+
+            yield return new object[]
+            {
+                new GoldCurrencyState(
+                    new Currency("BTC", 18, new Address("47d082a115c63e7b58b1532d20e631538eafadde"))),
+                false,
+            };
+
+            yield return new object[]
+            {
+                new GoldCurrencyState(
+                    new Currency("BTC", 2, new Address("47d082a115c63e7b58b1532d20e631538eafadde"))),
+                false,
+            };
+        }
+
+        public static IEnumerable<object[]> IsPreviewNetTestcases()
+        {
+            yield return new object[]
+            {
+                new GoldCurrencyState(
+                    new Currency("NCG", 2, new Address("340f110b91d0577a9ae0ea69ce15269436f217da"))),
+                true,
+            };
+
+            yield return new object[]
+            {
+                new GoldCurrencyState(
+                    new Currency("NCG", 18, new Address("340f110b91d0577a9ae0ea69ce15269436f217da"))),
+                false,
+            };
+
+            yield return new object[]
+            {
+                new GoldCurrencyState(
+                    new Currency("NCG", 2, new PrivateKey().ToAddress())),
+                false,
+            };
+
+            yield return new object[]
+            {
+                new GoldCurrencyState(
+                    new Currency("ETH", 2, new Address("340f110b91d0577a9ae0ea69ce15269436f217da"))),
+                false,
+            };
+
+            yield return new object[]
+            {
+                new GoldCurrencyState(
+                    new Currency("BTC", 18, new Address("340f110b91d0577a9ae0ea69ce15269436f217da"))),
+                false,
+            };
+
+            yield return new object[]
+            {
+                new GoldCurrencyState(
+                    new Currency("BTC", 2, new Address("340f110b91d0577a9ae0ea69ce15269436f217da"))),
+                false,
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(IsMainNetTestcases))]
+        public void IsMainNet(GoldCurrencyState goldCurrencyState, bool expected)
+        {
+            var state = new State().SetState(Addresses.GoldCurrency, goldCurrencyState.Serialize());
+            IActionContext context = new ActionContext
+            {
+                PreviousStates = state,
+            };
+
+            Assert.Equal(expected, context.IsMainNet());
+        }
+
+        [Fact]
+        public void Since()
+        {
+            Assert.True(new ActionContext
+            {
+                BlockIndex = 1001,
+            }.Since(1000));
+
+            Assert.True(new ActionContext
+            {
+                BlockIndex = 0,
+            }.Since(0));
+
+            Assert.False(new ActionContext
+            {
+                BlockIndex = 0,
+            }.Since(1));
+        }
+    }
+}

--- a/Lib9c/Action/ActionContextExtensions.cs
+++ b/Lib9c/Action/ActionContextExtensions.cs
@@ -1,0 +1,22 @@
+using Libplanet;
+using Libplanet.Action;
+
+namespace Nekoyume.Action
+{
+    public static class ActionContextExtensions
+    {
+        public static bool IsMainNet(this IActionContext context)
+        {
+            var goldCurrency = context.PreviousStates.GetGoldCurrency();
+            return goldCurrency.Minters
+                       .Contains(new Address("47d082a115c63e7b58b1532d20e631538eafadde"))
+                   && goldCurrency.Ticker == "NCG"
+                   && goldCurrency.DecimalPlaces == 2;
+        }
+
+        public static bool Since(this IActionContext context, long blockIndex)
+        {
+            return blockIndex <= context.BlockIndex;
+        }
+    }
+}


### PR DESCRIPTION
This pull request resolves #1087.

This pull request introduces new extension methods of the `IActionContext` interface to help branch bugfixes by chain and block index. The methods are the same as the below list:

- `bool Since(long blockIndex)`
- `bool IsMainNet()`

I expected a use-case like the below code:

```csharp
const long hardforkBlockIndex = 1_000_000;
if (context.IsMainNet() && context.Since(hardforkBlockIndex))
```

I wrote code assuming that the `GoldCurrencyState.Currency` will not be changed. I think the gold currency should be static because everyone will lose their NCG if the gold currency is altered and it becomes a new standard. If you have an opinion about this, feel free to start a discussion about it.

And I wonder your opinions about what is better between using a new extension method `Since()` and comparing it by using `IActionContext.BlockIndex` directly, in your experience side.

Of course, we can close this pull request if the discussion's result is these changes are useless or not helpful.