### PR TITLE
Upgrade Libplanet and follow up API changes related to native tokens and system actions

### DIFF
--- a/.Lib9c.Tests/Action/ActionContext.cs
+++ b/.Lib9c.Tests/Action/ActionContext.cs
@@ -3,11 +3,14 @@ namespace Lib9c.Tests.Action
     using System.Security.Cryptography;
     using Libplanet;
     using Libplanet.Action;
+    using Libplanet.Assets;
     using Libplanet.Blocks;
     using Libplanet.Tx;
 
     public class ActionContext : IActionContext
     {
+        public BlockHash? GenesisHash { get; set; }
+
         public Address Signer { get; set; }
 
         public TxId? TxId { get; set; }
@@ -27,6 +30,8 @@ namespace Lib9c.Tests.Action
         public HashDigest<SHA256>? PreviousStateRootHash { get; set; }
 
         public bool BlockAction { get; }
+
+        public bool IsNativeToken(Currency currency) => false;
 
         public IActionContext GetUnconsumedContext()
         {

--- a/.Lib9c.Tools/SubCommand/Market.cs
+++ b/.Lib9c.Tools/SubCommand/Market.cs
@@ -101,7 +101,9 @@ namespace Lib9c.Tools.SubCommand
                     .Where(tx => includeFails ||
                         !(chain.GetTxExecution(block.Hash, tx.Id) is { } e) ||
                         e is TxSuccess)
-                    .SelectMany(tx => tx.Actions.Reverse().Select(a => (tx, a)));
+                    .SelectMany(tx => tx.CustomActions is { } ca
+                        ? ca.Reverse().Select(a => (tx, a))
+                        : Enumerable.Empty<(Transaction<NCAction>, NCAction)>());
 
                 foreach (var (tx, act) in actions)
                 {

--- a/.Lib9c.Tools/SubCommand/State.cs
+++ b/.Lib9c.Tools/SubCommand/State.cs
@@ -114,7 +114,11 @@ namespace Lib9c.Tools.SubCommand
                 );
                 IImmutableDictionary<string, IValue> delta;
                 HashDigest<SHA256> stateRootHash = block.Index < 1
-                    ? preEvalBlock.DetermineStateRootHash(chain.Policy.BlockAction, stateStore, out delta)
+                    ? preEvalBlock.DetermineStateRootHash(
+                        policy.BlockAction,
+                        policy.NativeTokens.Contains,
+                        stateStore,
+                        out delta)
                     : preEvalBlock.DetermineStateRootHash(
                         chain,
                         StateCompleterSet<NCAction>.Reject,

--- a/.Lib9c.Tools/SubCommand/Tx.cs
+++ b/.Lib9c.Tools/SubCommand/Tx.cs
@@ -12,11 +12,9 @@ using Nekoyume.Model;
 using Nekoyume.Model.State;
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using Libplanet.Action;
 using Nekoyume.TableData;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
@@ -38,7 +36,7 @@ namespace Lib9c.Tools.SubCommand
             var genesisDict = (Bencodex.Types.Dictionary)_codec.Decode(genesisBytes);
             IReadOnlyList<Transaction<NCAction>> genesisTxs =
                 BlockMarshaler.UnmarshalBlockTransactions<NCAction>(genesisDict);
-            var initStates = (InitializeStates)genesisTxs.Single().Actions.Single().InnerAction;
+            var initStates = (InitializeStates)genesisTxs.Single().CustomActions!.Single().InnerAction;
             Currency currency = new GoldCurrencyState(initStates.GoldCurrency).Currency;
 
             var action = new TransferAsset(
@@ -107,7 +105,7 @@ namespace Lib9c.Tools.SubCommand
                 privateKey: new PrivateKey(ByteUtil.ParseHex(privateKey)),
                 genesisHash: (genesisHash is null) ? default : BlockHash.FromString(genesisHash),
                 timestamp: (timestamp is null) ? default : DateTimeOffset.Parse(timestamp),
-                actions: parsedActions
+                customActions: parsedActions
             );
             byte[] raw = tx.Serialize(true);
 

--- a/Lib9c/Policy/BlockPolicySource.Utils.cs
+++ b/Lib9c/Policy/BlockPolicySource.Utils.cs
@@ -16,9 +16,9 @@ namespace Nekoyume.BlockChain.Policy
     // Collection of helper methods not directly used as a pluggable component.
     public partial class BlockPolicySource
     {
-        internal static bool IsObsolete(Transaction<NCAction> transaction, long blockIndex)
-        {
-            return transaction.Actions
+        internal static bool IsObsolete(Transaction<NCAction> transaction, long blockIndex) =>
+            transaction.CustomActions is { } customActions &&
+            customActions
                 .Select(action => action.InnerAction.GetType())
                 .Any(
                     at =>
@@ -27,7 +27,6 @@ namespace Nekoyume.BlockChain.Policy
                         .OfType<ActionObsoleteAttribute>()
                         .FirstOrDefault()?.ObsoleteIndex < blockIndex
                 );
-        }
 
         internal static bool IsAdminTransaction(
             BlockChain<NCAction> blockChain, Transaction<NCAction> transaction)

--- a/Lib9c/Policy/BlockPolicySource.cs
+++ b/Lib9c/Policy/BlockPolicySource.cs
@@ -332,8 +332,9 @@ namespace Nekoyume.BlockChain.Policy
                 }
 
                 // Check ActivateAccount
-                if (transaction.Actions.Count == 1 &&
-                    transaction.Actions.First().InnerAction is IActivateAction aa)
+                if (transaction.CustomActions is { } customActions &&
+                    customActions.Count == 1 &&
+                    customActions.First().InnerAction is IActivateAction aa)
                 {
                     return transaction.Nonce == 0 &&
                         blockChain.GetState(aa.GetPendingAddress()) is Dictionary rawPending &&

--- a/Lib9c/Policy/DebugPolicy.cs
+++ b/Lib9c/Policy/DebugPolicy.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Security.Cryptography;
 using Libplanet;
 using Libplanet.Action;
+using Libplanet.Assets;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blocks;
@@ -52,5 +54,7 @@ namespace Nekoyume.BlockChain.Policy
         public int GetMaxTransactionsPerBlock(long index) => int.MaxValue;
 
         public int GetMaxTransactionsPerSignerPerBlock(long index) => int.MaxValue;
+
+        public IImmutableSet<Currency> NativeTokens => ImmutableHashSet<Currency>.Empty;
     }
 }


### PR DESCRIPTION
As [Libplanet recently introduced native tokens and system actions][1], Lib9c also needs to follow up these changes.  It's also a preparation for adopting Libplanet 0.40.0.

[1]: https://github.com/planetarium/libplanet/pull/2175