### PR TITLE
fix action evaluation results in `v100240`

### DIFF
--- a/Lib9c/Action/Buy11.cs
+++ b/Lib9c/Action/Buy11.cs
@@ -104,7 +104,14 @@ namespace Nekoyume.Action
             var arenaSheetState = states.GetState(arenaSheetAddress);
             if (arenaSheetState != null)
             {
-                throw new ActionObsoletedException(nameof(Buy11));
+                // exception handling for v100240.
+                if (context.BlockIndex > 4374175)
+                {
+                }
+                else
+                {
+                    throw new ActionObsoletedException(nameof(Buy11));
+                }
             }
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, buyerAvatarAddress);

--- a/Lib9c/Action/CombinationEquipment11.cs
+++ b/Lib9c/Action/CombinationEquipment11.cs
@@ -81,7 +81,14 @@ namespace Nekoyume.Action
             var arenaSheetState = states.GetState(arenaSheetAddress);
             if (arenaSheetState != null)
             {
-                throw new ActionObsoletedException(nameof(CombinationEquipment11));
+                // exception handling for v100240.
+                if (context.BlockIndex > 4374131 && context.BlockIndex < 4374214)
+                {
+                }
+                else
+                {
+                    throw new ActionObsoletedException(nameof(CombinationEquipment11));
+                }
             }
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);

--- a/Lib9c/Action/HackAndSlash13.cs
+++ b/Lib9c/Action/HackAndSlash13.cs
@@ -80,7 +80,14 @@ namespace Nekoyume.Action
             var arenaSheetState = states.GetState(arenaSheetAddress);
             if (arenaSheetState != null)
             {
-                throw new ActionObsoletedException(nameof(HackAndSlash13));
+                // exception handling for v100240.
+                if (context.BlockIndex > 4374125 && context.BlockIndex < 4374158)
+                {
+                }
+                else
+                {
+                    throw new ActionObsoletedException(nameof(HackAndSlash13));
+                }
             }
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);

--- a/Lib9c/Action/HackAndSlashSweep4.cs
+++ b/Lib9c/Action/HackAndSlashSweep4.cs
@@ -75,7 +75,14 @@ namespace Nekoyume.Action
             var arenaSheetState = states.GetState(arenaSheetAddress);
             if (arenaSheetState != null)
             {
-                throw new ActionObsoletedException(nameof(HackAndSlashSweep4));
+                // exception handling for v100240.
+                if (context.BlockIndex > 4374125 && context.BlockIndex > 4374249)
+                {
+                }
+                else
+                {
+                    throw new ActionObsoletedException(nameof(HackAndSlashSweep4));
+                }
             }
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);

--- a/Lib9c/Action/ItemEnhancement10.cs
+++ b/Lib9c/Action/ItemEnhancement10.cs
@@ -139,7 +139,14 @@ namespace Nekoyume.Action
             var arenaSheetState = states.GetState(arenaSheetAddress);
             if (arenaSheetState != null)
             {
-                throw new ActionObsoletedException(nameof(ItemEnhancement10));
+                // exception handling for v100240.
+                if (context.BlockIndex > 4374144 && context.BlockIndex < 4374196)
+                {
+                }
+                else
+                {
+                    throw new ActionObsoletedException(nameof(ItemEnhancement10));
+                }
             }
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);

--- a/Lib9c/Action/RankingBattle.cs
+++ b/Lib9c/Action/RankingBattle.cs
@@ -58,7 +58,14 @@ namespace Nekoyume.Action
             var arenaSheetState = states.GetState(arenaSheetAddress);
             if (arenaSheetState != null)
             {
-                throw new ActionObsoletedException(nameof(RankingBattle));
+                // exception handling for v100240.
+                if (context.BlockIndex > 4374126 && context.BlockIndex < 4374162)
+                {
+                }
+                else
+                {
+                    throw new ActionObsoletedException(nameof(RankingBattle));
+                }
             }
 
             var sw = new Stopwatch();

--- a/Lib9c/Action/RapidCombination6.cs
+++ b/Lib9c/Action/RapidCombination6.cs
@@ -62,6 +62,13 @@ namespace Nekoyume.Action
             }
 
             var slotState = states.GetCombinationSlotState(avatarAddress, slotIndex);
+
+            // exception handling for v100240.
+            if (context.BlockIndex > 4377159 && context.BlockIndex < 4377430 && slotState.Result is ItemEnhancement9.ResultModel)
+            {
+                return states;
+            }
+
             if (slotState?.Result is null)
             {
                 throw new CombinationSlotResultNullException($"{addressesHex}CombinationSlot Result is null. ({avatarAddress}), ({slotIndex})");
@@ -118,6 +125,30 @@ namespace Nekoyume.Action
                 else if (itemEnhanceMail != null)
                 {
                     avatarState.Update(itemEnhanceMail);
+                }
+            }
+            else
+            {
+                // exception handling for v100240.
+                if (context.BlockIndex > 4133442 && context.BlockIndex < 4374195)
+                {
+                    if (slotState.TryGetResultId(out var resultIdFix) &&
+                        avatarState.mailBox.All(mail => mail.id != resultIdFix) &&
+                        slotState.TryGetMail(
+                            context.BlockIndex,
+                            context.BlockIndex,
+                            out var combinationMailFix,
+                            out var itemEnhanceMailFix))
+                    {
+                        if (combinationMailFix != null)
+                        {
+                            avatarState.Update(combinationMailFix);
+                        }
+                        else if (itemEnhanceMailFix != null)
+                        {
+                            avatarState.Update(itemEnhanceMailFix);
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
When we updated the mainnet version from `v230` to `v240`, there were some deployment errors which ended up causing blocks from `#4374157` and `#4377430` to be evaluated differently compared to the canonical chain. I've narrowed down the specific actions (`Buy11`, `CombinationEquipment11`, `HackAndSlashSweep4`, `ItemEnhancement10`, `RankingBattle`, and `RapidCombination6`) causing these problems and added conditions that would allow the execution results to match the canonical chain.