### PR TITLE
Obsolete Lib9c.tools with warning message

### DIFF
--- a/.Lib9c.Tools/Program.cs
+++ b/.Lib9c.Tools/Program.cs
@@ -1,5 +1,7 @@
+using System;
 using Cocona;
 using Lib9c.Tools.SubCommand;
+using Action = Lib9c.Tools.SubCommand.Action;
 
 namespace Lib9c.Tools
 {
@@ -10,7 +12,13 @@ namespace Lib9c.Tools
     [HasSubCommands(typeof(Action), Description = "Get metadata of actions.")]
     class Program
     {
-        static void Main(string[] args) => CoconaLiteApp.Run<Program>(args);
+        static void Main(string[] args)
+        {
+            Console.Error.WriteLine(
+                "`lib9c.Tools` is deprecated. " +
+                "Please use `NineChronicles.Headless.Executable [command]` instead.");
+            CoconaLiteApp.Run<Program>(args);
+        }
 
         public void Help()
         {

--- a/.Lib9c.Tools/SubCommand/Account.cs
+++ b/.Lib9c.Tools/SubCommand/Account.cs
@@ -20,6 +20,7 @@ namespace Lib9c.Tools.SubCommand
 {
     public class Account
     {
+        [Obsolete("This function is deprecated. Please use `NineChronicles.Headless.Executable account` command instead.")]
         [Command(Description = "Query accounts' balances.")]
         public void Balance(
             [Option('v', Description = "Print more logs.")]

--- a/.Lib9c.Tools/SubCommand/Action.cs
+++ b/.Lib9c.Tools/SubCommand/Action.cs
@@ -10,6 +10,7 @@ namespace Lib9c.Tools.SubCommand
 {
     public class Action
     {
+        [Obsolete("This function is deprecated. Please use `NineChronicles.Headless.Executable action list` command instead.")]
         [Command(Description = "Lists all actions' type ids.")]
         public void List(
             [Option(

--- a/.Lib9c.Tools/SubCommand/Market.cs
+++ b/.Lib9c.Tools/SubCommand/Market.cs
@@ -22,6 +22,7 @@ namespace Lib9c.Tools.SubCommand
 {
     public class Market
     {
+        [Obsolete("This function is deprecated. Please use `NineChronicles.Headless.Executable market` command instead.")]
         [Command(Description = "Query market transactions.")]
         public void Query(
             [Option('v', Description = "Print more logs.")]

--- a/.Lib9c.Tools/SubCommand/State.cs
+++ b/.Lib9c.Tools/SubCommand/State.cs
@@ -26,6 +26,7 @@ namespace Lib9c.Tools.SubCommand
     {
         private static readonly Codec _codec = new Codec();
 
+        [Obsolete("This function is deprecated. Please use `NineChronicles.Headless.Executable state rebuild` command instead.")]
         [Command(Description = "Rebuild entire states by executing the chain from the genesis.")]
         public void Rebuild(
             [Option('v', Description = "Print more logs.")]
@@ -188,6 +189,7 @@ namespace Lib9c.Tools.SubCommand
             stateStore.Dispose();
         }
 
+        [Obsolete("This function is deprecated. Please use `NineChronicles.Headless.Executable state check` command instead.")]
         [Command(Description = "Check if states for the specified block are available " +
             "in the state store.")]
         public void Check(

--- a/.Lib9c.Tools/SubCommand/Tx.cs
+++ b/.Lib9c.Tools/SubCommand/Tx.cs
@@ -25,6 +25,7 @@ namespace Lib9c.Tools.SubCommand
     {
         private static Codec _codec = new Codec();
 
+        [Obsolete("This function is deprecated. Please use `NineChronicles.Headless.Executable tx transfer-asset` command instead.")]
         [Command(Description = "Create TransferAsset action and dump it.")]
         public void TransferAsset(
             [Argument("SENDER", Description = "An address of sender.")] string sender,
@@ -55,6 +56,7 @@ namespace Lib9c.Tools.SubCommand
             Console.Write(ByteUtil.Hex(raw));
         }
 
+        [Obsolete("This function is deprecated. Please use `NineChronicles.Headless.Executable tx sign` command instead.")]
         [Command(Description = "Create new transaction with given actions and dump it.")]
         public void Sign(
             [Argument("PRIVATE-KEY", Description = "A hex-encoded private key for signing.")] string privateKey,
@@ -122,6 +124,7 @@ namespace Lib9c.Tools.SubCommand
             }
         }
 
+        [Obsolete("This function is deprecated. Please use `NineChronicles.Headless.Executable tx patch-table` command instead.")]
         [Command(Description = "Create PatchTable action and dump it.")]
         public void PatchTable(
             [Argument("TABLE-PATH", Description = "A table file path for patch.")]
@@ -164,6 +167,7 @@ namespace Lib9c.Tools.SubCommand
             Console.WriteLine(ByteUtil.Hex(raw));
         }
 
+        [Obsolete("This function is deprecated. Please use `NineChronicles.Headless.Executable tx migration-legacy-shop` command instead.")]
         [Command(Description = "Create MigrationLegacyShop action and dump it.")]
         public void MigrationLegacyShop()
         {
@@ -178,6 +182,7 @@ namespace Lib9c.Tools.SubCommand
             Console.WriteLine(ByteUtil.Hex(raw));
         }
 
+        [Obsolete("This function is deprecated. Please use `NineChronicles.Headless.Executable tx migration-activated-accounts-state` command instead.")]
         [Command(Description = "Create MigrationActivatedAccountsState action and dump it.")]
         public void MigrationActivatedAccountsState()
         {
@@ -191,6 +196,7 @@ namespace Lib9c.Tools.SubCommand
             Console.WriteLine(ByteUtil.Hex(raw));
         }
 
+        [Obsolete("This function is deprecated. Please use `NineChronicles.Headless.Executable tx migration-avatar-state` command instead.")]
         [Command(Description = "Create MigrationAvatarState action and dump it.")]
         public void MigrationAvatarState(
         [Argument("directory-path", Description = "path of the directory contained hex-encoded avatar states.")] string directoryPath,
@@ -217,6 +223,7 @@ namespace Lib9c.Tools.SubCommand
             File.WriteAllText(outputPath, ByteUtil.Hex(raw));
         }
 
+        [Obsolete("This function is deprecated. Please use `NineChronicles.Headless.Executable tx add-redeem-code` command instead.")]
         [Command(Description = "Create AddRedeemCode action and dump it.")]
         public void AddRedeemCode(
             [Argument("TABLE-PATH", Description = "A table file path for RedeemCodeListSheet")] string tablePath
@@ -235,6 +242,7 @@ namespace Lib9c.Tools.SubCommand
             Console.WriteLine(ByteUtil.Hex(raw));
         }
 
+        [Obsolete("This function is deprecated. Please use `NineChronicles.Headless.Executable tx create-pending-activations` command instead.")]
         [Command(Description = "Create CreatePendingActivations action and dump it.")]
         public void CreatePendingActivations(
             [Argument("CSV-PATH", Description = "A csv file path for CreatePendingActivations")] string csvPath
@@ -266,6 +274,7 @@ namespace Lib9c.Tools.SubCommand
             Console.WriteLine(ByteUtil.Hex(raw));
         }
 
+        [Obsolete("This function is deprecated. Please use `NineChronicles.Headless.Executable tx renew-admin-state` command instead.")]
         [Command(Description = "Create RenewAdminState action and dump it.")]
         public void RenewAdminState(
             [Argument("NEW-VALID-UNTIL")]
@@ -281,6 +290,7 @@ namespace Lib9c.Tools.SubCommand
             Console.WriteLine(ByteUtil.Hex(raw));
         }
 
+        [Obsolete("This function is deprecated. Please use `NineChronicles.Headless.Executable tx create-activation-keys` command instead.")]
         [Command(Description = "Create ActvationKey-nonce pairs and dump them as csv")]
         public void CreateActivationKeys(
             [Argument("COUNT", Description = "An amount of pairs")] int count
@@ -307,6 +317,7 @@ namespace Lib9c.Tools.SubCommand
             }
         }
 
+        [Obsolete("This function is deprecated. Please use `NineChronicles.Headless.Executable tx create-prepare-reward-assets` command instead.")]
         [Command(Description = "Create PrepareRewardAssets")]
         public void CreatePrepareRewardAssets(
             [Argument("ASSETS")] string[] assets,


### PR DESCRIPTION
Commands in `lib9c.Tools` is bound to NineChronicles and `NineChronicles.Headless` already has several commands.
This PR deprecates `lib9c.Tools` commands and move to `NineChronicles.Headless`. 

Related Issue: https://github.com/planetarium/NineChronicles.Headless/pull/1602