### PR TITLE
Turn on nullable reference checker

### DIFF
--- a/.Lib9c.Tests/Action/AccountStateDeltaExtensionsTest.cs
+++ b/.Lib9c.Tests/Action/AccountStateDeltaExtensionsTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/ActionContext.cs
+++ b/.Lib9c.Tests/Action/ActionContext.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Security.Cryptography;

--- a/.Lib9c.Tests/Action/ActionContextExtensionsTest.cs
+++ b/.Lib9c.Tests/Action/ActionContextExtensionsTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/ActionEvaluationTest.cs
+++ b/.Lib9c.Tests/Action/ActionEvaluationTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/ActivateAccount0Test.cs
+++ b/.Lib9c.Tests/Action/ActivateAccount0Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Immutable;

--- a/.Lib9c.Tests/Action/ActivateAccountTest.cs
+++ b/.Lib9c.Tests/Action/ActivateAccountTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/AddActivatedAccount0Test.cs
+++ b/.Lib9c.Tests/Action/AddActivatedAccount0Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Immutable;

--- a/.Lib9c.Tests/Action/AddActivatedAccountTest.cs
+++ b/.Lib9c.Tests/Action/AddActivatedAccountTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/AddRedeemCodeTest.cs
+++ b/.Lib9c.Tests/Action/AddRedeemCodeTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Immutable;

--- a/.Lib9c.Tests/Action/ArenahelperTest.cs
+++ b/.Lib9c.Tests/Action/ArenahelperTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/BattleArena1Test.cs
+++ b/.Lib9c.Tests/Action/BattleArena1Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/BattleArena2Test.cs
+++ b/.Lib9c.Tests/Action/BattleArena2Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/BattleArena3Test.cs
+++ b/.Lib9c.Tests/Action/BattleArena3Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/BattleArena4Test.cs
+++ b/.Lib9c.Tests/Action/BattleArena4Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/BattleArenaTest.cs
+++ b/.Lib9c.Tests/Action/BattleArenaTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/Buy10Test.cs
+++ b/.Lib9c.Tests/Action/Buy10Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/Buy11Test.cs
+++ b/.Lib9c.Tests/Action/Buy11Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/Buy2Test.cs
+++ b/.Lib9c.Tests/Action/Buy2Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/Buy3Test.cs
+++ b/.Lib9c.Tests/Action/Buy3Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Linq;

--- a/.Lib9c.Tests/Action/Buy4Test.cs
+++ b/.Lib9c.Tests/Action/Buy4Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/Buy5Test.cs
+++ b/.Lib9c.Tests/Action/Buy5Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/Buy6Test.cs
+++ b/.Lib9c.Tests/Action/Buy6Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/Buy7Test.cs
+++ b/.Lib9c.Tests/Action/Buy7Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/Buy8Test.cs
+++ b/.Lib9c.Tests/Action/Buy8Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/Buy9Test.cs
+++ b/.Lib9c.Tests/Action/Buy9Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/BuyMultipleTest.cs
+++ b/.Lib9c.Tests/Action/BuyMultipleTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/BuyTest.cs
+++ b/.Lib9c.Tests/Action/BuyTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/CancelMonsterCollectTest.cs
+++ b/.Lib9c.Tests/Action/CancelMonsterCollectTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/ChargeActionPoint0Test.cs
+++ b/.Lib9c.Tests/Action/ChargeActionPoint0Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/ChargeActionPoint2Test.cs
+++ b/.Lib9c.Tests/Action/ChargeActionPoint2Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/ChargeActionPointTest.cs
+++ b/.Lib9c.Tests/Action/ChargeActionPointTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/ClaimMonsterCollectionReward0Test.cs
+++ b/.Lib9c.Tests/Action/ClaimMonsterCollectionReward0Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/ClaimMonsterCollectionReward2Test.cs
+++ b/.Lib9c.Tests/Action/ClaimMonsterCollectionReward2Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections;

--- a/.Lib9c.Tests/Action/ClaimMonsterCollectionRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimMonsterCollectionRewardTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/ClaimRaidRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimRaidRewardTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/ClaimStakeReward1Test.cs
+++ b/.Lib9c.Tests/Action/ClaimStakeReward1Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Linq;

--- a/.Lib9c.Tests/Action/ClaimStakeRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimStakeRewardTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Linq;

--- a/.Lib9c.Tests/Action/ClaimWorldBossKillRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimWorldBossKillRewardTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/CombinationConsumable0Test.cs
+++ b/.Lib9c.Tests/Action/CombinationConsumable0Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/CombinationConsumable2Test.cs
+++ b/.Lib9c.Tests/Action/CombinationConsumable2Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/CombinationConsumable3Test.cs
+++ b/.Lib9c.Tests/Action/CombinationConsumable3Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/CombinationConsumable4Test.cs
+++ b/.Lib9c.Tests/Action/CombinationConsumable4Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/CombinationConsumable5Test.cs
+++ b/.Lib9c.Tests/Action/CombinationConsumable5Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/CombinationConsumable6Test.cs
+++ b/.Lib9c.Tests/Action/CombinationConsumable6Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;
     using System.Globalization;

--- a/.Lib9c.Tests/Action/CombinationConsumable7Test.cs
+++ b/.Lib9c.Tests/Action/CombinationConsumable7Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/CombinationConsumableTest.cs
+++ b/.Lib9c.Tests/Action/CombinationConsumableTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Globalization;

--- a/.Lib9c.Tests/Action/CombinationEquipment0Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment0Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/CombinationEquipment10Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment10Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/CombinationEquipment11Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment11Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/CombinationEquipment12Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment12Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/CombinationEquipment13Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment13Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Globalization;

--- a/.Lib9c.Tests/Action/CombinationEquipment2Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment2Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/CombinationEquipment3Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment3Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/CombinationEquipment4Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment4Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/CombinationEquipment5Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment5Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/CombinationEquipment6Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment6Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/CombinationEquipment7Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment7Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/CombinationEquipment8Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment8Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/CombinationEquipment9Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment9Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/CombinationEquipmentTest.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipmentTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Globalization;

--- a/.Lib9c.Tests/Action/Common/Doomfist.cs
+++ b/.Lib9c.Tests/Action/Common/Doomfist.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/Common/TestRandom.cs
+++ b/.Lib9c.Tests/Action/Common/TestRandom.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using Libplanet.Action;

--- a/.Lib9c.Tests/Action/CreateAvatar0Test.cs
+++ b/.Lib9c.Tests/Action/CreateAvatar0Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/CreateAvatar2Test.cs
+++ b/.Lib9c.Tests/Action/CreateAvatar2Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/CreateAvatar3Test.cs
+++ b/.Lib9c.Tests/Action/CreateAvatar3Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;
     using System.Collections.Immutable;

--- a/.Lib9c.Tests/Action/CreateAvatar6Test.cs
+++ b/.Lib9c.Tests/Action/CreateAvatar6Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/CreateAvatar7Test.cs
+++ b/.Lib9c.Tests/Action/CreateAvatar7Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/CreateAvatarTest.cs
+++ b/.Lib9c.Tests/Action/CreateAvatarTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/CreatePendingActivationTest.cs
+++ b/.Lib9c.Tests/Action/CreatePendingActivationTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/CreatePendingActivationsTest.cs
+++ b/.Lib9c.Tests/Action/CreatePendingActivationsTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Immutable;

--- a/.Lib9c.Tests/Action/CreateTestbedTest.cs
+++ b/.Lib9c.Tests/Action/CreateTestbedTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System.Linq;
     using Lib9c.Tests.TestHelper;

--- a/.Lib9c.Tests/Action/DailyReward0Test.cs
+++ b/.Lib9c.Tests/Action/DailyReward0Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using Libplanet;
     using Libplanet.Action;

--- a/.Lib9c.Tests/Action/DailyReward2Test.cs
+++ b/.Lib9c.Tests/Action/DailyReward2Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Linq;

--- a/.Lib9c.Tests/Action/DailyReward3Test.cs
+++ b/.Lib9c.Tests/Action/DailyReward3Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/DailyReward4Test.cs
+++ b/.Lib9c.Tests/Action/DailyReward4Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/DailyReward5Test.cs
+++ b/.Lib9c.Tests/Action/DailyReward5Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/DailyRewardTest.cs
+++ b/.Lib9c.Tests/Action/DailyRewardTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/EventConsumableItemCraftsTest.cs
+++ b/.Lib9c.Tests/Action/EventConsumableItemCraftsTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Linq;

--- a/.Lib9c.Tests/Action/EventDungeonBattleTest.cs
+++ b/.Lib9c.Tests/Action/EventDungeonBattleTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/EventDungeonBattleV1Test.cs
+++ b/.Lib9c.Tests/Action/EventDungeonBattleV1Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/ExceptionTest.cs
+++ b/.Lib9c.Tests/Action/ExceptionTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/GoldDistributionTest.cs
+++ b/.Lib9c.Tests/Action/GoldDistributionTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.IO;

--- a/.Lib9c.Tests/Action/GrindingTest.cs
+++ b/.Lib9c.Tests/Action/GrindingTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/HackAndSlash0Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash0Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/HackAndSlash10Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash10Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/HackAndSlash11Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash11Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/HackAndSlash12Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash12Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/HackAndSlash13Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash13Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/HackAndSlash15Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash15Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/HackAndSlash16Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash16Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/HackAndSlash17Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash17Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/HackAndSlash2Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash2Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/HackAndSlash3Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash3Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/HackAndSlash4Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash4Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/HackAndSlash5Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash5Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/HackAndSlash6Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash6Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/HackAndSlash7Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash7Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/HackAndSlash8Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash8Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/HackAndSlash9Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash9Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/HackAndSlashRandomBuffTest.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashRandomBuffTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/HackAndSlashSweep1Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweep1Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/HackAndSlashSweep2Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweep2Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/HackAndSlashSweep3Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweep3Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/HackAndSlashSweep4Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweep4Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/HackAndSlashSweep5Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweep5Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/HackAndSlashSweep6Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweep6Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/HackAndSlashSweepTest.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweepTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/HackAndSlashTest.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/HackAndSlashTest14.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashTest14.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/InitializeStatesTest.cs
+++ b/.Lib9c.Tests/Action/InitializeStatesTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/InvalidSignatureExceptionTest.cs
+++ b/.Lib9c.Tests/Action/InvalidSignatureExceptionTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.IO;

--- a/.Lib9c.Tests/Action/InvalidTransferSiginerExceptionTest.cs
+++ b/.Lib9c.Tests/Action/InvalidTransferSiginerExceptionTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.IO;

--- a/.Lib9c.Tests/Action/ItemEnhancement0Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement0Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/ItemEnhancement10Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement10Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/ItemEnhancement2Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement2Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/ItemEnhancement3Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement3Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/ItemEnhancement4Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement4Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/ItemEnhancement5Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement5Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/ItemEnhancement6Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement6Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/ItemEnhancement7Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement7Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/ItemEnhancement8Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement8Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/ItemEnhancement9Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement9Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/ItemEnhancementTest.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancementTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/JoinArenaTest.cs
+++ b/.Lib9c.Tests/Action/JoinArenaTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/MemoLengthOverflowExceptionTest.cs
+++ b/.Lib9c.Tests/Action/MemoLengthOverflowExceptionTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.IO;

--- a/.Lib9c.Tests/Action/MigrateMonsterCollectionTest.cs
+++ b/.Lib9c.Tests/Action/MigrateMonsterCollectionTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/MigrationActivatedAccountsStateTest.cs
+++ b/.Lib9c.Tests/Action/MigrationActivatedAccountsStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/MigrationAvatarStateTest.cs
+++ b/.Lib9c.Tests/Action/MigrationAvatarStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/MigrationLegacyShopTest.cs
+++ b/.Lib9c.Tests/Action/MigrationLegacyShopTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle0Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle0Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle2Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle2Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle3Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle3Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle4Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle4Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle5Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle5Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle6Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle6Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle7Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle7Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle8Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle8Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle9Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle9Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/MimisbrunnrBattleTest.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattleTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/MonsterCollect0Test.cs
+++ b/.Lib9c.Tests/Action/MonsterCollect0Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/MonsterCollect2Test.cs
+++ b/.Lib9c.Tests/Action/MonsterCollect2Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/MonsterCollectTest.cs
+++ b/.Lib9c.Tests/Action/MonsterCollectTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/PatchTableSheetTest.cs
+++ b/.Lib9c.Tests/Action/PatchTableSheetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Immutable;

--- a/.Lib9c.Tests/Action/PendingActivationDoesNotExistsExceptionTest.cs
+++ b/.Lib9c.Tests/Action/PendingActivationDoesNotExistsExceptionTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.IO;

--- a/.Lib9c.Tests/Action/PrepareRewardAssetsTest.cs
+++ b/.Lib9c.Tests/Action/PrepareRewardAssetsTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/PurchaseInfoTest.cs
+++ b/.Lib9c.Tests/Action/PurchaseInfoTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RaidTest.cs
+++ b/.Lib9c.Tests/Action/RaidTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RankingBattle0Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle0Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RankingBattle10Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle10Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RankingBattle11Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle11Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RankingBattle2Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle2Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RankingBattle3Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle3Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RankingBattle4Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle4Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RankingBattle5Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle5Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/RankingBattle6Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle6Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RankingBattle7Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle7Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/RankingBattle8Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle8Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/RankingBattle9Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle9Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RankingBattleTest.cs
+++ b/.Lib9c.Tests/Action/RankingBattleTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RapidCombination0Test.cs
+++ b/.Lib9c.Tests/Action/RapidCombination0Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RapidCombination2Test.cs
+++ b/.Lib9c.Tests/Action/RapidCombination2Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RapidCombination3Test.cs
+++ b/.Lib9c.Tests/Action/RapidCombination3Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RapidCombination4Test.cs
+++ b/.Lib9c.Tests/Action/RapidCombination4Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/RapidCombination5Test.cs
+++ b/.Lib9c.Tests/Action/RapidCombination5Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RapidCombination6Test.cs
+++ b/.Lib9c.Tests/Action/RapidCombination6Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RapidCombinationTest.cs
+++ b/.Lib9c.Tests/Action/RapidCombinationTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RapidCombinationTest7.cs
+++ b/.Lib9c.Tests/Action/RapidCombinationTest7.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RawState.cs
+++ b/.Lib9c.Tests/Action/RawState.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RedeemCode0Test.cs
+++ b/.Lib9c.Tests/Action/RedeemCode0Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/RedeemCodeTest.cs
+++ b/.Lib9c.Tests/Action/RedeemCodeTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/RenewAdminStateTest.cs
+++ b/.Lib9c.Tests/Action/RenewAdminStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RewardGoldTest.cs
+++ b/.Lib9c.Tests/Action/RewardGoldTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/RuneHelperTest.cs
+++ b/.Lib9c.Tests/Action/RuneHelperTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/Scenario/ArenaScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/ArenaScenarioTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action.Scenario
 {
     using System;

--- a/.Lib9c.Tests/Action/Scenario/CombinationAndRapidCombinationTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/CombinationAndRapidCombinationTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action.Scenario
+﻿#nullable disable
+namespace Lib9c.Tests.Action.Scenario
 {
     using System.Globalization;
     using System.Linq;

--- a/.Lib9c.Tests/Action/Scenario/StakeAndClaimStakeRewardScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/StakeAndClaimStakeRewardScenarioTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action.Scenario
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/Scenario/WorldUnlockScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/WorldUnlockScenarioTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action.Scenario
 {
     using System;

--- a/.Lib9c.Tests/Action/Sell0Test.cs
+++ b/.Lib9c.Tests/Action/Sell0Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/Sell10Test.cs
+++ b/.Lib9c.Tests/Action/Sell10Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/Sell2Test.cs
+++ b/.Lib9c.Tests/Action/Sell2Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Linq;

--- a/.Lib9c.Tests/Action/Sell3Test.cs
+++ b/.Lib9c.Tests/Action/Sell3Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Linq;

--- a/.Lib9c.Tests/Action/Sell4Test.cs
+++ b/.Lib9c.Tests/Action/Sell4Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/Sell5Test.cs
+++ b/.Lib9c.Tests/Action/Sell5Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/Sell6Test.cs
+++ b/.Lib9c.Tests/Action/Sell6Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/Sell7Test.cs
+++ b/.Lib9c.Tests/Action/Sell7Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/Sell8Test.cs
+++ b/.Lib9c.Tests/Action/Sell8Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/Sell9Test.cs
+++ b/.Lib9c.Tests/Action/Sell9Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/SellCancellation0Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation0Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/SellCancellation2Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation2Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/SellCancellation3Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation3Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Linq;

--- a/.Lib9c.Tests/Action/SellCancellation4Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation4Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Linq;

--- a/.Lib9c.Tests/Action/SellCancellation5Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation5Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/SellCancellation6Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation6Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/SellCancellation7Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation7Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/SellCancellation8Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation8Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/SellCancellationTest.cs
+++ b/.Lib9c.Tests/Action/SellCancellationTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/SellTest.cs
+++ b/.Lib9c.Tests/Action/SellTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/Stake0Test.cs
+++ b/.Lib9c.Tests/Action/Stake0Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/StakeTest.cs
+++ b/.Lib9c.Tests/Action/StakeTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/State.cs
+++ b/.Lib9c.Tests/Action/State.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/TransferAsset2Test.cs
+++ b/.Lib9c.Tests/Action/TransferAsset2Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/TransferAssetTest.cs
+++ b/.Lib9c.Tests/Action/TransferAssetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/TransferAssetTest0.cs
+++ b/.Lib9c.Tests/Action/TransferAssetTest0.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/UnlockEquipmentRecipeTest.cs
+++ b/.Lib9c.Tests/Action/UnlockEquipmentRecipeTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/UnlockWorld1Test.cs
+++ b/.Lib9c.Tests/Action/UnlockWorld1Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/UnlockWorldTest.cs
+++ b/.Lib9c.Tests/Action/UnlockWorldTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using System;

--- a/.Lib9c.Tests/Action/UpdateSell0Test.cs
+++ b/.Lib9c.Tests/Action/UpdateSell0Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/UpdateSell2Test.cs
+++ b/.Lib9c.Tests/Action/UpdateSell2Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/UpdateSellTest.cs
+++ b/.Lib9c.Tests/Action/UpdateSellTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Action
+﻿#nullable disable
+namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Action/WorldBossHelperTest.cs
+++ b/.Lib9c.Tests/Action/WorldBossHelperTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Action
 {
     using Libplanet.Assets;

--- a/.Lib9c.Tests/ActionSerializer.cs
+++ b/.Lib9c.Tests/ActionSerializer.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests
 {
     using Lib9c.Formatters;

--- a/.Lib9c.Tests/Battle/ArenaScoreHelperTest.cs
+++ b/.Lib9c.Tests/Battle/ArenaScoreHelperTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests
 {
     using System;

--- a/.Lib9c.Tests/Battle/EnemyPlayerDigestTest.cs
+++ b/.Lib9c.Tests/Battle/EnemyPlayerDigestTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests
 {
     using System.Linq;

--- a/.Lib9c.Tests/Battle/SimplePriorityQueueTest.cs
+++ b/.Lib9c.Tests/Battle/SimplePriorityQueueTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests
 {
     using System;

--- a/.Lib9c.Tests/CrystalCalculatorTest.cs
+++ b/.Lib9c.Tests/CrystalCalculatorTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests
 {
     using System;

--- a/.Lib9c.Tests/Extensions/EquipmentExtensionsTest.cs
+++ b/.Lib9c.Tests/Extensions/EquipmentExtensionsTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Extensions
+﻿#nullable disable
+namespace Lib9c.Tests.Extensions
 {
     using System;
     using System.Linq;

--- a/.Lib9c.Tests/Extensions/EventDungeonExtensionsTest.cs
+++ b/.Lib9c.Tests/Extensions/EventDungeonExtensionsTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Extensions
+﻿#nullable disable
+namespace Lib9c.Tests.Extensions
 {
     using System;
     using Nekoyume.Extensions;

--- a/.Lib9c.Tests/Extensions/EventScheduleExtensionsTest.cs
+++ b/.Lib9c.Tests/Extensions/EventScheduleExtensionsTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Extensions
 {
     using System;

--- a/.Lib9c.Tests/Extensions/SheetsExtensionsTest.cs
+++ b/.Lib9c.Tests/Extensions/SheetsExtensionsTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Extensions
+﻿#nullable disable
+namespace Lib9c.Tests.Extensions
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/JsonStatesLoader.cs
+++ b/.Lib9c.Tests/JsonStatesLoader.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests
 {
     using System;

--- a/.Lib9c.Tests/JsonStatesLoaderTest.cs
+++ b/.Lib9c.Tests/JsonStatesLoaderTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests
 {
     using System;

--- a/.Lib9c.Tests/Lib9c.Tests.csproj
+++ b/.Lib9c.Tests/Lib9c.Tests.csproj
@@ -6,6 +6,7 @@
     <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS0162;CS8032;CS0618;CS0612;SYSLIB0011</NoWarn>
     <CodeAnalysisRuleSet>.\Lib9c.Tests.ruleset</CodeAnalysisRuleSet>

--- a/.Lib9c.Tests/Model/ActivationKeyTest.cs
+++ b/.Lib9c.Tests/Model/ActivationKeyTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using Libplanet;

--- a/.Lib9c.Tests/Model/Arena/ArenaAvatarStateTest.cs
+++ b/.Lib9c.Tests/Model/Arena/ArenaAvatarStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Arena
 {
     using Bencodex.Types;

--- a/.Lib9c.Tests/Model/Arena/ArenaInformationTest.cs
+++ b/.Lib9c.Tests/Model/Arena/ArenaInformationTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Arena
 {
     using Bencodex.Types;

--- a/.Lib9c.Tests/Model/Arena/ArenaParticipantsTest.cs
+++ b/.Lib9c.Tests/Model/Arena/ArenaParticipantsTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Arena
 {
     using Bencodex.Types;

--- a/.Lib9c.Tests/Model/Arena/ArenaScoreTest.cs
+++ b/.Lib9c.Tests/Model/Arena/ArenaScoreTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Arena
 {
     using Bencodex.Types;

--- a/.Lib9c.Tests/Model/Arena/PlayerDigestTest.cs
+++ b/.Lib9c.Tests/Model/Arena/PlayerDigestTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Arena
 {
     using System;

--- a/.Lib9c.Tests/Model/ArenaSimulatorTest.cs
+++ b/.Lib9c.Tests/Model/ArenaSimulatorTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Model/BattleLogTest.cs
+++ b/.Lib9c.Tests/Model/BattleLogTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System;

--- a/.Lib9c.Tests/Model/Event/EventDungeonInfoTest.cs
+++ b/.Lib9c.Tests/Model/Event/EventDungeonInfoTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System;

--- a/.Lib9c.Tests/Model/ExceptionTest.cs
+++ b/.Lib9c.Tests/Model/ExceptionTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Model
+﻿#nullable disable
+namespace Lib9c.Tests.Model
 {
     using System;
     using System.IO;

--- a/.Lib9c.Tests/Model/Item/ArmorTest.cs
+++ b/.Lib9c.Tests/Model/Item/ArmorTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Item
 {
     using System;

--- a/.Lib9c.Tests/Model/Item/BeltTest.cs
+++ b/.Lib9c.Tests/Model/Item/BeltTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Item
 {
     using System;

--- a/.Lib9c.Tests/Model/Item/ConsumableTest.cs
+++ b/.Lib9c.Tests/Model/Item/ConsumableTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Item
 {
     using System;

--- a/.Lib9c.Tests/Model/Item/CostumeTest.cs
+++ b/.Lib9c.Tests/Model/Item/CostumeTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Item
 {
     using System;

--- a/.Lib9c.Tests/Model/Item/EquipmentTest.cs
+++ b/.Lib9c.Tests/Model/Item/EquipmentTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Item
 {
     using System;

--- a/.Lib9c.Tests/Model/Item/InventoryTest.cs
+++ b/.Lib9c.Tests/Model/Item/InventoryTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Model.Item
+﻿#nullable disable
+namespace Lib9c.Tests.Model.Item
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Model/Item/MaterialTest.cs
+++ b/.Lib9c.Tests/Model/Item/MaterialTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Item
 {
     using System.IO;

--- a/.Lib9c.Tests/Model/Item/NecklaceTest.cs
+++ b/.Lib9c.Tests/Model/Item/NecklaceTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Item
 {
     using System;

--- a/.Lib9c.Tests/Model/Item/OrderLockTest.cs
+++ b/.Lib9c.Tests/Model/Item/OrderLockTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Item
 {
     using System;

--- a/.Lib9c.Tests/Model/Item/ShopItemTest.cs
+++ b/.Lib9c.Tests/Model/Item/ShopItemTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Model.Item
+﻿#nullable disable
+namespace Lib9c.Tests.Model.Item
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Model/Item/TradableMaterialTest.cs
+++ b/.Lib9c.Tests/Model/Item/TradableMaterialTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Item
 {
     using System.IO;

--- a/.Lib9c.Tests/Model/ItemGradeQuestTest.cs
+++ b/.Lib9c.Tests/Model/ItemGradeQuestTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Model/ItemNotificationTest.cs
+++ b/.Lib9c.Tests/Model/ItemNotificationTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System;

--- a/.Lib9c.Tests/Model/ItemTypeCollectQuestTest.cs
+++ b/.Lib9c.Tests/Model/ItemTypeCollectQuestTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Model/ItemUsableTest.cs
+++ b/.Lib9c.Tests/Model/ItemUsableTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System.Linq;

--- a/.Lib9c.Tests/Model/Mail/CancelOrderMailTest.cs
+++ b/.Lib9c.Tests/Model/Mail/CancelOrderMailTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Mail
 {
     using System;

--- a/.Lib9c.Tests/Model/Mail/GrindingMailTest.cs
+++ b/.Lib9c.Tests/Model/Mail/GrindingMailTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Mail
 {
     using System;

--- a/.Lib9c.Tests/Model/Mail/MonsterCollectMailTest.cs
+++ b/.Lib9c.Tests/Model/Mail/MonsterCollectMailTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Mail
 {
     using System;

--- a/.Lib9c.Tests/Model/Mail/OrderExpirationMailTest.cs
+++ b/.Lib9c.Tests/Model/Mail/OrderExpirationMailTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Mail
 {
     using System;

--- a/.Lib9c.Tests/Model/MonsterCollectSheetTest.cs
+++ b/.Lib9c.Tests/Model/MonsterCollectSheetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using Nekoyume.TableData;

--- a/.Lib9c.Tests/Model/MonsterCollectionRewardSheetTest.cs
+++ b/.Lib9c.Tests/Model/MonsterCollectionRewardSheetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Model/Order/FungibleOrderTest.cs
+++ b/.Lib9c.Tests/Model/Order/FungibleOrderTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Order
 {
     using System;

--- a/.Lib9c.Tests/Model/Order/NonFungibleOrderTest.cs
+++ b/.Lib9c.Tests/Model/Order/NonFungibleOrderTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Order
 {
     using System;

--- a/.Lib9c.Tests/Model/Order/OrderBaseTest.cs
+++ b/.Lib9c.Tests/Model/Order/OrderBaseTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Order
 {
     using System;

--- a/.Lib9c.Tests/Model/Order/OrderDigestListStateTest.cs
+++ b/.Lib9c.Tests/Model/Order/OrderDigestListStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Order
 {
     using System;

--- a/.Lib9c.Tests/Model/Order/OrderDigestTest.cs
+++ b/.Lib9c.Tests/Model/Order/OrderDigestTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Order
 {
     using System;

--- a/.Lib9c.Tests/Model/Order/OrderFactoryTest.cs
+++ b/.Lib9c.Tests/Model/Order/OrderFactoryTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Order
 {
     using System;

--- a/.Lib9c.Tests/Model/Order/OrderReceiptTest.cs
+++ b/.Lib9c.Tests/Model/Order/OrderReceiptTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Order
 {
     using System;

--- a/.Lib9c.Tests/Model/PlayerTest.cs
+++ b/.Lib9c.Tests/Model/PlayerTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System;

--- a/.Lib9c.Tests/Model/QuestListTest.cs
+++ b/.Lib9c.Tests/Model/QuestListTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Model/QuestRewardTest.cs
+++ b/.Lib9c.Tests/Model/QuestRewardTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Model/RaidSimulatorTest.cs
+++ b/.Lib9c.Tests/Model/RaidSimulatorTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System;

--- a/.Lib9c.Tests/Model/RankingSimulatorTest.cs
+++ b/.Lib9c.Tests/Model/RankingSimulatorTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System;

--- a/.Lib9c.Tests/Model/RankingSimulatorV1Test.cs
+++ b/.Lib9c.Tests/Model/RankingSimulatorV1Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System;

--- a/.Lib9c.Tests/Model/RedeemRewardSheetTest.cs
+++ b/.Lib9c.Tests/Model/RedeemRewardSheetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System.Linq;

--- a/.Lib9c.Tests/Model/SimulatorTest.cs
+++ b/.Lib9c.Tests/Model/SimulatorTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Model/Skill/NormalAttackTest.cs
+++ b/.Lib9c.Tests/Model/Skill/NormalAttackTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.Skill
 {
     using System;

--- a/.Lib9c.Tests/Model/SkillsTest.cs
+++ b/.Lib9c.Tests/Model/SkillsTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Model
+﻿#nullable disable
+namespace Lib9c.Tests.Model
 {
     using System;
     using System.Linq;

--- a/.Lib9c.Tests/Model/StageSimulatorTest.cs
+++ b/.Lib9c.Tests/Model/StageSimulatorTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System;

--- a/.Lib9c.Tests/Model/StageSimulatorV1Test.cs
+++ b/.Lib9c.Tests/Model/StageSimulatorV1Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System;

--- a/.Lib9c.Tests/Model/State/ActivatedAccountsStateTest.cs
+++ b/.Lib9c.Tests/Model/State/ActivatedAccountsStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using System.Collections.Immutable;

--- a/.Lib9c.Tests/Model/State/AdminStateTest.cs
+++ b/.Lib9c.Tests/Model/State/AdminStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using System.IO;

--- a/.Lib9c.Tests/Model/State/AgentStateTest.cs
+++ b/.Lib9c.Tests/Model/State/AgentStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using System.IO;

--- a/.Lib9c.Tests/Model/State/AuthorizedMinersStateTest.cs
+++ b/.Lib9c.Tests/Model/State/AuthorizedMinersStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using System.IO;

--- a/.Lib9c.Tests/Model/State/AvatarStateTest.cs
+++ b/.Lib9c.Tests/Model/State/AvatarStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using System;

--- a/.Lib9c.Tests/Model/State/CollectionMapTest.cs
+++ b/.Lib9c.Tests/Model/State/CollectionMapTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using Bencodex.Types;

--- a/.Lib9c.Tests/Model/State/CreditsStateTest.cs
+++ b/.Lib9c.Tests/Model/State/CreditsStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using Bencodex.Types;

--- a/.Lib9c.Tests/Model/State/CrystalCostStateTest.cs
+++ b/.Lib9c.Tests/Model/State/CrystalCostStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using Bencodex.Types;

--- a/.Lib9c.Tests/Model/State/CrystalRandomSkillStateTest.cs
+++ b/.Lib9c.Tests/Model/State/CrystalRandomSkillStateTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Model.State
+﻿#nullable disable
+namespace Lib9c.Tests.Model.State
 {
     using System.Collections.Generic;
     using Bencodex.Types;

--- a/.Lib9c.Tests/Model/State/GoldCurrencyStateTest.cs
+++ b/.Lib9c.Tests/Model/State/GoldCurrencyStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using System.IO;

--- a/.Lib9c.Tests/Model/State/HammerPointStateTest.cs
+++ b/.Lib9c.Tests/Model/State/HammerPointStateTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.Model.State
+﻿#nullable disable
+namespace Lib9c.Tests.Model.State
 {
     using System;
     using Bencodex.Types;

--- a/.Lib9c.Tests/Model/State/LazyStateTest.cs
+++ b/.Lib9c.Tests/Model/State/LazyStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Model/State/MonsterCollectionState0Test.cs
+++ b/.Lib9c.Tests/Model/State/MonsterCollectionState0Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using System;

--- a/.Lib9c.Tests/Model/State/MonsterCollectionStateTest.cs
+++ b/.Lib9c.Tests/Model/State/MonsterCollectionStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using System.IO;

--- a/.Lib9c.Tests/Model/State/PendingActivationStateTest.cs
+++ b/.Lib9c.Tests/Model/State/PendingActivationStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using System.IO;

--- a/.Lib9c.Tests/Model/State/RankingMapStateTest.cs
+++ b/.Lib9c.Tests/Model/State/RankingMapStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using System.Linq;

--- a/.Lib9c.Tests/Model/State/RankingState1Test.cs
+++ b/.Lib9c.Tests/Model/State/RankingState1Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Model/State/RankingStateTest.cs
+++ b/.Lib9c.Tests/Model/State/RankingStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Model/State/ShardedShopStateTest.cs
+++ b/.Lib9c.Tests/Model/State/ShardedShopStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using System;

--- a/.Lib9c.Tests/Model/State/ShardedShopStateV2Test.cs
+++ b/.Lib9c.Tests/Model/State/ShardedShopStateV2Test.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using System;

--- a/.Lib9c.Tests/Model/State/SheetStateTest.cs
+++ b/.Lib9c.Tests/Model/State/SheetStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Model/State/ShopStateTest.cs
+++ b/.Lib9c.Tests/Model/State/ShopStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using System;

--- a/.Lib9c.Tests/Model/State/StakeStateTest.cs
+++ b/.Lib9c.Tests/Model/State/StakeStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using Bencodex.Types;

--- a/.Lib9c.Tests/Model/State/StateExtensionsTest.cs
+++ b/.Lib9c.Tests/Model/State/StateExtensionsTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using System;

--- a/.Lib9c.Tests/Model/State/WeeklyArenaStateTest.cs
+++ b/.Lib9c.Tests/Model/State/WeeklyArenaStateTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model.State
 {
     using System;

--- a/.Lib9c.Tests/Model/WeeklyArenaRewardSheetTest.cs
+++ b/.Lib9c.Tests/Model/WeeklyArenaRewardSheetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using Nekoyume.TableData;

--- a/.Lib9c.Tests/Model/WeightedSelectorTest.cs
+++ b/.Lib9c.Tests/Model/WeightedSelectorTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Model/WorldBossKillRewardRecordTest.cs
+++ b/.Lib9c.Tests/Model/WorldBossKillRewardRecordTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/Model/WorldInformationTest.cs
+++ b/.Lib9c.Tests/Model/WorldInformationTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Model
 {
     using System.Linq;

--- a/.Lib9c.Tests/Policy/BlockPolicyTest.cs
+++ b/.Lib9c.Tests/Policy/BlockPolicyTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests
 {
     using System;

--- a/.Lib9c.Tests/Policy/GenericSubPolicyTest.cs
+++ b/.Lib9c.Tests/Policy/GenericSubPolicyTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests
 {
     using System;

--- a/.Lib9c.Tests/Policy/SpannedSubPolicyTest.cs
+++ b/.Lib9c.Tests/Policy/SpannedSubPolicyTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests
 {
     using System;

--- a/.Lib9c.Tests/SerializeKeysTest.cs
+++ b/.Lib9c.Tests/SerializeKeysTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests
 {
     using System;

--- a/.Lib9c.Tests/StagePolicyTest.cs
+++ b/.Lib9c.Tests/StagePolicyTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/TableData/ArenaSheetTest.cs
+++ b/.Lib9c.Tests/TableData/ArenaSheetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.TableData
 {
     using System;

--- a/.Lib9c.Tests/TableData/Cost/EnhancementCostSheetTest.cs
+++ b/.Lib9c.Tests/TableData/Cost/EnhancementCostSheetTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.TableData.Cost
+﻿#nullable disable
+namespace Lib9c.Tests.TableData.Cost
 {
     using Nekoyume.Model.Item;
     using Nekoyume.TableData;

--- a/.Lib9c.Tests/TableData/Cost/EnhancementCostSheetV2Test.cs
+++ b/.Lib9c.Tests/TableData/Cost/EnhancementCostSheetV2Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.TableData.Cost
+﻿#nullable disable
+namespace Lib9c.Tests.TableData.Cost
 {
     using Nekoyume.Model.Item;
     using Nekoyume.TableData;

--- a/.Lib9c.Tests/TableData/Crystal/CrystalEquipmentGrindingSheetTest.cs
+++ b/.Lib9c.Tests/TableData/Crystal/CrystalEquipmentGrindingSheetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.TableData.Crystal
 {
     using System.Linq;

--- a/.Lib9c.Tests/TableData/Crystal/CrystalHammerPointSheetTest.cs
+++ b/.Lib9c.Tests/TableData/Crystal/CrystalHammerPointSheetTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.TableData.Crystal
+﻿#nullable disable
+namespace Lib9c.Tests.TableData.Crystal
 {
     using System.Linq;
     using Nekoyume.TableData.Crystal;

--- a/.Lib9c.Tests/TableData/Crystal/CrystalMaterialCostSheetTest.cs
+++ b/.Lib9c.Tests/TableData/Crystal/CrystalMaterialCostSheetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.TableData.Crystal
 {
     using System.Linq;

--- a/.Lib9c.Tests/TableData/Crystal/CrystalMonsterCollectionMultiplierSheetTest.cs
+++ b/.Lib9c.Tests/TableData/Crystal/CrystalMonsterCollectionMultiplierSheetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.TableData.Crystal
 {
     using System.Linq;

--- a/.Lib9c.Tests/TableData/Crystal/CrystalRandomBuffSheetTest.cs
+++ b/.Lib9c.Tests/TableData/Crystal/CrystalRandomBuffSheetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.TableData.Crystal
 {
     using System.Linq;

--- a/.Lib9c.Tests/TableData/Crystal/CrystalStageBuffGachaSheetTest.cs
+++ b/.Lib9c.Tests/TableData/Crystal/CrystalStageBuffGachaSheetTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.TableData.Crystal
+﻿#nullable disable
+namespace Lib9c.Tests.TableData.Crystal
 {
     using System.Linq;
     using Nekoyume.TableData.Crystal;

--- a/.Lib9c.Tests/TableData/Event/EventConsumableItemRecipeSheetTest.cs
+++ b/.Lib9c.Tests/TableData/Event/EventConsumableItemRecipeSheetTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.TableData.Event
+﻿#nullable disable
+namespace Lib9c.Tests.TableData.Event
 {
     using System.Text;
     using Nekoyume.TableData.Event;

--- a/.Lib9c.Tests/TableData/Event/EventDungeonSheetTest.cs
+++ b/.Lib9c.Tests/TableData/Event/EventDungeonSheetTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.TableData.Event
+﻿#nullable disable
+namespace Lib9c.Tests.TableData.Event
 {
     using System.Text;
     using Nekoyume.TableData.Event;

--- a/.Lib9c.Tests/TableData/Event/EventDungeonStageSheetTest.cs
+++ b/.Lib9c.Tests/TableData/Event/EventDungeonStageSheetTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.TableData.Event
+﻿#nullable disable
+namespace Lib9c.Tests.TableData.Event
 {
     using Nekoyume.TableData.Event;
     using Xunit;

--- a/.Lib9c.Tests/TableData/Event/EventDungeonStageWaveSheetTest.cs
+++ b/.Lib9c.Tests/TableData/Event/EventDungeonStageWaveSheetTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.TableData.Event
+﻿#nullable disable
+namespace Lib9c.Tests.TableData.Event
 {
     using Nekoyume.TableData.Event;
     using Xunit;

--- a/.Lib9c.Tests/TableData/Event/EventScheduleSheetTest.cs
+++ b/.Lib9c.Tests/TableData/Event/EventScheduleSheetTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.TableData.Event
+﻿#nullable disable
+namespace Lib9c.Tests.TableData.Event
 {
     using System.Text;
     using Nekoyume.TableData.Event;

--- a/.Lib9c.Tests/TableData/Item/EquipmentItemOptionSheetTest.cs
+++ b/.Lib9c.Tests/TableData/Item/EquipmentItemOptionSheetTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.TableData.Item
+﻿#nullable disable
+namespace Lib9c.Tests.TableData.Item
 {
     using Nekoyume.Model.Stat;
     using Nekoyume.TableData;

--- a/.Lib9c.Tests/TableData/Item/EquipmentItemRecipeSheetTest.cs
+++ b/.Lib9c.Tests/TableData/Item/EquipmentItemRecipeSheetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.TableData.Item
 {
     using Nekoyume.Model.Item;

--- a/.Lib9c.Tests/TableData/Item/EquipmentItemSubRecipeSheetTest.cs
+++ b/.Lib9c.Tests/TableData/Item/EquipmentItemSubRecipeSheetTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.TableData.Item
+﻿#nullable disable
+namespace Lib9c.Tests.TableData.Item
 {
     using Nekoyume.TableData;
     using Xunit;

--- a/.Lib9c.Tests/TableData/Item/EquipmentItemSubRecipeSheetV2Test.cs
+++ b/.Lib9c.Tests/TableData/Item/EquipmentItemSubRecipeSheetV2Test.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.TableData.Item
+﻿#nullable disable
+namespace Lib9c.Tests.TableData.Item
 {
     using Nekoyume.TableData;
     using Xunit;

--- a/.Lib9c.Tests/TableData/Item/ItemRequirementSheetTest.cs
+++ b/.Lib9c.Tests/TableData/Item/ItemRequirementSheetTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.TableData.Item
+﻿#nullable disable
+namespace Lib9c.Tests.TableData.Item
 {
     using Nekoyume.TableData;
     using Xunit;

--- a/.Lib9c.Tests/TableData/RuneWeightSheetTest.cs
+++ b/.Lib9c.Tests/TableData/RuneWeightSheetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.TableData
 {
     using System.Linq;

--- a/.Lib9c.Tests/TableData/StakeAchievementRewardSheetTest.cs
+++ b/.Lib9c.Tests/TableData/StakeAchievementRewardSheetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.TableData
 {
     using Libplanet.Action;

--- a/.Lib9c.Tests/TableData/StakeActionPointCoefficientSheetTest.cs
+++ b/.Lib9c.Tests/TableData/StakeActionPointCoefficientSheetTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.TableData
+﻿#nullable disable
+namespace Lib9c.Tests.TableData
 {
     using Libplanet.Action;
     using Libplanet.Assets;

--- a/.Lib9c.Tests/TableData/StakeRegularFixedRewardSheetTest.cs
+++ b/.Lib9c.Tests/TableData/StakeRegularFixedRewardSheetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.TableData
 {
     using Libplanet.Action;

--- a/.Lib9c.Tests/TableData/StakeRegularRewardSheetTest.cs
+++ b/.Lib9c.Tests/TableData/StakeRegularRewardSheetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.TableData
 {
     using Libplanet.Action;

--- a/.Lib9c.Tests/TableData/SweepRequiredCPSheetTest.cs
+++ b/.Lib9c.Tests/TableData/SweepRequiredCPSheetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.TableData
 {
     using Nekoyume.TableData;

--- a/.Lib9c.Tests/TableData/WorldAndStage/WorldUnlockSheetTest.cs
+++ b/.Lib9c.Tests/TableData/WorldAndStage/WorldUnlockSheetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.TableData.WorldAndStage
 {
     using Nekoyume.TableData;

--- a/.Lib9c.Tests/TableData/WorldBossListSheetTest.cs
+++ b/.Lib9c.Tests/TableData/WorldBossListSheetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.TableData
 {
     using System;

--- a/.Lib9c.Tests/TableData/WorldBossRankingRewardSheetTest.cs
+++ b/.Lib9c.Tests/TableData/WorldBossRankingRewardSheetTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.TableData
 {
     using System;

--- a/.Lib9c.Tests/TableSheets.cs
+++ b/.Lib9c.Tests/TableSheets.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests
 {
     using System;

--- a/.Lib9c.Tests/TableSheetsImporter.cs
+++ b/.Lib9c.Tests/TableSheetsImporter.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests
 {
     using System.Collections.Generic;

--- a/.Lib9c.Tests/TestHelper/BencodexHelper.cs
+++ b/.Lib9c.Tests/TestHelper/BencodexHelper.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.TestHelper
 {
     using System;

--- a/.Lib9c.Tests/TestHelper/BlockChainHelper.cs
+++ b/.Lib9c.Tests/TestHelper/BlockChainHelper.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.TestHelper
+﻿#nullable disable
+namespace Lib9c.Tests.TestHelper
 {
     using System;
     using System.Collections.Generic;

--- a/.Lib9c.Tests/TestHelper/MakeInitialStateResult.cs
+++ b/.Lib9c.Tests/TestHelper/MakeInitialStateResult.cs
@@ -1,4 +1,5 @@
-﻿namespace Lib9c.Tests.TestHelper
+﻿#nullable disable
+namespace Lib9c.Tests.TestHelper
 {
     using Lib9c.DevExtensions.Action;
     using Libplanet;

--- a/.Lib9c.Tests/Types/BencodexTypesListTest.cs
+++ b/.Lib9c.Tests/Types/BencodexTypesListTest.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c.Tests.Types
 {
     using System.Collections.Generic;

--- a/BTAI/BT.cs
+++ b/BTAI/BT.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#nullable disable
+using System.Collections.Generic;
 
 namespace BTAI
 {

--- a/Lib9c/Action/AccountStateDeltaExtensions.cs
+++ b/Lib9c/Action/AccountStateDeltaExtensions.cs
@@ -18,6 +18,7 @@ using Nekoyume.TableData.Event;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     public static class AccountStateDeltaExtensions

--- a/Lib9c/Action/ActionBase.cs
+++ b/Lib9c/Action/ActionBase.cs
@@ -21,6 +21,7 @@ using System.Reactive.Subjects;
 using System.Reactive.Linq;
 #endif
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ActionContextExtensions.cs
+++ b/Lib9c/Action/ActionContextExtensions.cs
@@ -1,6 +1,7 @@
 using Libplanet;
 using Libplanet.Action;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     public static class ActionContextExtensions

--- a/Lib9c/Action/ActionObsoleteAttribute.cs
+++ b/Lib9c/Action/ActionObsoleteAttribute.cs
@@ -1,5 +1,6 @@
 using System;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     public class ActionObsoleteAttribute : Attribute

--- a/Lib9c/Action/ActionObsoletedException.cs
+++ b/Lib9c/Action/ActionObsoletedException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ActionPointExceededException.cs
+++ b/Lib9c/Action/ActionPointExceededException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ActivateAccount.cs
+++ b/Lib9c/Action/ActivateAccount.cs
@@ -7,6 +7,7 @@ using Nekoyume.Model;
 using Nekoyume.Model.State;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ActivateAccount0.cs
+++ b/Lib9c/Action/ActivateAccount0.cs
@@ -6,6 +6,7 @@ using Libplanet.Action;
 using Nekoyume.Model.State;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ActivatedAccountsDoesNotExistsException.cs
+++ b/Lib9c/Action/ActivatedAccountsDoesNotExistsException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ActivationException.cs
+++ b/Lib9c/Action/ActivationException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     public abstract class ActivationException : Exception

--- a/Lib9c/Action/AddActivatedAccount.cs
+++ b/Lib9c/Action/AddActivatedAccount.cs
@@ -6,6 +6,7 @@ using Libplanet.Action;
 using Nekoyume.Model;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/AddActivatedAccount0.cs
+++ b/Lib9c/Action/AddActivatedAccount0.cs
@@ -5,6 +5,7 @@ using Libplanet;
 using Libplanet.Action;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/AddRedeemCode.cs
+++ b/Lib9c/Action/AddRedeemCode.cs
@@ -5,6 +5,7 @@ using Libplanet.Action;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/AddressExtension.cs
+++ b/Lib9c/Action/AddressExtension.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using System.Text;
 using Libplanet;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     public static class AddressExtension

--- a/Lib9c/Action/AgentStateNotContainsAvatarAddressException.cs
+++ b/Lib9c/Action/AgentStateNotContainsAvatarAddressException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/AlreadyActivatedException.cs
+++ b/Lib9c/Action/AlreadyActivatedException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/AlreadyReceivedException.cs
+++ b/Lib9c/Action/AlreadyReceivedException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/AlreadyRecipeUnlockedException.cs
+++ b/Lib9c/Action/AlreadyRecipeUnlockedException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/AlreadyWorldUnlockedException.cs
+++ b/Lib9c/Action/AlreadyWorldUnlockedException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/AppraiseBlockNotReachedException.cs
+++ b/Lib9c/Action/AppraiseBlockNotReachedException.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ArenaNotEndedException.cs
+++ b/Lib9c/Action/ArenaNotEndedException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/AttachmentActionResult.cs
+++ b/Lib9c/Action/AttachmentActionResult.cs
@@ -8,6 +8,7 @@ using Serilog;
 using BxDictionary = Bencodex.Types.Dictionary;
 using BxText = Bencodex.Types.Text;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/AvatarIndexAlreadyUsedException.cs
+++ b/Lib9c/Action/AvatarIndexAlreadyUsedException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/AvatarIndexOutOfRangeException.cs
+++ b/Lib9c/Action/AvatarIndexOutOfRangeException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     public class AvatarIndexOutOfRangeException : Exception

--- a/Lib9c/Action/BalanceDoesNotExistsException.cs
+++ b/Lib9c/Action/BalanceDoesNotExistsException.cs
@@ -3,6 +3,7 @@ using Libplanet.Assets;
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/BattleArena.cs
+++ b/Lib9c/Action/BattleArena.cs
@@ -18,6 +18,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/BattleArena1.cs
+++ b/Lib9c/Action/BattleArena1.cs
@@ -18,6 +18,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/BattleArena2.cs
+++ b/Lib9c/Action/BattleArena2.cs
@@ -19,6 +19,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/BattleArena3.cs
+++ b/Lib9c/Action/BattleArena3.cs
@@ -19,6 +19,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/BattleArena4.cs
+++ b/Lib9c/Action/BattleArena4.cs
@@ -18,6 +18,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/Buy.cs
+++ b/Lib9c/Action/Buy.cs
@@ -17,6 +17,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/Buy0.cs
+++ b/Lib9c/Action/Buy0.cs
@@ -14,6 +14,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Buy10.cs
+++ b/Lib9c/Action/Buy10.cs
@@ -15,6 +15,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Buy11.cs
+++ b/Lib9c/Action/Buy11.cs
@@ -15,6 +15,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/Buy2.cs
+++ b/Lib9c/Action/Buy2.cs
@@ -14,6 +14,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Buy3.cs
+++ b/Lib9c/Action/Buy3.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Buy4.cs
+++ b/Lib9c/Action/Buy4.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Buy5.cs
+++ b/Lib9c/Action/Buy5.cs
@@ -15,6 +15,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Buy6.cs
+++ b/Lib9c/Action/Buy6.cs
@@ -15,6 +15,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Buy7.cs
+++ b/Lib9c/Action/Buy7.cs
@@ -15,6 +15,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Buy8.cs
+++ b/Lib9c/Action/Buy8.cs
@@ -16,6 +16,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Buy9.cs
+++ b/Lib9c/Action/Buy9.cs
@@ -16,6 +16,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/BuyMultiple.cs
+++ b/Lib9c/Action/BuyMultiple.cs
@@ -14,6 +14,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/ByteSerializer.cs
+++ b/Lib9c/Action/ByteSerializer.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     public static class ByteSerializer

--- a/Lib9c/Action/CancelMonsterCollect.cs
+++ b/Lib9c/Action/CancelMonsterCollect.cs
@@ -9,6 +9,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/ChargeActionPoint.cs
+++ b/Lib9c/Action/ChargeActionPoint.cs
@@ -10,6 +10,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/ChargeActionPoint0.cs
+++ b/Lib9c/Action/ChargeActionPoint0.cs
@@ -10,6 +10,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ChargeActionPoint2.cs
+++ b/Lib9c/Action/ChargeActionPoint2.cs
@@ -9,6 +9,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ClaimMonsterCollectionReward.cs
+++ b/Lib9c/Action/ClaimMonsterCollectionReward.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/ClaimMonsterCollectionReward0.cs
+++ b/Lib9c/Action/ClaimMonsterCollectionReward0.cs
@@ -11,6 +11,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ClaimMonsterCollectionReward2.cs
+++ b/Lib9c/Action/ClaimMonsterCollectionReward2.cs
@@ -11,6 +11,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ClaimRaidReward.cs
+++ b/Lib9c/Action/ClaimRaidReward.cs
@@ -11,6 +11,7 @@ using Nekoyume.Helper;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ClaimStakeReward.cs
+++ b/Lib9c/Action/ClaimStakeReward.cs
@@ -8,6 +8,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/ClaimStakeReward1.cs
+++ b/Lib9c/Action/ClaimStakeReward1.cs
@@ -9,6 +9,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [ActionType("claim_stake_reward")]

--- a/Lib9c/Action/ClaimWordBossKillReward.cs
+++ b/Lib9c/Action/ClaimWordBossKillReward.cs
@@ -10,6 +10,7 @@ using Nekoyume.Helper;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CombinationConsumable.cs
+++ b/Lib9c/Action/CombinationConsumable.cs
@@ -14,6 +14,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/CombinationConsumable0.cs
+++ b/Lib9c/Action/CombinationConsumable0.cs
@@ -15,6 +15,7 @@ using Nekoyume.TableData;
 using Serilog;
 using Material = Nekoyume.Model.Item.Material;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CombinationConsumable2.cs
+++ b/Lib9c/Action/CombinationConsumable2.cs
@@ -15,6 +15,7 @@ using Nekoyume.TableData;
 using Serilog;
 using Material = Nekoyume.Model.Item.Material;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CombinationConsumable3.cs
+++ b/Lib9c/Action/CombinationConsumable3.cs
@@ -15,6 +15,7 @@ using Nekoyume.TableData;
 using Serilog;
 using Material = Nekoyume.Model.Item.Material;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CombinationConsumable4.cs
+++ b/Lib9c/Action/CombinationConsumable4.cs
@@ -15,6 +15,7 @@ using Nekoyume.TableData;
 using Serilog;
 using Material = Nekoyume.Model.Item.Material;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CombinationConsumable5.cs
+++ b/Lib9c/Action/CombinationConsumable5.cs
@@ -15,6 +15,7 @@ using Nekoyume.TableData;
 using Serilog;
 using Material = Nekoyume.Model.Item.Material;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CombinationConsumable6.cs
+++ b/Lib9c/Action/CombinationConsumable6.cs
@@ -15,6 +15,7 @@ using Serilog;
 using Material = Nekoyume.Model.Item.Material;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CombinationConsumable7.cs
+++ b/Lib9c/Action/CombinationConsumable7.cs
@@ -16,6 +16,7 @@ using Serilog;
 using Material = Nekoyume.Model.Item.Material;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CombinationEquipment.cs
+++ b/Lib9c/Action/CombinationEquipment.cs
@@ -17,6 +17,7 @@ using Nekoyume.TableData;
 using Nekoyume.TableData.Crystal;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/CombinationEquipment0.cs
+++ b/Lib9c/Action/CombinationEquipment0.cs
@@ -16,6 +16,7 @@ using Nekoyume.Model.Stat;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CombinationEquipment10.cs
+++ b/Lib9c/Action/CombinationEquipment10.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CombinationEquipment11.cs
+++ b/Lib9c/Action/CombinationEquipment11.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/CombinationEquipment12.cs
+++ b/Lib9c/Action/CombinationEquipment12.cs
@@ -16,6 +16,7 @@ using Nekoyume.TableData;
 using Nekoyume.TableData.Crystal;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/CombinationEquipment13.cs
+++ b/Lib9c/Action/CombinationEquipment13.cs
@@ -18,6 +18,7 @@ using Nekoyume.TableData;
 using Nekoyume.TableData.Crystal;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/CombinationEquipment2.cs
+++ b/Lib9c/Action/CombinationEquipment2.cs
@@ -16,6 +16,7 @@ using Nekoyume.Model.Stat;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CombinationEquipment3.cs
+++ b/Lib9c/Action/CombinationEquipment3.cs
@@ -16,6 +16,7 @@ using Nekoyume.Model.Stat;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CombinationEquipment4.cs
+++ b/Lib9c/Action/CombinationEquipment4.cs
@@ -16,6 +16,7 @@ using Nekoyume.Model.Stat;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CombinationEquipment5.cs
+++ b/Lib9c/Action/CombinationEquipment5.cs
@@ -16,6 +16,7 @@ using Nekoyume.Model.Stat;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CombinationEquipment6.cs
+++ b/Lib9c/Action/CombinationEquipment6.cs
@@ -17,6 +17,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CombinationEquipment7.cs
+++ b/Lib9c/Action/CombinationEquipment7.cs
@@ -16,6 +16,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CombinationEquipment8.cs
+++ b/Lib9c/Action/CombinationEquipment8.cs
@@ -14,6 +14,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CombinationEquipment9.cs
+++ b/Lib9c/Action/CombinationEquipment9.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CombinationSlotResultNullException.cs
+++ b/Lib9c/Action/CombinationSlotResultNullException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CombinationSlotUnlockException.cs
+++ b/Lib9c/Action/CombinationSlotUnlockException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ConsumableSlotOutOfRangeException.cs
+++ b/Lib9c/Action/ConsumableSlotOutOfRangeException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ConsumableSlotUnlockException.cs
+++ b/Lib9c/Action/ConsumableSlotUnlockException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CostumeSlotUnlockException.cs
+++ b/Lib9c/Action/CostumeSlotUnlockException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CreateAvatar.cs
+++ b/Lib9c/Action/CreateAvatar.cs
@@ -12,6 +12,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/CreateAvatar0.cs
+++ b/Lib9c/Action/CreateAvatar0.cs
@@ -20,6 +20,7 @@ using Lib9c.DevExtensions;
 using Lib9c.DevExtensions.Model;
 #endif
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CreateAvatar2.cs
+++ b/Lib9c/Action/CreateAvatar2.cs
@@ -14,6 +14,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CreateAvatar3.cs
+++ b/Lib9c/Action/CreateAvatar3.cs
@@ -11,6 +11,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CreateAvatar4.cs
+++ b/Lib9c/Action/CreateAvatar4.cs
@@ -11,6 +11,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CreateAvatar5.cs
+++ b/Lib9c/Action/CreateAvatar5.cs
@@ -11,6 +11,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CreateAvatar6.cs
+++ b/Lib9c/Action/CreateAvatar6.cs
@@ -11,6 +11,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/CreateAvatar7.cs
+++ b/Lib9c/Action/CreateAvatar7.cs
@@ -11,6 +11,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/CreatePendingActivation.cs
+++ b/Lib9c/Action/CreatePendingActivation.cs
@@ -4,6 +4,7 @@ using Bencodex.Types;
 using Libplanet.Action;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/CreatePendingActivations.cs
+++ b/Lib9c/Action/CreatePendingActivations.cs
@@ -7,6 +7,7 @@ using Libplanet;
 using Libplanet.Action;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/DailyReward.cs
+++ b/Lib9c/Action/DailyReward.cs
@@ -8,6 +8,7 @@ using Libplanet.Action;
 using Nekoyume.Model.State;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/DailyReward0.cs
+++ b/Lib9c/Action/DailyReward0.cs
@@ -6,6 +6,7 @@ using Libplanet;
 using Libplanet.Action;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/DailyReward2.cs
+++ b/Lib9c/Action/DailyReward2.cs
@@ -10,6 +10,7 @@ using Nekoyume.Model.Mail;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/DailyReward3.cs
+++ b/Lib9c/Action/DailyReward3.cs
@@ -9,6 +9,7 @@ using Nekoyume.Model.Mail;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/DailyReward4.cs
+++ b/Lib9c/Action/DailyReward4.cs
@@ -10,6 +10,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/DailyReward5.cs
+++ b/Lib9c/Action/DailyReward5.cs
@@ -7,6 +7,7 @@ using Libplanet;
 using Libplanet.Action;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/DuplicateCostumeException.cs
+++ b/Lib9c/Action/DuplicateCostumeException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/DuplicateEquipmentException.cs
+++ b/Lib9c/Action/DuplicateEquipmentException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/DuplicateMaterialException.cs
+++ b/Lib9c/Action/DuplicateMaterialException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/DuplicateOrderIdException.cs
+++ b/Lib9c/Action/DuplicateOrderIdException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/EquipmentLevelExceededException.cs
+++ b/Lib9c/Action/EquipmentLevelExceededException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/EquipmentSlotUnlockException.cs
+++ b/Lib9c/Action/EquipmentSlotUnlockException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/EventConsumableItemCrafts.cs
+++ b/Lib9c/Action/EventConsumableItemCrafts.cs
@@ -15,6 +15,7 @@ using Nekoyume.TableData.Event;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/EventDungeonBattle.cs
+++ b/Lib9c/Action/EventDungeonBattle.cs
@@ -17,6 +17,7 @@ using Nekoyume.TableData.Event;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/EventDungeonBattleV1.cs
+++ b/Lib9c/Action/EventDungeonBattleV1.cs
@@ -17,6 +17,7 @@ using Nekoyume.TableData.Event;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/FailedLoadSheetException.cs
+++ b/Lib9c/Action/FailedLoadSheetException.cs
@@ -2,6 +2,7 @@
 using System.Runtime.Serialization;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/FailedLoadStateException.cs
+++ b/Lib9c/Action/FailedLoadStateException.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.Serialization;
 using Libplanet;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/GameAction.cs
+++ b/Lib9c/Action/GameAction.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Bencodex.Types;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/GoldDistribution.cs
+++ b/Lib9c/Action/GoldDistribution.cs
@@ -10,6 +10,7 @@ using CsvHelper.Configuration.Attributes;
 using Libplanet;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Grinding.cs
+++ b/Lib9c/Action/Grinding.cs
@@ -15,6 +15,7 @@ using Nekoyume.TableData;
 using Nekoyume.TableData.Crystal;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [ActionType("grinding")]

--- a/Lib9c/Action/HackAndSlash.cs
+++ b/Lib9c/Action/HackAndSlash.cs
@@ -17,6 +17,7 @@ using Nekoyume.TableData.Crystal;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/HackAndSlash0.cs
+++ b/Lib9c/Action/HackAndSlash0.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/HackAndSlash10.cs
+++ b/Lib9c/Action/HackAndSlash10.cs
@@ -13,6 +13,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/HackAndSlash11.cs
+++ b/Lib9c/Action/HackAndSlash11.cs
@@ -12,6 +12,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/HackAndSlash12.cs
+++ b/Lib9c/Action/HackAndSlash12.cs
@@ -13,6 +13,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/HackAndSlash13.cs
+++ b/Lib9c/Action/HackAndSlash13.cs
@@ -13,6 +13,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/HackAndSlash14.cs
+++ b/Lib9c/Action/HackAndSlash14.cs
@@ -14,6 +14,7 @@ using Nekoyume.TableData.Crystal;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/HackAndSlash15.cs
+++ b/Lib9c/Action/HackAndSlash15.cs
@@ -15,6 +15,7 @@ using Nekoyume.TableData.Crystal;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/HackAndSlash16.cs
+++ b/Lib9c/Action/HackAndSlash16.cs
@@ -16,6 +16,7 @@ using Nekoyume.TableData.Crystal;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/HackAndSlash17.cs
+++ b/Lib9c/Action/HackAndSlash17.cs
@@ -16,6 +16,7 @@ using Nekoyume.TableData.Crystal;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/HackAndSlash2.cs
+++ b/Lib9c/Action/HackAndSlash2.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/HackAndSlash3.cs
+++ b/Lib9c/Action/HackAndSlash3.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/HackAndSlash4.cs
+++ b/Lib9c/Action/HackAndSlash4.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/HackAndSlash5.cs
+++ b/Lib9c/Action/HackAndSlash5.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/HackAndSlash6.cs
+++ b/Lib9c/Action/HackAndSlash6.cs
@@ -13,6 +13,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/HackAndSlash7.cs
+++ b/Lib9c/Action/HackAndSlash7.cs
@@ -13,6 +13,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/HackAndSlash8.cs
+++ b/Lib9c/Action/HackAndSlash8.cs
@@ -13,6 +13,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/HackAndSlash9.cs
+++ b/Lib9c/Action/HackAndSlash9.cs
@@ -13,6 +13,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/HackAndSlashRandomBuff.cs
+++ b/Lib9c/Action/HackAndSlashRandomBuff.cs
@@ -11,6 +11,7 @@ using Nekoyume.Helper;
 using Nekoyume.Model.State;
 using Nekoyume.TableData.Crystal;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/HackAndSlashSweep.cs
+++ b/Lib9c/Action/HackAndSlashSweep.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/HackAndSlashSweep1.cs
+++ b/Lib9c/Action/HackAndSlashSweep1.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/HackAndSlashSweep2.cs
+++ b/Lib9c/Action/HackAndSlashSweep2.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/HackAndSlashSweep3.cs
+++ b/Lib9c/Action/HackAndSlashSweep3.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/HackAndSlashSweep4.cs
+++ b/Lib9c/Action/HackAndSlashSweep4.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/HackAndSlashSweep5.cs
+++ b/Lib9c/Action/HackAndSlashSweep5.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/HackAndSlashSweep6.cs
+++ b/Lib9c/Action/HackAndSlashSweep6.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/IActivateAction.cs
+++ b/Lib9c/Action/IActivateAction.cs
@@ -1,5 +1,6 @@
 using Libplanet;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     internal interface IActivateAction

--- a/Lib9c/Action/IBuy0.cs
+++ b/Lib9c/Action/IBuy0.cs
@@ -2,6 +2,7 @@ using System;
 using Libplanet;
 using Libplanet.Action;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/IBuy5.cs
+++ b/Lib9c/Action/IBuy5.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Libplanet;
 using Libplanet.Action;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/IPurchaseInfo.cs
+++ b/Lib9c/Action/IPurchaseInfo.cs
@@ -3,6 +3,7 @@ using Libplanet;
 using Libplanet.Assets;
 using Nekoyume.Model.Item;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     public interface IPurchaseInfo

--- a/Lib9c/Action/InitializeStates.cs
+++ b/Lib9c/Action/InitializeStates.cs
@@ -6,6 +6,7 @@ using Bencodex.Types;
 using Libplanet.Action;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/InvalidAddressException.cs
+++ b/Lib9c/Action/InvalidAddressException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidClaimException.cs
+++ b/Lib9c/Action/InvalidClaimException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidElementalException.cs
+++ b/Lib9c/Action/InvalidElementalException.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidEquipmentException.cs
+++ b/Lib9c/Action/InvalidEquipmentException.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidItemCountException.cs
+++ b/Lib9c/Action/InvalidItemCountException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidItemTypeException.cs
+++ b/Lib9c/Action/InvalidItemTypeException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidLevelException.cs
+++ b/Lib9c/Action/InvalidLevelException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidMaterialException.cs
+++ b/Lib9c/Action/InvalidMaterialException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidMonsterCollectionRoundException.cs
+++ b/Lib9c/Action/InvalidMonsterCollectionRoundException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidNamePatternException.cs
+++ b/Lib9c/Action/InvalidNamePatternException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidPriceException.cs
+++ b/Lib9c/Action/InvalidPriceException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidRecipeIdException.cs
+++ b/Lib9c/Action/InvalidRecipeIdException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidRepeatPlayException.cs
+++ b/Lib9c/Action/InvalidRepeatPlayException.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidShopItemException.cs
+++ b/Lib9c/Action/InvalidShopItemException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidSignatureException.cs
+++ b/Lib9c/Action/InvalidSignatureException.cs
@@ -3,6 +3,7 @@ using Nekoyume.Model.State;
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidStageException.cs
+++ b/Lib9c/Action/InvalidStageException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidTradableIdException.cs
+++ b/Lib9c/Action/InvalidTradableIdException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidTradableItemException.cs
+++ b/Lib9c/Action/InvalidTradableItemException.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     public class InvalidTradableItemException : InvalidOperationException

--- a/Lib9c/Action/InvalidTransferMinterException.cs
+++ b/Lib9c/Action/InvalidTransferMinterException.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Libplanet;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidTransferRecipientException.cs
+++ b/Lib9c/Action/InvalidTransferRecipientException.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidTransferSignerException.cs
+++ b/Lib9c/Action/InvalidTransferSignerException.cs
@@ -3,6 +3,7 @@ using Libplanet.Tx;
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidTransferUnactivatedRecipientException.cs
+++ b/Lib9c/Action/InvalidTransferUnactivatedRecipientException.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/InvalidWorldException.cs
+++ b/Lib9c/Action/InvalidWorldException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ItemDoesNotExistException.cs
+++ b/Lib9c/Action/ItemDoesNotExistException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ItemEnhancement.cs
+++ b/Lib9c/Action/ItemEnhancement.cs
@@ -22,6 +22,7 @@ using Serilog;
 
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/ItemEnhancement0.cs
+++ b/Lib9c/Action/ItemEnhancement0.cs
@@ -14,6 +14,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ItemEnhancement10.cs
+++ b/Lib9c/Action/ItemEnhancement10.cs
@@ -16,6 +16,7 @@ using Serilog;
 
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/ItemEnhancement2.cs
+++ b/Lib9c/Action/ItemEnhancement2.cs
@@ -14,6 +14,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ItemEnhancement3.cs
+++ b/Lib9c/Action/ItemEnhancement3.cs
@@ -14,6 +14,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ItemEnhancement4.cs
+++ b/Lib9c/Action/ItemEnhancement4.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ItemEnhancement5.cs
+++ b/Lib9c/Action/ItemEnhancement5.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ItemEnhancement6.cs
+++ b/Lib9c/Action/ItemEnhancement6.cs
@@ -14,6 +14,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ItemEnhancement7.cs
+++ b/Lib9c/Action/ItemEnhancement7.cs
@@ -15,6 +15,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ItemEnhancement8.cs
+++ b/Lib9c/Action/ItemEnhancement8.cs
@@ -15,6 +15,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ItemEnhancement9.cs
+++ b/Lib9c/Action/ItemEnhancement9.cs
@@ -16,6 +16,7 @@ using Serilog;
 
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/JoinArena.cs
+++ b/Lib9c/Action/JoinArena.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.EnumType;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/MemoLengthOverflowException.cs
+++ b/Lib9c/Action/MemoLengthOverflowException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/MigrateMonsterCollection.cs
+++ b/Lib9c/Action/MigrateMonsterCollection.cs
@@ -6,6 +6,7 @@ using Nekoyume.Model.State;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/MigrationActivatedAccountsState.cs
+++ b/Lib9c/Action/MigrationActivatedAccountsState.cs
@@ -9,6 +9,7 @@ using Nekoyume.Model;
 using Nekoyume.Model.State;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/MigrationAvatarState.cs
+++ b/Lib9c/Action/MigrationAvatarState.cs
@@ -6,6 +6,7 @@ using Libplanet.Action;
 using Nekoyume.Model.State;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/MigrationLegacyShop.cs
+++ b/Lib9c/Action/MigrationLegacyShop.cs
@@ -8,6 +8,7 @@ using Libplanet.Action;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/MigrationLegacyShop0.cs
+++ b/Lib9c/Action/MigrationLegacyShop0.cs
@@ -7,6 +7,7 @@ using Libplanet;
 using Libplanet.Action;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/MimisbrunnrBattle.cs
+++ b/Lib9c/Action/MimisbrunnrBattle.cs
@@ -15,6 +15,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/MimisbrunnrBattle0.cs
+++ b/Lib9c/Action/MimisbrunnrBattle0.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/MimisbrunnrBattle2.cs
+++ b/Lib9c/Action/MimisbrunnrBattle2.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/MimisbrunnrBattle3.cs
+++ b/Lib9c/Action/MimisbrunnrBattle3.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/MimisbrunnrBattle4.cs
+++ b/Lib9c/Action/MimisbrunnrBattle4.cs
@@ -13,6 +13,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/MimisbrunnrBattle5.cs
+++ b/Lib9c/Action/MimisbrunnrBattle5.cs
@@ -13,6 +13,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/MimisbrunnrBattle6.cs
+++ b/Lib9c/Action/MimisbrunnrBattle6.cs
@@ -13,6 +13,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/MimisbrunnrBattle7.cs
+++ b/Lib9c/Action/MimisbrunnrBattle7.cs
@@ -13,6 +13,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/MimisbrunnrBattle8.cs
+++ b/Lib9c/Action/MimisbrunnrBattle8.cs
@@ -13,6 +13,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/MimisbrunnrBattle9.cs
+++ b/Lib9c/Action/MimisbrunnrBattle9.cs
@@ -13,6 +13,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/MonsterCollect.cs
+++ b/Lib9c/Action/MonsterCollect.cs
@@ -10,6 +10,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/MonsterCollect0.cs
+++ b/Lib9c/Action/MonsterCollect0.cs
@@ -9,6 +9,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/MonsterCollect2.cs
+++ b/Lib9c/Action/MonsterCollect2.cs
@@ -9,6 +9,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/MonsterCollectionExistingClaimableException.cs
+++ b/Lib9c/Action/MonsterCollectionExistingClaimableException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/MonsterCollectionExistingException.cs
+++ b/Lib9c/Action/MonsterCollectionExistingException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/MonsterCollectionExpiredException.cs
+++ b/Lib9c/Action/MonsterCollectionExpiredException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/MonsterCollectionLevelException.cs
+++ b/Lib9c/Action/MonsterCollectionLevelException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/NCActionEvaluation.cs
+++ b/Lib9c/Action/NCActionEvaluation.cs
@@ -9,6 +9,7 @@ using Libplanet.Action;
 using MessagePack;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [MessagePackObject]

--- a/Lib9c/Action/NotEnoughActionPointException.cs
+++ b/Lib9c/Action/NotEnoughActionPointException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/NotEnoughAvatarLevelException.cs
+++ b/Lib9c/Action/NotEnoughAvatarLevelException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/NotEnoughClearedStageLevelException.cs
+++ b/Lib9c/Action/NotEnoughClearedStageLevelException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/NotEnoughCombatPointException.cs
+++ b/Lib9c/Action/NotEnoughCombatPointException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     public class NotEnoughCombatPointException : InvalidOperationException

--- a/Lib9c/Action/NotEnoughFungibleAssetValueException.cs
+++ b/Lib9c/Action/NotEnoughFungibleAssetValueException.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using System.Runtime.Serialization;
 using Libplanet.Assets;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/NotEnoughHammerPointException.cs
+++ b/Lib9c/Action/NotEnoughHammerPointException.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     public class NotEnoughHammerPointException : Exception

--- a/Lib9c/Action/NotEnoughMaterialException.cs
+++ b/Lib9c/Action/NotEnoughMaterialException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/NotEnoughMedalException.cs
+++ b/Lib9c/Action/NotEnoughMedalException.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/NotEnoughRankException.cs
+++ b/Lib9c/Action/NotEnoughRankException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/NotEnoughStarException.cs
+++ b/Lib9c/Action/NotEnoughStarException.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     public class NotEnoughStarException : Exception

--- a/Lib9c/Action/NotEnoughWeeklyArenaChallengeCountException.cs
+++ b/Lib9c/Action/NotEnoughWeeklyArenaChallengeCountException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/OrderIdDoesNotExistException.cs
+++ b/Lib9c/Action/OrderIdDoesNotExistException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/PatchTableSheet.cs
+++ b/Lib9c/Action/PatchTableSheet.cs
@@ -6,6 +6,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/PendingActivationDoesNotExistsException.cs
+++ b/Lib9c/Action/PendingActivationDoesNotExistsException.cs
@@ -2,6 +2,7 @@ using Libplanet;
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/PermissionDeniedException.cs
+++ b/Lib9c/Action/PermissionDeniedException.cs
@@ -4,6 +4,7 @@ using System;
 using System.Runtime.Serialization;
 using Libplanet.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/PermissionException.cs
+++ b/Lib9c/Action/PermissionException.cs
@@ -3,6 +3,7 @@ using System;
 using System.Runtime.Serialization;
 using Libplanet.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/PlayCountIsZeroException.cs
+++ b/Lib9c/Action/PlayCountIsZeroException.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/PolicyExpiredException.cs
+++ b/Lib9c/Action/PolicyExpiredException.cs
@@ -3,6 +3,7 @@ using System;
 using System.Runtime.Serialization;
 using Libplanet.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/PrepareRewardAssets.cs
+++ b/Lib9c/Action/PrepareRewardAssets.cs
@@ -6,6 +6,7 @@ using Libplanet.Action;
 using Libplanet.Assets;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [ActionType("prepare_reward_assets")]

--- a/Lib9c/Action/PurchaseInfo.cs
+++ b/Lib9c/Action/PurchaseInfo.cs
@@ -7,6 +7,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/PurchaseInfo0.cs
+++ b/Lib9c/Action/PurchaseInfo0.cs
@@ -7,6 +7,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Raid.cs
+++ b/Lib9c/Action/Raid.cs
@@ -14,6 +14,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RankingBattle.cs
+++ b/Lib9c/Action/RankingBattle.cs
@@ -14,6 +14,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/RankingBattle0.cs
+++ b/Lib9c/Action/RankingBattle0.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RankingBattle10.cs
+++ b/Lib9c/Action/RankingBattle10.cs
@@ -16,6 +16,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RankingBattle11.cs
+++ b/Lib9c/Action/RankingBattle11.cs
@@ -15,6 +15,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/RankingBattle2.cs
+++ b/Lib9c/Action/RankingBattle2.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RankingBattle3.cs
+++ b/Lib9c/Action/RankingBattle3.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RankingBattle4.cs
+++ b/Lib9c/Action/RankingBattle4.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RankingBattle5.cs
+++ b/Lib9c/Action/RankingBattle5.cs
@@ -14,6 +14,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RankingBattle6.cs
+++ b/Lib9c/Action/RankingBattle6.cs
@@ -14,6 +14,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RankingBattle7.cs
+++ b/Lib9c/Action/RankingBattle7.cs
@@ -14,6 +14,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RankingBattle8.cs
+++ b/Lib9c/Action/RankingBattle8.cs
@@ -14,6 +14,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RankingBattle9.cs
+++ b/Lib9c/Action/RankingBattle9.cs
@@ -15,6 +15,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RankingExceededException.cs
+++ b/Lib9c/Action/RankingExceededException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RapidCombination.cs
+++ b/Lib9c/Action/RapidCombination.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/RapidCombination0.cs
+++ b/Lib9c/Action/RapidCombination0.cs
@@ -11,6 +11,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RapidCombination2.cs
+++ b/Lib9c/Action/RapidCombination2.cs
@@ -10,6 +10,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RapidCombination3.cs
+++ b/Lib9c/Action/RapidCombination3.cs
@@ -10,6 +10,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RapidCombination4.cs
+++ b/Lib9c/Action/RapidCombination4.cs
@@ -11,6 +11,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RapidCombination5.cs
+++ b/Lib9c/Action/RapidCombination5.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RapidCombination6.cs
+++ b/Lib9c/Action/RapidCombination6.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/RapidCombination7.cs
+++ b/Lib9c/Action/RapidCombination7.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/RedeemCode.cs
+++ b/Lib9c/Action/RedeemCode.cs
@@ -11,6 +11,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/RedeemCode0.cs
+++ b/Lib9c/Action/RedeemCode0.cs
@@ -11,6 +11,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RedeemCode2.cs
+++ b/Lib9c/Action/RedeemCode2.cs
@@ -11,6 +11,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RenewAdminState.cs
+++ b/Lib9c/Action/RenewAdminState.cs
@@ -5,6 +5,7 @@ using Bencodex.Types;
 using Libplanet.Action;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/RequiredBlockIndexException.cs
+++ b/Lib9c/Action/RequiredBlockIndexException.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 using Libplanet;
 using Libplanet.Blocks;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RequiredBlockIntervalException.cs
+++ b/Lib9c/Action/RequiredBlockIntervalException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/RewardGold.cs
+++ b/Lib9c/Action/RewardGold.cs
@@ -9,6 +9,7 @@ using Libplanet.Assets;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/Sell.cs
+++ b/Lib9c/Action/Sell.cs
@@ -13,6 +13,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/Sell0.cs
+++ b/Lib9c/Action/Sell0.cs
@@ -11,6 +11,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Sell10.cs
+++ b/Lib9c/Action/Sell10.cs
@@ -13,6 +13,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/Sell2.cs
+++ b/Lib9c/Action/Sell2.cs
@@ -11,6 +11,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Sell3.cs
+++ b/Lib9c/Action/Sell3.cs
@@ -11,6 +11,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Sell4.cs
+++ b/Lib9c/Action/Sell4.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Sell5.cs
+++ b/Lib9c/Action/Sell5.cs
@@ -16,6 +16,7 @@ using BxDictionary = Bencodex.Types.Dictionary;
 using BxList = Bencodex.Types.List;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Sell6.cs
+++ b/Lib9c/Action/Sell6.cs
@@ -15,6 +15,7 @@ using BxDictionary = Bencodex.Types.Dictionary;
 using BxList = Bencodex.Types.List;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Sell7.cs
+++ b/Lib9c/Action/Sell7.cs
@@ -14,6 +14,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Sell8.cs
+++ b/Lib9c/Action/Sell8.cs
@@ -14,6 +14,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Sell9.cs
+++ b/Lib9c/Action/Sell9.cs
@@ -13,6 +13,7 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/SellCancellation.cs
+++ b/Lib9c/Action/SellCancellation.cs
@@ -15,6 +15,7 @@ using BxDictionary = Bencodex.Types.Dictionary;
 using BxList = Bencodex.Types.List;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/SellCancellation0.cs
+++ b/Lib9c/Action/SellCancellation0.cs
@@ -10,6 +10,7 @@ using Nekoyume.Model.Mail;
 using Nekoyume.Model.State;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/SellCancellation2.cs
+++ b/Lib9c/Action/SellCancellation2.cs
@@ -10,6 +10,7 @@ using Nekoyume.Model.Mail;
 using Nekoyume.Model.State;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/SellCancellation3.cs
+++ b/Lib9c/Action/SellCancellation3.cs
@@ -10,6 +10,7 @@ using Nekoyume.Model.Mail;
 using Nekoyume.Model.State;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/SellCancellation4.cs
+++ b/Lib9c/Action/SellCancellation4.cs
@@ -10,6 +10,7 @@ using Nekoyume.Model.Mail;
 using Nekoyume.Model.State;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/SellCancellation5.cs
+++ b/Lib9c/Action/SellCancellation5.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.State;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/SellCancellation6.cs
+++ b/Lib9c/Action/SellCancellation6.cs
@@ -14,6 +14,7 @@ using BxDictionary = Bencodex.Types.Dictionary;
 using BxList = Bencodex.Types.List;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/SellCancellation7.cs
+++ b/Lib9c/Action/SellCancellation7.cs
@@ -15,6 +15,7 @@ using BxDictionary = Bencodex.Types.Dictionary;
 using BxList = Bencodex.Types.List;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/SellCancellation8.cs
+++ b/Lib9c/Action/SellCancellation8.cs
@@ -15,6 +15,7 @@ using BxDictionary = Bencodex.Types.Dictionary;
 using BxList = Bencodex.Types.List;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/ShopErrorType.cs
+++ b/Lib9c/Action/ShopErrorType.cs
@@ -1,4 +1,5 @@
-﻿namespace Nekoyume.Action
+﻿#nullable disable
+namespace Nekoyume.Action
 {
     public enum ShopErrorType
     {

--- a/Lib9c/Action/ShopItemExpiredException.cs
+++ b/Lib9c/Action/ShopItemExpiredException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/StageClearedException.cs
+++ b/Lib9c/Action/StageClearedException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/Stake.cs
+++ b/Lib9c/Action/Stake.cs
@@ -11,6 +11,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [ActionType("stake2")]

--- a/Lib9c/Action/Stake0.cs
+++ b/Lib9c/Action/Stake0.cs
@@ -10,6 +10,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [ActionType("stake")]

--- a/Lib9c/Action/StakeExistingClaimableException.cs
+++ b/Lib9c/Action/StakeExistingClaimableException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/TotalSupplyDoesNotExistException.cs
+++ b/Lib9c/Action/TotalSupplyDoesNotExistException.cs
@@ -3,6 +3,7 @@ using Libplanet.Assets;
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/TransferAsset.cs
+++ b/Lib9c/Action/TransferAsset.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using Nekoyume.Model;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/TransferAsset0.cs
+++ b/Lib9c/Action/TransferAsset0.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/TransferAsset2.cs
+++ b/Lib9c/Action/TransferAsset2.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using Nekoyume.Model;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/UnlockEquipmentRecipe.cs
+++ b/Lib9c/Action/UnlockEquipmentRecipe.cs
@@ -14,6 +14,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [ActionType("unlock_equipment_recipe")]

--- a/Lib9c/Action/UnlockWorld.cs
+++ b/Lib9c/Action/UnlockWorld.cs
@@ -11,6 +11,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/UnlockWorld1.cs
+++ b/Lib9c/Action/UnlockWorld1.cs
@@ -11,6 +11,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [ActionType("unlock_world")]

--- a/Lib9c/Action/UpdateSell.cs
+++ b/Lib9c/Action/UpdateSell.cs
@@ -16,6 +16,7 @@ using static Lib9c.SerializeKeys;
 using BxDictionary = Bencodex.Types.Dictionary;
 using BxList = Bencodex.Types.List;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/UpdateSell0.cs
+++ b/Lib9c/Action/UpdateSell0.cs
@@ -17,6 +17,7 @@ using static Lib9c.SerializeKeys;
 using BxDictionary = Bencodex.Types.Dictionary;
 using BxList = Bencodex.Types.List;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/UpdateSell2.cs
+++ b/Lib9c/Action/UpdateSell2.cs
@@ -17,6 +17,7 @@ using static Lib9c.SerializeKeys;
 using BxDictionary = Bencodex.Types.Dictionary;
 using BxList = Bencodex.Types.List;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     /// <summary>

--- a/Lib9c/Action/UpdateSellInfo.cs
+++ b/Lib9c/Action/UpdateSellInfo.cs
@@ -6,6 +6,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/UsageLimitExceedException.cs
+++ b/Lib9c/Action/UsageLimitExceedException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/WeeklyArenaStateAlreadyEndedException.cs
+++ b/Lib9c/Action/WeeklyArenaStateAlreadyEndedException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Action/WeeklyArenaStateNotContainsAvatarAddressException.cs
+++ b/Lib9c/Action/WeeklyArenaStateNotContainsAvatarAddressException.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.Serialization;
 using Libplanet;
 
+#nullable disable
 namespace Nekoyume.Action
 {
     [Serializable]

--- a/Lib9c/Addresses.cs
+++ b/Lib9c/Addresses.cs
@@ -5,6 +5,7 @@ using Nekoyume.Action;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume
 {
     public static class Addresses

--- a/Lib9c/AppProtocolVersionExtra.cs
+++ b/Lib9c/AppProtocolVersionExtra.cs
@@ -2,6 +2,7 @@ using System;
 using System.Globalization;
 using Bencodex.Types;
 
+#nullable disable
 namespace Nekoyume
 {
     public readonly struct AppProtocolVersionExtra

--- a/Lib9c/Arena/ArenaHelper.cs
+++ b/Lib9c/Arena/ArenaHelper.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Arena
 {
     /// <summary>

--- a/Lib9c/Arena/ArenaSimulator.cs
+++ b/Lib9c/Arena/ArenaSimulator.cs
@@ -8,6 +8,7 @@ using Nekoyume.Model.BattleStatus.Arena;
 using Nekoyume.TableData;
 using Priority_Queue;
 
+#nullable disable
 namespace Nekoyume.Arena
 {
     /// <summary>

--- a/Lib9c/Arena/ArenaSimulator2.cs
+++ b/Lib9c/Arena/ArenaSimulator2.cs
@@ -10,6 +10,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.TableData;
 using Priority_Queue;
 
+#nullable disable
 namespace Nekoyume.Arena
 {
     /// <summary>

--- a/Lib9c/Battle/ArenaScoreHelper.cs
+++ b/Lib9c/Battle/ArenaScoreHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Nekoyume.Model.BattleStatus;
 
+#nullable disable
 namespace Nekoyume.Battle
 {
     public static class ArenaScoreHelper

--- a/Lib9c/Battle/AttackCountHelper.cs
+++ b/Lib9c/Battle/AttackCountHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Battle
 {
     public static class AttackCountHelper

--- a/Lib9c/Battle/CPHelper.cs
+++ b/Lib9c/Battle/CPHelper.cs
@@ -6,6 +6,7 @@ using Nekoyume.Model.Stat;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Battle
 {
     public static class CPHelper

--- a/Lib9c/Battle/EnemyPlayerDigest.cs
+++ b/Lib9c/Battle/EnemyPlayerDigest.cs
@@ -5,6 +5,7 @@ using Nekoyume.Model;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Battle
 {
     public readonly struct EnemyPlayerDigest: IState

--- a/Lib9c/Battle/HitHelper.cs
+++ b/Lib9c/Battle/HitHelper.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Text;
 
+#nullable disable
 namespace Nekoyume.Battle
 {
     public static class HitHelper

--- a/Lib9c/Battle/ISimulator.cs
+++ b/Lib9c/Battle/ISimulator.cs
@@ -4,6 +4,7 @@ using Nekoyume.Model.BattleStatus;
 using Nekoyume.Model.Item;
 using Priority_Queue;
 
+#nullable disable
 namespace Nekoyume.Battle
 {
     public interface ISimulator

--- a/Lib9c/Battle/IStageSimulator.cs
+++ b/Lib9c/Battle/IStageSimulator.cs
@@ -1,6 +1,7 @@
 ﻿using Nekoyume.Model;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Battle
 {
     public interface IStageSimulator : ISimulator

--- a/Lib9c/Battle/RaidBoss.cs
+++ b/Lib9c/Battle/RaidBoss.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable disable
 namespace Nekoyume.Model
 {
     public class RaidBoss : Enemy

--- a/Lib9c/Battle/RaidSimulator.cs
+++ b/Lib9c/Battle/RaidSimulator.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable disable
 namespace Nekoyume.Battle
 {
     public class RaidSimulator : Simulator

--- a/Lib9c/Battle/RankingSimulator.cs
+++ b/Lib9c/Battle/RankingSimulator.cs
@@ -11,6 +11,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Priority_Queue;
 
+#nullable disable
 namespace Nekoyume.Battle
 {
     public class RankingSimulator : Simulator

--- a/Lib9c/Battle/RankingSimulatorV1.cs
+++ b/Lib9c/Battle/RankingSimulatorV1.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Priority_Queue;
 
+#nullable disable
 namespace Nekoyume.Battle
 {
     public class RankingSimulatorV1 : Simulator

--- a/Lib9c/Battle/RewardSelector.cs
+++ b/Lib9c/Battle/RewardSelector.cs
@@ -4,6 +4,7 @@ using Libplanet.Action;
 using Nekoyume.Model.Item;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Battle
 {
     public static class RewardSelector

--- a/Lib9c/Battle/Simulator.cs
+++ b/Lib9c/Battle/Simulator.cs
@@ -9,6 +9,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Priority_Queue;
 
+#nullable disable
 namespace Nekoyume.Battle
 {
     public abstract class Simulator : ISimulator

--- a/Lib9c/Battle/StageRewardExpHelper.cs
+++ b/Lib9c/Battle/StageRewardExpHelper.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Battle
 {
     public static class StageRewardExpHelper

--- a/Lib9c/Battle/StageSimulator.cs
+++ b/Lib9c/Battle/StageSimulator.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.Buff;
 using Nekoyume.TableData;
 using Priority_Queue;
 
+#nullable disable
 namespace Nekoyume.Battle
 {
     public class StageSimulator : Simulator, IStageSimulator

--- a/Lib9c/Battle/StageSimulatorV1.cs
+++ b/Lib9c/Battle/StageSimulatorV1.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.Buff;
 using Nekoyume.TableData;
 using Priority_Queue;
 
+#nullable disable
 namespace Nekoyume.Battle
 {
     public class StageSimulatorV1 : Simulator, IStageSimulator

--- a/Lib9c/Battle/Wave.cs
+++ b/Lib9c/Battle/Wave.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Nekoyume.Model;
 using Nekoyume.Model.BattleStatus;
 
+#nullable disable
 namespace Nekoyume.Battle
 {
     public class Wave

--- a/Lib9c/Battle/WeightedSelector.cs
+++ b/Lib9c/Battle/WeightedSelector.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Libplanet.Action;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Battle
 {
     public class WeightedSelector<T>

--- a/Lib9c/BlockHelper.cs
+++ b/Lib9c/BlockHelper.cs
@@ -15,6 +15,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume
 {
     public static class BlockHelper

--- a/Lib9c/CurrencyExtensions.cs
+++ b/Lib9c/CurrencyExtensions.cs
@@ -5,6 +5,7 @@ using Bencodex.Types;
 using Libplanet;
 using Libplanet.Assets;
 
+#nullable disable
 namespace Nekoyume
 {
     public static class CurrencyExtensions

--- a/Lib9c/Exceptions/InvalidActionFieldException.cs
+++ b/Lib9c/Exceptions/InvalidActionFieldException.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Exceptions
 {
     [Serializable]

--- a/Lib9c/Exceptions/NotEnoughEventDungeonTicketsException.cs
+++ b/Lib9c/Exceptions/NotEnoughEventDungeonTicketsException.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Exceptions
 {
     [Serializable]

--- a/Lib9c/Extensions/CombinationSlotStateExtensions.cs
+++ b/Lib9c/Extensions/CombinationSlotStateExtensions.cs
@@ -3,6 +3,7 @@ using Nekoyume.Action;
 using Nekoyume.Model.Mail;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Extensions
 {
     public static class CombinationSlotStateExtensions

--- a/Lib9c/Extensions/EquipmentExtensions.cs
+++ b/Lib9c/Extensions/EquipmentExtensions.cs
@@ -7,6 +7,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.Stat;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Extensions
 {
     public static class EquipmentExtensions

--- a/Lib9c/Extensions/EventDungeonExtensions.cs
+++ b/Lib9c/Extensions/EventDungeonExtensions.cs
@@ -7,6 +7,7 @@ using Nekoyume.Model.Event;
 using Nekoyume.TableData;
 using Nekoyume.TableData.Event;
 
+#nullable disable
 namespace Nekoyume.Extensions
 {
     public static class EventDungeonExtensions

--- a/Lib9c/Extensions/EventRecipeExtensions.cs
+++ b/Lib9c/Extensions/EventRecipeExtensions.cs
@@ -4,6 +4,7 @@ using Nekoyume.Exceptions;
 using Nekoyume.TableData;
 using Nekoyume.TableData.Event;
 
+#nullable disable
 namespace Nekoyume.Extensions
 {
     public static class EventRecipeExtensions

--- a/Lib9c/Extensions/EventScheduleExtensions.cs
+++ b/Lib9c/Extensions/EventScheduleExtensions.cs
@@ -7,6 +7,7 @@ using Nekoyume.Exceptions;
 using Nekoyume.TableData;
 using Nekoyume.TableData.Event;
 
+#nullable disable
 namespace Nekoyume.Extensions
 {
     public static class EventScheduleExtensions

--- a/Lib9c/Extensions/IntegerExtensions.cs
+++ b/Lib9c/Extensions/IntegerExtensions.cs
@@ -1,4 +1,5 @@
-﻿namespace Nekoyume.Extensions
+﻿#nullable disable
+namespace Nekoyume.Extensions
 {
     public static class IntegerExtensions
     {

--- a/Lib9c/Extensions/MaterialItemSheetExtensions.cs
+++ b/Lib9c/Extensions/MaterialItemSheetExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Extensions
 {
     public static class MaterialItemSheetExtensions

--- a/Lib9c/Extensions/SheetsExtensions.cs
+++ b/Lib9c/Extensions/SheetsExtensions.cs
@@ -7,6 +7,7 @@ using Libplanet.Assets;
 using Nekoyume.Action;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Extensions
 {
     public static class SheetsExtensions

--- a/Lib9c/Extensions/WorldInformationExtensions.cs
+++ b/Lib9c/Extensions/WorldInformationExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Nekoyume.Action;
 using Nekoyume.Model;
 
+#nullable disable
 namespace Nekoyume.Extensions
 {
     public static class WorldInformationExtensions

--- a/Lib9c/Formatters/AccountStateDeltaFormatter.cs
+++ b/Lib9c/Formatters/AccountStateDeltaFormatter.cs
@@ -11,6 +11,7 @@ using MessagePack.Formatters;
 using Nekoyume;
 using Nekoyume.Action;
 
+#nullable disable
 namespace Lib9c.Formatters
 {
     public class AccountStateDeltaFormatter : IMessagePackFormatter<IAccountStateDelta>

--- a/Lib9c/Formatters/AddressFormatter.cs
+++ b/Lib9c/Formatters/AddressFormatter.cs
@@ -4,6 +4,7 @@ using Libplanet;
 using MessagePack;
 using MessagePack.Formatters;
 
+#nullable disable
 namespace Lib9c.Formatters
 {
     public class AddressFormatter : IMessagePackFormatter<Address>

--- a/Lib9c/Formatters/BencodexFormatter.cs
+++ b/Lib9c/Formatters/BencodexFormatter.cs
@@ -5,6 +5,7 @@ using Bencodex.Types;
 using MessagePack;
 using MessagePack.Formatters;
 
+#nullable disable
 namespace Lib9c.Formatters
 {
     public class BencodexFormatter<T> : IMessagePackFormatter<T> where T: IValue

--- a/Lib9c/Formatters/ExceptionFormatter.cs
+++ b/Lib9c/Formatters/ExceptionFormatter.cs
@@ -5,6 +5,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 using MessagePack;
 using MessagePack.Formatters;
 
+#nullable disable
 namespace Lib9c.Formatters
 {
     public class ExceptionFormatter<T> : IMessagePackFormatter<T> where T : Exception

--- a/Lib9c/Formatters/FungibleAssetValueFormatter.cs
+++ b/Lib9c/Formatters/FungibleAssetValueFormatter.cs
@@ -7,6 +7,7 @@ using MessagePack;
 using MessagePack.Formatters;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Lib9c.Formatters
 {
     public class FungibleAssetValueFormatter : IMessagePackFormatter<FungibleAssetValue>

--- a/Lib9c/Formatters/NCActionFormatter.cs
+++ b/Lib9c/Formatters/NCActionFormatter.cs
@@ -11,6 +11,7 @@ using MessagePack.Formatters;
 using Nekoyume.Action;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
+#nullable disable
 namespace Lib9c.Formatters
 {
     public class NCActionFormatter : IMessagePackFormatter<NCAction>

--- a/Lib9c/Formatters/NineChroniclesResolver.cs
+++ b/Lib9c/Formatters/NineChroniclesResolver.cs
@@ -1,6 +1,7 @@
 using MessagePack;
 using MessagePack.Formatters;
 
+#nullable disable
 namespace Lib9c.Formatters
 {
     public class NineChroniclesResolver : IFormatterResolver

--- a/Lib9c/Formatters/NineChroniclesResolverGetFormatterHelper.cs
+++ b/Lib9c/Formatters/NineChroniclesResolverGetFormatterHelper.cs
@@ -8,6 +8,7 @@ using Libplanet.Crypto;
 using MessagePack.Formatters;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
+#nullable disable
 namespace Lib9c.Formatters
 {
     public static class NineChroniclesResolverGetFormatterHelper

--- a/Lib9c/Formatters/PublicKeyFormatter.cs
+++ b/Lib9c/Formatters/PublicKeyFormatter.cs
@@ -4,6 +4,7 @@ using Libplanet.Crypto;
 using MessagePack;
 using MessagePack.Formatters;
 
+#nullable disable
 namespace Lib9c.Formatters
 {
     public class PublicKeyFormatter : IMessagePackFormatter<PublicKey>

--- a/Lib9c/GameConfig.cs
+++ b/Lib9c/GameConfig.cs
@@ -1,5 +1,6 @@
 using System;
 
+#nullable disable
 namespace Nekoyume
 {
     public static class GameConfig

--- a/Lib9c/Helper/AvatarStateExtensions.cs
+++ b/Lib9c/Helper/AvatarStateExtensions.cs
@@ -8,6 +8,7 @@ using Nekoyume.Model.Quest;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Helper
 {
     public static class AvatarStateExtensions

--- a/Lib9c/Helper/CrystalCalculator.cs
+++ b/Lib9c/Helper/CrystalCalculator.cs
@@ -11,6 +11,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Nekoyume.TableData.Crystal;
 
+#nullable disable
 namespace Nekoyume.Helper
 {
     public static class CrystalCalculator

--- a/Lib9c/Helper/InventoryExtensions.cs
+++ b/Lib9c/Helper/InventoryExtensions.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Nekoyume.Model.Item;
 
+#nullable disable
 namespace Nekoyume.Helper
 {
     public static class InventoryExtensions

--- a/Lib9c/Helper/ItemOptionHelper.cs
+++ b/Lib9c/Helper/ItemOptionHelper.cs
@@ -4,6 +4,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.Stat;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Helper
 {
     using System.Linq;

--- a/Lib9c/Helper/RuneHelper.cs
+++ b/Lib9c/Helper/RuneHelper.cs
@@ -8,6 +8,7 @@ using Libplanet.Assets;
 using Nekoyume.Battle;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Helper
 {
     public static class RuneHelper

--- a/Lib9c/Helper/Validator.cs
+++ b/Lib9c/Helper/Validator.cs
@@ -9,6 +9,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Helper
 {
     public static class Validator

--- a/Lib9c/Helper/WorldBossHelper.cs
+++ b/Lib9c/Helper/WorldBossHelper.cs
@@ -3,6 +3,7 @@ using Libplanet.Assets;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Helper
 {
     public static class WorldBossHelper

--- a/Lib9c/InvalidMinerException.cs
+++ b/Lib9c/InvalidMinerException.cs
@@ -3,6 +3,7 @@ using Libplanet.Blocks;
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Lib9c
 {
     [Serializable]

--- a/Lib9c/Lib9c.csproj
+++ b/Lib9c/Lib9c.csproj
@@ -9,6 +9,7 @@
     <IntermediateOutputPath>.obj</IntermediateOutputPath>
     <RootNamespace>Nekoyume</RootNamespace>
     <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Lib9c/Miner.cs
+++ b/Lib9c/Miner.cs
@@ -14,6 +14,7 @@ using Libplanet.Tx;
 using Serilog;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
+#nullable disable
 namespace Nekoyume.BlockChain
 {
     public class Miner

--- a/Lib9c/Model/ActivationKey.cs
+++ b/Lib9c/Model/ActivationKey.cs
@@ -4,6 +4,7 @@ using Libplanet.Crypto;
 using Nekoyume.Action;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Model
 {
     public struct ActivationKey

--- a/Lib9c/Model/Arena/ArenaExceptions.cs
+++ b/Lib9c/Model/Arena/ArenaExceptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Model.Arena
 {
     [Serializable]

--- a/Lib9c/Model/Arena/ArenaInformation.cs
+++ b/Lib9c/Model/Arena/ArenaInformation.cs
@@ -5,6 +5,7 @@ using Nekoyume.Arena;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Arena
 {
     /// <summary>

--- a/Lib9c/Model/Arena/ArenaParticipants.cs
+++ b/Lib9c/Model/Arena/ArenaParticipants.cs
@@ -5,6 +5,7 @@ using Libplanet;
 using Nekoyume.Action;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Model.Arena
 {
     /// <summary>

--- a/Lib9c/Model/Arena/ArenaScore.cs
+++ b/Lib9c/Model/Arena/ArenaScore.cs
@@ -4,6 +4,7 @@ using Nekoyume.Model.State;
 using Libplanet;
 using Nekoyume.Action;
 
+#nullable disable
 namespace Nekoyume.Model.Arena
 {
     /// <summary>

--- a/Lib9c/Model/BattleStatus/AreaAttack.cs
+++ b/Lib9c/Model/BattleStatus/AreaAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/Arena/ArenaAreaAttack.cs
+++ b/Lib9c/Model/BattleStatus/Arena/ArenaAreaAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus.Arena
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/Arena/ArenaBlowAttack.cs
+++ b/Lib9c/Model/BattleStatus/Arena/ArenaBlowAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus.Arena
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/Arena/ArenaBuff.cs
+++ b/Lib9c/Model/BattleStatus/Arena/ArenaBuff.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus.Arena
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/Arena/ArenaBuffRemovalAttack.cs
+++ b/Lib9c/Model/BattleStatus/Arena/ArenaBuffRemovalAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus.Arena
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/Arena/ArenaDead.cs
+++ b/Lib9c/Model/BattleStatus/Arena/ArenaDead.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus.Arena
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/Arena/ArenaDoubleAttack.cs
+++ b/Lib9c/Model/BattleStatus/Arena/ArenaDoubleAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus.Arena
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/Arena/ArenaEventBase.cs
+++ b/Lib9c/Model/BattleStatus/Arena/ArenaEventBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus.Arena
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/Arena/ArenaHeal.cs
+++ b/Lib9c/Model/BattleStatus/Arena/ArenaHeal.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus.Arena
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/Arena/ArenaLog.cs
+++ b/Lib9c/Model/BattleStatus/Arena/ArenaLog.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus.Arena
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/Arena/ArenaNormalAttack.cs
+++ b/Lib9c/Model/BattleStatus/Arena/ArenaNormalAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus.Arena
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/Arena/ArenaRemoveBuffs.cs
+++ b/Lib9c/Model/BattleStatus/Arena/ArenaRemoveBuffs.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus.Arena
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/Arena/ArenaSkill.cs
+++ b/Lib9c/Model/BattleStatus/Arena/ArenaSkill.cs
@@ -4,6 +4,7 @@ using JetBrains.Annotations;
 using Nekoyume.Model.Elemental;
 using Nekoyume.Model.Skill;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus.Arena
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/Arena/ArenaSpawnCharacter.cs
+++ b/Lib9c/Model/BattleStatus/Arena/ArenaSpawnCharacter.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus.Arena
 {
     public class ArenaSpawnCharacter : ArenaEventBase

--- a/Lib9c/Model/BattleStatus/Arena/ArenaTurnEnd.cs
+++ b/Lib9c/Model/BattleStatus/Arena/ArenaTurnEnd.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus.Arena
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/BattleLog.cs
+++ b/Lib9c/Model/BattleStatus/BattleLog.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/BlowAttack.cs
+++ b/Lib9c/Model/BattleStatus/BlowAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/BuffRemovalAttack.cs
+++ b/Lib9c/Model/BattleStatus/BuffRemovalAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/BuffSkill.cs
+++ b/Lib9c/Model/BattleStatus/BuffSkill.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/Dead.cs
+++ b/Lib9c/Model/BattleStatus/Dead.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/DoubleAttack.cs
+++ b/Lib9c/Model/BattleStatus/DoubleAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/DropBox.cs
+++ b/Lib9c/Model/BattleStatus/DropBox.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Nekoyume.Model.Item;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/EventBase.cs
+++ b/Lib9c/Model/BattleStatus/EventBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/GetExp.cs
+++ b/Lib9c/Model/BattleStatus/GetExp.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/GetReward.cs
+++ b/Lib9c/Model/BattleStatus/GetReward.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Nekoyume.Model.Item;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/HealSkill.cs
+++ b/Lib9c/Model/BattleStatus/HealSkill.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/NormalAttack.cs
+++ b/Lib9c/Model/BattleStatus/NormalAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/RemoveBuffs.cs
+++ b/Lib9c/Model/BattleStatus/RemoveBuffs.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/Skill.cs
+++ b/Lib9c/Model/BattleStatus/Skill.cs
@@ -4,6 +4,7 @@ using JetBrains.Annotations;
 using Nekoyume.Model.Elemental;
 using Nekoyume.Model.Skill;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/SpawnEnemyPlayer.cs
+++ b/Lib9c/Model/BattleStatus/SpawnEnemyPlayer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/SpawnPlayer.cs
+++ b/Lib9c/Model/BattleStatus/SpawnPlayer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/SpawnWave.cs
+++ b/Lib9c/Model/BattleStatus/SpawnWave.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/TickDamage.cs
+++ b/Lib9c/Model/BattleStatus/TickDamage.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/BattleStatus/WaveTurnEnd.cs
+++ b/Lib9c/Model/BattleStatus/WaveTurnEnd.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 
+#nullable disable
 namespace Nekoyume.Model.BattleStatus
 {
     [Serializable]

--- a/Lib9c/Model/Buff/ActionBuff.cs
+++ b/Lib9c/Model/Buff/ActionBuff.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Buff
 {
     [Serializable]

--- a/Lib9c/Model/Buff/AttackBuff.cs
+++ b/Lib9c/Model/Buff/AttackBuff.cs
@@ -1,6 +1,7 @@
 using System;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Buff
 {
     [Serializable]

--- a/Lib9c/Model/Buff/Bleed.cs
+++ b/Lib9c/Model/Buff/Bleed.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Nekoyume.Model.Skill;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Buff
 {
     [Serializable]

--- a/Lib9c/Model/Buff/Buff.cs
+++ b/Lib9c/Model/Buff/Buff.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.Model.Skill;
 
+#nullable disable
 namespace Nekoyume.Model.Buff
 {
     [Serializable]

--- a/Lib9c/Model/Buff/BuffFactory.cs
+++ b/Lib9c/Model/Buff/BuffFactory.cs
@@ -4,6 +4,7 @@ using Nekoyume.Model.Skill;
 using Nekoyume.Model.Stat;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Buff
 {
     public static class BuffFactory

--- a/Lib9c/Model/Buff/CriticalBuff.cs
+++ b/Lib9c/Model/Buff/CriticalBuff.cs
@@ -1,6 +1,7 @@
 using System;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Buff
 {
     [Serializable]

--- a/Lib9c/Model/Buff/DefenseBuff.cs
+++ b/Lib9c/Model/Buff/DefenseBuff.cs
@@ -2,6 +2,7 @@ using System;
 using Nekoyume.Model;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Buff
 {
     [Serializable]

--- a/Lib9c/Model/Buff/HPBuff.cs
+++ b/Lib9c/Model/Buff/HPBuff.cs
@@ -1,6 +1,7 @@
 using System;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Buff
 {
     [Serializable]

--- a/Lib9c/Model/Buff/HitBuff.cs
+++ b/Lib9c/Model/Buff/HitBuff.cs
@@ -1,6 +1,7 @@
 using System;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Buff
 {
     [Serializable]

--- a/Lib9c/Model/Buff/SpeedBuff.cs
+++ b/Lib9c/Model/Buff/SpeedBuff.cs
@@ -1,6 +1,7 @@
 using System;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Buff
 {
     [Serializable]

--- a/Lib9c/Model/Buff/StatBuff.cs
+++ b/Lib9c/Model/Buff/StatBuff.cs
@@ -2,6 +2,7 @@ using System;
 using Nekoyume.Model.Stat;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Buff
 {
     [Serializable]

--- a/Lib9c/Model/Character/ArenaCharacter.cs
+++ b/Lib9c/Model/Character/ArenaCharacter.cs
@@ -14,6 +14,7 @@ using Nekoyume.Model.Skill;
 using Nekoyume.Model.Stat;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model
 {
     public class ArenaCharacter : ICloneable

--- a/Lib9c/Model/Character/ArenaPlayerDigest.cs
+++ b/Lib9c/Model/Character/ArenaPlayerDigest.cs
@@ -5,6 +5,7 @@ using Bencodex.Types;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Model
 {
     /// <summary>

--- a/Lib9c/Model/Character/ArenaSkills.cs
+++ b/Lib9c/Model/Character/ArenaSkills.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Linq;
 using Nekoyume.Model.Skill.Arena;
 
+#nullable disable
 namespace Nekoyume.Model
 {
     [Serializable]

--- a/Lib9c/Model/Character/CharacterBase.cs
+++ b/Lib9c/Model/Character/CharacterBase.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.Skill;
 using Nekoyume.Model.Stat;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model
 {
     [Serializable]

--- a/Lib9c/Model/Character/Enemy.cs
+++ b/Lib9c/Model/Character/Enemy.cs
@@ -8,6 +8,7 @@ using Nekoyume.Model.Skill;
 using Nekoyume.Model.Stat;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model
 {
     [Serializable]

--- a/Lib9c/Model/Character/EnemyPlayer.cs
+++ b/Lib9c/Model/Character/EnemyPlayer.cs
@@ -7,6 +7,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model
 {
     [Serializable]

--- a/Lib9c/Model/Character/Player.cs
+++ b/Lib9c/Model/Character/Player.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Inventory = Nekoyume.Model.Item.Inventory;
 
+#nullable disable
 namespace Nekoyume.Model
 {
     [Serializable]

--- a/Lib9c/Model/Character/SizeType.cs
+++ b/Lib9c/Model/Character/SizeType.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Nekoyume.Model.Character
 {
     public enum SizeType

--- a/Lib9c/Model/Character/Skills.cs
+++ b/Lib9c/Model/Character/Skills.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Linq;
 using Nekoyume.Battle;
 
+#nullable disable
 namespace Nekoyume.Model
 {
     [Serializable]

--- a/Lib9c/Model/CollectionMap.cs
+++ b/Lib9c/Model/CollectionMap.cs
@@ -8,6 +8,7 @@ using System.Runtime.Serialization;
 using Bencodex.Types;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Model
 {
     [Serializable]

--- a/Lib9c/Model/Elemental/ElementalType.cs
+++ b/Lib9c/Model/Elemental/ElementalType.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.Elemental
 {
     public enum ElementalType

--- a/Lib9c/Model/EnumType/ArenaType.cs
+++ b/Lib9c/Model/EnumType/ArenaType.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Nekoyume.Model.EnumType
 {
     public enum ArenaType

--- a/Lib9c/Model/EnumType/TradeType.cs
+++ b/Lib9c/Model/EnumType/TradeType.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Nekoyume.Model.EnumType
 {
     public enum TradeType

--- a/Lib9c/Model/Event/EventDungeonInfo.cs
+++ b/Lib9c/Model/Event/EventDungeonInfo.cs
@@ -4,6 +4,7 @@ using Libplanet;
 using Nekoyume.Action;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Model.Event
 {
     public class EventDungeonInfo : IState

--- a/Lib9c/Model/IArena.cs
+++ b/Lib9c/Model/IArena.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Nekoyume.Model.BattleStatus.Arena;
 
+#nullable disable
 namespace Nekoyume.Model
 {
     public interface IArena

--- a/Lib9c/Model/IStage.cs
+++ b/Lib9c/Model/IStage.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Nekoyume.Model.Item;
 
+#nullable disable
 namespace Nekoyume.Model
 {
     public interface IStage

--- a/Lib9c/Model/Item/Armor.cs
+++ b/Lib9c/Model/Item/Armor.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 using Bencodex.Types;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     [Serializable]

--- a/Lib9c/Model/Item/Belt.cs
+++ b/Lib9c/Model/Item/Belt.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 using Bencodex.Types;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     [Serializable]

--- a/Lib9c/Model/Item/Consumable.cs
+++ b/Lib9c/Model/Item/Consumable.cs
@@ -7,6 +7,7 @@ using Nekoyume.Model.Stat;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     [Serializable]

--- a/Lib9c/Model/Item/Costume.cs
+++ b/Lib9c/Model/Item/Costume.cs
@@ -7,6 +7,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     [Serializable]

--- a/Lib9c/Model/Item/Equipment.cs
+++ b/Lib9c/Model/Item/Equipment.cs
@@ -11,6 +11,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     [Serializable]

--- a/Lib9c/Model/Item/IEquippableItem.cs
+++ b/Lib9c/Model/Item/IEquippableItem.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     public interface IEquippableItem: IItem

--- a/Lib9c/Model/Item/IFungibleItem.cs
+++ b/Lib9c/Model/Item/IFungibleItem.cs
@@ -1,6 +1,7 @@
 ﻿using System.Security.Cryptography;
 using Libplanet;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     public interface IFungibleItem: IItem

--- a/Lib9c/Model/Item/IItem.cs
+++ b/Lib9c/Model/Item/IItem.cs
@@ -1,5 +1,6 @@
 ﻿using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     public interface IItem: IState

--- a/Lib9c/Model/Item/ILock.cs
+++ b/Lib9c/Model/Item/ILock.cs
@@ -1,5 +1,6 @@
 using Bencodex.Types;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     public interface ILock

--- a/Lib9c/Model/Item/INonFungibleItem.cs
+++ b/Lib9c/Model/Item/INonFungibleItem.cs
@@ -1,5 +1,6 @@
 using System;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     public interface INonFungibleItem: ITradableItem

--- a/Lib9c/Model/Item/ITradableFungibleItem.cs
+++ b/Lib9c/Model/Item/ITradableFungibleItem.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     public interface ITradableFungibleItem : ITradableItem, IFungibleItem, ICloneable

--- a/Lib9c/Model/Item/ITradableItem.cs
+++ b/Lib9c/Model/Item/ITradableItem.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     public interface ITradableItem: IItem

--- a/Lib9c/Model/Item/Inventory.cs
+++ b/Lib9c/Model/Item/Inventory.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     [Serializable]

--- a/Lib9c/Model/Item/ItemBase.cs
+++ b/Lib9c/Model/Item/ItemBase.cs
@@ -6,6 +6,7 @@ using Nekoyume.Model.Elemental;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     [Serializable]

--- a/Lib9c/Model/Item/ItemFactory.cs
+++ b/Lib9c/Model/Item/ItemFactory.cs
@@ -6,6 +6,7 @@ using Nekoyume.TableData;
 using Nekoyume.Model.State;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     public static class ItemFactory

--- a/Lib9c/Model/Item/ItemType.cs
+++ b/Lib9c/Model/Item/ItemType.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     public enum ItemType

--- a/Lib9c/Model/Item/ItemUsable.cs
+++ b/Lib9c/Model/Item/ItemUsable.cs
@@ -8,6 +8,7 @@ using Nekoyume.Model.Stat;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     // todo: 소모품과 장비가 함께 쓰기에는 장비 위주의 모델이 된 느낌. 아이템 정리하면서 정리를 흐음..

--- a/Lib9c/Model/Item/LockType.cs
+++ b/Lib9c/Model/Item/LockType.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     public enum LockType

--- a/Lib9c/Model/Item/Material.cs
+++ b/Lib9c/Model/Item/Material.cs
@@ -6,6 +6,7 @@ using Libplanet;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     [Serializable]

--- a/Lib9c/Model/Item/Necklace.cs
+++ b/Lib9c/Model/Item/Necklace.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 using Bencodex.Types;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     [Serializable]

--- a/Lib9c/Model/Item/OrderLock.cs
+++ b/Lib9c/Model/Item/OrderLock.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Bencodex.Types;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     [Serializable]

--- a/Lib9c/Model/Item/Ring.cs
+++ b/Lib9c/Model/Item/Ring.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 using Bencodex.Types;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     [Serializable]

--- a/Lib9c/Model/Item/ShopItem.cs
+++ b/Lib9c/Model/Item/ShopItem.cs
@@ -8,6 +8,7 @@ using Libplanet.Assets;
 using Nekoyume.Model.State;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     [Serializable]

--- a/Lib9c/Model/Item/TradableMaterial.cs
+++ b/Lib9c/Model/Item/TradableMaterial.cs
@@ -7,6 +7,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     [Serializable]

--- a/Lib9c/Model/Item/Weapon.cs
+++ b/Lib9c/Model/Item/Weapon.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 using Bencodex.Types;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Item
 {
     [Serializable]

--- a/Lib9c/Model/Mail/AttachmentMail.cs
+++ b/Lib9c/Model/Mail/AttachmentMail.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Bencodex.Types;
 using Nekoyume.Action;
 
+#nullable disable
 namespace Nekoyume.Model.Mail
 {
     [Serializable]

--- a/Lib9c/Model/Mail/BuyerMail.cs
+++ b/Lib9c/Model/Mail/BuyerMail.cs
@@ -1,6 +1,7 @@
 using System;
 using Nekoyume.Action;
 
+#nullable disable
 namespace Nekoyume.Model.Mail
 {
     [Serializable]

--- a/Lib9c/Model/Mail/CancelOrderMail.cs
+++ b/Lib9c/Model/Mail/CancelOrderMail.cs
@@ -5,6 +5,7 @@ using Bencodex.Types;
 using Nekoyume.Model.State;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Model.Mail
 {
     [Serializable]

--- a/Lib9c/Model/Mail/CombinationMail.cs
+++ b/Lib9c/Model/Mail/CombinationMail.cs
@@ -1,6 +1,7 @@
 using System;
 using Nekoyume.Action;
 
+#nullable disable
 namespace Nekoyume.Model.Mail
 {
     // todo: `CombineConsumable`, `CombineEquipment`, `EnhanceEquipment`로 분리할 필요가 있어 보임(소모품을 n개 만들었을 때 재료가 n개 씩 노출됨)

--- a/Lib9c/Model/Mail/DailyRewardMail.cs
+++ b/Lib9c/Model/Mail/DailyRewardMail.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Nekoyume.Action;
 
+#nullable disable
 namespace Nekoyume.Model.Mail
 {
     [Serializable]

--- a/Lib9c/Model/Mail/GrindingMail.cs
+++ b/Lib9c/Model/Mail/GrindingMail.cs
@@ -5,6 +5,7 @@ using Bencodex.Types;
 using Libplanet.Assets;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Model.Mail
 {
     public class GrindingMail : Mail

--- a/Lib9c/Model/Mail/IMail.cs
+++ b/Lib9c/Model/Mail/IMail.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Nekoyume.Model.Mail
 {
     public interface IMail

--- a/Lib9c/Model/Mail/ItemEnhanceMail.cs
+++ b/Lib9c/Model/Mail/ItemEnhanceMail.cs
@@ -1,6 +1,7 @@
 using System;
 using Nekoyume.Action;
 
+#nullable disable
 namespace Nekoyume.Model.Mail
 {
     [Serializable]

--- a/Lib9c/Model/Mail/Mail.cs
+++ b/Lib9c/Model/Mail/Mail.cs
@@ -6,6 +6,7 @@ using Bencodex.Types;
 using Nekoyume.Model.State;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Model.Mail
 {
     public enum MailType

--- a/Lib9c/Model/Mail/MonsterCollectionMail.cs
+++ b/Lib9c/Model/Mail/MonsterCollectionMail.cs
@@ -2,6 +2,7 @@ using System;
 using Bencodex.Types;
 using Nekoyume.Action;
 
+#nullable disable
 namespace Nekoyume.Model.Mail
 {
     [Serializable]

--- a/Lib9c/Model/Mail/OrderBuyerMail.cs
+++ b/Lib9c/Model/Mail/OrderBuyerMail.cs
@@ -5,6 +5,7 @@ using Bencodex.Types;
 using Nekoyume.Model.State;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Model.Mail
 {
     [Serializable]

--- a/Lib9c/Model/Mail/OrderExpirationMail.cs
+++ b/Lib9c/Model/Mail/OrderExpirationMail.cs
@@ -5,6 +5,7 @@ using Bencodex.Types;
 using Nekoyume.Model.State;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Model.Mail
 {
     [Serializable]

--- a/Lib9c/Model/Mail/OrderSellerMail.cs
+++ b/Lib9c/Model/Mail/OrderSellerMail.cs
@@ -5,6 +5,7 @@ using Bencodex.Types;
 using Nekoyume.Model.State;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Model.Mail
 {
     [Serializable]

--- a/Lib9c/Model/Mail/SellCancelMail.cs
+++ b/Lib9c/Model/Mail/SellCancelMail.cs
@@ -1,6 +1,7 @@
 using System;
 using Nekoyume.Action;
 
+#nullable disable
 namespace Nekoyume.Model.Mail
 {
     [Serializable]

--- a/Lib9c/Model/Mail/SellerMail.cs
+++ b/Lib9c/Model/Mail/SellerMail.cs
@@ -2,6 +2,7 @@ using System;
 using Bencodex.Types;
 using Nekoyume.Action;
 
+#nullable disable
 namespace Nekoyume.Model.Mail
 {
     [Serializable]

--- a/Lib9c/Model/Order/FungibleOrder.cs
+++ b/Lib9c/Model/Order/FungibleOrder.cs
@@ -11,6 +11,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Lib9c.Model.Order
 {
     [Serializable]

--- a/Lib9c/Model/Order/NonFungibleOrder.cs
+++ b/Lib9c/Model/Order/NonFungibleOrder.cs
@@ -8,6 +8,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Lib9c.Model.Order
 {
     [Serializable]

--- a/Lib9c/Model/Order/Order.cs
+++ b/Lib9c/Model/Order/Order.cs
@@ -9,6 +9,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Lib9c.Model.Order
 {
     [Serializable]

--- a/Lib9c/Model/Order/OrderBase.cs
+++ b/Lib9c/Model/Order/OrderBase.cs
@@ -4,6 +4,7 @@ using Bencodex.Types;
 using Nekoyume.Model.State;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Lib9c.Model.Order
 {
     [Serializable]

--- a/Lib9c/Model/Order/OrderDigest.cs
+++ b/Lib9c/Model/Order/OrderDigest.cs
@@ -5,6 +5,7 @@ using Libplanet.Assets;
 using Nekoyume.Model.State;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Lib9c.Model.Order
 {
     [Serializable]

--- a/Lib9c/Model/Order/OrderDigestListState.cs
+++ b/Lib9c/Model/Order/OrderDigestListState.cs
@@ -7,6 +7,7 @@ using Nekoyume.Action;
 using Nekoyume.Model.State;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Lib9c.Model.Order
 {
     [Serializable]

--- a/Lib9c/Model/Order/OrderFactory.cs
+++ b/Lib9c/Model/Order/OrderFactory.cs
@@ -7,6 +7,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Lib9c.Model.Order
 {
     public static class OrderFactory

--- a/Lib9c/Model/Order/OrderReceipt.cs
+++ b/Lib9c/Model/Order/OrderReceipt.cs
@@ -5,6 +5,7 @@ using Nekoyume.Action;
 using Nekoyume.Model.State;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Lib9c.Model.Order
 {
     [Serializable]

--- a/Lib9c/Model/Quest/CollectQuest.cs
+++ b/Lib9c/Model/Quest/CollectQuest.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Bencodex.Types;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Quest
 {
     [Serializable]

--- a/Lib9c/Model/Quest/CombinationEquipmentQuest.cs
+++ b/Lib9c/Model/Quest/CombinationEquipmentQuest.cs
@@ -6,6 +6,7 @@ using Bencodex.Types;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Quest
 {
     public class CombinationEquipmentQuest : Quest

--- a/Lib9c/Model/Quest/CombinationQuest.cs
+++ b/Lib9c/Model/Quest/CombinationQuest.cs
@@ -6,6 +6,7 @@ using Bencodex.Types;
 using Nekoyume.Model.Item;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Quest
 {
     [Serializable]

--- a/Lib9c/Model/Quest/GeneralQuest.cs
+++ b/Lib9c/Model/Quest/GeneralQuest.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Bencodex.Types;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Quest
 {
     [Serializable]

--- a/Lib9c/Model/Quest/GoldQuest.cs
+++ b/Lib9c/Model/Quest/GoldQuest.cs
@@ -8,6 +8,7 @@ using Libplanet.Assets;
 using Nekoyume.Model.EnumType;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Quest
 {
     [Serializable]

--- a/Lib9c/Model/Quest/ItemEnhancementQuest.cs
+++ b/Lib9c/Model/Quest/ItemEnhancementQuest.cs
@@ -6,6 +6,7 @@ using Bencodex.Types;
 using Nekoyume.Model.Item;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Quest
 {
     [Serializable]

--- a/Lib9c/Model/Quest/ItemGradeQuest.cs
+++ b/Lib9c/Model/Quest/ItemGradeQuest.cs
@@ -7,6 +7,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Quest
 {
     [Serializable]

--- a/Lib9c/Model/Quest/ItemTypeCollectQuest.cs
+++ b/Lib9c/Model/Quest/ItemTypeCollectQuest.cs
@@ -7,6 +7,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Quest
 {
     [Serializable]

--- a/Lib9c/Model/Quest/MonsterQuest.cs
+++ b/Lib9c/Model/Quest/MonsterQuest.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Bencodex.Types;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Quest
 {
     [Serializable]

--- a/Lib9c/Model/Quest/Quest.cs
+++ b/Lib9c/Model/Quest/Quest.cs
@@ -6,6 +6,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.Model.Quest
 {
     public enum QuestType

--- a/Lib9c/Model/Quest/QuestEventType.cs
+++ b/Lib9c/Model/Quest/QuestEventType.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Nekoyume.Model.Quest
 {
     public enum QuestEventType

--- a/Lib9c/Model/Quest/QuestList.cs
+++ b/Lib9c/Model/Quest/QuestList.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Model.Quest
 {
     #region Exceptions

--- a/Lib9c/Model/Quest/QuestReward.cs
+++ b/Lib9c/Model/Quest/QuestReward.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Bencodex.Types;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Model.Quest
 {
     [Serializable]

--- a/Lib9c/Model/Quest/TradeQuest.cs
+++ b/Lib9c/Model/Quest/TradeQuest.cs
@@ -6,6 +6,7 @@ using Bencodex.Types;
 using Nekoyume.Model.EnumType;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Quest
 {
     [Serializable]

--- a/Lib9c/Model/Quest/WorldQuest.cs
+++ b/Lib9c/Model/Quest/WorldQuest.cs
@@ -2,6 +2,7 @@ using System;
 using Bencodex.Types;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Quest
 {
     [Serializable]

--- a/Lib9c/Model/Skill/ActionBuffType.cs
+++ b/Lib9c/Model/Skill/ActionBuffType.cs
@@ -1,4 +1,5 @@
 
+#nullable disable
 namespace Nekoyume.Model.Skill
 {
     public enum ActionBuffType

--- a/Lib9c/Model/Skill/AreaAttack.cs
+++ b/Lib9c/Model/Skill/AreaAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill
 {
     [Serializable]

--- a/Lib9c/Model/Skill/Arena/ArenaAreaAttack.cs
+++ b/Lib9c/Model/Skill/Arena/ArenaAreaAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill.Arena
 {
     [Serializable]

--- a/Lib9c/Model/Skill/Arena/ArenaAttackSkill.cs
+++ b/Lib9c/Model/Skill/Arena/ArenaAttackSkill.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Nekoyume.Model.Elemental;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill.Arena
 {
     [Serializable]

--- a/Lib9c/Model/Skill/Arena/ArenaBlowAttack.cs
+++ b/Lib9c/Model/Skill/Arena/ArenaBlowAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill.Arena
 {
     [Serializable]

--- a/Lib9c/Model/Skill/Arena/ArenaBuffRemovalAttack.cs
+++ b/Lib9c/Model/Skill/Arena/ArenaBuffRemovalAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill.Arena
 {
     [Serializable]

--- a/Lib9c/Model/Skill/Arena/ArenaBuffSkill.cs
+++ b/Lib9c/Model/Skill/Arena/ArenaBuffSkill.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill.Arena
 {
     [Serializable]

--- a/Lib9c/Model/Skill/Arena/ArenaDoubleAttack.cs
+++ b/Lib9c/Model/Skill/Arena/ArenaDoubleAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill.Arena
 {
     [Serializable]

--- a/Lib9c/Model/Skill/Arena/ArenaHealSkill.cs
+++ b/Lib9c/Model/Skill/Arena/ArenaHealSkill.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill.Arena
 {
     [Serializable]

--- a/Lib9c/Model/Skill/Arena/ArenaNormalAttack.cs
+++ b/Lib9c/Model/Skill/Arena/ArenaNormalAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill.Arena
 {
     [Serializable]

--- a/Lib9c/Model/Skill/Arena/ArenaSkill.cs
+++ b/Lib9c/Model/Skill/Arena/ArenaSkill.cs
@@ -5,6 +5,7 @@ using Nekoyume.Model.Elemental;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill.Arena
 {
     [Serializable]

--- a/Lib9c/Model/Skill/AttackSkill.cs
+++ b/Lib9c/Model/Skill/AttackSkill.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Nekoyume.Model.Elemental;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill
 {
     [Serializable]

--- a/Lib9c/Model/Skill/BlowAttack.cs
+++ b/Lib9c/Model/Skill/BlowAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill
 {
     [Serializable]

--- a/Lib9c/Model/Skill/BuffRemovalAttack.cs
+++ b/Lib9c/Model/Skill/BuffRemovalAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill
 {
     [Serializable]

--- a/Lib9c/Model/Skill/BuffSkill.cs
+++ b/Lib9c/Model/Skill/BuffSkill.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill
 {
     [Serializable]

--- a/Lib9c/Model/Skill/DoubleAttack.cs
+++ b/Lib9c/Model/Skill/DoubleAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill
 {
     [Serializable]

--- a/Lib9c/Model/Skill/HealSkill.cs
+++ b/Lib9c/Model/Skill/HealSkill.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill
 {
     [Serializable]

--- a/Lib9c/Model/Skill/ISkill.cs
+++ b/Lib9c/Model/Skill/ISkill.cs
@@ -1,5 +1,6 @@
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill
 {
     public interface ISkill

--- a/Lib9c/Model/Skill/NormalAttack.cs
+++ b/Lib9c/Model/Skill/NormalAttack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill
 {
     [Serializable]

--- a/Lib9c/Model/Skill/Skill.cs
+++ b/Lib9c/Model/Skill/Skill.cs
@@ -6,6 +6,7 @@ using Nekoyume.Model.Elemental;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill
 {
     [Serializable]

--- a/Lib9c/Model/Skill/SkillCategory.cs
+++ b/Lib9c/Model/Skill/SkillCategory.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Nekoyume.Model.Skill
 {
     public enum SkillCategory

--- a/Lib9c/Model/Skill/SkillFactory.cs
+++ b/Lib9c/Model/Skill/SkillFactory.cs
@@ -3,6 +3,7 @@ using Nekoyume.Model.Skill.Arena;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Skill
 {
     public static class SkillFactory

--- a/Lib9c/Model/Skill/SkillTargetType.cs
+++ b/Lib9c/Model/Skill/SkillTargetType.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable disable
 namespace Nekoyume.Model.Skill
 {
     public enum SkillTargetType

--- a/Lib9c/Model/Skill/SkillType.cs
+++ b/Lib9c/Model/Skill/SkillType.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Nekoyume.Model.Skill
 {
     public enum SkillType

--- a/Lib9c/Model/Skill/UnexpectedOperationException.cs
+++ b/Lib9c/Model/Skill/UnexpectedOperationException.cs
@@ -1,5 +1,6 @@
 using System;
 
+#nullable disable
 namespace Nekoyume.Model.Skill
 {
     public class UnexpectedOperationException : Exception

--- a/Lib9c/Model/Stat/CharacterStats.cs
+++ b/Lib9c/Model/Stat/CharacterStats.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Nekoyume.Model.Item;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.Stat
 {
     /// <summary>

--- a/Lib9c/Model/Stat/DecimalStat.cs
+++ b/Lib9c/Model/Stat/DecimalStat.cs
@@ -1,5 +1,6 @@
 using System;
 
+#nullable disable
 namespace Nekoyume.Model.Stat
 {
     [Serializable]

--- a/Lib9c/Model/Stat/DecimalStatWithCurrent.cs
+++ b/Lib9c/Model/Stat/DecimalStatWithCurrent.cs
@@ -1,5 +1,6 @@
 using System;
 
+#nullable disable
 namespace Nekoyume.Model.Stat
 {
     [Serializable]

--- a/Lib9c/Model/Stat/IBaseAndAdditionalStats.cs
+++ b/Lib9c/Model/Stat/IBaseAndAdditionalStats.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.Stat
 {
     public interface IBaseAndAdditionalStats

--- a/Lib9c/Model/Stat/IStats.cs
+++ b/Lib9c/Model/Stat/IStats.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.Model.Stat
 {
     public interface IStats

--- a/Lib9c/Model/Stat/IntStat.cs
+++ b/Lib9c/Model/Stat/IntStat.cs
@@ -1,5 +1,6 @@
 using System;
 
+#nullable disable
 namespace Nekoyume.Model.Stat
 {
     [Serializable]

--- a/Lib9c/Model/Stat/IntStatWithCurrent.cs
+++ b/Lib9c/Model/Stat/IntStatWithCurrent.cs
@@ -1,5 +1,6 @@
 using System;
 
+#nullable disable
 namespace Nekoyume.Model.Stat
 {
     [Serializable]

--- a/Lib9c/Model/Stat/StatMap.cs
+++ b/Lib9c/Model/Stat/StatMap.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Bencodex.Types;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Model.Stat
 {
     // todo: `DecimalStat`나 `StatModifier`으로 대체되어야 함.

--- a/Lib9c/Model/Stat/StatMapEx.cs
+++ b/Lib9c/Model/Stat/StatMapEx.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Bencodex.Types;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Model.Stat
 {
     // todo: 없어질 대상.

--- a/Lib9c/Model/Stat/StatModifier.cs
+++ b/Lib9c/Model/Stat/StatModifier.cs
@@ -1,5 +1,6 @@
 using System;
 
+#nullable disable
 namespace Nekoyume.Model.Stat
 {
     [Serializable]

--- a/Lib9c/Model/Stat/StatType.cs
+++ b/Lib9c/Model/Stat/StatType.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Bencodex.Types;
 
+#nullable disable
 namespace Nekoyume.Model.Stat
 {
     public enum StatType

--- a/Lib9c/Model/Stat/Stats.cs
+++ b/Lib9c/Model/Stat/Stats.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable disable
 namespace Nekoyume.Model.Stat
 {
     [Serializable]

--- a/Lib9c/Model/Stat/StatsMap.cs
+++ b/Lib9c/Model/Stat/StatsMap.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Bencodex.Types;
 using Nekoyume.Model.State;
 
+#nullable disable
 namespace Nekoyume.Model.Stat
 {
     // todo: `Stats`나 `StatModifier`로 대체되어야 함.

--- a/Lib9c/Model/State/ActivatedAccountsState.cs
+++ b/Lib9c/Model/State/ActivatedAccountsState.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/AdminState.cs
+++ b/Lib9c/Model/State/AdminState.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/AgentState.cs
+++ b/Lib9c/Model/State/AgentState.cs
@@ -5,6 +5,7 @@ using Bencodex.Types;
 using Libplanet;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     /// <summary>

--- a/Lib9c/Model/State/ArenaAvatarState.cs
+++ b/Lib9c/Model/State/ArenaAvatarState.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     /// <summary>

--- a/Lib9c/Model/State/ArenaInfo.cs
+++ b/Lib9c/Model/State/ArenaInfo.cs
@@ -8,6 +8,7 @@ using Nekoyume.Model.BattleStatus;
 using Nekoyume.Model.Item;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     public class ArenaInfo : IState

--- a/Lib9c/Model/State/AuthorizedMinersState.cs
+++ b/Lib9c/Model/State/AuthorizedMinersState.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     public class AuthorizedMinersState : State

--- a/Lib9c/Model/State/AvatarState.cs
+++ b/Lib9c/Model/State/AvatarState.cs
@@ -16,6 +16,7 @@ using Nekoyume.Model.Quest;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     /// <summary>

--- a/Lib9c/Model/State/CombinationSlotState.cs
+++ b/Lib9c/Model/State/CombinationSlotState.cs
@@ -6,6 +6,7 @@ using Libplanet;
 using Nekoyume.Action;
 using Nekoyume.Model.Item;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     public class CombinationSlotState : State

--- a/Lib9c/Model/State/CreditsState.cs
+++ b/Lib9c/Model/State/CreditsState.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/CrystalCostState.cs
+++ b/Lib9c/Model/State/CrystalCostState.cs
@@ -4,6 +4,7 @@ using JetBrains.Annotations;
 using Libplanet;
 using Libplanet.Assets;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/CrystalRandomSkillState.cs
+++ b/Lib9c/Model/State/CrystalRandomSkillState.cs
@@ -7,6 +7,7 @@ using Libplanet;
 using Nekoyume.TableData;
 using Nekoyume.Model.Skill;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     public class CrystalRandomSkillState : IState

--- a/Lib9c/Model/State/DeletedAvatarState.cs
+++ b/Lib9c/Model/State/DeletedAvatarState.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Bencodex.Types;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/FailedToUnregisterInShopStateException.cs
+++ b/Lib9c/Model/State/FailedToUnregisterInShopStateException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/GameConfigState.cs
+++ b/Lib9c/Model/State/GameConfigState.cs
@@ -5,6 +5,7 @@ using Bencodex.Types;
 using Libplanet;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/GoldBalanceState.cs
+++ b/Lib9c/Model/State/GoldBalanceState.cs
@@ -4,6 +4,7 @@ using Bencodex.Types;
 using Libplanet;
 using Libplanet.Assets;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/GoldCurrencyState.cs
+++ b/Lib9c/Model/State/GoldCurrencyState.cs
@@ -7,6 +7,7 @@ using Bencodex.Types;
 using Libplanet;
 using Libplanet.Assets;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/HammerPointState.cs
+++ b/Lib9c/Model/State/HammerPointState.cs
@@ -3,6 +3,7 @@ using Bencodex.Types;
 using Libplanet;
 using Nekoyume.TableData.Crystal;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     public class HammerPointState : IState

--- a/Lib9c/Model/State/IState.cs
+++ b/Lib9c/Model/State/IState.cs
@@ -1,5 +1,6 @@
 using Bencodex.Types;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     public interface IState

--- a/Lib9c/Model/State/LazyState.cs
+++ b/Lib9c/Model/State/LazyState.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Bencodex.Types;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/MonsterCollectionResult.cs
+++ b/Lib9c/Model/State/MonsterCollectionResult.cs
@@ -7,6 +7,7 @@ using Libplanet;
 using Nekoyume.Action;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/MonsterCollectionState.cs
+++ b/Lib9c/Model/State/MonsterCollectionState.cs
@@ -8,6 +8,7 @@ using Nekoyume.Action;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/MonsterCollectionState0.cs
+++ b/Lib9c/Model/State/MonsterCollectionState0.cs
@@ -8,6 +8,7 @@ using Nekoyume.Action;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Obsolete("This class is reserved for backwards compatibility with MonsterCollection0 only.", false)]

--- a/Lib9c/Model/State/PendingActivationState.cs
+++ b/Lib9c/Model/State/PendingActivationState.cs
@@ -8,6 +8,7 @@ using Libplanet;
 using Libplanet.Crypto;
 using Nekoyume.Action;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/RaiderState.cs
+++ b/Lib9c/Model/State/RaiderState.cs
@@ -3,6 +3,7 @@ using Bencodex.Types;
 using Libplanet;
 using Nekoyume.Helper;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/RankingMapState.cs
+++ b/Lib9c/Model/State/RankingMapState.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Bencodex.Types;
 using Libplanet;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     public class RankingMapState : State

--- a/Lib9c/Model/State/RankingState.cs
+++ b/Lib9c/Model/State/RankingState.cs
@@ -8,6 +8,7 @@ using Bencodex.Types;
 using Libplanet;
 using Nekoyume.Action;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/RankingState0.cs
+++ b/Lib9c/Model/State/RankingState0.cs
@@ -8,6 +8,7 @@ using Bencodex.Types;
 using Libplanet;
 using Nekoyume.Action;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/RankingState1.cs
+++ b/Lib9c/Model/State/RankingState1.cs
@@ -8,6 +8,7 @@ using Bencodex.Types;
 using Libplanet;
 using Nekoyume.Action;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/RedeemCodeState.cs
+++ b/Lib9c/Model/State/RedeemCodeState.cs
@@ -8,6 +8,7 @@ using Libplanet;
 using Libplanet.Crypto;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/ShardedShopState.cs
+++ b/Lib9c/Model/State/ShardedShopState.cs
@@ -7,6 +7,7 @@ using Nekoyume.Action;
 using Nekoyume.Model.Item;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     public class ShardedShopState : State

--- a/Lib9c/Model/State/ShardedShopStateV2.cs
+++ b/Lib9c/Model/State/ShardedShopStateV2.cs
@@ -8,6 +8,7 @@ using Nekoyume.Action;
 using Nekoyume.Model.Item;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/ShopState.cs
+++ b/Lib9c/Model/State/ShopState.cs
@@ -5,6 +5,7 @@ using Bencodex.Types;
 using Libplanet;
 using Nekoyume.Model.Item;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     /// <summary>

--- a/Lib9c/Model/State/ShopStateAlreadyContainsException.cs
+++ b/Lib9c/Model/State/ShopStateAlreadyContainsException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/StakeState.cs
+++ b/Lib9c/Model/State/StakeState.cs
@@ -9,6 +9,7 @@ using Nekoyume.Action;
 using Nekoyume.BlockChain.Policy;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     public class StakeState : State

--- a/Lib9c/Model/State/State.cs
+++ b/Lib9c/Model/State/State.cs
@@ -4,6 +4,7 @@ using Bencodex.Types;
 using Libplanet;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/StateExtensions.cs
+++ b/Lib9c/Model/State/StateExtensions.cs
@@ -16,6 +16,7 @@ using Nekoyume.Model.Elemental;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.Stat;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     public static class StateExtensions

--- a/Lib9c/Model/State/WeeklyArenaState.cs
+++ b/Lib9c/Model/State/WeeklyArenaState.cs
@@ -11,6 +11,7 @@ using Nekoyume.TableData;
 using LazyArenaInfo =
     Nekoyume.Model.State.LazyState<Nekoyume.Model.State.ArenaInfo, Bencodex.Types.Dictionary>;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/State/WorldBossKillRewardRecord.cs
+++ b/Lib9c/Model/State/WorldBossKillRewardRecord.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Bencodex.Types;
 using Libplanet.Assets;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     public class WorldBossKillRewardRecord : IDictionary<int, bool>, IState

--- a/Lib9c/Model/State/WorldBossState.cs
+++ b/Lib9c/Model/State/WorldBossState.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using Bencodex.Types;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model.State
 {
     [Serializable]

--- a/Lib9c/Model/WorldInformation.cs
+++ b/Lib9c/Model/WorldInformation.cs
@@ -7,6 +7,7 @@ using Bencodex.Types;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
+#nullable disable
 namespace Nekoyume.Model
 {
     [Serializable]

--- a/Lib9c/Policy/AuthorizedMinersPolicy.cs
+++ b/Lib9c/Policy/AuthorizedMinersPolicy.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Libplanet;
 
+#nullable disable
 namespace Nekoyume.BlockChain.Policy
 {
     public sealed class AuthorizedMinersPolicy : VariableSubPolicy<ImmutableHashSet<Address>>

--- a/Lib9c/Policy/BlockPolicy.cs
+++ b/Lib9c/Policy/BlockPolicy.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
+#nullable disable
 namespace Nekoyume.BlockChain.Policy
 {
     public class BlockPolicy : BlockPolicy<NCAction>

--- a/Lib9c/Policy/BlockPolicySource.Utils.cs
+++ b/Lib9c/Policy/BlockPolicySource.Utils.cs
@@ -11,6 +11,7 @@ using Nekoyume.Model.State;
 using static Libplanet.Blocks.BlockMarshaler;
 using NCAction = Libplanet.Action.PolymorphicAction<Nekoyume.Action.ActionBase>;
 
+#nullable disable
 namespace Nekoyume.BlockChain.Policy
 {
     // Collection of helper methods not directly used as a pluggable component.

--- a/Lib9c/Policy/BlockPolicySource.cs
+++ b/Lib9c/Policy/BlockPolicySource.cs
@@ -27,6 +27,7 @@ using Lib9c.DevExtensions;
 using Lib9c.DevExtensions.Model;
 #endif
 
+#nullable disable
 namespace Nekoyume.BlockChain.Policy
 {
     public partial class BlockPolicySource

--- a/Lib9c/Policy/DebugPolicy.cs
+++ b/Lib9c/Policy/DebugPolicy.cs
@@ -10,6 +10,7 @@ using Libplanet.Blocks;
 using Libplanet.Tx;
 using Nekoyume.Action;
 
+#nullable disable
 namespace Nekoyume.BlockChain.Policy
 {
     public class DebugPolicy : IBlockPolicy<PolymorphicAction<ActionBase>>

--- a/Lib9c/Policy/GenericSubPolicy.cs
+++ b/Lib9c/Policy/GenericSubPolicy.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Nekoyume.BlockChain.Policy
 {
     public sealed class GenericSubPolicy<T> : VariableSubPolicy<T>

--- a/Lib9c/Policy/IVariableSubPolicy.cs
+++ b/Lib9c/Policy/IVariableSubPolicy.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.Contracts;
 using System.Collections.Immutable;
 using Libplanet.Blocks;
 
+#nullable disable
 namespace Nekoyume.BlockChain.Policy
 {
     public interface IVariableSubPolicy<T>

--- a/Lib9c/Policy/MaxBlockBytesPolicy.cs
+++ b/Lib9c/Policy/MaxBlockBytesPolicy.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 
+#nullable disable
 namespace Nekoyume.BlockChain.Policy
 {
     public sealed class MaxBlockBytesPolicy : VariableSubPolicy<long>

--- a/Lib9c/Policy/MaxTransactionsPerBlockPolicy.cs
+++ b/Lib9c/Policy/MaxTransactionsPerBlockPolicy.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Nekoyume.BlockChain.Policy
 {
     public sealed class MaxTransactionsPerBlockPolicy : VariableSubPolicy<int>

--- a/Lib9c/Policy/MaxTransactionsPerSignerPerBlockPolicy.cs
+++ b/Lib9c/Policy/MaxTransactionsPerSignerPerBlockPolicy.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Nekoyume.BlockChain.Policy
 {
     public sealed class MaxTransactionsPerSignerPerBlockPolicy : VariableSubPolicy<int>

--- a/Lib9c/Policy/MinTransactionsPerBlockPolicy.cs
+++ b/Lib9c/Policy/MinTransactionsPerBlockPolicy.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Nekoyume.BlockChain.Policy
 {
     public sealed class MinTransactionsPerBlockPolicy : VariableSubPolicy<int>

--- a/Lib9c/Policy/PermanentBlockPolicySource.cs
+++ b/Lib9c/Policy/PermanentBlockPolicySource.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Immutable;
 using Libplanet;
 
+#nullable disable
 namespace Nekoyume.BlockChain.Policy
 {
     public static class PermanentBlockPolicySource

--- a/Lib9c/Policy/PermissionedMinersPolicy.cs
+++ b/Lib9c/Policy/PermissionedMinersPolicy.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Libplanet;
 
+#nullable disable
 namespace Nekoyume.BlockChain.Policy
 {
     public sealed class PermissionedMinersPolicy : VariableSubPolicy<ImmutableHashSet<Address>>

--- a/Lib9c/Policy/SpannedSubPolicy.cs
+++ b/Lib9c/Policy/SpannedSubPolicy.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics.Contracts;
 
+#nullable disable
 namespace Nekoyume.BlockChain.Policy
 {
     public class SpannedSubPolicy<T>

--- a/Lib9c/Policy/VariableSubPolicy.cs
+++ b/Lib9c/Policy/VariableSubPolicy.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using Libplanet.Blocks;
 
+#nullable disable
 namespace Nekoyume.BlockChain.Policy
 {
     public abstract class VariableSubPolicy<T> : IVariableSubPolicy<T>

--- a/Lib9c/Renderer/ActionRenderer.cs
+++ b/Lib9c/Renderer/ActionRenderer.cs
@@ -13,6 +13,7 @@ using System.Reactive.Subjects;
 using System.Reactive.Linq;
 #endif
 
+#nullable disable
 namespace Lib9c.Renderer
 {
     using NCAction = PolymorphicAction<ActionBase>;

--- a/Lib9c/Renderer/BlockRenderer.cs
+++ b/Lib9c/Renderer/BlockRenderer.cs
@@ -10,6 +10,7 @@ using System.Reactive.Subjects;
 using System.Reactive.Linq;
 #endif
 
+#nullable disable
 namespace Lib9c.Renderer
 {
     using NCAction = PolymorphicAction<ActionBase>;

--- a/Lib9c/ReorgMiner.cs
+++ b/Lib9c/ReorgMiner.cs
@@ -12,6 +12,7 @@ using Libplanet.Tx;
 using Nekoyume.Action;
 using Serilog;
 
+#nullable disable
 namespace Nekoyume.BlockChain
 {
     /// <summary>

--- a/Lib9c/Secp256K1CryptoBackend.cs
+++ b/Lib9c/Secp256K1CryptoBackend.cs
@@ -4,6 +4,7 @@ using Libplanet;
 using Secp256k1Net;
 using Libplanet.Crypto;
 
+#nullable disable
 namespace Nekoyume.BlockChain
 {
     public class Secp256K1CryptoBackend<T> : ICryptoBackend<T>

--- a/Lib9c/SerializeKeys.cs
+++ b/Lib9c/SerializeKeys.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Lib9c
 {
     public static class SerializeKeys

--- a/Lib9c/StagePolicy.cs
+++ b/Lib9c/StagePolicy.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Nekoyume.BlockChain
 {
     using System;

--- a/Lib9c/StoreUtils.cs
+++ b/Lib9c/StoreUtils.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 
+#nullable disable
 namespace Nekoyume
 {
     public static class StoreUtils

--- a/Lib9c/TableData/ArenaSheet.cs
+++ b/Lib9c/TableData/ArenaSheet.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Nekoyume.Model.Arena;
 using Nekoyume.Model.EnumType;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     using static TableExtensions;

--- a/Lib9c/TableData/AvatarSheets.cs
+++ b/Lib9c/TableData/AvatarSheets.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Nekoyume.TableData
 {
     public class AvatarSheets

--- a/Lib9c/TableData/Character/CharacterLevelSheet.cs
+++ b/Lib9c/TableData/Character/CharacterLevelSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Character/CharacterSheet.cs
+++ b/Lib9c/TableData/Character/CharacterSheet.cs
@@ -6,6 +6,7 @@ using Nekoyume.Model.Elemental;
 using Nekoyume.Model.Stat;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Character/WorldBossCharacterSheet.cs
+++ b/Lib9c/TableData/Character/WorldBossCharacterSheet.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Cost/EnhancementCostSheet.cs
+++ b/Lib9c/TableData/Cost/EnhancementCostSheet.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using Nekoyume.Model.Item;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     public class EnhancementCostSheet : Sheet<int, EnhancementCostSheet.Row>

--- a/Lib9c/TableData/Cost/EnhancementCostSheetV2.cs
+++ b/Lib9c/TableData/Cost/EnhancementCostSheetV2.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Numerics;
 using Nekoyume.Model.Item;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     using static TableExtensions;

--- a/Lib9c/TableData/Crystal/CrystalEquipmentGrindingSheet.cs
+++ b/Lib9c/TableData/Crystal/CrystalEquipmentGrindingSheet.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData.Crystal
 {
     public class CrystalEquipmentGrindingSheet: Sheet<int, CrystalEquipmentGrindingSheet.Row>

--- a/Lib9c/TableData/Crystal/CrystalFluctuationSheet.cs
+++ b/Lib9c/TableData/Crystal/CrystalFluctuationSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData.Crystal
 {
     public class CrystalFluctuationSheet : Sheet<int, CrystalFluctuationSheet.Row>

--- a/Lib9c/TableData/Crystal/CrystalHammerPointSheet.cs
+++ b/Lib9c/TableData/Crystal/CrystalHammerPointSheet.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData.Crystal
 {
     public class CrystalHammerPointSheet : Sheet<int, CrystalHammerPointSheet.Row>

--- a/Lib9c/TableData/Crystal/CrystalMaterialCostSheet.cs
+++ b/Lib9c/TableData/Crystal/CrystalMaterialCostSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData.Crystal
 {
     [Serializable]

--- a/Lib9c/TableData/Crystal/CrystalMonsterCollectionMultiplierSheet.cs
+++ b/Lib9c/TableData/Crystal/CrystalMonsterCollectionMultiplierSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData.Crystal
 {
     [Serializable]

--- a/Lib9c/TableData/Crystal/CrystalRandomBuffSheet.cs
+++ b/Lib9c/TableData/Crystal/CrystalRandomBuffSheet.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Nekoyume.Model.Buff;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData.Crystal
 {
     [Serializable]

--- a/Lib9c/TableData/Crystal/CrystalStageBuffGachaSheet.cs
+++ b/Lib9c/TableData/Crystal/CrystalStageBuffGachaSheet.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData.Crystal
 {
     [Serializable]

--- a/Lib9c/TableData/Event/EventConsumableItemRecipeSheet.cs
+++ b/Lib9c/TableData/Event/EventConsumableItemRecipeSheet.cs
@@ -1,5 +1,6 @@
 using System;
 
+#nullable disable
 namespace Nekoyume.TableData.Event
 {
     [Serializable]

--- a/Lib9c/TableData/Event/EventDungeonSheet.cs
+++ b/Lib9c/TableData/Event/EventDungeonSheet.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 
+#nullable disable
 namespace Nekoyume.TableData.Event
 {
     [Serializable]

--- a/Lib9c/TableData/Event/EventDungeonStageSheet.cs
+++ b/Lib9c/TableData/Event/EventDungeonStageSheet.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 
+#nullable disable
 namespace Nekoyume.TableData.Event
 {
     [Serializable]

--- a/Lib9c/TableData/Event/EventDungeonStageWaveSheet.cs
+++ b/Lib9c/TableData/Event/EventDungeonStageWaveSheet.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 
+#nullable disable
 namespace Nekoyume.TableData.Event
 {
     [Serializable]

--- a/Lib9c/TableData/Event/EventScheduleSheet.cs
+++ b/Lib9c/TableData/Event/EventScheduleSheet.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData.Event
 {
     public class EventScheduleSheet : Sheet<int, EventScheduleSheet.Row>

--- a/Lib9c/TableData/Exceptions.cs
+++ b/Lib9c/TableData/Exceptions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Globalization;
 using System.Runtime.Serialization;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/GameConfigSheet.cs
+++ b/Lib9c/TableData/GameConfigSheet.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/ISheet.cs
+++ b/Lib9c/TableData/ISheet.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Nekoyume.TableData
 {
     public interface ISheet

--- a/Lib9c/TableData/IStakeRewardRow.cs
+++ b/Lib9c/TableData/IStakeRewardRow.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Libplanet.Assets;
 using Nekoyume.Action;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     public interface IStakeRewardRow

--- a/Lib9c/TableData/IStakeRewardSheet.cs
+++ b/Lib9c/TableData/IStakeRewardSheet.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     public interface IStakeRewardSheet : ISheet

--- a/Lib9c/TableData/IWorldBossRewardRow.cs
+++ b/Lib9c/TableData/IWorldBossRewardRow.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Nekoyume.TableData
 {
     public interface IWorldBossRewardRow

--- a/Lib9c/TableData/IWorldBossRewardSheet.cs
+++ b/Lib9c/TableData/IWorldBossRewardSheet.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     public interface IWorldBossRewardSheet : ISheet

--- a/Lib9c/TableData/Item/ConsumableItemRecipeSheet.cs
+++ b/Lib9c/TableData/Item/ConsumableItemRecipeSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Item/ConsumableItemSheet.cs
+++ b/Lib9c/TableData/Item/ConsumableItemSheet.cs
@@ -7,6 +7,7 @@ using Nekoyume.Model.Stat;
 using Nekoyume.Model.State;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Item/CostumeItemSheet.cs
+++ b/Lib9c/TableData/Item/CostumeItemSheet.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Bencodex.Types;
 using Nekoyume.Model.Item;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Item/CostumeStatSheet.cs
+++ b/Lib9c/TableData/Item/CostumeStatSheet.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Nekoyume.Model.Stat;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Item/EquipmentItemOptionSheet.cs
+++ b/Lib9c/TableData/Item/EquipmentItemOptionSheet.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Nekoyume.Model.Stat;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     public class EquipmentItemOptionSheet : Sheet<int, EquipmentItemOptionSheet.Row>

--- a/Lib9c/TableData/Item/EquipmentItemRecipeSheet.cs
+++ b/Lib9c/TableData/Item/EquipmentItemRecipeSheet.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Nekoyume.Model.Item;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     public class EquipmentItemRecipeSheet : Sheet<int, EquipmentItemRecipeSheet.Row>

--- a/Lib9c/TableData/Item/EquipmentItemSetEffectSheet.cs
+++ b/Lib9c/TableData/Item/EquipmentItemSetEffectSheet.cs
@@ -6,6 +6,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.Stat;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Item/EquipmentItemSheet.cs
+++ b/Lib9c/TableData/Item/EquipmentItemSheet.cs
@@ -8,6 +8,7 @@ using Nekoyume.Model.Stat;
 using Nekoyume.Model.State;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Item/EquipmentItemSubRecipeSheet.cs
+++ b/Lib9c/TableData/Item/EquipmentItemSubRecipeSheet.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     using static TableExtensions;

--- a/Lib9c/TableData/Item/EquipmentItemSubRecipeSheetV2.cs
+++ b/Lib9c/TableData/Item/EquipmentItemSubRecipeSheetV2.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     using static TableExtensions;

--- a/Lib9c/TableData/Item/ItemConfigForGradeSheet.cs
+++ b/Lib9c/TableData/Item/ItemConfigForGradeSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Item/ItemRequirementSheet.cs
+++ b/Lib9c/TableData/Item/ItemRequirementSheet.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     using static TableExtensions;

--- a/Lib9c/TableData/Item/ItemSheet.cs
+++ b/Lib9c/TableData/Item/ItemSheet.cs
@@ -5,6 +5,7 @@ using Nekoyume.Model.Elemental;
 using Nekoyume.Model.Item;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Item/MaterialItemSheet.cs
+++ b/Lib9c/TableData/Item/MaterialItemSheet.cs
@@ -8,6 +8,7 @@ using Bencodex.Types;
 using Libplanet;
 using Nekoyume.Model.Item;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/MimisbrunnrSheet.cs
+++ b/Lib9c/TableData/MimisbrunnrSheet.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Nekoyume.Model.Elemental;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/MonsterCollectionRewardSheet.cs
+++ b/Lib9c/TableData/MonsterCollectionRewardSheet.cs
@@ -6,6 +6,7 @@ using Nekoyume.Model.State;
 using static Nekoyume.TableData.TableExtensions;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/MonsterCollectionSheet.cs
+++ b/Lib9c/TableData/MonsterCollectionSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Quest/CollectQuestSheet.cs
+++ b/Lib9c/TableData/Quest/CollectQuestSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Quest/CombinationEquipmentQuestSheet.cs
+++ b/Lib9c/TableData/Quest/CombinationEquipmentQuestSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Quest/CombinationQuestSheet.cs
+++ b/Lib9c/TableData/Quest/CombinationQuestSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.Model.Item;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Quest/GeneralQuestSheet.cs
+++ b/Lib9c/TableData/Quest/GeneralQuestSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.Model.Quest;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Quest/GoldQuestSheet.cs
+++ b/Lib9c/TableData/Quest/GoldQuestSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.Model.EnumType;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Quest/ItemEnhancementQuestSheet.cs
+++ b/Lib9c/TableData/Quest/ItemEnhancementQuestSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Quest/ItemGradeQuestSheet.cs
+++ b/Lib9c/TableData/Quest/ItemGradeQuestSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Quest/ItemTypeCollectQuestSheet.cs
+++ b/Lib9c/TableData/Quest/ItemTypeCollectQuestSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.Model.Item;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Quest/MonsterQuestSheet.cs
+++ b/Lib9c/TableData/Quest/MonsterQuestSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Quest/QuestItemRewardSheet.cs
+++ b/Lib9c/TableData/Quest/QuestItemRewardSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Quest/QuestRewardSheet.cs
+++ b/Lib9c/TableData/Quest/QuestRewardSheet.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Quest/QuestSheet.cs
+++ b/Lib9c/TableData/Quest/QuestSheet.cs
@@ -4,6 +4,7 @@ using Bencodex.Types;
 using Nekoyume.Model.State;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Quest/TradeQuestSheet.cs
+++ b/Lib9c/TableData/Quest/TradeQuestSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.Model.EnumType;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Quest/WorldQuestSheet.cs
+++ b/Lib9c/TableData/Quest/WorldQuestSheet.cs
@@ -1,5 +1,6 @@
 using System;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/RedeemCodeListSheet.cs
+++ b/Lib9c/TableData/RedeemCodeListSheet.cs
@@ -6,6 +6,7 @@ using Libplanet.Crypto;
 using Nekoyume.Model.State;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/RedeemRewardSheet.cs
+++ b/Lib9c/TableData/RedeemRewardSheet.cs
@@ -5,6 +5,7 @@ using Bencodex.Types;
 using Nekoyume.Model.State;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/RuneSheet.cs
+++ b/Lib9c/TableData/RuneSheet.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     public class RuneSheet : Sheet<int, RuneSheet.Row>

--- a/Lib9c/TableData/RuneWeightSheet.cs
+++ b/Lib9c/TableData/RuneWeightSheet.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     public class RuneWeightSheet : Sheet<int, RuneWeightSheet.Row>

--- a/Lib9c/TableData/Sheet.cs
+++ b/Lib9c/TableData/Sheet.cs
@@ -14,6 +14,7 @@ using Serilog;
 using Serilog;
 #endif
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/SheetRow.cs
+++ b/Lib9c/TableData/SheetRow.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/SimulatorSheets.cs
+++ b/Lib9c/TableData/SimulatorSheets.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace Nekoyume.TableData
 {
     public class SimulatorSheets

--- a/Lib9c/TableData/Skill/ActionBuffSheet.cs
+++ b/Lib9c/TableData/Skill/ActionBuffSheet.cs
@@ -4,6 +4,7 @@ using Nekoyume.Model.Elemental;
 using Nekoyume.Model.Skill;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Skill/EnemySkillSheet.cs
+++ b/Lib9c/TableData/Skill/EnemySkillSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Skill/SkillActionBuffSheet.cs
+++ b/Lib9c/TableData/Skill/SkillActionBuffSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Skill/SkillBuffSheet.cs
+++ b/Lib9c/TableData/Skill/SkillBuffSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Skill/SkillSheet.cs
+++ b/Lib9c/TableData/Skill/SkillSheet.cs
@@ -6,6 +6,7 @@ using Nekoyume.Model.Skill;
 using Nekoyume.Model.State;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/Skill/StatBuffSheet.cs
+++ b/Lib9c/TableData/Skill/StatBuffSheet.cs
@@ -4,6 +4,7 @@ using Nekoyume.Model.Stat;
 using Nekoyume.Model.Skill;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/StakeAchievementRewardSheet.cs
+++ b/Lib9c/TableData/StakeAchievementRewardSheet.cs
@@ -7,6 +7,7 @@ using Nekoyume.Model.State;
 using static Nekoyume.TableData.TableExtensions;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/StakeActionPointCoefficientSheet.cs
+++ b/Lib9c/TableData/StakeActionPointCoefficientSheet.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/StakeRegularFixedRewardSheet.cs
+++ b/Lib9c/TableData/StakeRegularFixedRewardSheet.cs
@@ -7,6 +7,7 @@ using Nekoyume.Model.State;
 using static Nekoyume.TableData.TableExtensions;
 using static Lib9c.SerializeKeys;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/StakeRegularRewardSheet.cs
+++ b/Lib9c/TableData/StakeRegularRewardSheet.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/SweepRequiredCPSheet.cs
+++ b/Lib9c/TableData/SweepRequiredCPSheet.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     using static TableExtensions;

--- a/Lib9c/TableData/TableExtensions.cs
+++ b/Lib9c/TableData/TableExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Globalization;
 using System.Numerics;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     public static class TableExtensions

--- a/Lib9c/TableData/UnlockHelper.cs
+++ b/Lib9c/TableData/UnlockHelper.cs
@@ -1,6 +1,7 @@
 using Nekoyume.Model.Item;
 using System.Collections.Generic;
 
+#nullable disable
 namespace Nekoyume
 {
     public static class UnlockHelper

--- a/Lib9c/TableData/WeeklyArenaRewardSheet.cs
+++ b/Lib9c/TableData/WeeklyArenaRewardSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/WorldAndStage/StageDialogSheet.cs
+++ b/Lib9c/TableData/WorldAndStage/StageDialogSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/WorldAndStage/StageSheet.cs
+++ b/Lib9c/TableData/WorldAndStage/StageSheet.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Nekoyume.Model.Stat;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/WorldAndStage/StageWaveSheet.cs
+++ b/Lib9c/TableData/WorldAndStage/StageWaveSheet.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/WorldAndStage/WorldSheet.cs
+++ b/Lib9c/TableData/WorldAndStage/WorldSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/WorldAndStage/WorldUnlockSheet.cs
+++ b/Lib9c/TableData/WorldAndStage/WorldUnlockSheet.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/WorldBossActionPatternSheet.cs
+++ b/Lib9c/TableData/WorldBossActionPatternSheet.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/WorldBossBattleRewardSheet.cs
+++ b/Lib9c/TableData/WorldBossBattleRewardSheet.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Libplanet.Action;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     public class WorldBossBattleRewardSheet : Sheet<int, WorldBossBattleRewardSheet.Row>, IWorldBossRewardSheet

--- a/Lib9c/TableData/WorldBossGlobalHPSheet.cs
+++ b/Lib9c/TableData/WorldBossGlobalHPSheet.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Numerics;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     [Serializable]

--- a/Lib9c/TableData/WorldBossKillRewardSheet.cs
+++ b/Lib9c/TableData/WorldBossKillRewardSheet.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Libplanet.Action;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     public class WorldBossKillRewardSheet : Sheet<int, WorldBossKillRewardSheet.Row>, IWorldBossRewardSheet

--- a/Lib9c/TableData/WorldBossListSheet.cs
+++ b/Lib9c/TableData/WorldBossListSheet.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     public class WorldBossListSheet : Sheet<int, WorldBossListSheet.Row>

--- a/Lib9c/TableData/WorldBossRankRewardSheet.cs
+++ b/Lib9c/TableData/WorldBossRankRewardSheet.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     public class WorldBossRankRewardSheet: Sheet<int, WorldBossRankRewardSheet.Row>, IWorldBossRewardSheet

--- a/Lib9c/TableData/WorldBossRankingRewardSheet.cs
+++ b/Lib9c/TableData/WorldBossRankingRewardSheet.cs
@@ -5,6 +5,7 @@ using Libplanet.Assets;
 using Nekoyume.Helper;
 using static Nekoyume.TableData.TableExtensions;
 
+#nullable disable
 namespace Nekoyume.TableData
 {
     // This sheet not on-chain data. don't call this sheet in `IAction.Execute()`


### PR DESCRIPTION
This pull request enables nullable reference feature at `Lib9c` and `Lib9c.Tests` project and disables the feature for every files of the projects. It's to fix build errors in step by step.

## 🤔 What's null reference checker

Since C# 8.0, it was introduced. It separates `nonnull` type and `nullable` type. For example, every type was nullable. When you wrote `string name` line, you can assign `null` to the `name` variable like `string name = null`. But it should be `string? name = null` with `?` operator with the feature. It means you can believe the `name` variable in `string name` line, cannot have `null`. And you don't have to check `name is null` every time with the feature.

- https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references

## 🙀 There are too many files to check

Yes, so I suggest to use replacement feature of editors. Before this pull request, this repository may not have any `#nullable disable` lines. You can replace `#nullable disable` with empty string and check difference with the development branch.