### PR TITLE
Correct `Stake` action

### DIFF
--- a/.Lib9c.Tests/Action/Stake0Test.cs
+++ b/.Lib9c.Tests/Action/Stake0Test.cs
@@ -1,0 +1,255 @@
+namespace Lib9c.Tests.Action
+{
+    using System;
+    using System.Linq;
+    using Bencodex.Types;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Assets;
+    using Libplanet.Crypto;
+    using Nekoyume;
+    using Nekoyume.Action;
+    using Nekoyume.Model.State;
+    using Nekoyume.TableData;
+    using Serilog;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class Stake0Test
+    {
+        private readonly IAccountStateDelta _initialState;
+        private readonly Currency _currency;
+        private readonly GoldCurrencyState _goldCurrencyState;
+        private readonly TableSheets _tableSheets;
+        private readonly Address _signerAddress;
+
+        public Stake0Test(ITestOutputHelper outputHelper)
+        {
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.TestOutput(outputHelper)
+                .CreateLogger();
+
+            _initialState = new State();
+
+            var sheets = TableSheetsImporter.ImportSheets();
+            foreach (var (key, value) in sheets)
+            {
+                _initialState = _initialState
+                    .SetState(Addresses.TableSheet.Derive(key), value.Serialize());
+            }
+
+            _tableSheets = new TableSheets(sheets);
+
+            _currency = new Currency("NCG", 2, minters: null);
+            _goldCurrencyState = new GoldCurrencyState(_currency);
+
+            _signerAddress = new PrivateKey().ToAddress();
+            _initialState = _initialState
+                .SetState(GoldCurrencyState.Address, _goldCurrencyState.Serialize())
+                .MintAsset(_signerAddress, _currency * 100);
+        }
+
+        [Fact]
+        public void Execute_Throws_WhenNotEnoughBalance()
+        {
+            var action = new Stake0(200);
+            Assert.Throws<NotEnoughFungibleAssetValueException>(() =>
+                action.Execute(new ActionContext
+                {
+                    PreviousStates = _initialState,
+                    Signer = _signerAddress,
+                    BlockIndex = 100,
+                }));
+        }
+
+        [Fact]
+        public void Execute_Throws_WhenThereIsMonsterCollection()
+        {
+            Address monsterCollectionAddress =
+                MonsterCollectionState.DeriveAddress(_signerAddress, 0);
+            var agentState = new AgentState(_signerAddress)
+            {
+                avatarAddresses = { [0] = new PrivateKey().ToAddress(), },
+            };
+            var states = _initialState
+                .SetState(_signerAddress, agentState.Serialize())
+                .SetState(
+                    monsterCollectionAddress,
+                    new MonsterCollectionState(monsterCollectionAddress, 1, 0).SerializeV2());
+            var action = new Stake0(200);
+            Assert.Throws<MonsterCollectionExistingException>(() =>
+                action.Execute(new ActionContext
+                {
+                    PreviousStates = states,
+                    Signer = _signerAddress,
+                    BlockIndex = 100,
+                }));
+        }
+
+        [Fact]
+        public void Execute_Throws_WhenClaimableExisting()
+        {
+            Address stakeStateAddress = StakeState.DeriveAddress(_signerAddress);
+            var states = _initialState
+                .SetState(stakeStateAddress, new StakeState(stakeStateAddress, 0).Serialize())
+                .MintAsset(stakeStateAddress, _currency * 50);
+            var action = new Stake0(100);
+            Assert.Throws<StakeExistingClaimableException>(() =>
+                action.Execute(new ActionContext
+                {
+                    PreviousStates = states,
+                    Signer = _signerAddress,
+                    BlockIndex = StakeState.RewardInterval,
+                }));
+        }
+
+        [Fact]
+        public void Execute_Throws_WhenCancelOrUpdateWhileLockup()
+        {
+            var action = new Stake0(51);
+            var states = action.Execute(new ActionContext
+            {
+                PreviousStates = _initialState,
+                Signer = _signerAddress,
+                BlockIndex = 0,
+            });
+
+            // Cancel
+            var updateAction = new Stake0(0);
+            Assert.Throws<RequiredBlockIndexException>(() => updateAction.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _signerAddress,
+                BlockIndex = 1,
+            }));
+
+            // Less
+            updateAction = new Stake0(50);
+            Assert.Throws<RequiredBlockIndexException>(() => updateAction.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _signerAddress,
+                BlockIndex = 1,
+            }));
+
+            // Same (since 4611070)
+            if (states.TryGetStakeState(_signerAddress, out StakeState stakeState))
+            {
+                states = states.SetState(
+                    stakeState.address,
+                    new StakeState(stakeState.address, 4611070 - 100).Serialize());
+            }
+
+            updateAction = new Stake0(51);
+            Assert.Throws<RequiredBlockIndexException>(() => updateAction.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _signerAddress,
+                BlockIndex = 4611070,
+            }));
+
+            // At 4611070 - 99, it should be updated.
+            Assert.True(updateAction.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _signerAddress,
+                BlockIndex = 4611070 - 99,
+            }).TryGetStakeState(_signerAddress, out stakeState));
+            Assert.Equal(4611070 - 99, stakeState.StartedBlockIndex);
+        }
+
+        [Fact]
+        public void Execute()
+        {
+            var action = new Stake0(100);
+            var states = action.Execute(new ActionContext
+            {
+                PreviousStates = _initialState,
+                Signer = _signerAddress,
+                BlockIndex = 0,
+            });
+
+            Assert.Equal(_currency * 0, states.GetBalance(_signerAddress, _currency));
+            Assert.Equal(
+                _currency * 100,
+                states.GetBalance(StakeState.DeriveAddress(_signerAddress), _currency));
+
+            states.TryGetStakeState(_signerAddress, out StakeState stakeState);
+            Assert.Equal(0, stakeState.StartedBlockIndex);
+            Assert.Equal(0 + StakeState.LockupInterval, stakeState.CancellableBlockIndex);
+            Assert.Equal(0, stakeState.ReceivedBlockIndex);
+            Assert.Equal(_currency * 100, states.GetBalance(stakeState.address, _currency));
+            Assert.Equal(_currency * 0, states.GetBalance(_signerAddress, _currency));
+
+            var achievements = stakeState.Achievements;
+            Assert.False(achievements.Check(0, 0));
+            Assert.False(achievements.Check(0, 1));
+            Assert.False(achievements.Check(1, 0));
+
+            StakeState producedStakeState = new StakeState(
+                stakeState.address,
+                stakeState.StartedBlockIndex,
+                // Produce a situation that it already received rewards.
+                StakeState.LockupInterval - 1,
+                stakeState.CancellableBlockIndex,
+                stakeState.Achievements);
+            states = states.SetState(stakeState.address, producedStakeState.SerializeV2());
+            var cancelAction = new Stake0(0);
+            states = cancelAction.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _signerAddress,
+                BlockIndex = StakeState.LockupInterval,
+            });
+
+            Assert.Equal(Null.Value, states.GetState(stakeState.address));
+            Assert.Equal(_currency * 0, states.GetBalance(stakeState.address, _currency));
+            Assert.Equal(_currency * 100, states.GetBalance(_signerAddress, _currency));
+        }
+
+        [Fact]
+        public void Update()
+        {
+            var action = new Stake0(50);
+            var states = action.Execute(new ActionContext
+            {
+                PreviousStates = _initialState,
+                Signer = _signerAddress,
+                BlockIndex = 0,
+            });
+
+            states.TryGetStakeState(_signerAddress, out StakeState stakeState);
+            Assert.Equal(0, stakeState.StartedBlockIndex);
+            Assert.Equal(0 + StakeState.LockupInterval, stakeState.CancellableBlockIndex);
+            Assert.Equal(0, stakeState.ReceivedBlockIndex);
+            Assert.Equal(_currency * 50, states.GetBalance(stakeState.address, _currency));
+            Assert.Equal(_currency * 50, states.GetBalance(_signerAddress, _currency));
+
+            var updateAction = new Stake0(100);
+            states = updateAction.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _signerAddress,
+                BlockIndex = 1,
+            });
+
+            states.TryGetStakeState(_signerAddress, out stakeState);
+            Assert.Equal(1, stakeState.StartedBlockIndex);
+            Assert.Equal(1 + StakeState.LockupInterval, stakeState.CancellableBlockIndex);
+            Assert.Equal(0, stakeState.ReceivedBlockIndex);
+            Assert.Equal(_currency * 100, states.GetBalance(stakeState.address, _currency));
+            Assert.Equal(_currency * 0, states.GetBalance(_signerAddress, _currency));
+        }
+
+        [Fact]
+        public void Serialization()
+        {
+            var action = new Stake0(100);
+            var deserialized = new Stake0();
+            deserialized.LoadPlainValue(action.PlainValue);
+
+            Assert.Equal(action.Amount, deserialized.Amount);
+        }
+    }
+}

--- a/Lib9c/Action/Stake.cs
+++ b/Lib9c/Action/Stake.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
@@ -13,7 +14,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [ActionType("stake2")]
-    public class Stake : ActionBase
+    public class Stake : GameAction
     {
         internal BigInteger Amount { get; set; }
 
@@ -28,13 +29,12 @@ namespace Nekoyume.Action
         {
         }
 
-        public override IValue PlainValue =>
-            Dictionary.Empty.Add(AmountKey, (IValue) (Integer) Amount);
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            ImmutableDictionary<string, IValue>.Empty.Add(AmountKey, (IValue) (Integer) Amount);
 
-        public override void LoadPlainValue(IValue plainValue)
+        protected override void LoadPlainValueInternal(IImmutableDictionary<string, IValue> plainValue)
         {
-            var dictionary = (Dictionary) plainValue;
-            Amount = dictionary[AmountKey].ToBigInteger();
+            Amount = plainValue[AmountKey].ToBigInteger();
         }
 
         public override IAccountStateDelta Execute(IActionContext context)

--- a/Lib9c/Action/Stake.cs
+++ b/Lib9c/Action/Stake.cs
@@ -87,8 +87,6 @@ namespace Nekoyume.Action
             // Stake if it doesn't exist yet.
             if (!states.TryGetStakeState(context.Signer, out StakeState stakeState))
             {
-                var stakeAchievementRewardSheet = states.GetSheet<StakeAchievementRewardSheet>();
-
                 stakeState = new StakeState(stakeStateAddress, context.BlockIndex);
                 return states
                     .SetState(

--- a/Lib9c/Action/Stake.cs
+++ b/Lib9c/Action/Stake.cs
@@ -87,6 +87,8 @@ namespace Nekoyume.Action
             // Stake if it doesn't exist yet.
             if (!states.TryGetStakeState(context.Signer, out StakeState stakeState))
             {
+                var stakeAchievementRewardSheet = states.GetSheet<StakeAchievementRewardSheet>();
+
                 stakeState = new StakeState(stakeStateAddress, context.BlockIndex);
                 return states
                     .SetState(

--- a/Lib9c/Action/Stake0.cs
+++ b/Lib9c/Action/Stake0.cs
@@ -12,19 +12,19 @@ using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Action
 {
-    [ActionType("stake2")]
-    public class Stake : ActionBase
+    [ActionType("stake")]
+    public class Stake0 : ActionBase
     {
         internal BigInteger Amount { get; set; }
 
-        public Stake(BigInteger amount)
+        public Stake0(BigInteger amount)
         {
             Amount = amount >= 0
                 ? amount
                 : throw new ArgumentOutOfRangeException(nameof(amount));
         }
 
-        public Stake()
+        public Stake0()
         {
         }
 


### PR DESCRIPTION
This pull request does:

 - Correct `stake` action.
 - Introduce a new action called `stake2` to continue `stake`.
   - `stake2` action became `GameAction` now.
 
You can review it through commits because they have a commit to copy files.