### PR TITLE
Fix dependecny conflict in headless

### DIFF
--- a/.Lib9c.Tests/Lib9c.Tests.csproj
+++ b/.Lib9c.Tests/Lib9c.Tests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="DiffPlex" Version="1.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
-    <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />
+    <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />


### PR DESCRIPTION
- Update depedency for avoid version conflict.
https://github.com/planetarium/NineChronicles.Headless/runs/7758859828?check_suite_focus=true