### PR TITLE
Fix Arena exception handling for InvalidBlockStateRootHashException

### DIFF
--- a/Lib9c/Action/RankingBattle.cs
+++ b/Lib9c/Action/RankingBattle.cs
@@ -54,8 +54,9 @@ namespace Nekoyume.Action
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress, enemyAddress);
 
-            var arenaSheet = states.GetSheet<ArenaSheet>();
-            if (arenaSheet != null)
+            var arenaSheetAddress = Addresses.GetSheetAddress<ArenaSheet>();
+            var arenaSheetState = states.GetState(arenaSheetAddress);
+            if (arenaSheetState != null)
             {
                 throw new ActionObsoletedException(nameof(RankingBattle));
             }


### PR DESCRIPTION
- Target version : `v100240`
- Update Rankingbattle : Fix Arena exception handling for InvalidBlockStateRootHashException
- Related link: https://planetariumhq.slack.com/archives/C032BBQTQJY/p1656470290663319