### PR TITLE
Explicitly initialize variables with value types

### DIFF
--- a/Lib9c/Extensions/CombinationSlotStateExtensions.cs
+++ b/Lib9c/Extensions/CombinationSlotStateExtensions.cs
@@ -11,6 +11,7 @@ namespace Nekoyume.Extensions
         {
             if (state?.Result is null)
             {
+                resultId = default(Guid);
                 return false;
             }
 
@@ -56,6 +57,7 @@ namespace Nekoyume.Extensions
                     resultId = r.id;
                     break;
                 default:
+                    resultId = default(Guid);
                     return false;
             }
 
@@ -67,6 +69,7 @@ namespace Nekoyume.Extensions
         {
             if (state?.Result is null)
             {
+                resultId = default(Guid);
                 return false;
             }
 
@@ -106,6 +109,7 @@ namespace Nekoyume.Extensions
                     resultId = r.id;
                     break;
                 default:
+                    resultId = default(Guid);
                     return false;
             }
 


### PR DESCRIPTION
Newer C# versions require variables with value types to be explicitly initialized.  (The older compiler silently added zero-fill initialization for these uninitialized variables.)

Note that this branch (*migration*) does not catch up the latest *development*, but stick with the *main* is intended, because it shouldn't hard-fork the mainnet so that we can easily test with it.