### PR TITLE
Refactor `StageSimulator` and `MimisbrunnrBattle`

### DIFF
--- a/.Lib9c.Tests/Action/HackAndSlashTest.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashTest.cs
@@ -1177,9 +1177,12 @@
                 new List<Skill>(),
                 worldId,
                 stageId,
+                _tableSheets.StageSheet[stageId],
+                _tableSheets.StageWaveSheet[stageId],
                 false,
                 20,
-                _tableSheets.GetStageSimulatorSheets(),
+                _tableSheets.GetSimulatorSheets(),
+                _tableSheets.EnemySkillSheet,
                 _tableSheets.CostumeStatSheet,
                 1);
             simulator.Simulate(1);

--- a/.Lib9c.Tests/Model/BattleLogTest.cs
+++ b/.Lib9c.Tests/Model/BattleLogTest.cs
@@ -40,9 +40,12 @@ namespace Lib9c.Tests.Model
                 new List<Nekoyume.Model.Skill.Skill>(),
                 1,
                 1,
+                _tableSheets.StageSheet[1],
+                _tableSheets.StageWaveSheet[1],
                 false,
                 20,
-                _tableSheets.GetStageSimulatorSheets(),
+                _tableSheets.GetSimulatorSheets(),
+                _tableSheets.EnemySkillSheet,
                 _tableSheets.CostumeStatSheet,
                 1
             );

--- a/.Lib9c.Tests/Model/PlayerTest.cs
+++ b/.Lib9c.Tests/Model/PlayerTest.cs
@@ -47,9 +47,12 @@ namespace Lib9c.Tests.Model
                 new List<Nekoyume.Model.Skill.Skill>(),
                 1,
                 1,
+                _tableSheets.StageSheet[1],
+                _tableSheets.StageWaveSheet[1],
                 false,
                 20,
-                _tableSheets.GetStageSimulatorSheets(),
+                _tableSheets.GetSimulatorSheets(),
+                _tableSheets.EnemySkillSheet,
                 _tableSheets.CostumeStatSheet,
                 1
             );
@@ -73,9 +76,12 @@ namespace Lib9c.Tests.Model
                 new List<Nekoyume.Model.Skill.Skill>(),
                 1,
                 1,
+                _tableSheets.StageSheet[1],
+                _tableSheets.StageWaveSheet[1],
                 false,
                 20,
-                _tableSheets.GetStageSimulatorSheets(),
+                _tableSheets.GetSimulatorSheets(),
+                _tableSheets.EnemySkillSheet,
                 _tableSheets.CostumeStatSheet,
                 1
             );
@@ -116,9 +122,12 @@ namespace Lib9c.Tests.Model
                 new List<Nekoyume.Model.Skill.Skill>(),
                 1,
                 1,
+                _tableSheets.StageSheet[1],
+                _tableSheets.StageWaveSheet[1],
                 false,
                 20,
-                _tableSheets.GetStageSimulatorSheets(),
+                _tableSheets.GetSimulatorSheets(),
+                _tableSheets.EnemySkillSheet,
                 _tableSheets.CostumeStatSheet,
                 1
             );
@@ -236,9 +245,12 @@ namespace Lib9c.Tests.Model
                 new List<Nekoyume.Model.Skill.Skill>(),
                 1,
                 1,
+                _tableSheets.StageSheet[1],
+                _tableSheets.StageWaveSheet[1],
                 false,
                 20,
-                _tableSheets.GetStageSimulatorSheets(),
+                _tableSheets.GetSimulatorSheets(),
+                _tableSheets.EnemySkillSheet,
                 _tableSheets.CostumeStatSheet,
                 1
             );

--- a/.Lib9c.Tests/Model/Skill/NormalAttackTest.cs
+++ b/.Lib9c.Tests/Model/Skill/NormalAttackTest.cs
@@ -52,9 +52,12 @@ namespace Lib9c.Tests.Model.Skill
                 new List<Nekoyume.Model.Skill.Skill>(),
                 1,
                 1,
+                tableSheets.StageSheet[1],
+                tableSheets.StageWaveSheet[1],
                 false,
                 20,
-                tableSheets.GetStageSimulatorSheets(),
+                tableSheets.GetSimulatorSheets(),
+                tableSheets.EnemySkillSheet,
                 tableSheets.CostumeStatSheet,
                 1
             );

--- a/.Lib9c.Tests/Model/StageSimulatorTest.cs
+++ b/.Lib9c.Tests/Model/StageSimulatorTest.cs
@@ -49,9 +49,12 @@ namespace Lib9c.Tests.Model
                 new List<Nekoyume.Model.Skill.Skill>(),
                 1,
                 1,
+                _tableSheets.StageSheet[1],
+                _tableSheets.StageWaveSheet[1],
                 false,
                 20,
-                _tableSheets.GetStageSimulatorSheets(),
+                _tableSheets.GetSimulatorSheets(),
+                _tableSheets.EnemySkillSheet,
                 _tableSheets.CostumeStatSheet,
                 1);
 

--- a/.Lib9c.Tests/TableSheets.cs
+++ b/.Lib9c.Tests/TableSheets.cs
@@ -182,6 +182,19 @@ namespace Lib9c.Tests
             QuestSheet.Set(CombinationEquipmentQuestSheet);
         }
 
+        public SimulatorSheets GetSimulatorSheets()
+        {
+            return new SimulatorSheets(
+                MaterialItemSheet,
+                SkillSheet,
+                SkillBuffSheet,
+                BuffSheet,
+                CharacterSheet,
+                CharacterLevelSheet,
+                EquipmentItemSetEffectSheet
+            );
+        }
+
         public StageSimulatorSheets GetStageSimulatorSheets()
         {
             return new StageSimulatorSheets(

--- a/Lib9c/Action/AccountStateDeltaExtensions.cs
+++ b/Lib9c/Action/AccountStateDeltaExtensions.cs
@@ -527,6 +527,7 @@ namespace Nekoyume.Action
             bool containAvatarSheets = false,
             bool containItemSheet = false,
             bool containQuestSheet = false,
+            bool containSimulatorSheets = false,
             bool containStageSimulatorSheets = false,
             bool containRankingSimulatorSheets = false,
             bool containArenaSimulatorSheets = false,
@@ -565,6 +566,17 @@ namespace Nekoyume.Action
                 sheetTypeList.Add(typeof(ItemTypeCollectQuestSheet));
                 sheetTypeList.Add(typeof(GoldQuestSheet));
                 sheetTypeList.Add(typeof(CombinationEquipmentQuestSheet));
+            }
+
+            if (containSimulatorSheets)
+            {
+                sheetTypeList.Add(typeof(MaterialItemSheet));
+                sheetTypeList.Add(typeof(SkillSheet));
+                sheetTypeList.Add(typeof(SkillBuffSheet));
+                sheetTypeList.Add(typeof(BuffSheet));
+                sheetTypeList.Add(typeof(CharacterSheet));
+                sheetTypeList.Add(typeof(CharacterLevelSheet));
+                sheetTypeList.Add(typeof(EquipmentItemSetEffectSheet));
             }
 
             if (containStageSimulatorSheets)

--- a/Lib9c/Action/HackAndSlash.cs
+++ b/Lib9c/Action/HackAndSlash.cs
@@ -125,16 +125,18 @@ namespace Nekoyume.Action
             sw.Restart();
             var sheets = states.GetSheets(
                 containQuestSheet: true,
-                containStageSimulatorSheets: true,
+                containSimulatorSheets: true,
                 sheetTypes: new[]
                 {
                     typeof(WorldSheet),
                     typeof(StageSheet),
+                    typeof(StageWaveSheet),
+                    typeof(EnemySkillSheet),
+                    typeof(CostumeStatSheet),
                     typeof(SkillSheet),
                     typeof(QuestRewardSheet),
                     typeof(QuestItemRewardSheet),
                     typeof(EquipmentItemRecipeSheet),
-                    typeof(CostumeStatSheet),
                     typeof(WorldUnlockSheet),
                     typeof(MaterialItemSheet),
                     typeof(ItemRequirementSheet),
@@ -244,9 +246,12 @@ namespace Nekoyume.Action
                     i == 0 ? skillsOnWaveStart : new List<Skill>(),
                     WorldId,
                     StageId,
+                    sheets.GetSheet<StageSheet>()[StageId],
+                    sheets.GetSheet<StageWaveSheet>()[StageId],
                     avatarState.worldInformation.IsStageCleared(StageId),
                     StageRewardExpHelper.GetExp(avatarState.level, StageId),
-                    sheets.GetStageSimulatorSheets(),
+                    sheets.GetSimulatorSheets(),
+                    sheets.GetSheet<EnemySkillSheet>(),
                     sheets.GetSheet<CostumeStatSheet>(),
                     1);
                 sw.Stop();

--- a/Lib9c/Action/HackAndSlash.cs
+++ b/Lib9c/Action/HackAndSlash.cs
@@ -21,6 +21,7 @@ namespace Nekoyume.Action
     /// <summary>
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1229
     /// Updated at https://github.com/planetarium/lib9c/pull/1241
+    /// Updated at https://github.com/planetarium/lib9c/pull/1244
     /// </summary>
     [Serializable]
     [ActionType("hack_and_slash16")]

--- a/Lib9c/Action/MimisbrunnrBattle.cs
+++ b/Lib9c/Action/MimisbrunnrBattle.cs
@@ -19,6 +19,7 @@ namespace Nekoyume.Action
 {
     /// <summary>
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1241
+    /// Updated at https://github.com/planetarium/lib9c/pull/1244
     /// </summary>
     [Serializable]
     [ActionType("mimisbrunnr_battle10")]

--- a/Lib9c/Action/MimisbrunnrBattle.cs
+++ b/Lib9c/Action/MimisbrunnrBattle.cs
@@ -111,7 +111,10 @@ namespace Nekoyume.Action
                     typeof(MaterialItemSheet),
                 });
             sw.Stop();
-            Log.Verbose("{AddressesHex}HAS Get Sheets: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Verbose(
+                "{AddressesHex}Get Sheets: {Elapsed}",
+                addressesHex,
+                sw.Elapsed);
 
             sw.Restart();
             var worldSheet = sheets.GetSheet<WorldSheet>();

--- a/Lib9c/Action/MimisbrunnrBattle.cs
+++ b/Lib9c/Action/MimisbrunnrBattle.cs
@@ -131,8 +131,7 @@ namespace Nekoyume.Action
                     $" {worldRow.StageBegin}-{worldRow.StageEnd}");
             }
 
-            var stageSheet = sheets.GetSheet<StageSheet>();
-            if (!stageSheet.TryGetValue(stageId, out var stageRow))
+            if (!sheets.GetSheet<StageSheet>().TryGetValue(stageId, out var stageRow))
             {
                 throw new SheetRowNotFoundException(addressesHex, nameof(StageSheet), stageId);
             }
@@ -265,7 +264,6 @@ namespace Nekoyume.Action
                 sw.Elapsed);
 
             sw.Restart();
-            sheets.GetSheet<StageWaveSheet>().TryGetValue(stageId, out var stageWaveRow, true);
             var simulator = new StageSimulator(
                 context.Random,
                 avatarState,

--- a/Lib9c/Battle/StageSimulator.cs
+++ b/Lib9c/Battle/StageSimulator.cs
@@ -38,16 +38,19 @@ namespace Nekoyume.Battle
             List<Model.Skill.Skill> skillsOnWaveStart,
             int worldId,
             int stageId,
+            StageSheet.Row stageRow,
+            StageWaveSheet.Row stageWaveRow,
             bool isCleared,
             int exp,
-            StageSimulatorSheets stageSimulatorSheets,
+            SimulatorSheets simulatorSheets,
+            EnemySkillSheet enemySkillSheet,
             CostumeStatSheet costumeStatSheet,
             int playCount)
             : base(
                 random,
                 avatarState,
                 foods,
-                stageSimulatorSheets)
+                simulatorSheets)
         {
             Player.SetCostumeStat(costumeStatSheet);
 
@@ -57,17 +60,9 @@ namespace Nekoyume.Battle
             StageId = stageId;
             IsCleared = isCleared;
             Exp = exp;
-            EnemySkillSheet = stageSimulatorSheets.EnemySkillSheet;
-            stageSimulatorSheets.StageSheet.TryGetValue(
-                StageId,
-                out var stageRow,
-                true);
+            EnemySkillSheet = enemySkillSheet;
             TurnLimit = stageRow.TurnLimit;
 
-            stageSimulatorSheets.StageWaveSheet.TryGetValue(
-                StageId,
-                out var stageWaveRow,
-                true);
             SetWave(stageRow, stageWaveRow);
 
             var maxCountForItemDrop = Random.Next(

--- a/Lib9c/Extensions/SheetsExtensions.cs
+++ b/Lib9c/Extensions/SheetsExtensions.cs
@@ -162,6 +162,20 @@ namespace Nekoyume.Extensions
             return questSheet;
         }
 
+        public static SimulatorSheets GetSimulatorSheets(
+            this Dictionary<Type, (Address address, ISheet sheet)> sheets)
+        {
+            return new SimulatorSheets(
+                sheets.GetSheet<MaterialItemSheet>(),
+                sheets.GetSheet<SkillSheet>(),
+                sheets.GetSheet<SkillBuffSheet>(),
+                sheets.GetSheet<BuffSheet>(),
+                sheets.GetSheet<CharacterSheet>(),
+                sheets.GetSheet<CharacterLevelSheet>(),
+                sheets.GetSheet<EquipmentItemSetEffectSheet>()
+            );
+        }
+
         public static StageSimulatorSheets GetStageSimulatorSheets(
             this Dictionary<Type, (Address address, ISheet sheet)> sheets)
         {

--- a/Lib9c/TableData/SimulatorSheets.cs
+++ b/Lib9c/TableData/SimulatorSheets.cs
@@ -1,6 +1,6 @@
 namespace Nekoyume.TableData
 {
-    public abstract class SimulatorSheets
+    public class SimulatorSheets
     {
         public readonly MaterialItemSheet MaterialItemSheet;
         public readonly SkillSheet SkillSheet;
@@ -10,7 +10,7 @@ namespace Nekoyume.TableData
         public readonly CharacterLevelSheet CharacterLevelSheet;
         public readonly EquipmentItemSetEffectSheet EquipmentItemSetEffectSheet;
 
-        protected SimulatorSheets(
+        public SimulatorSheets(
             MaterialItemSheet materialItemSheet,
             SkillSheet skillSheet,
             SkillBuffSheet skillBuffSheet,


### PR DESCRIPTION
This pull request contains changes of `HackAndSlash`(15) and `MimisbrunnrBattle`(10). But these actions are not deployed yet. So do not upgrade these actions.

- Inject `StageSheet.Row` and `StageWaveSheet.Row` as arguments of `StageSimulator`'s constructor.
- Update `SimulatorSheets` to not be abstract
- Apply changes of `StageSimulator` to `HackAndSlash`(15) and `MimisbrunnrBattle`(10)
- Use `IAccountStateDelta.GetSheets()` on `MimisbrunnrBattle`(10)
