### PR TITLE
Make `transfer_asset*` actions implement common interface

### DIFF
--- a/Lib9c/Action/ITransferAsset.cs
+++ b/Lib9c/Action/ITransferAsset.cs
@@ -1,0 +1,14 @@
+#nullable enable
+using Libplanet;
+using Libplanet.Assets;
+
+namespace Nekoyume.Action
+{
+    public interface ITransferAsset
+    {
+        Address Sender { get; }
+        Address Recipient { get; }
+        FungibleAssetValue Amount { get; }
+        string? Memo { get; }
+    }
+}

--- a/Lib9c/Action/TransferAsset.cs
+++ b/Lib9c/Action/TransferAsset.cs
@@ -18,7 +18,7 @@ namespace Nekoyume.Action
     /// </summary>
     [Serializable]
     [ActionType("transfer_asset3")]
-    public class TransferAsset : ActionBase, ISerializable
+    public class TransferAsset : ActionBase, ISerializable, ITransferAsset
     {
         private const int MemoMaxLength = 80;
 

--- a/Lib9c/Action/TransferAsset0.cs
+++ b/Lib9c/Action/TransferAsset0.cs
@@ -14,7 +14,7 @@ namespace Nekoyume.Action
     [Serializable]
     [ActionObsolete(BlockChain.Policy.BlockPolicySource.V100080ObsoleteIndex)]
     [ActionType("transfer_asset")]
-    public class TransferAsset0 : ActionBase, ISerializable
+    public class TransferAsset0 : ActionBase, ISerializable, ITransferAsset
     {
         private const int MemoMaxLength = 80;
 

--- a/Lib9c/Action/TransferAsset2.cs
+++ b/Lib9c/Action/TransferAsset2.cs
@@ -18,7 +18,7 @@ namespace Nekoyume.Action
     /// </summary>
     [Serializable]
     [ActionType("transfer_asset2")]
-    public class TransferAsset2 : ActionBase, ISerializable
+    public class TransferAsset2 : ActionBase, ISerializable, ITransferAsset
     {
         private const int MemoMaxLength = 80;
 


### PR DESCRIPTION
This pull request just do only `transfer_asset*` actions implement common interface, `ITransferAsset`. Fortunately. their variables organizations are all same so it was easy. It is related with #1406.

I requested a review for @ipdae because he made `transfer_asset3` and I want to request a check about it.