### PR TITLE
Introduce RequiredBlockIntervalException for render client exc

### DIFF
--- a/.Lib9c.Tests/Action/ExceptionTest.cs
+++ b/.Lib9c.Tests/Action/ExceptionTest.cs
@@ -63,6 +63,7 @@ namespace Lib9c.Tests.Action
         [InlineData(typeof(InvalidActionFieldException))]
         [InlineData(typeof(NotEnoughEventDungeonTicketsException))]
         [InlineData(typeof(InvalidClaimException))]
+        [InlineData(typeof(RequiredBlockIntervalException))]
         public void Exception_Serializable(Type excType)
         {
             if (Activator.CreateInstance(excType, "for testing") is Exception exc)

--- a/.Lib9c.Tests/Action/RaidTest.cs
+++ b/.Lib9c.Tests/Action/RaidTest.cs
@@ -59,7 +59,7 @@ namespace Lib9c.Tests.Action
         // Insufficient NCG.
         [InlineData(typeof(InsufficientBalanceException), true, true, false, true, 0, 0L, true, false, 0, false, false, false, -Raid.RequiredInterval)]
         // Wait interval.
-        [InlineData(typeof(RequiredBlockIndexException), true, true, false, true, 3, 10L, false, false, 0, false, false, false, -Raid.RequiredInterval + 4L)]
+        [InlineData(typeof(RequiredBlockIntervalException), true, true, false, true, 3, 10L, false, false, 0, false, false, false, -Raid.RequiredInterval + 4L)]
         // Exceed purchase limit.
         [InlineData(typeof(ExceedTicketPurchaseLimitException), true, true, false, true, 0, 100L, true, false, 1_000, false, false, false, -Raid.RequiredInterval)]
         // Exceed challenge count.

--- a/Lib9c/Action/Raid.cs
+++ b/Lib9c/Action/Raid.cs
@@ -93,7 +93,7 @@ namespace Nekoyume.Action
 
             if (context.BlockIndex - raiderState.UpdatedBlockIndex < RequiredInterval)
             {
-                throw new RequiredBlockIndexException($"wait for interval. {context.BlockIndex - raiderState.UpdatedBlockIndex}");
+                throw new RequiredBlockIntervalException($"wait for interval. {context.BlockIndex - raiderState.UpdatedBlockIndex}");
             }
 
             if (WorldBossHelper.CanRefillTicket(context.BlockIndex, raiderState.RefillBlockIndex, row.StartedBlockIndex))

--- a/Lib9c/Action/RequiredBlockIntervalException.cs
+++ b/Lib9c/Action/RequiredBlockIntervalException.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Nekoyume.Action
+{
+    [Serializable]
+    public class RequiredBlockIntervalException : RequiredBlockIndexException
+    {
+        public RequiredBlockIntervalException()
+        {
+        }
+
+        public RequiredBlockIntervalException(string msg) : base(msg)
+        {
+        }
+
+        public RequiredBlockIntervalException(
+            string actionType,
+            string addressesHex,
+            long currentBlockIndex)
+            : base(actionType, addressesHex, currentBlockIndex)
+        {
+        }
+
+        public RequiredBlockIntervalException(
+            string actionType,
+            string addressesHex,
+            long requiredBlockIndex,
+            long currentBlockIndex)
+            : base(actionType, addressesHex, requiredBlockIndex, currentBlockIndex)
+        {
+        }
+
+        protected RequiredBlockIntervalException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3193043/190937972-4600c269-834e-4865-a570-25f60cdbb7ad.png)

use `RequiredBlockIntervalException` for client avoid wrong render exception.