### PR TITLE
Fix inventory notification

### DIFF
--- a/.Lib9c.Tests/Model/ItemNotificationTest.cs
+++ b/.Lib9c.Tests/Model/ItemNotificationTest.cs
@@ -53,7 +53,14 @@ namespace Lib9c.Tests.Model
             avatarState.EquipEquipments(equipmentList);
 
             var inventory = avatarState.inventory;
-            var hasNotification = inventory.HasNotification(avatarState.level, 0);
+            var hasNotification = inventory.HasNotification(
+                avatarState.level,
+                0,
+                _tableSheets.ItemRequirementSheet,
+                _tableSheets.EquipmentItemRecipeSheet,
+                _tableSheets.EquipmentItemSubRecipeSheetV2,
+                _tableSheets.EquipmentItemOptionSheet
+            );
             // When inventory is empty.
             Assert.False(hasNotification);
 
@@ -68,7 +75,14 @@ namespace Lib9c.Tests.Model
                     inventory.AddItem(equipment);
                 }
 
-                hasNotification = inventory.HasNotification(avatarState.level, 0);
+                hasNotification = inventory.HasNotification(
+                    avatarState.level,
+                    0,
+                    _tableSheets.ItemRequirementSheet,
+                    _tableSheets.EquipmentItemRecipeSheet,
+                    _tableSheets.EquipmentItemSubRecipeSheetV2,
+                    _tableSheets.EquipmentItemOptionSheet
+                );
                 // When all of the items are unequipped.
                 Assert.True(hasNotification);
 
@@ -79,7 +93,14 @@ namespace Lib9c.Tests.Model
                 var weakest = ordered.First();
                 equipmentList.Add(weakest.ItemId);
                 avatarState.EquipEquipments(equipmentList);
-                hasNotification = inventory.HasNotification(avatarState.level, 0);
+                hasNotification = inventory.HasNotification(
+                    avatarState.level,
+                    0,
+                    _tableSheets.ItemRequirementSheet,
+                    _tableSheets.EquipmentItemRecipeSheet,
+                    _tableSheets.EquipmentItemSubRecipeSheetV2,
+                    _tableSheets.EquipmentItemOptionSheet
+                );
                 // When weakest item is equipped.
                 Assert.True(hasNotification);
 
@@ -88,7 +109,14 @@ namespace Lib9c.Tests.Model
                 var strongest = ordered.Last();
                 equipmentList.Add(strongest.ItemId);
                 avatarState.EquipEquipments(equipmentList);
-                hasNotification = inventory.HasNotification(avatarState.level, 0);
+                hasNotification = inventory.HasNotification(
+                    avatarState.level,
+                    0,
+                    _tableSheets.ItemRequirementSheet,
+                    _tableSheets.EquipmentItemRecipeSheet,
+                    _tableSheets.EquipmentItemSubRecipeSheetV2,
+                    _tableSheets.EquipmentItemOptionSheet
+                );
                 // When strongest item is equipped.
                 Assert.False(hasNotification);
             }
@@ -112,7 +140,14 @@ namespace Lib9c.Tests.Model
             avatarState.EquipEquipments(equipmentList);
 
             var inventory = avatarState.inventory;
-            var hasNotification = inventory.HasNotification(avatarState.level, 0);
+            var hasNotification = inventory.HasNotification(
+                avatarState.level,
+                0,
+                _tableSheets.ItemRequirementSheet,
+                _tableSheets.EquipmentItemRecipeSheet,
+                _tableSheets.EquipmentItemSubRecipeSheetV2,
+                _tableSheets.EquipmentItemOptionSheet
+            );
             // When inventory is empty.
             Assert.False(hasNotification);
 
@@ -125,7 +160,14 @@ namespace Lib9c.Tests.Model
                 inventory.AddItem(equipment);
             }
 
-            hasNotification = inventory.HasNotification(avatarState.level, 0);
+            hasNotification = inventory.HasNotification(
+                avatarState.level,
+                0,
+                _tableSheets.ItemRequirementSheet,
+                _tableSheets.EquipmentItemRecipeSheet,
+                _tableSheets.EquipmentItemSubRecipeSheetV2,
+                _tableSheets.EquipmentItemOptionSheet
+            );
             // When all of the items are unequipped.
             Assert.True(hasNotification);
 
@@ -134,7 +176,14 @@ namespace Lib9c.Tests.Model
             var strongest = ordered.Last();
             equipmentList.Add(strongest.ItemId);
             avatarState.EquipEquipments(equipmentList);
-            hasNotification = inventory.HasNotification(avatarState.level, 0);
+            hasNotification = inventory.HasNotification(
+                avatarState.level,
+                0,
+                _tableSheets.ItemRequirementSheet,
+                _tableSheets.EquipmentItemRecipeSheet,
+                _tableSheets.EquipmentItemSubRecipeSheetV2,
+                _tableSheets.EquipmentItemOptionSheet
+            );
             // When one strongest ring is equipped.
             Assert.True(hasNotification);
 
@@ -143,7 +192,14 @@ namespace Lib9c.Tests.Model
             var strongests = ordered.TakeLast(2).Select(i => i.ItemId);
             equipmentList.AddRange(strongests);
             avatarState.EquipEquipments(equipmentList);
-            hasNotification = inventory.HasNotification(avatarState.level, 0);
+            hasNotification = inventory.HasNotification(
+                avatarState.level,
+                0,
+                _tableSheets.ItemRequirementSheet,
+                _tableSheets.EquipmentItemRecipeSheet,
+                _tableSheets.EquipmentItemSubRecipeSheetV2,
+                _tableSheets.EquipmentItemOptionSheet
+            );
             // When the 1st strongest, the 2nd strongest items are equipped.
             Assert.False(hasNotification);
         }
@@ -168,7 +224,14 @@ namespace Lib9c.Tests.Model
             avatarState.EquipEquipments(equipmentList);
 
             var inventory = avatarState.inventory;
-            var hasNotification = inventory.HasNotification(avatarState.level, blockIndex);
+            var hasNotification = inventory.HasNotification(
+                avatarState.level,
+                blockIndex,
+                _tableSheets.ItemRequirementSheet,
+                _tableSheets.EquipmentItemRecipeSheet,
+                _tableSheets.EquipmentItemSubRecipeSheetV2,
+                _tableSheets.EquipmentItemOptionSheet
+            );
             // When inventory is empty.
             Assert.False(false);
 
@@ -181,7 +244,14 @@ namespace Lib9c.Tests.Model
                 inventory.AddItem(equipment);
             }
 
-            hasNotification = inventory.HasNotification(avatarState.level, 0);
+            hasNotification = inventory.HasNotification(
+                avatarState.level,
+                0,
+                _tableSheets.ItemRequirementSheet,
+                _tableSheets.EquipmentItemRecipeSheet,
+                _tableSheets.EquipmentItemSubRecipeSheetV2,
+                _tableSheets.EquipmentItemOptionSheet
+            );
             Assert.Equal(blockIndex >= requiredBlockIndex, expected);
         }
     }

--- a/Lib9c/Extensions/EquipmentExtensions.cs
+++ b/Lib9c/Extensions/EquipmentExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Nekoyume.Battle;
 using Nekoyume.Helper;
 using Nekoyume.Model.Elemental;
 using Nekoyume.Model.Item;
@@ -251,6 +252,26 @@ namespace Nekoyume.Extensions
                 default:
                     return false;
             }
+        }
+
+        public static int GetRequirementLevel(this Equipment equipment,
+            ItemRequirementSheet requirementSheet,
+            EquipmentItemRecipeSheet recipeSheet,
+            EquipmentItemSubRecipeSheetV2 subRecipeSheet,
+            EquipmentItemOptionSheet itemOptionSheet)
+        {
+            if (!requirementSheet.TryGetValue(equipment.Id, out var row))
+            {
+                throw new SheetRowNotFoundException(nameof(ItemRequirementSheet), equipment.Id);
+            }
+
+            var isMadeWithMimisbrunnrRecipe = equipment.IsMadeWithMimisbrunnrRecipe(
+                recipeSheet,
+                subRecipeSheet,
+                itemOptionSheet
+            );
+            
+            return isMadeWithMimisbrunnrRecipe ? row.MimisLevel : row.Level;
         }
     }
 }

--- a/Lib9c/Model/Item/Inventory.cs
+++ b/Lib9c/Model/Item/Inventory.cs
@@ -7,6 +7,7 @@ using Lib9c.Model.Order;
 using Libplanet;
 using Nekoyume.Action;
 using Nekoyume.Battle;
+using Nekoyume.Extensions;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
@@ -652,7 +653,13 @@ namespace Nekoyume.Model.Item
 
         #endregion
 
-        public bool HasNotification(int level, long blockIndex)
+        public bool HasNotification(
+            int level,
+            long blockIndex,
+            ItemRequirementSheet requirementSheet,
+            EquipmentItemRecipeSheet recipeSheet,
+            EquipmentItemSubRecipeSheetV2 subRecipeSheet,
+            EquipmentItemOptionSheet itemOptionSheet)
         {
             var availableSlots = UnlockHelper.GetAvailableEquipmentSlots(level);
 
@@ -679,9 +686,18 @@ namespace Nekoyume.Model.Item
                     }
 
                     var cp = CPHelper.GetCP(equipment);
-                    if (current.Any(i => CPHelper.GetCP(i) < cp))
+                    foreach (var i in current)
                     {
-                        return true;
+                        var requirementLevel = i.GetRequirementLevel(
+                            requirementSheet,
+                            recipeSheet,
+                            subRecipeSheet,
+                            itemOptionSheet);
+                        
+                        if (level < requirementLevel && CPHelper.GetCP(i) < cp)
+                        {
+                            return true;
+                        }
                     }
                 }
             }

--- a/Lib9c/Model/Item/Inventory.cs
+++ b/Lib9c/Model/Item/Inventory.cs
@@ -694,7 +694,8 @@ namespace Nekoyume.Model.Item
                             subRecipeSheet,
                             itemOptionSheet);
                         
-                        if (level < requirementLevel && CPHelper.GetCP(i) < cp)
+
+                        if (level >= requirementLevel && CPHelper.GetCP(i) < cp)
                         {
                             return true;
                         }


### PR DESCRIPTION
### Description

- Fix inventory notification
  The inventory notification(red dot) appears when the player doesn't equip the best equipments.
  but, item requirement level check was not included in the best equipment.
  - **Fix notification check, add equipment extention** (get requirment level)
- 9c PR : https://github.com/planetarium/NineChronicles/pull/1999

### How to test

1. Equip all best equipments.
2. Check the inventory icon of header menu has not red dot.

### Related Links

[CP가 높더라도 장착불가 템이면 인디케이터 안보여줘야 하는데, 인벤토리 아이콘에서 인디케이터를 보여주는 문제](https://app.asana.com/0/1141562434100787/1202619716401117/f)

### Screenshot

![image](https://user-images.githubusercontent.com/63496908/191429401-8f6abf8b-1f84-432e-9ef7-58932d5c1efa.png)
