### PR TITLE
Upgrade Libplanet and incorporate Currency API changes

### DIFF
--- a/.Lib9c.Tests/Action/ActionContextExtensionsTest.cs
+++ b/.Lib9c.Tests/Action/ActionContextExtensionsTest.cs
@@ -17,44 +17,62 @@ namespace Lib9c.Tests.Action
             yield return new object[]
             {
                 new GoldCurrencyState(
-                    new Currency("NCG", 2, new Address("47d082a115c63e7b58b1532d20e631538eafadde"))),
+#pragma warning disable CS0618
+                    // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                    Currency.Legacy("NCG", 2, new Address("47d082a115c63e7b58b1532d20e631538eafadde"))),
+#pragma warning restore CS0618
                 true,
             };
 
             yield return new object[]
             {
                 new GoldCurrencyState(
-                    new Currency("NCG", 18, new Address("47d082a115c63e7b58b1532d20e631538eafadde"))),
+#pragma warning disable CS0618
+                    // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                    Currency.Legacy("NCG", 18, new Address("47d082a115c63e7b58b1532d20e631538eafadde"))),
+#pragma warning restore CS0618
                 false,
             };
 
             yield return new object[]
             {
                 new GoldCurrencyState(
-                    new Currency("NCG", 2, new PrivateKey().ToAddress())),
+#pragma warning disable CS0618
+                    // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                    Currency.Legacy("NCG", 2, new PrivateKey().ToAddress())),
+#pragma warning restore CS0618
                 false,
             };
 
             yield return new object[]
             {
                 new GoldCurrencyState(
-                    new Currency("ETH", 2, new Address("47d082a115c63e7b58b1532d20e631538eafadde"))),
+#pragma warning disable CS0618
+                    // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                    Currency.Legacy("ETH", 2, new Address("47d082a115c63e7b58b1532d20e631538eafadde"))),
+#pragma warning restore CS0618
                 false,
             };
 
             yield return new object[]
             {
                 new GoldCurrencyState(
-                    new Currency("BTC", 18, new Address("47d082a115c63e7b58b1532d20e631538eafadde"))),
+#pragma warning disable CS0618
+                    // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                    Currency.Legacy("BTC", 18, new Address("47d082a115c63e7b58b1532d20e631538eafadde"))),
+#pragma warning restore CS0618
                 false,
             };
 
             yield return new object[]
             {
                 new GoldCurrencyState(
-                    new Currency("BTC", 2, new Address("47d082a115c63e7b58b1532d20e631538eafadde"))),
+#pragma warning disable CS0618
+                    // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                    Currency.Legacy("BTC", 2, new Address("47d082a115c63e7b58b1532d20e631538eafadde"))),
                 false,
             };
+            #pragma warning restore CS0618
         }
 
         public static IEnumerable<object[]> IsPreviewNetTestcases()
@@ -62,42 +80,60 @@ namespace Lib9c.Tests.Action
             yield return new object[]
             {
                 new GoldCurrencyState(
-                    new Currency("NCG", 2, new Address("340f110b91d0577a9ae0ea69ce15269436f217da"))),
+#pragma warning disable CS0618
+                    // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                    Currency.Legacy("NCG", 2, new Address("340f110b91d0577a9ae0ea69ce15269436f217da"))),
+#pragma warning restore CS0618
                 true,
             };
 
             yield return new object[]
             {
                 new GoldCurrencyState(
-                    new Currency("NCG", 18, new Address("340f110b91d0577a9ae0ea69ce15269436f217da"))),
+#pragma warning disable CS0618
+                    // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                    Currency.Legacy("NCG", 18, new Address("340f110b91d0577a9ae0ea69ce15269436f217da"))),
+#pragma warning restore CS0618
                 false,
             };
 
             yield return new object[]
             {
                 new GoldCurrencyState(
-                    new Currency("NCG", 2, new PrivateKey().ToAddress())),
+#pragma warning disable CS0618
+                    // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                    Currency.Legacy("NCG", 2, new PrivateKey().ToAddress())),
+#pragma warning restore CS0618
                 false,
             };
 
             yield return new object[]
             {
                 new GoldCurrencyState(
-                    new Currency("ETH", 2, new Address("340f110b91d0577a9ae0ea69ce15269436f217da"))),
+#pragma warning disable CS0618
+                    // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                    Currency.Legacy("ETH", 2, new Address("340f110b91d0577a9ae0ea69ce15269436f217da"))),
+#pragma warning restore CS0618
                 false,
             };
 
             yield return new object[]
             {
                 new GoldCurrencyState(
-                    new Currency("BTC", 18, new Address("340f110b91d0577a9ae0ea69ce15269436f217da"))),
+#pragma warning disable CS0618
+                    // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                    Currency.Legacy("BTC", 18, new Address("340f110b91d0577a9ae0ea69ce15269436f217da"))),
+#pragma warning restore CS0618
                 false,
             };
 
             yield return new object[]
             {
                 new GoldCurrencyState(
-                    new Currency("BTC", 2, new Address("340f110b91d0577a9ae0ea69ce15269436f217da"))),
+#pragma warning disable CS0618
+                    // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                    Currency.Legacy("BTC", 2, new Address("340f110b91d0577a9ae0ea69ce15269436f217da"))),
+#pragma warning restore CS0618
                 false,
             };
         }

--- a/.Lib9c.Tests/Action/ActionEvaluationTest.cs
+++ b/.Lib9c.Tests/Action/ActionEvaluationTest.cs
@@ -26,7 +26,10 @@ namespace Lib9c.Tests.Action
 
         public ActionEvaluationTest()
         {
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _signer = new PrivateKey().ToAddress();
             _sender = new PrivateKey().ToAddress();
             _states = new State()
@@ -181,7 +184,10 @@ namespace Lib9c.Tests.Action
                             _signer,
                             new PrivateKey().ToAddress(),
                             ItemSubType.Armor,
-                            new Currency("NCG", 2, minters: null) * 10
+#pragma warning disable CS0618
+                    // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                            Currency.Legacy("NCG", 2, null) * 10
+#pragma warning restore CS0618
                         ),
                     },
                 },

--- a/.Lib9c.Tests/Action/ArenahelperTest.cs
+++ b/.Lib9c.Tests/Action/ArenahelperTest.cs
@@ -46,8 +46,11 @@ namespace Lib9c.Tests.Action
 
             tableSheets = new TableSheets(sheets);
 
-            _crystal = new Currency("CRYSTAL", 18, minters: null);
-            var ncg = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _crystal = Currency.Legacy("CRYSTAL", 18, null);
+            var ncg = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(ncg);
 
             var rankingMapAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/BattleArena1Test.cs
+++ b/.Lib9c.Tests/Action/BattleArena1Test.cs
@@ -57,8 +57,11 @@ namespace Lib9c.Tests.Action
             }
 
             _tableSheets = new TableSheets(_sheets);
-            _crystal = new Currency("CRYSTAL", 18, minters: null);
-            _ncg = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _crystal = Currency.Legacy("CRYSTAL", 18, null);
+            _ncg = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(_ncg);
 
             var rankingMapAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/BattleArenaTest.cs
+++ b/.Lib9c.Tests/Action/BattleArenaTest.cs
@@ -59,8 +59,11 @@ namespace Lib9c.Tests.Action
             }
 
             _tableSheets = new TableSheets(_sheets);
-            _crystal = new Currency("CRYSTAL", 18, minters: null);
-            _ncg = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _crystal = Currency.Legacy("CRYSTAL", 18, null);
+            _ncg = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(_ncg);
 
             var rankingMapAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/BattleArenaTest2.cs
+++ b/.Lib9c.Tests/Action/BattleArenaTest2.cs
@@ -59,8 +59,11 @@ namespace Lib9c.Tests.Action
             }
 
             _tableSheets = new TableSheets(_sheets);
-            _crystal = new Currency("CRYSTAL", 18, minters: null);
-            _ncg = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _crystal = Currency.Legacy("CRYSTAL", 18, null);
+            _ncg = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(_ncg);
 
             var rankingMapAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/Buy10Test.cs
+++ b/.Lib9c.Tests/Action/Buy10Test.cs
@@ -57,7 +57,10 @@ namespace Lib9c.Tests.Action
 
             _tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(currency);
 
             _sellerAgentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/Buy11Test.cs
+++ b/.Lib9c.Tests/Action/Buy11Test.cs
@@ -59,7 +59,10 @@ namespace Lib9c.Tests.Action
 
             _tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(currency);
 
             _sellerAgentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/Buy2Test.cs
+++ b/.Lib9c.Tests/Action/Buy2Test.cs
@@ -45,7 +45,10 @@ namespace Lib9c.Tests.Action
 
             _tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(currency);
 
             _sellerAgentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/Buy3Test.cs
+++ b/.Lib9c.Tests/Action/Buy3Test.cs
@@ -45,7 +45,10 @@
 
             _tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(currency);
 
             _sellerAgentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/Buy4Test.cs
+++ b/.Lib9c.Tests/Action/Buy4Test.cs
@@ -47,7 +47,10 @@
 
             _tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(currency);
 
             _sellerAgentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/Buy5Test.cs
+++ b/.Lib9c.Tests/Action/Buy5Test.cs
@@ -48,7 +48,10 @@ namespace Lib9c.Tests.Action
 
             _tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(currency);
 
             _sellerAgentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/Buy6Test.cs
+++ b/.Lib9c.Tests/Action/Buy6Test.cs
@@ -49,7 +49,10 @@ namespace Lib9c.Tests.Action
 
             _tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(currency);
 
             _sellerAgentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/Buy7Test.cs
+++ b/.Lib9c.Tests/Action/Buy7Test.cs
@@ -49,7 +49,10 @@ namespace Lib9c.Tests.Action
 
             _tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(currency);
 
             _sellerAgentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/Buy8Test.cs
+++ b/.Lib9c.Tests/Action/Buy8Test.cs
@@ -51,7 +51,10 @@
 
             _tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(currency);
 
             _sellerAgentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/Buy9Test.cs
+++ b/.Lib9c.Tests/Action/Buy9Test.cs
@@ -51,7 +51,10 @@
 
             _tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(currency);
 
             _sellerAgentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/BuyMultipleTest.cs
+++ b/.Lib9c.Tests/Action/BuyMultipleTest.cs
@@ -47,7 +47,10 @@
 
             _tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(currency);
 
             _sellerAgentStateMap = new Dictionary<AvatarState, AgentState>();

--- a/.Lib9c.Tests/Action/BuyTest.cs
+++ b/.Lib9c.Tests/Action/BuyTest.cs
@@ -59,7 +59,10 @@ namespace Lib9c.Tests.Action
 
             _tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(currency);
 
             _sellerAgentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/CancelMonsterCollectTest.cs
+++ b/.Lib9c.Tests/Action/CancelMonsterCollectTest.cs
@@ -26,7 +26,10 @@ namespace Lib9c.Tests.Action
             Dictionary<string, string> sheets = TableSheetsImporter.ImportSheets();
             _tableSheets = new TableSheets(sheets);
             var agentState = new AgentState(_signer);
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
 
             _state = _state

--- a/.Lib9c.Tests/Action/ClaimMonsterCollectionReward0Test.cs
+++ b/.Lib9c.Tests/Action/ClaimMonsterCollectionReward0Test.cs
@@ -39,7 +39,10 @@ namespace Lib9c.Tests.Action
                 rankingMapAddress);
             agentState.avatarAddresses[0] = _avatarAddress;
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
 
             _state = _state

--- a/.Lib9c.Tests/Action/ClaimMonsterCollectionReward2Test.cs
+++ b/.Lib9c.Tests/Action/ClaimMonsterCollectionReward2Test.cs
@@ -50,7 +50,10 @@
                 rankingMapAddress);
             agentState.avatarAddresses[0] = _avatarAddress;
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
 
             _state = _state

--- a/.Lib9c.Tests/Action/ClaimMonsterCollectionRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimMonsterCollectionRewardTest.cs
@@ -50,7 +50,10 @@ namespace Lib9c.Tests.Action
                 rankingMapAddress);
             agentState.avatarAddresses[0] = _avatarAddress;
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
 
             _state = _state

--- a/.Lib9c.Tests/Action/ClaimStakeRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimStakeRewardTest.cs
@@ -41,7 +41,10 @@ namespace Lib9c.Tests.Action
 
             _tableSheets = new TableSheets(sheets);
 
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(_currency);
 
             _signerAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/CombinationConsumableTest.cs
+++ b/.Lib9c.Tests/Action/CombinationConsumableTest.cs
@@ -52,7 +52,10 @@ namespace Lib9c.Tests.Action
                 default
             );
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
 
             _initialState = new State()
                 .SetState(_agentAddress, agentState.Serialize())

--- a/.Lib9c.Tests/Action/CombinationEquipment0Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment0Test.cs
@@ -50,7 +50,10 @@ namespace Lib9c.Tests.Action
                 gameConfigState,
                 default
             );
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
 
             _initialState = new State()
                 .SetState(_agentAddress, agentState.Serialize())

--- a/.Lib9c.Tests/Action/CombinationEquipment10Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment10Test.cs
@@ -63,7 +63,10 @@ namespace Lib9c.Tests.Action
                 default
             );
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
 
             _initialState = new State()
                 .SetState(_agentAddress, agentState.Serialize())
@@ -188,7 +191,10 @@ namespace Lib9c.Tests.Action
             int? subRecipeId,
             bool isMadeWithMimisbrunnrRecipe)
         {
-            var currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var row = _tableSheets.EquipmentItemRecipeSheet[recipeId];
             var requiredStage = row.UnlockStage;
             var materialRow = _tableSheets.MaterialItemSheet[row.MaterialId];
@@ -260,7 +266,10 @@ namespace Lib9c.Tests.Action
 
         private void Execute(bool backward, int recipeId, int? subRecipeId, int mintNCG)
         {
-            var currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var row = _tableSheets.EquipmentItemRecipeSheet[recipeId];
             var requiredStage = row.UnlockStage;
             var costActionPoint = row.RequiredActionPoint;

--- a/.Lib9c.Tests/Action/CombinationEquipment11Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment11Test.cs
@@ -66,7 +66,10 @@ namespace Lib9c.Tests.Action
                 default
             );
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
 
             _initialState = new State()
                 .SetState(_agentAddress, agentState.Serialize())
@@ -195,7 +198,10 @@ namespace Lib9c.Tests.Action
             int? subRecipeId,
             bool isMadeWithMimisbrunnrRecipe)
         {
-            var currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var row = _tableSheets.EquipmentItemRecipeSheet[recipeId];
             var requiredStage = row.UnlockStage;
             var materialRow = _tableSheets.MaterialItemSheet[row.MaterialId];
@@ -267,7 +273,10 @@ namespace Lib9c.Tests.Action
 
         private void Execute(bool backward, int recipeId, int? subRecipeId, int mintNCG)
         {
-            var currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var row = _tableSheets.EquipmentItemRecipeSheet[recipeId];
             var requiredStage = row.UnlockStage;
             var costActionPoint = row.RequiredActionPoint;

--- a/.Lib9c.Tests/Action/CombinationEquipment12Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment12Test.cs
@@ -72,7 +72,10 @@ namespace Lib9c.Tests.Action
                 default
             );
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
 
             var combinationSlotState = new CombinationSlotState(
                 _slotAddress,

--- a/.Lib9c.Tests/Action/CombinationEquipment2Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment2Test.cs
@@ -50,7 +50,10 @@ namespace Lib9c.Tests.Action
                 gameConfigState,
                 default
             );
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
 
             _initialState = new State()
                 .SetState(_agentAddress, agentState.Serialize())

--- a/.Lib9c.Tests/Action/CombinationEquipment3Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment3Test.cs
@@ -55,7 +55,10 @@ namespace Lib9c.Tests.Action
                 gameConfigState,
                 default
             );
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
 
             _initialState = new State()
                 .SetState(_agentAddress, agentState.Serialize())
@@ -153,7 +156,10 @@ namespace Lib9c.Tests.Action
 
             var goldCurrencyState = nextState.GetGoldCurrency();
             var blackSmithGold = nextState.GetBalance(Addresses.Blacksmith, goldCurrencyState);
-            var currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             Assert.Equal(300 * currency, blackSmithGold);
             var agentGold = nextState.GetBalance(_agentAddress, goldCurrencyState);
             Assert.Equal(currency * 0, agentGold);

--- a/.Lib9c.Tests/Action/CombinationEquipment4Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment4Test.cs
@@ -55,7 +55,10 @@ namespace Lib9c.Tests.Action
                 gameConfigState,
                 default
             );
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
 
             _initialState = new State()
                 .SetState(_agentAddress, agentState.Serialize())
@@ -152,7 +155,10 @@ namespace Lib9c.Tests.Action
 
             var goldCurrencyState = nextState.GetGoldCurrency();
             var blackSmithGold = nextState.GetBalance(Addresses.Blacksmith, goldCurrencyState);
-            var currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             Assert.Equal(300 * currency, blackSmithGold);
             var agentGold = nextState.GetBalance(_agentAddress, goldCurrencyState);
             Assert.Equal(currency * 0, agentGold);

--- a/.Lib9c.Tests/Action/CombinationEquipment5Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment5Test.cs
@@ -55,7 +55,10 @@ namespace Lib9c.Tests.Action
                 gameConfigState,
                 default
             );
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
 
             _initialState = new State()
                 .SetState(_agentAddress, agentState.Serialize())
@@ -152,7 +155,10 @@ namespace Lib9c.Tests.Action
 
             var goldCurrencyState = nextState.GetGoldCurrency();
             var blackSmithGold = nextState.GetBalance(Addresses.Blacksmith, goldCurrencyState);
-            var currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             Assert.Equal(300 * currency, blackSmithGold);
             var agentGold = nextState.GetBalance(_agentAddress, goldCurrencyState);
             Assert.Equal(currency * 0, agentGold);

--- a/.Lib9c.Tests/Action/CombinationEquipment6Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment6Test.cs
@@ -57,7 +57,10 @@ namespace Lib9c.Tests.Action
                 gameConfigState,
                 default
             );
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
 
             _initialState = new State()
                 .SetState(_agentAddress, agentState.Serialize())
@@ -167,7 +170,10 @@ namespace Lib9c.Tests.Action
 
             var goldCurrencyState = nextState.GetGoldCurrency();
             var blackSmithGold = nextState.GetBalance(Addresses.Blacksmith, goldCurrencyState);
-            var currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             Assert.Equal(300 * currency, blackSmithGold);
             var agentGold = nextState.GetBalance(_agentAddress, goldCurrencyState);
             Assert.Equal(currency * 0, agentGold);

--- a/.Lib9c.Tests/Action/CombinationEquipment7Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment7Test.cs
@@ -57,7 +57,10 @@ namespace Lib9c.Tests.Action
                 gameConfigState,
                 default
             );
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
 
             _initialState = new State()
                 .SetState(_agentAddress, agentState.Serialize())
@@ -166,7 +169,10 @@ namespace Lib9c.Tests.Action
 
             var goldCurrencyState = nextState.GetGoldCurrency();
             var blackSmithGold = nextState.GetBalance(Addresses.Blacksmith, goldCurrencyState);
-            var currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             Assert.Equal(300 * currency, blackSmithGold);
             var agentGold = nextState.GetBalance(_agentAddress, goldCurrencyState);
             Assert.Equal(currency * 0, agentGold);

--- a/.Lib9c.Tests/Action/CombinationEquipment8Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment8Test.cs
@@ -62,7 +62,10 @@ namespace Lib9c.Tests.Action
                 default
             );
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
 
             _initialState = new State()
                 .SetState(_agentAddress, agentState.Serialize())
@@ -173,7 +176,10 @@ namespace Lib9c.Tests.Action
 
         private void Execute(bool backward, int recipeId, int? subRecipeId, int mintNCG)
         {
-            var currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var row = _tableSheets.EquipmentItemRecipeSheet[recipeId];
             var requiredStage = row.UnlockStage;
             var costActionPoint = row.RequiredActionPoint;

--- a/.Lib9c.Tests/Action/CombinationEquipment9Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment9Test.cs
@@ -62,7 +62,10 @@ namespace Lib9c.Tests.Action
                 default
             );
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
 
             _initialState = new State()
                 .SetState(_agentAddress, agentState.Serialize())
@@ -173,7 +176,10 @@ namespace Lib9c.Tests.Action
 
         private void Execute(bool backward, int recipeId, int? subRecipeId, int mintNCG)
         {
-            var currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var row = _tableSheets.EquipmentItemRecipeSheet[recipeId];
             var requiredStage = row.UnlockStage;
             var costActionPoint = row.RequiredActionPoint;

--- a/.Lib9c.Tests/Action/CombinationEquipmentTest.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipmentTest.cs
@@ -68,7 +68,10 @@
                 default
             );
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
 
             var combinationSlotState = new CombinationSlotState(
                 _slotAddress,

--- a/.Lib9c.Tests/Action/CreateAvatar0Test.cs
+++ b/.Lib9c.Tests/Action/CreateAvatar0Test.cs
@@ -41,7 +41,10 @@ namespace Lib9c.Tests.Action
                 name = "test",
             };
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
             var ranking = new RankingState0();
             for (var i = 0; i < RankingState0.RankingMapCapacity; i++)
             {
@@ -227,7 +230,10 @@ namespace Lib9c.Tests.Action
                 name = "test",
             };
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
             var updatedAddresses = new List<Address>()
             {
                 agentAddress,

--- a/.Lib9c.Tests/Action/CreateAvatar2Test.cs
+++ b/.Lib9c.Tests/Action/CreateAvatar2Test.cs
@@ -38,7 +38,10 @@ namespace Lib9c.Tests.Action
                 name = "test",
             };
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
             var ranking = new RankingState0();
             for (var i = 0; i < RankingState0.RankingMapCapacity; i++)
             {
@@ -250,7 +253,10 @@ namespace Lib9c.Tests.Action
                 name = "test",
             };
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
             var updatedAddresses = new List<Address>()
             {
                 agentAddress,

--- a/.Lib9c.Tests/Action/CreateAvatar3Test.cs
+++ b/.Lib9c.Tests/Action/CreateAvatar3Test.cs
@@ -39,7 +39,10 @@
                 name = "test",
             };
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
             var ranking = new RankingState0();
             for (var i = 0; i < RankingState0.RankingMapCapacity; i++)
             {
@@ -252,7 +255,10 @@
                 name = "test",
             };
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
             var updatedAddresses = new List<Address>()
             {
                 agentAddress,

--- a/.Lib9c.Tests/Action/CreateAvatar6Test.cs
+++ b/.Lib9c.Tests/Action/CreateAvatar6Test.cs
@@ -39,7 +39,10 @@ namespace Lib9c.Tests.Action
                 name = "test",
             };
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
             var ranking = new RankingState0();
             for (var i = 0; i < RankingState0.RankingMapCapacity; i++)
             {
@@ -252,7 +255,10 @@ namespace Lib9c.Tests.Action
                 name = "test",
             };
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
             var updatedAddresses = new List<Address>()
             {
                 agentAddress,

--- a/.Lib9c.Tests/Action/CreateAvatar7Test.cs
+++ b/.Lib9c.Tests/Action/CreateAvatar7Test.cs
@@ -39,7 +39,10 @@ namespace Lib9c.Tests.Action
                 name = "test",
             };
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
 
             var sheets = TableSheetsImporter.ImportSheets();
             var state = new State()
@@ -234,7 +237,10 @@ namespace Lib9c.Tests.Action
                 name = "test",
             };
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
             var updatedAddresses = new List<Address>()
             {
                 agentAddress,

--- a/.Lib9c.Tests/Action/CreateAvatarTest.cs
+++ b/.Lib9c.Tests/Action/CreateAvatarTest.cs
@@ -236,7 +236,10 @@ namespace Lib9c.Tests.Action
                 name = "test",
             };
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
             var updatedAddresses = new List<Address>()
             {
                 agentAddress,

--- a/.Lib9c.Tests/Action/EventDungeonBattleTest.cs
+++ b/.Lib9c.Tests/Action/EventDungeonBattleTest.cs
@@ -32,7 +32,10 @@ namespace Lib9c.Tests.Action
         {
             _initialStates = new State();
 
-            _ncgCurrency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _ncgCurrency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _initialStates = _initialStates.SetState(
                 GoldCurrencyState.Address,
                 new GoldCurrencyState(_ncgCurrency).Serialize());

--- a/.Lib9c.Tests/Action/EventDungeonBattleV1Test.cs
+++ b/.Lib9c.Tests/Action/EventDungeonBattleV1Test.cs
@@ -32,7 +32,10 @@ namespace Lib9c.Tests.Action
         {
             _initialStates = new State();
 
-            _ncgCurrency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _ncgCurrency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _initialStates = _initialStates.SetState(
                 GoldCurrencyState.Address,
                 new GoldCurrencyState(_ncgCurrency).Serialize());

--- a/.Lib9c.Tests/Action/GrindingTest.cs
+++ b/.Lib9c.Tests/Action/GrindingTest.cs
@@ -36,7 +36,10 @@ namespace Lib9c.Tests.Action
             _tableSheets = new TableSheets(sheets);
             _agentAddress = new PrivateKey().ToAddress();
             _avatarAddress = new PrivateKey().ToAddress();
-            _crystalCurrency = new Currency("CRYSTAL", 18, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _crystalCurrency = Currency.Legacy("CRYSTAL", 18, null);
+#pragma warning restore CS0618
             var gameConfigState = new GameConfigState(sheets[nameof(GameConfigSheet)]);
 
             _agentState = new AgentState(_agentAddress);
@@ -51,7 +54,10 @@ namespace Lib9c.Tests.Action
 
             _agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _ncgCurrency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _ncgCurrency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(_ncgCurrency);
 
             _initialState = new State()

--- a/.Lib9c.Tests/Action/InitializeStatesTest.cs
+++ b/.Lib9c.Tests/Action/InitializeStatesTest.cs
@@ -32,7 +32,10 @@ namespace Lib9c.Tests.Action
             var goldDistributionCsvPath = GoldDistributionTest.CreateFixtureCsvFile();
             var goldDistributions = GoldDistribution.LoadInDescendingEndBlockOrder(goldDistributionCsvPath);
             var minterKey = new PrivateKey();
-            var ncg = new Currency("NCG", 2, minterKey.ToAddress());
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var ncg = Currency.Legacy("NCG", 2, minterKey.ToAddress());
+#pragma warning restore CS0618
             var nonce = new byte[] { 0x00, 0x01, 0x02, 0x03 };
             var privateKey = new PrivateKey();
             (ActivationKey activationKey, PendingActivationState pendingActivation) =
@@ -90,7 +93,10 @@ namespace Lib9c.Tests.Action
             var goldDistributionCsvPath = GoldDistributionTest.CreateFixtureCsvFile();
             var goldDistributions = GoldDistribution.LoadInDescendingEndBlockOrder(goldDistributionCsvPath);
             var minterKey = new PrivateKey();
-            var ncg = new Currency("NCG", 2, minterKey.ToAddress());
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var ncg = Currency.Legacy("NCG", 2, minterKey.ToAddress());
+#pragma warning restore CS0618
             var nonce = new byte[] { 0x00, 0x01, 0x02, 0x03 };
             var privateKey = new PrivateKey();
             (ActivationKey activationKey, PendingActivationState pendingActivation) =
@@ -142,7 +148,10 @@ namespace Lib9c.Tests.Action
             var goldDistributionCsvPath = GoldDistributionTest.CreateFixtureCsvFile();
             var goldDistributions = GoldDistribution.LoadInDescendingEndBlockOrder(goldDistributionCsvPath);
             var minterKey = new PrivateKey();
-            var ncg = new Currency("NCG", 2, minterKey.ToAddress());
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var ncg = Currency.Legacy("NCG", 2, minterKey.ToAddress());
+#pragma warning restore CS0618
             var nonce = new byte[] { 0x00, 0x01, 0x02, 0x03 };
             var privateKey = new PrivateKey();
             (ActivationKey activationKey, PendingActivationState pendingActivation) =
@@ -184,7 +193,10 @@ namespace Lib9c.Tests.Action
             var goldDistributionCsvPath = GoldDistributionTest.CreateFixtureCsvFile();
             var goldDistributions = GoldDistribution.LoadInDescendingEndBlockOrder(goldDistributionCsvPath);
             var minterKey = new PrivateKey();
-            var ncg = new Currency("NCG", 2, minterKey.ToAddress());
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var ncg = Currency.Legacy("NCG", 2, minterKey.ToAddress());
+#pragma warning restore CS0618
             var nonce = new byte[] { 0x00, 0x01, 0x02, 0x03 };
             var adminAddress = new Address("F9A15F870701268Bd7bBeA6502eB15F4997f32f9");
             var creditState = new CreditsState(
@@ -233,7 +245,10 @@ namespace Lib9c.Tests.Action
             var goldDistributions =
                 GoldDistribution.LoadInDescendingEndBlockOrder(goldDistributionCsvPath);
             var minterKey = new PrivateKey();
-            var ncg = new Currency("NCG", 2, minterKey.ToAddress());
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var ncg = Currency.Legacy("NCG", 2, minterKey.ToAddress());
+#pragma warning restore CS0618
             var nonce = new byte[] { 0x00, 0x01, 0x02, 0x03 };
             var privateKey = new PrivateKey();
             (ActivationKey activationKey, PendingActivationState pendingActivation) =

--- a/.Lib9c.Tests/Action/ItemEnhancement0Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement0Test.cs
@@ -48,7 +48,10 @@ namespace Lib9c.Tests.Action
 
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var gold = new GoldCurrencyState(_currency);
             _slotAddress =
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));
@@ -486,7 +489,10 @@ namespace Lib9c.Tests.Action
                 slotIndex = 0,
             };
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
 
             var updatedAddresses = new List<Address>()
             {

--- a/.Lib9c.Tests/Action/ItemEnhancement10Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement10Test.cs
@@ -53,7 +53,10 @@ namespace Lib9c.Tests.Action
 
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var gold = new GoldCurrencyState(_currency);
             _slotAddress =
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));

--- a/.Lib9c.Tests/Action/ItemEnhancement2Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement2Test.cs
@@ -47,7 +47,10 @@ namespace Lib9c.Tests.Action
 
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var gold = new GoldCurrencyState(_currency);
             _slotAddress =
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));
@@ -451,7 +454,10 @@ namespace Lib9c.Tests.Action
                 slotIndex = 0,
             };
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
 
             var updatedAddresses = new List<Address>()
             {

--- a/.Lib9c.Tests/Action/ItemEnhancement3Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement3Test.cs
@@ -47,7 +47,10 @@ namespace Lib9c.Tests.Action
 
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var gold = new GoldCurrencyState(_currency);
             _slotAddress =
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));

--- a/.Lib9c.Tests/Action/ItemEnhancement4Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement4Test.cs
@@ -48,7 +48,10 @@ namespace Lib9c.Tests.Action
 
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var gold = new GoldCurrencyState(_currency);
             _slotAddress =
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));

--- a/.Lib9c.Tests/Action/ItemEnhancement5Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement5Test.cs
@@ -48,7 +48,10 @@ namespace Lib9c.Tests.Action
 
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var gold = new GoldCurrencyState(_currency);
             _slotAddress =
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));

--- a/.Lib9c.Tests/Action/ItemEnhancement6Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement6Test.cs
@@ -48,7 +48,10 @@ namespace Lib9c.Tests.Action
 
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var gold = new GoldCurrencyState(_currency);
             _slotAddress =
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));

--- a/.Lib9c.Tests/Action/ItemEnhancement7Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement7Test.cs
@@ -50,7 +50,10 @@
 
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var gold = new GoldCurrencyState(_currency);
             _slotAddress =
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));

--- a/.Lib9c.Tests/Action/ItemEnhancement8Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement8Test.cs
@@ -50,7 +50,10 @@ namespace Lib9c.Tests.Action
 
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var gold = new GoldCurrencyState(_currency);
             _slotAddress =
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));

--- a/.Lib9c.Tests/Action/ItemEnhancement9Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement9Test.cs
@@ -51,7 +51,10 @@ namespace Lib9c.Tests.Action
 
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var gold = new GoldCurrencyState(_currency);
             _slotAddress =
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));

--- a/.Lib9c.Tests/Action/ItemEnhancementTest.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancementTest.cs
@@ -53,7 +53,10 @@ namespace Lib9c.Tests.Action
 
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var gold = new GoldCurrencyState(_currency);
             var slotAddress = _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));
 

--- a/.Lib9c.Tests/Action/JoinArenaTest.cs
+++ b/.Lib9c.Tests/Action/JoinArenaTest.cs
@@ -87,9 +87,15 @@ namespace Lib9c.Tests.Action
                     1),
             };
             agent2State.avatarAddresses[0] = _avatar2Address;
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
-            _currency = new Currency("CRYSTAL", 18, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("CRYSTAL", 18, null);
+#pragma warning restore CS0618
 
             _state = _state
                 .SetState(_signer, agentState.Serialize())

--- a/.Lib9c.Tests/Action/MigrateMonsterCollectionTest.cs
+++ b/.Lib9c.Tests/Action/MigrateMonsterCollectionTest.cs
@@ -46,7 +46,10 @@ namespace Lib9c.Tests.Action
                 rankingMapAddress);
             agentState.avatarAddresses[0] = _avatarAddress;
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
 
             _state = _state

--- a/.Lib9c.Tests/Action/MigrationLegacyShopTest.cs
+++ b/.Lib9c.Tests/Action/MigrationLegacyShopTest.cs
@@ -59,7 +59,10 @@ namespace Lib9c.Tests.Action
                         adminAddress,
                         avatarAddress,
                         Guid.NewGuid(),
-                        new FungibleAssetValue(new Currency("NCG", 2, minter: null), 100, 0),
+#pragma warning disable CS0618
+                    // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                        Currency.Legacy("NCG", 2, null) * 100,
+#pragma warning restore CS0618
                         item);
                     shopState.Register(shopItem);
                     itemIds.Add(item.TradableId);

--- a/.Lib9c.Tests/Action/MonsterCollect0Test.cs
+++ b/.Lib9c.Tests/Action/MonsterCollect0Test.cs
@@ -23,7 +23,10 @@ namespace Lib9c.Tests.Action
             Dictionary<string, string> sheets = TableSheetsImporter.ImportSheets();
             _tableSheets = new TableSheets(sheets);
             _signer = default;
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
             _initialState = new State()
                 .SetState(Addresses.GoldCurrency, goldCurrencyState.Serialize());

--- a/.Lib9c.Tests/Action/MonsterCollect2Test.cs
+++ b/.Lib9c.Tests/Action/MonsterCollect2Test.cs
@@ -24,7 +24,10 @@ namespace Lib9c.Tests.Action
             Dictionary<string, string> sheets = TableSheetsImporter.ImportSheets();
             _tableSheets = new TableSheets(sheets);
             _signer = default;
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
             _initialState = new State()
                 .SetState(Addresses.GoldCurrency, goldCurrencyState.Serialize());

--- a/.Lib9c.Tests/Action/MonsterCollectTest.cs
+++ b/.Lib9c.Tests/Action/MonsterCollectTest.cs
@@ -24,7 +24,10 @@ namespace Lib9c.Tests.Action
             Dictionary<string, string> sheets = TableSheetsImporter.ImportSheets();
             _tableSheets = new TableSheets(sheets);
             _signer = default;
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
             _initialState = new State()
                 .SetState(Addresses.GoldCurrency, goldCurrencyState.Serialize());

--- a/.Lib9c.Tests/Action/PurchaseInfoTest.cs
+++ b/.Lib9c.Tests/Action/PurchaseInfoTest.cs
@@ -17,7 +17,10 @@ namespace Lib9c.Tests.Action
         {
             var orderId = new Guid("F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4");
             var tradableId = new Guid("936DA01F-9ABD-4d9d-80C7-02AF85C822A8");
-            var price = new FungibleAssetValue(new Currency("NCG", 2, minter: null), 100, 0);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var price = Currency.Legacy("NCG", 2, null) * 100;
+#pragma warning restore CS0618
             var purchaseInfo = new PurchaseInfo(
                 orderId,
                 tradableId,

--- a/.Lib9c.Tests/Action/RankingBattle0Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle0Test.cs
@@ -385,7 +385,10 @@ namespace Lib9c.Tests.Action
                 _weeklyArenaAddress,
                 previousWeeklyArenaState.Serialize());
 
-            var goldCurrency = new Currency("NCG", 2, Addresses.GoldCurrency);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var goldCurrency = Currency.Legacy("NCG", 2, Addresses.GoldCurrency);
+#pragma warning restore CS0618
             var previousAgentGoldState = _initialState.GetBalance(
                 _agent1Address,
                 goldCurrency);

--- a/.Lib9c.Tests/Action/RawState.cs
+++ b/.Lib9c.Tests/Action/RawState.cs
@@ -30,6 +30,9 @@ namespace Lib9c.Tests.Action
         public IImmutableDictionary<Address, IImmutableSet<Currency>> UpdatedFungibleAssets =>
             throw new NotSupportedException($"Currently, {nameof(UpdatedFungibleAssets)} is not supported in this implementation.");
 
+        public IImmutableSet<Currency> TotalSupplyUpdatedCurrencies =>
+            throw new NotSupportedException($"Currently, {nameof(TotalSupplyUpdatedCurrencies)} is not supported in this implementation.");
+
         public IValue GetState(Address address)
         {
             return _rawStates.TryGetValue(ToStateKey(address), out IValue value) ? value : null;
@@ -48,10 +51,41 @@ namespace Lib9c.Tests.Action
                 ? FungibleAssetValue.FromRawValue(currency, value is Bencodex.Types.Integer i ? i.Value : 0)
                 : currency * 0;
 
-        public IAccountStateDelta MintAsset(Address recipient, FungibleAssetValue value) => new RawState(
-            _rawStates.SetItem(
-                ToBalanceKey(recipient, value.Currency),
-                (Bencodex.Types.Integer)(GetBalance(recipient, value.Currency) + value).RawValue));
+        public FungibleAssetValue GetTotalSupply(Currency currency)
+        {
+            if (!currency.TotalSupplyTrackable)
+            {
+                var msg =
+                    $"The total supply value of the currency {currency} is not trackable"
+                    + " because it is a legacy untracked currency which might have been"
+                    + " established before the introduction of total supply tracking support.";
+                throw new TotalSupplyNotTrackableException(currency, msg);
+            }
+
+            // Return dirty state if it exists.
+            if (_rawStates.TryGetValue(ToTotalSupplyKey(currency), out var value))
+            {
+                return FungibleAssetValue.FromRawValue(currency, value is Bencodex.Types.Integer i ? i.Value : 0);
+            }
+
+            return currency * 0;
+        }
+
+        public IAccountStateDelta MintAsset(Address recipient, FungibleAssetValue value)
+        {
+            var currency = value.Currency;
+            var rawStates = _rawStates.SetItem(
+                    ToBalanceKey(recipient, currency),
+                    (Bencodex.Types.Integer)(GetBalance(recipient, currency) + value).RawValue);
+            if (value.Currency.TotalSupplyTrackable)
+            {
+                rawStates = rawStates.SetItem(
+                    ToTotalSupplyKey(currency),
+                    (Bencodex.Types.Integer)(GetTotalSupply(currency) + value).RawValue);
+            }
+
+            return new RawState(rawStates);
+        }
 
         public IAccountStateDelta TransferAsset(
             Address sender,
@@ -86,14 +120,26 @@ namespace Lib9c.Tests.Action
         }
 
         public IAccountStateDelta BurnAsset(Address owner, FungibleAssetValue value)
-            => new RawState(
-                _rawStates.SetItem(
-                    ToBalanceKey(owner, value.Currency),
-                    (Bencodex.Types.Integer)(GetBalance(owner, value.Currency) - value).RawValue));
+        {
+            var currency = value.Currency;
+            var rawStates = _rawStates.SetItem(
+                ToBalanceKey(owner, currency),
+                (Bencodex.Types.Integer)(GetBalance(owner, currency) - value).RawValue);
+            if (value.Currency.TotalSupplyTrackable)
+            {
+                rawStates = rawStates.SetItem(
+                    ToTotalSupplyKey(currency),
+                    (Bencodex.Types.Integer)(GetTotalSupply(currency) - value).RawValue);
+            }
+
+            return new RawState(rawStates);
+        }
 
         private string ToStateKey(Address address) => address.ToHex().ToLowerInvariant();
 
         private string ToBalanceKey(Address address, Currency currency) => "_" + address.ToHex().ToLowerInvariant() +
                                                                            "_" + ByteUtil.Hex(currency.Hash.ByteArray);
+
+        private string ToTotalSupplyKey(Currency currency) => "__" + ByteUtil.Hex(currency.Hash.ByteArray);
     }
 }

--- a/.Lib9c.Tests/Action/RedeemCode0Test.cs
+++ b/.Lib9c.Tests/Action/RedeemCode0Test.cs
@@ -63,7 +63,10 @@ namespace Lib9c.Tests.Action
                 default
             );
 
-            var goldState = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var goldState = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
 
             var initialState = new State()
                 .SetState(_agentAddress, agentState.Serialize())

--- a/.Lib9c.Tests/Action/RedeemCodeTest.cs
+++ b/.Lib9c.Tests/Action/RedeemCodeTest.cs
@@ -65,7 +65,10 @@ namespace Lib9c.Tests.Action
                 default
             );
 
-            var goldState = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var goldState = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
 
             var initialState = new State()
                 .SetState(_agentAddress, agentState.Serialize())

--- a/.Lib9c.Tests/Action/RewardGoldTest.cs
+++ b/.Lib9c.Tests/Action/RewardGoldTest.cs
@@ -70,7 +70,10 @@ namespace Lib9c.Tests.Action
                 default
             );
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
             _baseState = (State)new State()
                 .SetState(GoldCurrencyState.Address, gold.Serialize())
                 .SetState(Addresses.GoldDistribution, GoldDistributionTest.Fixture.Select(v => v.Serialize()).Serialize())
@@ -358,7 +361,10 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void GoldDistributedEachAccount()
         {
-            Currency currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            Currency currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             Address fund = GoldCurrencyState.Address;
             Address address1 = new Address("F9A15F870701268Bd7bBeA6502eB15F4997f32f9");
             Address address2 = new Address("Fb90278C67f9b266eA309E6AE8463042f5461449");
@@ -508,7 +514,10 @@ namespace Lib9c.Tests.Action
                     ),
                     adminAddressState: new AdminState(adminAddress, 1500000),
                     activatedAccountsState: new ActivatedAccountsState(activatedAccounts),
-                    goldCurrencyState: new GoldCurrencyState(new Currency("NCG", 2, minter: null)),
+#pragma warning disable CS0618
+                    // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                    goldCurrencyState: new GoldCurrencyState(Currency.Legacy("NCG", 2, null)),
+#pragma warning restore CS0618
                     goldDistributions: new GoldDistribution[0],
                     tableSheets: TableSheetsImporter.ImportSheets(),
                     pendingActivationStates: pendingActivationStates.ToArray()

--- a/.Lib9c.Tests/Action/Scenario/ArenaScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/ArenaScenarioTest.cs
@@ -47,8 +47,11 @@ namespace Lib9c.Tests.Action.Scenario
             }
 
             _tableSheets = new TableSheets(_sheets);
-            _crystal = new Currency("CRYSTAL", 18, minters: null);
-            _ncg = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _crystal = Currency.Legacy("CRYSTAL", 18, null);
+            _ncg = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(_ncg);
             _rankingMapAddress = new PrivateKey().ToAddress();
             var clearStageId = Math.Max(

--- a/.Lib9c.Tests/Action/Scenario/CombinationAndRapidCombinationTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/CombinationAndRapidCombinationTest.cs
@@ -39,7 +39,10 @@
             var sheets = TableSheetsImporter.ImportSheets();
             _tableSheets = new TableSheets(sheets);
 
-            var gold = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
             var gameConfigState = new GameConfigState(sheets[nameof(GameConfigSheet)]);
 
             _agentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/Scenario/StakeAndClaimStakeRewardScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/StakeAndClaimStakeRewardScenarioTest.cs
@@ -43,7 +43,10 @@ namespace Lib9c.Tests.Action.Scenario
 
             _tableSheets = new TableSheets(sheets);
 
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(_currency);
 
             _signerAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/Sell0Test.cs
+++ b/.Lib9c.Tests/Action/Sell0Test.cs
@@ -41,7 +41,10 @@ namespace Lib9c.Tests.Action
 
             _tableSheets = new TableSheets(sheets);
 
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(_currency);
 
             var shopState = new ShopState();

--- a/.Lib9c.Tests/Action/Sell2Test.cs
+++ b/.Lib9c.Tests/Action/Sell2Test.cs
@@ -41,7 +41,10 @@
 
             _tableSheets = new TableSheets(sheets);
 
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(_currency);
 
             var shopState = new ShopState();

--- a/.Lib9c.Tests/Action/Sell3Test.cs
+++ b/.Lib9c.Tests/Action/Sell3Test.cs
@@ -43,7 +43,10 @@
 
             _tableSheets = new TableSheets(sheets);
 
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(_currency);
 
             var shopState = new ShopState();

--- a/.Lib9c.Tests/Action/Sell4Test.cs
+++ b/.Lib9c.Tests/Action/Sell4Test.cs
@@ -46,7 +46,10 @@
 
             _tableSheets = new TableSheets(sheets);
 
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(_currency);
 
             var shopState = new ShopState();

--- a/.Lib9c.Tests/Action/Sell5Test.cs
+++ b/.Lib9c.Tests/Action/Sell5Test.cs
@@ -45,7 +45,10 @@ namespace Lib9c.Tests.Action
 
             _tableSheets = new TableSheets(sheets);
 
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(_currency);
 
             var shopState = new ShopState();

--- a/.Lib9c.Tests/Action/Sell6Test.cs
+++ b/.Lib9c.Tests/Action/Sell6Test.cs
@@ -45,7 +45,10 @@ namespace Lib9c.Tests.Action
 
             _tableSheets = new TableSheets(sheets);
 
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(_currency);
 
             var shopState = new ShopState();

--- a/.Lib9c.Tests/Action/Sell7Test.cs
+++ b/.Lib9c.Tests/Action/Sell7Test.cs
@@ -49,7 +49,10 @@
 
             _tableSheets = new TableSheets(sheets);
 
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(_currency);
 
             var shopState = new ShopState();

--- a/.Lib9c.Tests/Action/Sell8Test.cs
+++ b/.Lib9c.Tests/Action/Sell8Test.cs
@@ -49,7 +49,10 @@ namespace Lib9c.Tests.Action
 
             _tableSheets = new TableSheets(sheets);
 
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(_currency);
 
             var shopState = new ShopState();

--- a/.Lib9c.Tests/Action/Sell9Test.cs
+++ b/.Lib9c.Tests/Action/Sell9Test.cs
@@ -49,7 +49,10 @@
 
             _tableSheets = new TableSheets(sheets);
 
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(_currency);
 
             var shopState = new ShopState();

--- a/.Lib9c.Tests/Action/SellCancellation0Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation0Test.cs
@@ -38,7 +38,10 @@ namespace Lib9c.Tests.Action
 
             var tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
 
             _agentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/SellCancellation2Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation2Test.cs
@@ -40,7 +40,10 @@ namespace Lib9c.Tests.Action
 
             var tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
 
             _agentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/SellCancellation3Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation3Test.cs
@@ -38,7 +38,10 @@
 
             var tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
 
             _agentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/SellCancellation4Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation4Test.cs
@@ -38,7 +38,10 @@
 
             var tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
 
             _agentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/SellCancellation5Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation5Test.cs
@@ -42,7 +42,10 @@ namespace Lib9c.Tests.Action
 
             _tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(currency);
 
             _agentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/SellCancellation6Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation6Test.cs
@@ -44,7 +44,10 @@ namespace Lib9c.Tests.Action
 
             _tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(currency);
 
             _agentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/SellCancellation7Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation7Test.cs
@@ -47,7 +47,10 @@
 
             _tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(currency);
 
             _agentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/SellCancellation8Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation8Test.cs
@@ -47,7 +47,10 @@
 
             _tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(currency);
 
             _agentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/SellCancellationTest.cs
+++ b/.Lib9c.Tests/Action/SellCancellationTest.cs
@@ -47,7 +47,10 @@ namespace Lib9c.Tests.Action
 
             _tableSheets = new TableSheets(sheets);
 
-            var currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(currency);
 
             _agentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/SellTest.cs
+++ b/.Lib9c.Tests/Action/SellTest.cs
@@ -49,7 +49,10 @@ namespace Lib9c.Tests.Action
 
             _tableSheets = new TableSheets(sheets);
 
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(_currency);
 
             var shopState = new ShopState();

--- a/.Lib9c.Tests/Action/Stake0Test.cs
+++ b/.Lib9c.Tests/Action/Stake0Test.cs
@@ -41,7 +41,10 @@ namespace Lib9c.Tests.Action
 
             _tableSheets = new TableSheets(sheets);
 
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(_currency);
 
             _signerAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/StakeTest.cs
+++ b/.Lib9c.Tests/Action/StakeTest.cs
@@ -41,7 +41,10 @@ namespace Lib9c.Tests.Action
 
             _tableSheets = new TableSheets(sheets);
 
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(_currency);
 
             _signerAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/State.cs
+++ b/.Lib9c.Tests/Action/State.cs
@@ -14,13 +14,17 @@ namespace Lib9c.Tests.Action
     {
         private readonly IImmutableDictionary<Address, IValue> _state;
         private readonly IImmutableDictionary<(Address, Currency), FungibleAssetValue> _balance;
+        private readonly IImmutableDictionary<Currency, FungibleAssetValue> _totalSupplies;
 
         public State(
             IImmutableDictionary<Address, IValue> state = null,
-            IImmutableDictionary<(Address Address, Currency Currency), FungibleAssetValue> balance = null)
+            IImmutableDictionary<(Address Address, Currency Currency), FungibleAssetValue> balance = null,
+            IImmutableDictionary<Currency, FungibleAssetValue> totalSupplies = null)
         {
             _state = state ?? ImmutableDictionary<Address, IValue>.Empty;
             _balance = balance ?? ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty;
+            _totalSupplies =
+                totalSupplies ?? ImmutableDictionary<Currency, FungibleAssetValue>.Empty;
         }
 
         public IImmutableSet<Address> UpdatedAddresses =>
@@ -35,6 +39,9 @@ namespace Lib9c.Tests.Action
                 g => (IImmutableSet<Currency>)g.Select(kv => kv.Key.Item2).ToImmutableHashSet()
             );
 
+        public IImmutableSet<Currency> TotalSupplyUpdatedCurrencies =>
+            _totalSupplies.Keys.ToImmutableHashSet();
+
         public IValue GetState(Address address) =>
             _state.TryGetValue(address, out IValue value) ? value : null;
 
@@ -47,11 +54,58 @@ namespace Lib9c.Tests.Action
         public FungibleAssetValue GetBalance(Address address, Currency currency) =>
             _balance.TryGetValue((address, currency), out FungibleAssetValue balance) ? balance : currency * 0;
 
-        public IAccountStateDelta MintAsset(Address recipient, FungibleAssetValue value) =>
-            new State(_state, _balance.SetItem((recipient, value.Currency), GetBalance(recipient, value.Currency) + value));
+        public FungibleAssetValue GetTotalSupply(Currency currency)
+        {
+            if (!currency.TotalSupplyTrackable)
+            {
+                var msg =
+                    $"The total supply value of the currency {currency} is not trackable"
+                    + " because it is a legacy untracked currency which might have been"
+                    + " established before the introduction of total supply tracking support.";
+                throw new TotalSupplyNotTrackableException(currency, msg);
+            }
 
-        public IAccountStateDelta BurnAsset(Address owner, FungibleAssetValue value) =>
-            new State(_state, _balance.SetItem((owner, value.Currency), GetBalance(owner, value.Currency) - value));
+            // Return dirty state if it exists.
+            if (_totalSupplies.TryGetValue(currency, out var totalSupplyValue))
+            {
+                return totalSupplyValue;
+            }
+
+            return currency * 0;
+        }
+
+        public IAccountStateDelta MintAsset(Address recipient, FungibleAssetValue value)
+        {
+            var totalSupplies =
+                value.Currency.TotalSupplyTrackable
+                    ? _totalSupplies.SetItem(
+                        value.Currency,
+                        GetTotalSupply(value.Currency) + value)
+                    : _totalSupplies;
+            return new State(
+                _state,
+                _balance.SetItem(
+                    (recipient, value.Currency),
+                    GetBalance(recipient, value.Currency) + value),
+                totalSupplies
+            );
+        }
+
+        public IAccountStateDelta BurnAsset(Address owner, FungibleAssetValue value)
+        {
+            var totalSupplies =
+                value.Currency.TotalSupplyTrackable
+                    ? _totalSupplies.SetItem(
+                        value.Currency,
+                        GetTotalSupply(value.Currency) - value)
+                    : _totalSupplies;
+            return new State(
+                _state,
+                _balance.SetItem(
+                    (owner, value.Currency),
+                    GetBalance(owner, value.Currency) - value),
+                totalSupplies);
+        }
 
         public IAccountStateDelta TransferAsset(
             Address sender,

--- a/.Lib9c.Tests/Action/TransferAssetTest.cs
+++ b/.Lib9c.Tests/Action/TransferAssetTest.cs
@@ -34,7 +34,10 @@ namespace Lib9c.Tests.Action
             }
         );
 
-        private static readonly Currency _currency = new Currency("NCG", 2, default(Address?));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+        private static readonly Currency _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
 
         [Fact]
         public void Constructor_ThrowsMemoLengthOverflowException()
@@ -173,7 +176,10 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void ExecuteWithMinterAsSender()
         {
-            var currencyBySender = new Currency("NCG", 2, _sender);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currencyBySender = Currency.Legacy("NCG", 2, _sender);
+#pragma warning restore CS0618
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, currencyBySender), _currency * 1000)
                 .Add((_recipient, currencyBySender), _currency * 10);
@@ -204,7 +210,10 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void ExecuteWithMinterAsRecipient()
         {
-            var currencyByRecipient = new Currency("NCG", 2, _sender);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currencyByRecipient = Currency.Legacy("NCG", 2, _sender);
+#pragma warning restore CS0618
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, currencyByRecipient), _currency * 1000)
                 .Add((_recipient, currencyByRecipient), _currency * 10);

--- a/.Lib9c.Tests/Action/TransferAssetTest0.cs
+++ b/.Lib9c.Tests/Action/TransferAssetTest0.cs
@@ -32,7 +32,10 @@ namespace Lib9c.Tests.Action
             }
         );
 
-        private static readonly Currency _currency = new Currency("NCG", 2, default(Address?));
+#pragma warning disable CS0618
+        // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+        private static readonly Currency _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
 
         [Fact]
         public void Constructor_ThrowsMemoLengthOverflowException()
@@ -168,7 +171,10 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void ExecuteWithMinterAsSender()
         {
-            var currencyBySender = new Currency("NCG", 2, _sender);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currencyBySender = Currency.Legacy("NCG", 2, _sender);
+#pragma warning restore CS0618
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, currencyBySender), _currency * 1000)
                 .Add((_recipient, currencyBySender), _currency * 10);
@@ -199,7 +205,10 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void ExecuteWithMinterAsRecipient()
         {
-            var currencyByRecipient = new Currency("NCG", 2, _sender);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currencyByRecipient = Currency.Legacy("NCG", 2, _sender);
+#pragma warning restore CS0618
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, currencyByRecipient), _currency * 1000)
                 .Add((_recipient, currencyByRecipient), _currency * 10);

--- a/.Lib9c.Tests/Action/UnlockEquipmentRecipeTest.cs
+++ b/.Lib9c.Tests/Action/UnlockEquipmentRecipeTest.cs
@@ -33,7 +33,10 @@ namespace Lib9c.Tests.Action
             _tableSheets = new TableSheets(sheets);
             _agentAddress = new PrivateKey().ToAddress();
             _avatarAddress = new PrivateKey().ToAddress();
-            _currency = new Currency("CRYSTAL", 18, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("CRYSTAL", 18, null);
+#pragma warning restore CS0618
             var gameConfigState = new GameConfigState(sheets[nameof(GameConfigSheet)]);
 
             var agentState = new AgentState(_agentAddress);

--- a/.Lib9c.Tests/Action/UpdateSell0Test.cs
+++ b/.Lib9c.Tests/Action/UpdateSell0Test.cs
@@ -48,7 +48,10 @@
 
             _tableSheets = new TableSheets(sheets);
 
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(_currency);
 
             var shopState = new ShopState();

--- a/.Lib9c.Tests/Action/UpdateSell2Test.cs
+++ b/.Lib9c.Tests/Action/UpdateSell2Test.cs
@@ -48,7 +48,10 @@
 
             _tableSheets = new TableSheets(sheets);
 
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(_currency);
 
             var shopState = new ShopState();

--- a/.Lib9c.Tests/Action/UpdateSellTest.cs
+++ b/.Lib9c.Tests/Action/UpdateSellTest.cs
@@ -49,7 +49,10 @@
 
             _tableSheets = new TableSheets(sheets);
 
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _goldCurrencyState = new GoldCurrencyState(_currency);
 
             var shopState = new ShopState();

--- a/.Lib9c.Tests/CrystalCalculatorTest.cs
+++ b/.Lib9c.Tests/CrystalCalculatorTest.cs
@@ -26,7 +26,10 @@ namespace Lib9c.Tests
             _equipmentItemRecipeSheet = _tableSheets.EquipmentItemRecipeSheet;
             _worldUnlockSheet = _tableSheets.WorldUnlockSheet;
             _crystalMaterialCostSheet = _tableSheets.CrystalMaterialCostSheet;
-            _ncgCurrency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _ncgCurrency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
         }
 
         [Theory]

--- a/.Lib9c.Tests/Extensions/EventScheduleExtensionsTest.cs
+++ b/.Lib9c.Tests/Extensions/EventScheduleExtensionsTest.cs
@@ -105,7 +105,10 @@ namespace Lib9c.Tests.Extensions
                 "0",
                 "0",
             });
-            var currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             var cost = scheduleRow.GetDungeonTicketCost(
                 numberOfTicketPurchases,
                 currency);

--- a/.Lib9c.Tests/Model/Item/ShopItemTest.cs
+++ b/.Lib9c.Tests/Model/Item/ShopItemTest.cs
@@ -20,7 +20,10 @@
 
         public ShopItemTest()
         {
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
         }
 

--- a/.Lib9c.Tests/Model/Mail/GrindingMailTest.cs
+++ b/.Lib9c.Tests/Model/Mail/GrindingMailTest.cs
@@ -8,7 +8,10 @@ namespace Lib9c.Tests.Model.Mail
 
     public class GrindingMailTest
     {
-        private readonly Currency _currency = new Currency("CRYSTAL", 18, minters: null);
+#pragma warning disable CS0618
+        // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+        private readonly Currency _currency = Currency.Legacy("CRYSTAL", 18, null);
+#pragma warning restore CS0618
 
         [Fact]
         public void Serialize()

--- a/.Lib9c.Tests/Model/Order/FungibleOrderTest.cs
+++ b/.Lib9c.Tests/Model/Order/FungibleOrderTest.cs
@@ -24,7 +24,10 @@ namespace Lib9c.Tests.Model.Order
         public FungibleOrderTest()
         {
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
-            _currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _avatarState = new AvatarState(
                 Addresses.Blacksmith,
                 Addresses.Admin,
@@ -72,7 +75,10 @@ namespace Lib9c.Tests.Model.Order
         {
             Guid orderId = new Guid("6d460c1a-755d-48e4-ad67-65d5f519dbc8");
             Guid itemId = new Guid("15396359-04db-68d5-f24a-d89c18665900");
-            Currency currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            Currency currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             FungibleOrder order = OrderFactory.CreateFungibleOrder(
                 Addresses.Admin,
                 Addresses.Blacksmith,

--- a/.Lib9c.Tests/Model/Order/NonFungibleOrderTest.cs
+++ b/.Lib9c.Tests/Model/Order/NonFungibleOrderTest.cs
@@ -26,7 +26,10 @@ namespace Lib9c.Tests.Model.Order
         public NonFungibleOrderTest()
         {
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
-            _currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             _avatarState = new AvatarState(
                 Addresses.Blacksmith,
                 Addresses.Admin,
@@ -72,7 +75,10 @@ namespace Lib9c.Tests.Model.Order
         {
             Guid orderId = new Guid("6d460c1a-755d-48e4-ad67-65d5f519dbc8");
             Guid itemId = new Guid("15396359-04db-68d5-f24a-d89c18665900");
-            Currency currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            Currency currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             NonFungibleOrder order = OrderFactory.CreateNonFungibleOrder(
                 Addresses.Admin,
                 Addresses.Blacksmith,

--- a/.Lib9c.Tests/Model/Order/OrderDigestListStateTest.cs
+++ b/.Lib9c.Tests/Model/Order/OrderDigestListStateTest.cs
@@ -24,7 +24,10 @@ namespace Lib9c.Tests.Model.Order
                 1,
                 orderId,
                 tradableId,
-                new FungibleAssetValue(new Currency("NCG", 2, minter: null), 1, 0),
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                Currency.Legacy("NCG", 2, null) * 1,
+#pragma warning restore CS0618
                 2,
                 3,
                 4,

--- a/.Lib9c.Tests/Model/Order/OrderDigestTest.cs
+++ b/.Lib9c.Tests/Model/Order/OrderDigestTest.cs
@@ -14,7 +14,10 @@ namespace Lib9c.Tests.Model.Order
 
         public OrderDigestTest()
         {
-            _currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
         }
 
         [Fact]

--- a/.Lib9c.Tests/Model/Order/OrderFactoryTest.cs
+++ b/.Lib9c.Tests/Model/Order/OrderFactoryTest.cs
@@ -57,7 +57,10 @@ namespace Lib9c.Tests.Model.Order
                     throw new ArgumentOutOfRangeException(nameof(itemType), itemType, null);
             }
 
-            var currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             Guid orderId = new Guid("6d460c1a-755d-48e4-ad67-65d5f519dbc8");
 
             Order order = OrderFactory.Create(
@@ -131,7 +134,10 @@ namespace Lib9c.Tests.Model.Order
                     throw new ArgumentOutOfRangeException(nameof(itemType), itemType, null);
             }
 
-            var currency = new Currency("NCG", 2, minter: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
             Order order = OrderFactory.Create(
                 Addresses.Admin,
                 Addresses.Blacksmith,

--- a/.Lib9c.Tests/Model/State/GoldCurrencyStateTest.cs
+++ b/.Lib9c.Tests/Model/State/GoldCurrencyStateTest.cs
@@ -13,7 +13,10 @@ namespace Lib9c.Tests.Model.State
         [Fact]
         public void Serialize()
         {
-            var currency = new Currency("NCG", 2, default(Address));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, default(Address));
+#pragma warning restore CS0618
             var state = new GoldCurrencyState(currency);
             var serialized = (Dictionary)state.Serialize();
             GoldCurrencyState deserialized = new GoldCurrencyState(serialized);
@@ -24,7 +27,10 @@ namespace Lib9c.Tests.Model.State
         [Fact]
         public void SerializeWithDotnetAPI()
         {
-            var currency = new Currency("NCG", 2, default(Address));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, default(Address));
+#pragma warning restore CS0618
             var state = new GoldCurrencyState(currency);
             var formatter = new BinaryFormatter();
 

--- a/.Lib9c.Tests/Model/State/ShardedShopStateTest.cs
+++ b/.Lib9c.Tests/Model/State/ShardedShopStateTest.cs
@@ -18,7 +18,10 @@ namespace Lib9c.Tests.Model.State
         public ShardedShopStateTest()
         {
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
-            _price = new FungibleAssetValue(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _price = new FungibleAssetValue(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
         }
 
         [Theory]

--- a/.Lib9c.Tests/Model/State/ShardedShopStateV2Test.cs
+++ b/.Lib9c.Tests/Model/State/ShardedShopStateV2Test.cs
@@ -21,7 +21,10 @@ namespace Lib9c.Tests.Model.State
 
         public ShardedShopStateV2Test()
         {
-            _price = new FungibleAssetValue(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _price = new FungibleAssetValue(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
         }
 
         [Theory]

--- a/.Lib9c.Tests/Model/State/ShopStateTest.cs
+++ b/.Lib9c.Tests/Model/State/ShopStateTest.cs
@@ -28,7 +28,10 @@ namespace Lib9c.Tests.Model.State
                 weaponRow,
                 Guid.NewGuid(),
                 0);
-            var price = new FungibleAssetValue(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var price = new FungibleAssetValue(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
             var shopItem = new ShopItem(
                 agentAddress,
                 avatarAddress,
@@ -61,7 +64,10 @@ namespace Lib9c.Tests.Model.State
                 weaponRow,
                 Guid.NewGuid(),
                 0);
-            var price = new FungibleAssetValue(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var price = new FungibleAssetValue(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
             var shopItem = new ShopItem(
                 agentAddress,
                 avatarAddress,
@@ -92,7 +98,10 @@ namespace Lib9c.Tests.Model.State
                 weaponRow,
                 Guid.NewGuid(),
                 0);
-            var price = new FungibleAssetValue(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var price = new FungibleAssetValue(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
             var shopItem = new ShopItem(
                 agentAddress,
                 avatarAddress,
@@ -121,7 +130,10 @@ namespace Lib9c.Tests.Model.State
                 weaponRow,
                 Guid.NewGuid(),
                 0);
-            var price = new FungibleAssetValue(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var price = new FungibleAssetValue(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
             var shopItem = new ShopItem(
                 agentAddress,
                 avatarAddress,
@@ -154,7 +166,10 @@ namespace Lib9c.Tests.Model.State
                 weaponRow,
                 Guid.NewGuid(),
                 0);
-            var price = new FungibleAssetValue(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var price = new FungibleAssetValue(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
             var shopItem = new ShopItem(
                 agentAddress,
                 avatarAddress,
@@ -191,7 +206,10 @@ namespace Lib9c.Tests.Model.State
                 weaponRow,
                 Guid.NewGuid(),
                 0);
-            var price = new FungibleAssetValue(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var price = new FungibleAssetValue(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
             var shopItem = new ShopItem(
                 agentAddress,
                 avatarAddress,

--- a/.Lib9c.Tests/Policy/BlockPolicyTest.cs
+++ b/.Lib9c.Tests/Policy/BlockPolicyTest.cs
@@ -34,7 +34,10 @@ namespace Lib9c.Tests
         public BlockPolicyTest()
         {
             _privateKey = new PrivateKey();
-            _currency = new Currency("NCG", 2, minter: _privateKey.ToAddress());
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, _privateKey.ToAddress());
+#pragma warning restore CS0618
         }
 
         [Fact]

--- a/.Lib9c.Tests/TableData/StakeAchievementRewardSheetTest.cs
+++ b/.Lib9c.Tests/TableData/StakeAchievementRewardSheetTest.cs
@@ -15,7 +15,10 @@ namespace Lib9c.Tests.TableData
         {
             _sheet = new TableSheets(TableSheetsImporter.ImportSheets())
                 .StakeAchievementRewardSheet;
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
         }
 
         [Fact]

--- a/.Lib9c.Tests/TableData/StakeRegularFixedRewardSheetTest.cs
+++ b/.Lib9c.Tests/TableData/StakeRegularFixedRewardSheetTest.cs
@@ -22,7 +22,10 @@ namespace Lib9c.Tests.TableData
 
             _sheet = new StakeRegularFixedRewardSheet();
             _sheet.Set(TableContent);
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
         }
 
         [Fact]

--- a/.Lib9c.Tests/TableData/StakeRegularRewardSheetTest.cs
+++ b/.Lib9c.Tests/TableData/StakeRegularRewardSheetTest.cs
@@ -20,7 +20,10 @@ namespace Lib9c.Tests.TableData
 
             _sheet = new StakeRegularRewardSheet();
             _sheet.Set(TableContent);
-            _currency = new Currency("NCG", 2, minters: null);
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
         }
 
         [Fact]

--- a/.Lib9c.Tests/TestHelper/BlockChainHelper.cs
+++ b/.Lib9c.Tests/TestHelper/BlockChainHelper.cs
@@ -74,7 +74,10 @@
 
         public static MakeInitialStateResult MakeInitialState()
         {
-            var goldCurrencyState = new GoldCurrencyState(new Currency("NCG", 2, minter: null));
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var goldCurrencyState = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
+#pragma warning restore CS0618
             var ranking = new RankingState1();
             for (var i = 0; i < RankingState1.RankingMapCapacity; i++)
             {

--- a/Lib9c/Action/ActionBase.cs
+++ b/Lib9c/Action/ActionBase.cs
@@ -39,6 +39,7 @@ namespace Nekoyume.Action
         {
             private IImmutableDictionary<Address, IValue> _states;
             private IImmutableDictionary<(Address, Currency), BigInteger> _balances;
+            private IImmutableDictionary<Currency, BigInteger> _totalSupplies;
 
             public IImmutableSet<Address> UpdatedAddresses => _states.Keys.ToImmutableHashSet();
 
@@ -52,16 +53,21 @@ namespace Nekoyume.Action
                 );
 #pragma warning restore LAA1002
 
+            public IImmutableSet<Currency> TotalSupplyUpdatedCurrencies =>
+                _totalSupplies.Keys.ToImmutableHashSet();
+
             public AccountStateDelta(
                 IImmutableDictionary<Address, IValue> states,
-                IImmutableDictionary<(Address, Currency), BigInteger> balances
+                IImmutableDictionary<(Address, Currency), BigInteger> balances,
+                IImmutableDictionary<Currency, BigInteger> totalSupplies
             )
             {
                 _states = states;
                 _balances = balances;
+                _totalSupplies = totalSupplies;
             }
 
-            public AccountStateDelta(Dictionary states, List balances)
+            public AccountStateDelta(Dictionary states, List balances, Dictionary totalSupplies)
             {
                 // This assumes `states` consists of only Binary keys:
                 _states = states.ToImmutableDictionary(
@@ -73,12 +79,19 @@ namespace Nekoyume.Action
                     record => (record["address"].ToAddress(), CurrencyExtensions.Deserialize((Dictionary)record["currency"])),
                     record => record["amount"].ToBigInteger()
                 );
+
+                // This assumes `totalSupplies` consists of only Binary keys:
+                _totalSupplies = totalSupplies.ToImmutableDictionary(
+                    kv => CurrencyExtensions.Deserialize((Dictionary)((Binary)kv.Key as IValue)),
+                    kv => kv.Value.ToBigInteger()
+                );
             }
 
             public AccountStateDelta(IValue serialized)
                 : this(
                     (Dictionary)((Dictionary)serialized)["states"],
-                    (List)((Dictionary)serialized)["balances"]
+                    (List)((Dictionary)serialized)["balances"],
+                    (Dictionary)((Dictionary)serialized)["totalSupplies"]
                 )
             {
             }
@@ -95,7 +108,7 @@ namespace Nekoyume.Action
                 addresses.Select(_states.GetValueOrDefault).ToArray();
 
             public IAccountStateDelta SetState(Address address, IValue state) =>
-                new AccountStateDelta(_states.SetItem(address, state), _balances);
+                new AccountStateDelta(_states.SetItem(address, state), _balances, _totalSupplies);
 
             public FungibleAssetValue GetBalance(Address address, Currency currency)
             {
@@ -107,24 +120,68 @@ namespace Nekoyume.Action
                 return FungibleAssetValue.FromRawValue(currency, rawValue);
             }
 
+            public FungibleAssetValue GetTotalSupply(Currency currency)
+            {
+                if (!currency.TotalSupplyTrackable)
+                {
+                    var msg =
+                        $"The total supply value of the currency {currency} is not trackable"
+                        + " because it is a legacy untracked currency which might have been"
+                        + " established before the introduction of total supply tracking support.";
+                    throw new TotalSupplyNotTrackableException(currency, msg);
+                }
+
+                // Return dirty state if it exists.
+                if (_totalSupplies.TryGetValue(currency, out var totalSupplyValue))
+                {
+                    return FungibleAssetValue.FromRawValue(currency, totalSupplyValue);
+                }
+
+                throw new TotalSupplyDoesNotExistException(currency);
+            }
+
             public IAccountStateDelta MintAsset(Address recipient, FungibleAssetValue value)
             {
                 // FIXME: 트랜잭션 서명자를 알아내 currency.AllowsToMint() 확인해서 CurrencyPermissionException
                 // 던지는 처리를 해야하는데 여기서 트랜잭션 서명자를 무슨 수로 가져올지 잘 모르겠음.
 
-                if (value <= new FungibleAssetValue(value.Currency))
+                var currency = value.Currency;
+
+                if (value <= currency * 0)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value));
                 }
 
                 var nextAmount = GetBalance(recipient, value.Currency) + value;
 
+                if (currency.TotalSupplyTrackable)
+                {
+                    var currentTotalSupply = GetTotalSupply(currency);
+                    if (currency.MaximumSupply < currentTotalSupply + value)
+                    {
+                        var msg = $"The amount {value} attempted to be minted added to the current"
+                                  + $" total supply of {currentTotalSupply} exceeds the"
+                                  + $" maximum allowed supply of {currency.MaximumSupply}.";
+                        throw new SupplyOverflowException(value, msg);
+                    }
+
+                    return new AccountStateDelta(
+                        _states,
+                        _balances.SetItem(
+                            (recipient, value.Currency),
+                            nextAmount.RawValue
+                        ),
+                        _totalSupplies.SetItem(currency, (currentTotalSupply + value).RawValue)
+                    );
+                }
+
                 return new AccountStateDelta(
                     _states,
                     _balances.SetItem(
                         (recipient, value.Currency),
                         nextAmount.RawValue
-                    )
+                    ),
+                    _totalSupplies
                 );
             }
 
@@ -155,7 +212,7 @@ namespace Nekoyume.Action
                 var balances = _balances
                     .SetItem((sender, currency), senderRemains.RawValue)
                     .SetItem((recipient, currency), recipientRemains.RawValue);
-                return new AccountStateDelta(_states, balances);
+                return new AccountStateDelta(_states, balances, _totalSupplies);
             }
 
             public IAccountStateDelta BurnAsset(Address owner, FungibleAssetValue value)
@@ -163,12 +220,14 @@ namespace Nekoyume.Action
                 // FIXME: 트랜잭션 서명자를 알아내 currency.AllowsToMint() 확인해서 CurrencyPermissionException
                 // 던지는 처리를 해야하는데 여기서 트랜잭션 서명자를 무슨 수로 가져올지 잘 모르겠음.
 
-                if (value <= new FungibleAssetValue(value.Currency))
+                var currency = value.Currency;
+
+                if (value <= currency * 0)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value));
                 }
 
-                FungibleAssetValue balance = GetBalance(owner, value.Currency);
+                FungibleAssetValue balance = GetBalance(owner, currency);
                 if (balance < value)
                 {
                     throw new InsufficientBalanceException(
@@ -182,9 +241,14 @@ namespace Nekoyume.Action
                 return new AccountStateDelta(
                     _states,
                     _balances.SetItem(
-                        (owner, value.Currency),
+                        (owner, currency),
                         nextValue.RawValue
-                    )
+                    ),
+                    currency.TotalSupplyTrackable
+                        ? _totalSupplies.SetItem(
+                            currency,
+                            (GetTotalSupply(currency) - value).RawValue)
+                        : _totalSupplies
                 );
             }
         }
@@ -267,11 +331,17 @@ namespace Nekoyume.Action
                         )
                     ).Cast<IValue>()
                 );
+                var totalSupply = new Dictionary(
+                    delta.TotalSupplyUpdatedCurrencies.Select(currency =>
+                        new KeyValuePair<IKey, IValue>(
+                            (Binary)(IValue)CurrencyExtensions.Serialize(currency),
+                            (Integer)delta.GetTotalSupply(currency).RawValue)));
 
                 var bdict = new Dictionary(new[]
                 {
                     new KeyValuePair<IKey, IValue>((Text) "states", state),
                     new KeyValuePair<IKey, IValue>((Text) "balances", balance),
+                    new KeyValuePair<IKey, IValue>((Text) "totalSupplies", totalSupply),
                 });
 
                 return new Codec().Encode(bdict);

--- a/Lib9c/Action/TotalSupplyDoesNotExistException.cs
+++ b/Lib9c/Action/TotalSupplyDoesNotExistException.cs
@@ -1,0 +1,30 @@
+using Libplanet;
+using Libplanet.Assets;
+using System;
+using System.Runtime.Serialization;
+
+namespace Nekoyume.Action
+{
+    [Serializable]
+    public class TotalSupplyDoesNotExistException : Exception
+    {
+        public TotalSupplyDoesNotExistException(Currency currency)
+        {
+            Currency = currency;
+        }
+
+        protected TotalSupplyDoesNotExistException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            Currency = (Currency) info.GetValue(nameof(Currency), typeof(Currency));
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(Currency), Currency);
+        }
+
+        public Currency Currency { get; }
+    }
+}

--- a/Lib9c/BlockHelper.cs
+++ b/Lib9c/BlockHelper.cs
@@ -46,7 +46,10 @@ namespace Nekoyume
                 privateKey = new PrivateKey();
             }
 
-            var ncg = new Currency("NCG", 2, privateKey.ToAddress());
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var ncg = Currency.Legacy("NCG", 2, privateKey.ToAddress());
+#pragma warning restore CS0618
             activatedAccounts = activatedAccounts ?? ImmutableHashSet<Address>.Empty;
             var initialStatesAction = new InitializeStates
             (

--- a/Lib9c/CurrencyExtensions.cs
+++ b/Lib9c/CurrencyExtensions.cs
@@ -13,10 +13,25 @@ namespace Nekoyume
             IValue minters = currency.Minters is IImmutableSet<Address> m
                 ? new Bencodex.Types.List(m.Select<Address, IValue>(a => new Binary(a.ByteArray)))
                 : (IValue)Null.Value;
-            return Bencodex.Types.Dictionary.Empty
+            var serialized = Bencodex.Types.Dictionary.Empty
                 .Add("ticker", currency.Ticker)
                 .Add("minters", minters)
                 .Add("decimalPlaces", new[] { currency.DecimalPlaces });
+            if (currency.TotalSupplyTrackable)
+            {
+                serialized = serialized.Add("totalSupplyTrackable", true);
+                if (currency.MaximumSupply.HasValue)
+                {
+                    serialized = serialized.Add(
+                        "maximumSupplyMajor",
+                        (IValue)new Integer(currency.MaximumSupply!.Value.MajorUnit)
+                        ).Add(
+                        "maximumSupplyMinor",
+                        (IValue)new Integer(currency.MaximumSupply!.Value.MinorUnit));
+                }
+            }
+
+            return serialized;
         }
 
         public static Currency Deserialize(Bencodex.Types.Dictionary serialized)
@@ -26,8 +41,27 @@ namespace Nekoyume
             {
                 minters = mintersAsList.Select(b => new Address(((Binary) b).ByteArray)).ToImmutableHashSet();
             }
-            
-            return new Currency((Text)serialized["ticker"], ((Binary)serialized["decimalPlaces"]).First(), minters);
+
+            if (serialized.ContainsKey("totalSupplyTrackable"))
+            {
+                if (serialized.ContainsKey("maximumSupplyMajor"))
+                {
+                    return Currency.Capped(
+                        (Text)serialized["ticker"],
+                        ((Binary)serialized["decimalPlaces"]).First(),
+                        (
+                            (Integer)serialized["maximumSupplyMajor"],
+                            (Integer)serialized["maximumSupplyMinor"]
+                        ),
+                        minters);
+                }
+
+                return Currency.Uncapped((Text)serialized["ticker"], ((Binary)serialized["decimalPlaces"]).First(), minters);
+            }
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            return Currency.Legacy((Text)serialized["ticker"], ((Binary)serialized["decimalPlaces"]).First(), minters);
+#pragma warning restore CS0618
         }
     }
 }

--- a/Lib9c/Formatters/AccountStateDeltaFormatter.cs
+++ b/Lib9c/Formatters/AccountStateDeltaFormatter.cs
@@ -41,11 +41,17 @@ namespace Lib9c.Formatters
                     )
                 ).Cast<IValue>()
             );
+            var totalSupply = new Dictionary(
+                value.TotalSupplyUpdatedCurrencies.Select(currency =>
+                    new KeyValuePair<IKey, IValue>(
+                        (Binary)(IValue)CurrencyExtensions.Serialize(currency),
+                        (Integer)value.GetTotalSupply(currency).RawValue)));
 
             var bdict = new Dictionary(new[]
             {
                 new KeyValuePair<IKey, IValue>((Text) "states", state),
                 new KeyValuePair<IKey, IValue>((Text) "balances", balance),
+                new KeyValuePair<IKey, IValue>((Text) "totalSupplies", totalSupply),
             });
 
             writer.Write(new Codec().Encode(bdict));

--- a/Lib9c/Helper/CrystalCalculator.cs
+++ b/Lib9c/Helper/CrystalCalculator.cs
@@ -15,7 +15,10 @@ namespace Nekoyume.Helper
 {
     public static class CrystalCalculator
     {
-        public static readonly Currency CRYSTAL = new Currency("CRYSTAL", 18, minters: null);
+#pragma warning disable CS0618
+        // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+        public static readonly Currency CRYSTAL = Currency.Legacy("CRYSTAL", 18, minters: null);
+#pragma warning restore CS0618
 
         public static FungibleAssetValue CalculateRecipeUnlockCost(IEnumerable<int> recipeIds, EquipmentItemRecipeSheet equipmentItemRecipeSheet)
         {


### PR DESCRIPTION
[Recently, maximum supply cap and total supply tracking was introduced in `Currency` in Libplanet.](https://github.com/planetarium/libplanet/pull/2200) This introduced changes in `IAccountStateDelta` interface and how `Currency` is defined. This PR incorporates the API changes to lib9c.

Resolution order: planetarium/libplanet#2225 -> planetarium/lib9c#1308 -> planetarium/NineChronicles.Headless#1497 & planetarium/NineChronicles#1838