### PR TITLE
Check preivous execute block index in `Raid` action.

### DIFF
--- a/.Lib9c.Tests/Action/RaidTest.cs
+++ b/.Lib9c.Tests/Action/RaidTest.cs
@@ -38,30 +38,32 @@ namespace Lib9c.Tests.Action
 
         [Theory]
         // Join new raid.
-        [InlineData(null, true, true, 0L, true, false, 0, 0L, false, false, 0, false, false, false)]
+        [InlineData(null, true, true, 5L, true, false, 0, 0L, false, false, 0, false, false, false, 0L)]
         // Refill by interval.
-        [InlineData(null, true, true, 300L, false, true, 0, 0L, false, false, 0, false, false, false)]
+        [InlineData(null, true, true, 300L, false, true, 0, 0L, false, false, 0, false, false, false, 0L)]
         // Refill by NCG.
-        [InlineData(null, true, true, 200L, false, true, 0, 200L, true, true, 0, false, false, false)]
-        [InlineData(null, true, true, 200L, false, true, 0, 200L, true, true, 1, false, false, false)]
+        [InlineData(null, true, true, 200L, false, true, 0, 200L, true, true, 0, false, false, false, 0L)]
+        [InlineData(null, true, true, 200L, false, true, 0, 200L, true, true, 1, false, false, false, 0L)]
         // Boss level up.
-        [InlineData(null, true, true, 200L, false, true, 3, 100L, false, false, 0, true, true, false)]
+        [InlineData(null, true, true, 200L, false, true, 3, 100L, false, false, 0, true, true, false, 0L)]
         // Update RaidRewardInfo.
-        [InlineData(null, true, true, 200L, false, true, 3, 100L, false, false, 0, true, true, true)]
+        [InlineData(null, true, true, 200L, false, true, 3, 100L, false, false, 0, true, true, true, 0L)]
         // Boss skip level up.
-        [InlineData(null, true, true, 200L, false, true, 3, 100L, false, false, 0, true, false, false)]
+        [InlineData(null, true, true, 200L, false, true, 3, 100L, false, false, 0, true, false, false, 0L)]
         // AvatarState null.
-        [InlineData(typeof(FailedLoadStateException), false, false, 0L, false, false, 0, 0L, false, false, 0, false, false, false)]
+        [InlineData(typeof(FailedLoadStateException), false, false, 0L, false, false, 0, 0L, false, false, 0, false, false, false, 0L)]
         // Stage not cleared.
-        [InlineData(typeof(NotEnoughClearedStageLevelException), true, false, 0L, false, false, 0, 0L, false, false, 0, false, false, false)]
+        [InlineData(typeof(NotEnoughClearedStageLevelException), true, false, 0L, false, false, 0, 0L, false, false, 0, false, false, false, 0L)]
         // Insufficient CRYSTAL.
-        [InlineData(typeof(InsufficientBalanceException), true, true, 0L, false, false, 0, 0L, false, false, 0, false, false, false)]
+        [InlineData(typeof(InsufficientBalanceException), true, true, 10L, false, false, 0, 0L, false, false, 0, false, false, false, 0L)]
         // Insufficient NCG.
-        [InlineData(typeof(InsufficientBalanceException), true, true, 0L, false, true, 0, 10L, true, false, 0, false, false, false)]
+        [InlineData(typeof(InsufficientBalanceException), true, true, 10L, false, true, 0, 10L, true, false, 0, false, false, false, 0L)]
+        // Wait interval.
+        [InlineData(typeof(RequiredBlockIndexException), true, true, 10L, false, true, 0, 0L, true, false, 0, false, false, false, 9L)]
         // Exceed purchase limit.
-        [InlineData(typeof(ExceedTicketPurchaseLimitException), true, true, 0L, false, true, 0, 10L, true, false, 1_000, false, false, false)]
+        [InlineData(typeof(ExceedTicketPurchaseLimitException), true, true, 10L, false, true, 0, 10L, true, false, 1_000, false, false, false, 0L)]
         // Exceed challenge count.
-        [InlineData(typeof(ExceedPlayCountException), true, true, 0L, false, true, 0, 0L, false, false, 0, false, false, false)]
+        [InlineData(typeof(ExceedPlayCountException), true, true, 5L, false, true, 0, 0L, false, false, 0, false, false, false, 0L)]
         public void Execute(
             Type exc,
             bool avatarExist,
@@ -76,7 +78,9 @@ namespace Lib9c.Tests.Action
             int purchaseCount,
             bool kill,
             bool levelUp,
-            bool rewardRecordExist)
+            bool rewardRecordExist,
+            long updatedBlockIndex
+        )
         {
             var action = new Raid
             {
@@ -156,6 +160,7 @@ namespace Lib9c.Tests.Action
                     raiderState.IconId = 0;
                     raiderState.AvatarNameWithHash = "hash";
                     raiderState.AvatarAddress = _avatarAddress;
+                    raiderState.UpdatedBlockIndex = updatedBlockIndex;
 
                     state = state.SetState(raiderAddress, raiderState.Serialize());
                 }
@@ -351,7 +356,7 @@ namespace Lib9c.Tests.Action
                 FoodIds = new List<Guid>(),
                 PayNcg = false,
             };
-            long blockIndex = 1;
+            long blockIndex = 5;
             int raidId = _tableSheets.WorldBossListSheet.FindRaidIdByBlockIndex(blockIndex);
             Address raiderAddress = Addresses.GetRaiderAddress(_avatarAddress, raidId);
             var goldCurrencyState = new GoldCurrencyState(_goldCurrency);

--- a/.Lib9c.Tests/Action/RaidTest.cs
+++ b/.Lib9c.Tests/Action/RaidTest.cs
@@ -158,7 +158,7 @@ namespace Lib9c.Tests.Action
                     raiderState.Cp = 0;
                     raiderState.Level = 0;
                     raiderState.IconId = 0;
-                    raiderState.AvatarNameWithHash = "hash";
+                    raiderState.AvatarName = "hash";
                     raiderState.AvatarAddress = _avatarAddress;
                     raiderState.UpdatedBlockIndex = updatedBlockIndex;
 
@@ -396,7 +396,7 @@ namespace Lib9c.Tests.Action
             raiderState.Cp = 0;
             raiderState.Level = 0;
             raiderState.IconId = 0;
-            raiderState.AvatarNameWithHash = "hash";
+            raiderState.AvatarName = "hash";
             raiderState.AvatarAddress = _avatarAddress;
             state = state.SetState(raiderAddress, raiderState.Serialize());
 

--- a/Lib9c/Model/State/RaiderState.cs
+++ b/Lib9c/Model/State/RaiderState.cs
@@ -25,6 +25,7 @@ namespace Nekoyume.Model.State
         public Address AvatarAddress;
         public string AvatarNameWithHash;
         public int LatestBossLevel;
+        public long UpdatedBlockIndex;
 
         public RaiderState()
         {
@@ -51,9 +52,10 @@ namespace Nekoyume.Model.State
             AvatarAddress = rawState[11].ToAddress();
             AvatarNameWithHash = rawState[12].ToDotnetString();
             LatestBossLevel = rawState[13].ToInteger();
+            UpdatedBlockIndex = rawState[14].ToLong();
         }
 
-        public void Update(AvatarState avatarState, int cp, int score, bool payNcg)
+        public void Update(AvatarState avatarState, int cp, int score, bool payNcg, long blockIndex)
         {
             Level = avatarState.level;
             AvatarAddress = avatarState.address;
@@ -71,6 +73,7 @@ namespace Nekoyume.Model.State
             }
             TotalChallengeCount++;
             IconId = avatarState.inventory.GetEquippedFullCostumeOrArmorId();
+            UpdatedBlockIndex = blockIndex;
         }
 
         public IValue Serialize()
@@ -89,7 +92,8 @@ namespace Nekoyume.Model.State
                 .Add(IconId.Serialize())
                 .Add(AvatarAddress.Serialize())
                 .Add(AvatarNameWithHash.Serialize())
-                .Add(LatestBossLevel.Serialize());
+                .Add(LatestBossLevel.Serialize())
+                .Add(UpdatedBlockIndex.Serialize());
         }
     }
 }

--- a/Lib9c/Model/State/RaiderState.cs
+++ b/Lib9c/Model/State/RaiderState.cs
@@ -1,9 +1,6 @@
 using System;
-using System.Collections.Generic;
 using Bencodex.Types;
 using Libplanet;
-using Libplanet.Assets;
-using Nekoyume.Battle;
 using Nekoyume.Helper;
 
 namespace Nekoyume.Model.State
@@ -23,7 +20,7 @@ namespace Nekoyume.Model.State
         public int Level;
         public int IconId;
         public Address AvatarAddress;
-        public string AvatarNameWithHash;
+        public string AvatarName;
         public int LatestBossLevel;
         public long UpdatedBlockIndex;
 
@@ -33,7 +30,7 @@ namespace Nekoyume.Model.State
             HighScore = 0;
             TotalChallengeCount = 0;
             RemainChallengeCount = WorldBossHelper.MaxChallengeCount;
-            AvatarNameWithHash = "";
+            AvatarName = "";
         }
 
         public RaiderState(List rawState)
@@ -50,7 +47,7 @@ namespace Nekoyume.Model.State
             Level = rawState[9].ToInteger();
             IconId = rawState[10].ToInteger();
             AvatarAddress = rawState[11].ToAddress();
-            AvatarNameWithHash = rawState[12].ToDotnetString();
+            AvatarName = rawState[12].ToDotnetString();
             LatestBossLevel = rawState[13].ToInteger();
             UpdatedBlockIndex = rawState[14].ToLong();
         }
@@ -59,7 +56,7 @@ namespace Nekoyume.Model.State
         {
             Level = avatarState.level;
             AvatarAddress = avatarState.address;
-            AvatarNameWithHash = avatarState.NameWithHash;
+            AvatarName = avatarState.name;
             Cp = cp;
             if (HighScore < score)
             {
@@ -91,7 +88,7 @@ namespace Nekoyume.Model.State
                 .Add(Level.Serialize())
                 .Add(IconId.Serialize())
                 .Add(AvatarAddress.Serialize())
-                .Add(AvatarNameWithHash.Serialize())
+                .Add(AvatarName.Serialize())
                 .Add(LatestBossLevel.Serialize())
                 .Add(UpdatedBlockIndex.Serialize());
         }


### PR DESCRIPTION
- check previous execute block index for prevent spamming action execute.
- `RaiderState` save avatar name instead of NameWithHash