### PR TITLE
Introduce `EventDungeonInfo`

### DIFF
--- a/.Lib9c.Tests/Model/Event/EventDungeonInfoTest.cs
+++ b/.Lib9c.Tests/Model/Event/EventDungeonInfoTest.cs
@@ -1,0 +1,69 @@
+namespace Lib9c.Tests.Model
+{
+    using Nekoyume.Model.Event;
+    using Xunit;
+
+    public class EventDungeonInfoTest
+    {
+        [Fact]
+        public void Serialize()
+        {
+            var eventDungeonClearState = new EventDungeonInfo();
+            eventDungeonClearState.ClearStage(1);
+            var serialized = eventDungeonClearState.Serialize();
+            var deserialized = new EventDungeonInfo(serialized);
+            Assert.Equal(eventDungeonClearState, deserialized);
+            var reSerialized = deserialized.Serialize();
+            Assert.Equal(serialized, reSerialized);
+        }
+
+        [Fact]
+        public void ResetTickets_And_HasTickets()
+        {
+            var eventDungeonClearState = new EventDungeonInfo();
+            eventDungeonClearState.ResetTickets(1);
+            Assert.True(eventDungeonClearState.HasTickets(1));
+            Assert.False(eventDungeonClearState.HasTickets(2));
+            eventDungeonClearState.ResetTickets(2);
+            Assert.True(eventDungeonClearState.HasTickets(1));
+            Assert.True(eventDungeonClearState.HasTickets(2));
+            Assert.False(eventDungeonClearState.HasTickets(3));
+        }
+
+        [Fact]
+        public void ResetTickets_And_TryUseTickets()
+        {
+            var eventDungeonClearState = new EventDungeonInfo();
+            eventDungeonClearState.ResetTickets(1);
+            Assert.True(eventDungeonClearState.TryUseTicket(1));
+            Assert.False(eventDungeonClearState.TryUseTicket(1));
+            eventDungeonClearState.ResetTickets(2);
+            Assert.True(eventDungeonClearState.TryUseTicket(1));
+            Assert.True(eventDungeonClearState.TryUseTicket(1));
+            Assert.False(eventDungeonClearState.TryUseTicket(1));
+            eventDungeonClearState.ResetTickets(3);
+            Assert.True(eventDungeonClearState.TryUseTicket(2));
+            eventDungeonClearState.ResetTickets(3);
+            Assert.True(eventDungeonClearState.TryUseTicket(3));
+            eventDungeonClearState.ResetTickets(3);
+            Assert.False(eventDungeonClearState.TryUseTicket(4));
+        }
+
+        [Fact]
+        public void ClearStage_And_IsCleared()
+        {
+            var eventDungeonClearState = new EventDungeonInfo();
+            eventDungeonClearState.ClearStage(1);
+            Assert.True(eventDungeonClearState.IsCleared(1));
+            Assert.False(eventDungeonClearState.IsCleared(2));
+            eventDungeonClearState.ClearStage(2);
+            Assert.True(eventDungeonClearState.IsCleared(1));
+            Assert.True(eventDungeonClearState.IsCleared(2));
+            Assert.False(eventDungeonClearState.IsCleared(3));
+            eventDungeonClearState.ClearStage(1);
+            Assert.True(eventDungeonClearState.IsCleared(1));
+            Assert.True(eventDungeonClearState.IsCleared(2));
+            Assert.False(eventDungeonClearState.IsCleared(3));
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/Event/EventDungeonInfoTest.cs
+++ b/.Lib9c.Tests/Model/Event/EventDungeonInfoTest.cs
@@ -1,5 +1,6 @@
 namespace Lib9c.Tests.Model
 {
+    using System;
     using Nekoyume.Model.Event;
     using Xunit;
 
@@ -15,6 +16,36 @@ namespace Lib9c.Tests.Model
             Assert.Equal(eventDungeonClearState, deserialized);
             var reSerialized = deserialized.Serialize();
             Assert.Equal(serialized, reSerialized);
+        }
+
+        [Fact]
+        public void ResetTickets_Throw_ArgumentException()
+        {
+            var eventDungeonClearState = new EventDungeonInfo();
+            Assert.Throws<ArgumentException>(() =>
+                eventDungeonClearState.ResetTickets(int.MinValue));
+            Assert.Throws<ArgumentException>(() =>
+                eventDungeonClearState.ResetTickets(-1));
+        }
+
+        [Fact]
+        public void HasTickets_Throw_ArgumentException()
+        {
+            var eventDungeonClearState = new EventDungeonInfo();
+            Assert.Throws<ArgumentException>(() =>
+                eventDungeonClearState.HasTickets(int.MinValue));
+            Assert.Throws<ArgumentException>(() =>
+                eventDungeonClearState.HasTickets(-1));
+        }
+
+        [Fact]
+        public void TryUseTickets_Throw_ArgumentException()
+        {
+            var eventDungeonClearState = new EventDungeonInfo();
+            Assert.Throws<ArgumentException>(() =>
+                eventDungeonClearState.TryUseTickets(int.MinValue));
+            Assert.Throws<ArgumentException>(() =>
+                eventDungeonClearState.TryUseTickets(-1));
         }
 
         [Fact]
@@ -35,18 +66,18 @@ namespace Lib9c.Tests.Model
         {
             var eventDungeonClearState = new EventDungeonInfo();
             eventDungeonClearState.ResetTickets(1);
-            Assert.True(eventDungeonClearState.TryUseTicket(1));
-            Assert.False(eventDungeonClearState.TryUseTicket(1));
+            Assert.True(eventDungeonClearState.TryUseTickets(1));
+            Assert.False(eventDungeonClearState.TryUseTickets(1));
             eventDungeonClearState.ResetTickets(2);
-            Assert.True(eventDungeonClearState.TryUseTicket(1));
-            Assert.True(eventDungeonClearState.TryUseTicket(1));
-            Assert.False(eventDungeonClearState.TryUseTicket(1));
+            Assert.True(eventDungeonClearState.TryUseTickets(1));
+            Assert.True(eventDungeonClearState.TryUseTickets(1));
+            Assert.False(eventDungeonClearState.TryUseTickets(1));
             eventDungeonClearState.ResetTickets(3);
-            Assert.True(eventDungeonClearState.TryUseTicket(2));
+            Assert.True(eventDungeonClearState.TryUseTickets(2));
             eventDungeonClearState.ResetTickets(3);
-            Assert.True(eventDungeonClearState.TryUseTicket(3));
+            Assert.True(eventDungeonClearState.TryUseTickets(3));
             eventDungeonClearState.ResetTickets(3);
-            Assert.False(eventDungeonClearState.TryUseTicket(4));
+            Assert.False(eventDungeonClearState.TryUseTickets(4));
         }
 
         [Fact]

--- a/.Lib9c.Tests/Model/Event/EventDungeonInfoTest.cs
+++ b/.Lib9c.Tests/Model/Event/EventDungeonInfoTest.cs
@@ -18,83 +18,98 @@ namespace Lib9c.Tests.Model
             Assert.Equal(serialized, reSerialized);
         }
 
-        [Fact]
-        public void ResetTickets_Throw_ArgumentException()
+        [Theory]
+        [InlineData(int.MinValue)]
+        [InlineData(-1)]
+        public void ResetTickets_Throw_ArgumentException(int tickets)
         {
             var eventDungeonClearState = new EventDungeonInfo();
             Assert.Throws<ArgumentException>(() =>
-                eventDungeonClearState.ResetTickets(int.MinValue));
-            Assert.Throws<ArgumentException>(() =>
-                eventDungeonClearState.ResetTickets(-1));
+                eventDungeonClearState.ResetTickets(tickets));
         }
 
-        [Fact]
-        public void HasTickets_Throw_ArgumentException()
+        [Theory]
+        [InlineData(int.MinValue)]
+        [InlineData(-1)]
+        public void HasTickets_Throw_ArgumentException(int tickets)
         {
             var eventDungeonClearState = new EventDungeonInfo();
             Assert.Throws<ArgumentException>(() =>
-                eventDungeonClearState.HasTickets(int.MinValue));
-            Assert.Throws<ArgumentException>(() =>
-                eventDungeonClearState.HasTickets(-1));
+                eventDungeonClearState.HasTickets(tickets));
         }
 
-        [Fact]
-        public void TryUseTickets_Throw_ArgumentException()
+        [Theory]
+        [InlineData(int.MinValue)]
+        [InlineData(-1)]
+        public void TryUseTickets_Throw_ArgumentException(int tickets)
         {
             var eventDungeonClearState = new EventDungeonInfo();
             Assert.Throws<ArgumentException>(() =>
-                eventDungeonClearState.TryUseTickets(int.MinValue));
-            Assert.Throws<ArgumentException>(() =>
-                eventDungeonClearState.TryUseTickets(-1));
+                eventDungeonClearState.TryUseTickets(tickets));
         }
 
-        [Fact]
-        public void ResetTickets_And_HasTickets()
+        [Theory]
+        [InlineData(1)]
+        [InlineData(10)]
+        public void ResetTickets_And_HasTickets(int tickets)
         {
             var eventDungeonClearState = new EventDungeonInfo();
-            eventDungeonClearState.ResetTickets(1);
-            Assert.True(eventDungeonClearState.HasTickets(1));
-            Assert.False(eventDungeonClearState.HasTickets(2));
-            eventDungeonClearState.ResetTickets(2);
-            Assert.True(eventDungeonClearState.HasTickets(1));
-            Assert.True(eventDungeonClearState.HasTickets(2));
-            Assert.False(eventDungeonClearState.HasTickets(3));
+            eventDungeonClearState.ResetTickets(tickets);
+            for (var i = 0; i < tickets + 2; i++)
+            {
+                if (i < tickets + 1)
+                {
+                    Assert.True(eventDungeonClearState.HasTickets(i));
+                }
+                else
+                {
+                    Assert.False(eventDungeonClearState.HasTickets(i));
+                }
+            }
         }
 
-        [Fact]
-        public void ResetTickets_And_TryUseTickets()
+        [Theory]
+        [InlineData(1)]
+        [InlineData(10)]
+        public void ResetTickets_And_TryUseTickets(int tickets)
         {
             var eventDungeonClearState = new EventDungeonInfo();
-            eventDungeonClearState.ResetTickets(1);
-            Assert.True(eventDungeonClearState.TryUseTickets(1));
+            eventDungeonClearState.ResetTickets(tickets);
+            for (var i = 0; i < tickets + 1; i++)
+            {
+                if (i < tickets)
+                {
+                    Assert.True(eventDungeonClearState.TryUseTickets(1));
+                }
+                else
+                {
+                    Assert.False(eventDungeonClearState.TryUseTickets(1));
+                }
+            }
+
+            eventDungeonClearState.ResetTickets(tickets);
+            Assert.True(eventDungeonClearState.TryUseTickets(tickets));
             Assert.False(eventDungeonClearState.TryUseTickets(1));
-            eventDungeonClearState.ResetTickets(2);
-            Assert.True(eventDungeonClearState.TryUseTickets(1));
-            Assert.True(eventDungeonClearState.TryUseTickets(1));
-            Assert.False(eventDungeonClearState.TryUseTickets(1));
-            eventDungeonClearState.ResetTickets(3);
-            Assert.True(eventDungeonClearState.TryUseTickets(2));
-            eventDungeonClearState.ResetTickets(3);
-            Assert.True(eventDungeonClearState.TryUseTickets(3));
-            eventDungeonClearState.ResetTickets(3);
-            Assert.False(eventDungeonClearState.TryUseTickets(4));
         }
 
-        [Fact]
-        public void ClearStage_And_IsCleared()
+        [Theory]
+        [InlineData(10010001)]
+        [InlineData(10010010)]
+        public void ClearStage_And_IsCleared(int stageId)
         {
             var eventDungeonClearState = new EventDungeonInfo();
-            eventDungeonClearState.ClearStage(1);
-            Assert.True(eventDungeonClearState.IsCleared(1));
-            Assert.False(eventDungeonClearState.IsCleared(2));
-            eventDungeonClearState.ClearStage(2);
-            Assert.True(eventDungeonClearState.IsCleared(1));
-            Assert.True(eventDungeonClearState.IsCleared(2));
-            Assert.False(eventDungeonClearState.IsCleared(3));
-            eventDungeonClearState.ClearStage(1);
-            Assert.True(eventDungeonClearState.IsCleared(1));
-            Assert.True(eventDungeonClearState.IsCleared(2));
-            Assert.False(eventDungeonClearState.IsCleared(3));
+            eventDungeonClearState.ClearStage(stageId);
+            for (var i = 10010001; i < stageId + 2; i++)
+            {
+                if (i < stageId + 1)
+                {
+                    Assert.True(eventDungeonClearState.IsCleared(i));
+                }
+                else
+                {
+                    Assert.False(eventDungeonClearState.IsCleared(i));
+                }
+            }
         }
     }
 }

--- a/Lib9c/Model/Event/EventDungeonInfo.cs
+++ b/Lib9c/Model/Event/EventDungeonInfo.cs
@@ -40,14 +40,36 @@ namespace Nekoyume.Model.Event
             .Add(_remainingTickets.Serialize())
             .Add(_clearedStageId.Serialize());
 
-        public void ResetTickets(int tickets) =>
-            _remainingTickets = tickets;
-
-        public bool HasTickets(int tickets) =>
-            _remainingTickets >= tickets;
-
-        public bool TryUseTicket(int tickets)
+        public void ResetTickets(int tickets)
         {
+            if (tickets < 0)
+            {
+                throw new ArgumentException(
+                    $"{nameof(tickets)} must be greater than or equal to 0.");
+            }
+
+            _remainingTickets = tickets;
+        }
+
+        public bool HasTickets(int tickets)
+        {
+            if (tickets < 0)
+            {
+                throw new ArgumentException(
+                    $"{nameof(tickets)} must be greater than or equal to 0.");
+            }
+
+            return _remainingTickets >= tickets;
+        }
+
+        public bool TryUseTickets(int tickets)
+        {
+            if (tickets < 0)
+            {
+                throw new ArgumentException(
+                    $"{nameof(tickets)} must be greater than or equal to 0.");
+            }
+
             if (_remainingTickets < tickets)
             {
                 return false;

--- a/Lib9c/Model/Event/EventDungeonInfo.cs
+++ b/Lib9c/Model/Event/EventDungeonInfo.cs
@@ -22,18 +22,15 @@ namespace Nekoyume.Model.Event
             _clearedStageId = 0;
         }
 
-        public EventDungeonInfo(Bencodex.Types.IValue serialized)
+        public EventDungeonInfo(Bencodex.Types.List serialized)
         {
-            if (serialized is Bencodex.Types.List list)
-            {
-                _remainingTickets = list[0].ToInteger();
-                _clearedStageId = list[1].ToInteger();
-            }
-            else
-            {
-                throw new ArgumentException(
-                    $"{nameof(serialized)} must be a {typeof(Bencodex.Types.List).FullName}.");
-            }
+            _remainingTickets = serialized[0].ToInteger();
+            _clearedStageId = serialized[1].ToInteger();
+        }
+
+        public EventDungeonInfo(Bencodex.Types.IValue serialized)
+            : this((Bencodex.Types.List)serialized)
+        {
         }
 
         public IValue Serialize() => Bencodex.Types.List.Empty

--- a/Lib9c/Model/Event/EventDungeonInfo.cs
+++ b/Lib9c/Model/Event/EventDungeonInfo.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using Bencodex.Types;
+using Libplanet;
+using Nekoyume.Action;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Model.Event
+{
+    public class EventDungeonInfo : IState
+    {
+        public static Address DeriveAddress(Address address, int dungeonId)
+        {
+            return address.Derive($"event_dungeon_info_{dungeonId}");
+        }
+
+        private int _remainingTickets;
+        private int _clearedStageId;
+
+        public EventDungeonInfo()
+        {
+            _remainingTickets = 0;
+            _clearedStageId = 0;
+        }
+
+        public EventDungeonInfo(Bencodex.Types.IValue serialized)
+        {
+            if (serialized is Bencodex.Types.List list)
+            {
+                _remainingTickets = list[0].ToInteger();
+                _clearedStageId = list[1].ToInteger();
+            }
+            else
+            {
+                throw new ArgumentException(
+                    $"{nameof(serialized)} must be a {typeof(Bencodex.Types.List).FullName}.");
+            }
+        }
+
+        public IValue Serialize() => Bencodex.Types.List.Empty
+            .Add(_remainingTickets.Serialize())
+            .Add(_clearedStageId.Serialize());
+
+        public void ResetTickets(int tickets) =>
+            _remainingTickets = tickets;
+
+        public bool HasTickets(int tickets) =>
+            _remainingTickets >= tickets;
+
+        public bool TryUseTicket(int tickets)
+        {
+            if (_remainingTickets < tickets)
+            {
+                return false;
+            }
+
+            _remainingTickets -= tickets;
+            return true;
+        }
+
+        public void ClearStage(int stageId)
+        {
+            if (_clearedStageId >= stageId)
+            {
+                return;
+            }
+
+            _clearedStageId = stageId;
+        }
+
+        public bool IsCleared(int stageId) =>
+            _clearedStageId >= stageId;
+
+        protected bool Equals(EventDungeonInfo other)
+        {
+            return _remainingTickets == other._remainingTickets &&
+                   _clearedStageId == other._clearedStageId;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((EventDungeonInfo)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(_remainingTickets, _clearedStageId);
+        }
+    }
+}


### PR DESCRIPTION
The `EventDungeonInfo` class is a model stored at a unique address derived from the address of a specific `AvatarState` and the `Id` of a specific `EventDungeonSheet.Row`.

The `EventDungeonInfo` class stores the number of remaining tickets for a specific event dungeon in a specific `AvatarState`, and the `Id` of the highest cleared `EventDungeonStageSheet.Row` is stored.

Unlike the `WorldInformation` class, the `EventDungeonInfo` class does not validate the game logic deeply. Validation delegates to actions using the `EventDungeonInfo` class, etc.