### PR TITLE
[Bug Fix] Add case for `ItemEnhancement9`

### DIFF
--- a/Lib9c/Extensions/CombinationSlotStateExtensions.cs
+++ b/Lib9c/Extensions/CombinationSlotStateExtensions.cs
@@ -31,6 +31,9 @@ namespace Nekoyume.Extensions
                 case ItemEnhancement7.ResultModel r:
                     resultId = r.id;
                     break;
+                case ItemEnhancement9.ResultModel r:
+                    resultId = r.id;
+                    break;
                 case MonsterCollectionResult r:
                     resultId = r.id;
                     break;
@@ -81,6 +84,13 @@ namespace Nekoyume.Extensions
                         requiredBlockIndex);
                     return true;
                 case ItemEnhancement7.ResultModel r:
+                    itemEnhanceMail = new ItemEnhanceMail(
+                        r,
+                        blockIndex,
+                        resultId,
+                        requiredBlockIndex);
+                    return true;
+                case ItemEnhancement9.ResultModel r:
                     itemEnhanceMail = new ItemEnhanceMail(
                         r,
                         blockIndex,

--- a/Lib9c/Extensions/CombinationSlotStateExtensions.cs
+++ b/Lib9c/Extensions/CombinationSlotStateExtensions.cs
@@ -34,6 +34,9 @@ namespace Nekoyume.Extensions
                 case ItemEnhancement9.ResultModel r:
                     resultId = r.id;
                     break;
+                case ItemEnhancement10.ResultModel r:
+                    resultId = r.id;
+                    break;
                 case MonsterCollectionResult r:
                     resultId = r.id;
                     break;
@@ -91,6 +94,13 @@ namespace Nekoyume.Extensions
                         requiredBlockIndex);
                     return true;
                 case ItemEnhancement9.ResultModel r:
+                    itemEnhanceMail = new ItemEnhanceMail(
+                        r,
+                        blockIndex,
+                        resultId,
+                        requiredBlockIndex);
+                    return true;
+                case ItemEnhancement10.ResultModel r:
                     itemEnhanceMail = new ItemEnhanceMail(
                         r,
                         blockIndex,


### PR DESCRIPTION
Block [#4372674](https://9cscan.com/blocks/4372674) execution resulted in an `InvalidBlockStateRootHashException` since `v100231`.
The problem was due to `RapidCombination6` action not including the previous `ItemEnhancement9` action in `Lib9c/Extensions/CombinationSlotStateExtensions.cs` which resulted in the following error:

```
Libplanet.Action.UnexpectedlyTerminatedActionException: The action Libplanet.Action.PolymorphicAction<Nekoyume.Action.RapidCombination> (block #4372674, pre-evaluation hash ef0796837568bb6f9f260c9363d5dd690267df0cd394c633415395cf7e000000, tx b977a43e17dffb824d9c649e5239adb9a20f61acf5839a060d0ba626963a4c6a, previous state root hash 0e7cb552dfe8a2a3cad5f7ac07f00e26e7f894e005a1e4d27724f76d00e7c099) threw an exception during execution.  See also this exception's InnerException property.
 ---> System.InvalidOperationException: Sequence contains no matching element
   at System.Linq.ThrowHelper.ThrowNoMatchException()
   at System.Linq.Enumerable.First[TSource](IEnumerable`1 source, Func`2 predicate)
   at Nekoyume.Model.State.AvatarState.UpdateFromRapidCombinationV2(ResultModel result, Int64 requiredIndex) in C:\Users\kidon\Desktop\planetarium_repo\NineChronicles.Headless\Lib9c\Lib9c\Model\State\AvatarState.cs:line 363
   at Nekoyume.Action.RapidCombination.Execute(IActionContext context) in C:\Users\kidon\Desktop\planetarium_repo\NineChronicles.Headless\Lib9c\Lib9c\Action\RapidCombination.cs:line 124
   at Libplanet.Action.PolymorphicAction`1.Execute(IActionContext context) in C:\Users\kidon\Desktop\planetarium_repo\NineChronicles.Headless\Lib9c\.Libplanet\Libplanet\Action\PolymorphicAction.cs:line 251
   at Libplanet.Action.ActionEvaluator`1.EvaluateActions(ImmutableArray`1 preEvaluationHash, Int64 blockIndex, Nullable`1 txid, IAccountStateDelta previousStates, Address miner, Address signer, Byte[] signature, IImmutableList`1 actions, Boolean rehearsal, ITrie previousBlockStatesTrie, Boolean blockAction, ILogger logger)+MoveNext() in C:\Users\kidon\Desktop\planetarium_repo\NineChronicles.Headless\Lib9c\.Libplanet\Libplanet\Action\ActionEvaluator.cs:line 280
```

This PR resolves the `InvalidBlockStateRootHashException`.