### PR TITLE
Hard fork `UpdateSell` from 3 to 4

### DIFF
--- a/.Lib9c.Tests/Action/SellTest.cs
+++ b/.Lib9c.Tests/Action/SellTest.cs
@@ -222,70 +222,28 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Execute_Throw_InvalidPriceException_DueTo_InvalidCurrencyPrice()
         {
-            var action = new Sell
-            {
-                sellerAvatarAddress = _avatarAddress,
-                tradableId = default,
-                count = 1,
-                price = new FungibleAssetValue(
+            var price = new FungibleAssetValue(
 #pragma warning disable CS0618
-                    // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
-                    Currency.Legacy("KRW", 0, null),
+                // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+                Currency.Legacy("KRW", 0, null),
 #pragma warning restore CS0618
-                    1,
-                    0),
-                itemSubType = default,
-                orderId = default,
-            };
-
-            Assert.Throws<InvalidPriceException>(() => action.Execute(new ActionContext
-            {
-                BlockIndex = 0,
-                PreviousStates = _initialState,
-                Signer = _agentAddress,
-            }));
+                1,
+                0);
+            Assert.Throws<InvalidPriceException>(() => ExecuteWithPrice(price));
         }
 
         [Fact]
         public void Execute_Throw_InvalidPriceException_DueTo_NonZeroMinorUnitPrice()
         {
-            var action = new Sell
-            {
-                sellerAvatarAddress = _avatarAddress,
-                tradableId = default,
-                count = 1,
-                price = new FungibleAssetValue(_currency, 1, 1),
-                itemSubType = default,
-                orderId = default,
-            };
-
-            Assert.Throws<InvalidPriceException>(() => action.Execute(new ActionContext
-            {
-                BlockIndex = 0,
-                PreviousStates = _initialState,
-                Signer = _agentAddress,
-            }));
+            var price = new FungibleAssetValue(_currency, 1, 1);
+            Assert.Throws<InvalidPriceException>(() => ExecuteWithPrice(price));
         }
 
         [Fact]
         public void Execute_Throw_InvalidPriceException_DueTo_NegativePrice()
         {
-            var action = new Sell
-            {
-                sellerAvatarAddress = _avatarAddress,
-                tradableId = default,
-                count = 1,
-                price = new FungibleAssetValue(_currency, -1, 0),
-                itemSubType = default,
-                orderId = default,
-            };
-
-            Assert.Throws<InvalidPriceException>(() => action.Execute(new ActionContext
-            {
-                BlockIndex = 0,
-                PreviousStates = _initialState,
-                Signer = _agentAddress,
-            }));
+            var price = new FungibleAssetValue(_currency, -1, 0);
+            Assert.Throws<InvalidPriceException>(() => ExecuteWithPrice(price));
         }
 
         [Fact]
@@ -502,6 +460,26 @@ namespace Lib9c.Tests.Action
             });
 
             Assert.Equal(updatedAddresses.ToImmutableHashSet(), nextState.UpdatedAddresses);
+        }
+
+        private IAccountStateDelta ExecuteWithPrice(FungibleAssetValue price)
+        {
+            var action = new Sell
+            {
+                sellerAvatarAddress = _avatarAddress,
+                tradableId = default,
+                count = 1,
+                price = price,
+                itemSubType = default,
+                orderId = default,
+            };
+
+            return action.Execute(new ActionContext
+            {
+                BlockIndex = 0,
+                PreviousStates = _initialState,
+                Signer = _agentAddress,
+            });
         }
     }
 }

--- a/.Lib9c.Tests/Action/UpdateSell3Test.cs
+++ b/.Lib9c.Tests/Action/UpdateSell3Test.cs
@@ -21,7 +21,7 @@
     using Xunit.Abstractions;
     using static Lib9c.SerializeKeys;
 
-    public class UpdateSellTest
+    public class UpdateSell3Test
     {
         private const long ProductPrice = 100;
         private readonly Address _agentAddress;
@@ -32,7 +32,7 @@
         private readonly GoldCurrencyState _goldCurrencyState;
         private IAccountStateDelta _initialState;
 
-        public UpdateSellTest(ITestOutputHelper outputHelper)
+        public UpdateSell3Test(ITestOutputHelper outputHelper)
         {
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
@@ -223,7 +223,7 @@
                 itemCount
             );
 
-            var action = new UpdateSell
+            var action = new UpdateSell3
             {
                 sellerAvatarAddress = _avatarAddress,
                 updateSellInfos = new[] { updateSellInfo },
@@ -250,7 +250,7 @@
         [Fact]
         public void Execute_Throw_ListEmptyException()
         {
-            var action = new UpdateSell
+            var action = new UpdateSell3
             {
                 sellerAvatarAddress = _avatarAddress,
                 updateSellInfos = new List<UpdateSellInfo>(),
@@ -275,7 +275,7 @@
                 0 * _currency,
                 1);
 
-            var action = new UpdateSell
+            var action = new UpdateSell3
             {
                 sellerAvatarAddress = _avatarAddress,
                 updateSellInfos = new[] { updateSellInfo },
@@ -311,7 +311,7 @@
                 0 * _currency,
                 1);
 
-            var action = new UpdateSell
+            var action = new UpdateSell3
             {
                 sellerAvatarAddress = _avatarAddress,
                 updateSellInfos = new[] { updateSellInfo },
@@ -326,28 +326,7 @@
         }
 
         [Fact]
-        public void Execute_Throw_InvalidPriceException_DueTo_InvalidCurrencyPrice()
-        {
-            var invalidCurrency = Currency.Legacy("KRW", 0, null);
-            var price = new FungibleAssetValue(invalidCurrency, 1, 0);
-            Assert.Throws<InvalidPriceException>(() => ExecuteWithPrice(price));
-        }
-
-        [Fact]
-        public void Execute_Throw_InvalidPriceException_DueTo_NonZeroMinorUnitPrice()
-        {
-            var price = new FungibleAssetValue(_currency, 1, 1);
-            Assert.Throws<InvalidPriceException>(() => ExecuteWithPrice(price));
-        }
-
-        [Fact]
-        public void Execute_Throw_InvalidPriceException_DueTo_NegativePrice()
-        {
-            var price = -1 * _currency;
-            Assert.Throws<InvalidPriceException>(() => ExecuteWithPrice(price));
-        }
-
-        private IAccountStateDelta ExecuteWithPrice(FungibleAssetValue price)
+        public void Execute_Throw_InvalidPriceException()
         {
             var avatarState = new AvatarState(_avatarState)
             {
@@ -368,21 +347,21 @@
                 default,
                 default,
                 default,
-                price,
+                -1 * _currency,
                 1);
 
-            var action = new UpdateSell
+            var action = new UpdateSell3
             {
                 sellerAvatarAddress = _avatarAddress,
                 updateSellInfos = new[] { updateSellInfo },
             };
 
-            return action.Execute(new ActionContext
+            Assert.Throws<InvalidPriceException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
                 PreviousStates = _initialState,
                 Signer = _agentAddress,
-            });
+            }));
         }
     }
 }

--- a/.Lib9c.Tests/Extensions/FungibleAssetValueExtensionsTest.cs
+++ b/.Lib9c.Tests/Extensions/FungibleAssetValueExtensionsTest.cs
@@ -1,0 +1,61 @@
+namespace Lib9c.Tests.Extensions
+{
+    using Libplanet.Assets;
+    using Nekoyume.Extensions;
+    using Xunit;
+
+    public class FungibleAssetValueExtensionsTest
+    {
+        [Fact]
+        public void IsAvailableInMarket_Returns_False_With_Single_Currency()
+        {
+            var availableCurrency =
+                Currency.Legacy("NCG", 2, minters: null);
+            var notAvailableCurrency =
+                Currency.Legacy("KRW", 0, minters: null);
+            var value =
+                new FungibleAssetValue(notAvailableCurrency, 100, 0);
+            Assert.False(value.IsAvailableInMarket(availableCurrency));
+        }
+
+        [Fact]
+        public void IsAvailableInMarket_Returns_False_With_Multiple_Currencies()
+        {
+            var availableCurrency =
+                Currency.Legacy("NCG", 2, minters: null);
+            var availableCurrency2 =
+                Currency.Legacy("KRW", 0, minters: null);
+            var notAvailableCurrency =
+                Currency.Legacy("USD", 0, minters: null);
+            var value =
+                new FungibleAssetValue(notAvailableCurrency, 100, 0);
+            Assert.False(value.IsAvailableInMarket(
+                availableCurrency,
+                availableCurrency2));
+        }
+
+        [Fact]
+        public void IsAvailableInMarket_Returns_True_With_Single_Currency()
+        {
+            var availableCurrency =
+                Currency.Legacy("NCG", 2, minters: null);
+            var value =
+                new FungibleAssetValue(availableCurrency, 100, 0);
+            Assert.True(value.IsAvailableInMarket(availableCurrency));
+        }
+
+        [Fact]
+        public void IsAvailableInMarket_Returns_True_With_Multiple_Currencies()
+        {
+            var availableCurrency =
+                Currency.Legacy("NCG", 2, minters: null);
+            var availableCurrency2 =
+                Currency.Legacy("KRW", 0, minters: null);
+            var value =
+                new FungibleAssetValue(availableCurrency, 100, 0);
+            Assert.True(value.IsAvailableInMarket(
+                availableCurrency,
+                availableCurrency2));
+        }
+    }
+}

--- a/Lib9c/Action/Sell.cs
+++ b/Lib9c/Action/Sell.cs
@@ -7,6 +7,7 @@ using Lib9c.Model.Order;
 using Libplanet;
 using Libplanet.Action;
 using Libplanet.Assets;
+using Nekoyume.Extensions;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
@@ -83,9 +84,7 @@ namespace Nekoyume.Action
             Log.Verbose("{AddressesHex}Sell exec started", addressesHex);
 
             var ncg = states.GetGoldCurrency();
-            if (!price.Currency.Equals(ncg) ||
-                !price.MinorUnit.IsZero ||
-                price.Sign < 0)
+            if (!price.IsAvailableInMarket(ncg))
             {
                 throw new InvalidPriceException(
                     $"{addressesHex}Aborted as the price is less than zero: {price}.");

--- a/Lib9c/Action/UpdateSell.cs
+++ b/Lib9c/Action/UpdateSell.cs
@@ -8,6 +8,7 @@ using Lib9c.Model.Order;
 using Libplanet;
 using Libplanet.Action;
 using Nekoyume.Battle;
+using Nekoyume.Extensions;
 using Nekoyume.Model.Mail;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
@@ -100,9 +101,7 @@ namespace Nekoyume.Action
             var ncg = states.GetGoldCurrency();
             foreach (var updateSellInfo in updateSellInfos)
             {
-                if (!updateSellInfo.price.Currency.Equals(ncg) ||
-                    !updateSellInfo.price.MinorUnit.IsZero ||
-                    updateSellInfo.price.Sign < 0)
+                if (!updateSellInfo.price.IsAvailableInMarket(ncg))
                 {
                     throw new InvalidPriceException(
                         $"{addressesHex}Aborted as the price is less than zero: {updateSellInfo.price}.");

--- a/Lib9c/Action/UpdateSell3.cs
+++ b/Lib9c/Action/UpdateSell3.cs
@@ -19,11 +19,12 @@ using BxList = Bencodex.Types.List;
 namespace Nekoyume.Action
 {
     /// <summary>
-    /// Hard forked at https://github.com/planetarium/lib9c/pull/1404
+    /// Hard forked at https://github.com/planetarium/lib9c/pull/1022
+    /// Updated at https://github.com/planetarium/lib9c/pull/1022
     /// </summary>
     [Serializable]
-    [ActionType("update_sell4")]
-    public class UpdateSell : GameAction
+    [ActionType("update_sell3")]
+    public class UpdateSell3 : GameAction
     {
         public Address sellerAvatarAddress;
         public IEnumerable<UpdateSellInfo> updateSellInfos;
@@ -95,17 +96,13 @@ namespace Nekoyume.Action
                 throw new FailedLoadStateException(
                     $"{addressesHex} failed to load {nameof(OrderDigest)}({digestListAddress}).");
             }
-
             var digestList = new OrderDigestListState(rawList);
-            var ncg = states.GetGoldCurrency();
+
             foreach (var updateSellInfo in updateSellInfos)
             {
-                if (!updateSellInfo.price.Currency.Equals(ncg) ||
-                    !updateSellInfo.price.MinorUnit.IsZero ||
-                    updateSellInfo.price.Sign < 0)
+                if (updateSellInfo.price.Sign < 0)
                 {
-                    throw new InvalidPriceException(
-                        $"{addressesHex}Aborted as the price is less than zero: {updateSellInfo.price}.");
+                    throw new InvalidPriceException($"{addressesHex} Aborted as the price is less than zero: {updateSellInfo.price}.");
                 }
 
                 var shopAddress = ShardedShopStateV2.DeriveAddress(updateSellInfo.itemSubType, updateSellInfo.orderId);

--- a/Lib9c/Action/UpdateSell3.cs
+++ b/Lib9c/Action/UpdateSell3.cs
@@ -23,6 +23,7 @@ namespace Nekoyume.Action
     /// Updated at https://github.com/planetarium/lib9c/pull/1022
     /// </summary>
     [Serializable]
+    [ActionObsolete(BlockChain.Policy.BlockPolicySource.V100310ObsoleteIndex)]
     [ActionType("update_sell3")]
     public class UpdateSell3 : GameAction
     {
@@ -55,6 +56,8 @@ namespace Nekoyume.Action
             {
                 return states;
             }
+
+            CheckObsolete(BlockChain.Policy.BlockPolicySource.V100310ObsoleteIndex, context);
 
             // common
             var addressesHex = GetSignerAndOtherAddressesHex(context, sellerAvatarAddress);

--- a/Lib9c/Extensions/FungibleAssetValueExtensions.cs
+++ b/Lib9c/Extensions/FungibleAssetValueExtensions.cs
@@ -1,0 +1,15 @@
+using System.Linq;
+using Libplanet.Assets;
+
+namespace Nekoyume.Extensions
+{
+    public static class FungibleAssetValueExtensions
+    {
+        public static bool IsAvailableInMarket(
+            this FungibleAssetValue fav,
+            params Currency[] availableCurrencies) =>
+            availableCurrencies.Contains(fav.Currency) &&
+            fav.MinorUnit.IsZero &&
+            fav.Sign >= 0;
+    }
+}


### PR DESCRIPTION
## The bottom line of this pull request

- Hard fork `UpdateSell` from 3 to 4.
- Refactor test of `Sell` minor.

## Additional works

- since [5035337](https://github.com/planetarium/lib9c/pull/1405/commits/50353377127c427ce51241f78bcd095b3e86de06)
- Introduce `FungibleAssetValueExtensions` with `IsAvailableInMarket()` method.
- Apply it to `Sell` and `UpdateSell` action without hard fork.(`UpdateSell` hard forked before)