### PR TITLE
Introduce `Lib9c.Tools action list`

### DIFF
--- a/.Lib9c.Tools/Program.cs
+++ b/.Lib9c.Tools/Program.cs
@@ -7,6 +7,7 @@ namespace Lib9c.Tools
     [HasSubCommands(typeof(Market), Description = "Query about market.")]
     [HasSubCommands(typeof(State), Description = "Manage states.")]
     [HasSubCommands(typeof(Tx), Description = "Manage transactions.")]
+    [HasSubCommands(typeof(Action), Description = "Gets metadata of actions.")]
     class Program
     {
         static void Main(string[] args) => CoconaLiteApp.Run<Program>(args);

--- a/.Lib9c.Tools/Program.cs
+++ b/.Lib9c.Tools/Program.cs
@@ -7,7 +7,7 @@ namespace Lib9c.Tools
     [HasSubCommands(typeof(Market), Description = "Query about market.")]
     [HasSubCommands(typeof(State), Description = "Manage states.")]
     [HasSubCommands(typeof(Tx), Description = "Manage transactions.")]
-    [HasSubCommands(typeof(Action), Description = "Gets metadata of actions.")]
+    [HasSubCommands(typeof(Action), Description = "Get metadata of actions.")]
     class Program
     {
         static void Main(string[] args) => CoconaLiteApp.Run<Program>(args);

--- a/.Lib9c.Tools/SubCommand/Action.cs
+++ b/.Lib9c.Tools/SubCommand/Action.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Cocona;
+using Cocona.Help;
+using Libplanet.Action;
+using Nekoyume.Action;
+
+namespace Lib9c.Tools.SubCommand
+{
+    public class Action
+    {
+        [Command(Description = "Lists all actions' type ids.")]
+        public void List(
+            [Option(
+                Description = "If true, filter obsoleted actions since the --block-index option."
+            )] bool excludeObsolete = false,
+            [Option(
+                Description = "The current block index to filter obsoleted actions."
+            )] long blockIndex = 0
+        )
+        {
+            Type baseType = typeof(Nekoyume.Action.ActionBase);
+            Type attrType = typeof(ActionTypeAttribute);
+            Type obsoleteType = typeof(ActionObsoleteAttribute);
+
+            bool IsTarget(Type type)
+            {
+                return baseType.IsAssignableFrom(type) &&
+                    type.IsDefined(attrType) &&
+                    ActionTypeAttribute.ValueOf(type) is { } &&
+                    (
+                        !excludeObsolete ||
+                        !type.IsDefined(obsoleteType) ||
+                        type
+                            .GetCustomAttributes()
+                            .OfType<ActionObsoleteAttribute>()
+                            .Select(attr => attr.ObsoleteIndex)
+                            .FirstOrDefault() > blockIndex
+                    );
+            }
+
+            var assembly = baseType.Assembly;
+            var typeIds = assembly.GetTypes()
+                .Where(IsTarget)
+                .Select(type => ActionTypeAttribute.ValueOf(type))
+                .OrderBy(type => type);
+
+            foreach (string typeId in typeIds) {
+                Console.WriteLine(typeId);
+            }
+        }
+
+        [PrimaryCommand]
+        public void Help([FromService] ICoconaHelpMessageBuilder helpMessageBuilder)
+        {
+            Console.Error.WriteLine(helpMessageBuilder.BuildAndRenderForCurrentContext());
+        }
+    }
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: true
     - name: Check if a new tag refers a merge commit
       if: github.ref_type == 'tag'
       run: |
@@ -78,6 +80,20 @@ jobs:
         targets: |
           ${{ github.repository_owner }}/NineChronicles:rc-${{ github.ref_name }}?
           ${{ github.repository_owner }}/NineChronicles.Headless:rc-${{ github.ref_name }}?
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.100
+    - name: Collect available action type ids
+      run: |
+        mkdir publish
+        dotnet run --project .Lib9c.Tools/Lib9c.Tools.csproj -- action list > publish/all_action_type_ids.txt
+    - name: Publish available action type ids
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./publish
+        destination_dir: ${{ github.ref_name }}
 
   update-submodule:
     if: github.ref_type == 'branch' && startsWith(github.ref_name, 'rc-v')


### PR DESCRIPTION
This pull request resolves #1279 

This pull request does:

 - Introduce `Lib9c.Tools action list` command.
 - Publish `all_action_type_ids.txt` for every `v` release tag pushed.
   - You can see the example at https://github.com/moreal/lib9c/blob/gh-pages/vtt/all_action_type_ids.txt