### PR TITLE
Update debug log for `InvalidBlockStateRootHashException` debugging

### DIFF
--- a/Lib9c/Action/BattleArena.cs
+++ b/Lib9c/Action/BattleArena.cs
@@ -16,6 +16,7 @@ using Nekoyume.Model.EnumType;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
+using Serilog;
 using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Action
@@ -79,6 +80,8 @@ namespace Nekoyume.Action
                 myAvatarAddress,
                 enemyAvatarAddress);
 
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}BattleArena exec started", addressesHex);
             if (myAvatarAddress.Equals(enemyAvatarAddress))
             {
                 throw new InvalidAddressException(
@@ -356,6 +359,8 @@ namespace Nekoyume.Action
                         avatarState.questList.Serialize());
             }
 
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}BattleArena Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(myArenaAvatarStateAdr, myArenaAvatarState.Serialize())
                 .SetState(myArenaScoreAdr, myArenaScore.Serialize())

--- a/Lib9c/Action/Buy.cs
+++ b/Lib9c/Action/Buy.cs
@@ -77,7 +77,7 @@ namespace Nekoyume.Action
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Verbose("{AddressesHex}Buy exec started", addressesHex);
+            Log.Debug("{AddressesHex}Buy exec started", addressesHex);
 
             if (!states.TryGetAvatarStateV2(ctx.Signer, buyerAvatarAddress, out var buyerAvatarState, out _))
             {
@@ -296,7 +296,7 @@ namespace Nekoyume.Action
             sw.Restart();
 
             var ended = DateTimeOffset.UtcNow;
-            Log.Verbose("{AddressesHex}Buy Total Executed Time: {Elapsed}", addressesHex, ended - started);
+            Log.Debug("{AddressesHex}Buy Total Executed Time: {Elapsed}", addressesHex, ended - started);
 
             return states;
         }

--- a/Lib9c/Action/BuyMultiple.cs
+++ b/Lib9c/Action/BuyMultiple.cs
@@ -255,7 +255,7 @@ namespace Nekoyume.Action
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Verbose("{Addresses}BuyMultiple exec started", addressesHex);
+            Log.Debug("{Addresses}BuyMultiple exec started", addressesHex);
 
             if (!states.TryGetAvatarState(ctx.Signer, buyerAvatarAddress, out var buyerAvatarState))
             {
@@ -436,7 +436,7 @@ namespace Nekoyume.Action
             sw.Stop();
             var ended = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}BuyMultiple Set ShopState: {Elapsed}", addressesHex, sw.Elapsed);
-            Log.Verbose("{AddressesHex}BuyMultiple Total Executed Time: {Elapsed}", addressesHex, ended - started);
+            Log.Debug("{AddressesHex}BuyMultiple Total Executed Time: {Elapsed}", addressesHex, ended - started);
 
             return states;
         }

--- a/Lib9c/Action/CancelMonsterCollect.cs
+++ b/Lib9c/Action/CancelMonsterCollect.cs
@@ -7,6 +7,7 @@ using Libplanet.Action;
 using Libplanet.Assets;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
+using Serilog;
 using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Action
@@ -38,6 +39,9 @@ namespace Nekoyume.Action
 
             CheckObsolete(BlockChain.Policy.BlockPolicySource.V100080ObsoleteIndex, context);
 
+            var addressesHex = GetSignerAndOtherAddressesHex(context, context.Signer);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}CancelMonsterCollect exec started", addressesHex);
             AgentState agentState = states.GetAgentState(context.Signer);
             if (agentState is null)
             {
@@ -72,6 +76,8 @@ namespace Nekoyume.Action
                 balance += monsterCollectionSheet[i].RequiredGold * currency;
             }
 
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}CancelMonsterCollect Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(collectionAddress, monsterCollectionState.Serialize())
                 .TransferAsset(collectionAddress, context.Signer, balance);

--- a/Lib9c/Action/ChargeActionPoint.cs
+++ b/Lib9c/Action/ChargeActionPoint.cs
@@ -8,6 +8,7 @@ using Libplanet.Action;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
+using Serilog;
 using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Action
@@ -42,6 +43,8 @@ namespace Nekoyume.Action
             }
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}ChargeActionPoint exec started", addressesHex);
 
             if (!states.TryGetAvatarStateV2(context.Signer, avatarAddress, out var avatarState, out _))
             {
@@ -69,6 +72,8 @@ namespace Nekoyume.Action
             }
 
             avatarState.actionPoint = gameConfigState.ActionPointMax;
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}ChargeActionPoint Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(inventoryAddress, avatarState.inventory.Serialize())
                 .SetState(worldInformationAddress, avatarState.worldInformation.Serialize())

--- a/Lib9c/Action/ClaimMonsterCollectionReward.cs
+++ b/Lib9c/Action/ClaimMonsterCollectionReward.cs
@@ -10,6 +10,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.Mail;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
+using Serilog;
 using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Action
@@ -31,6 +32,9 @@ namespace Nekoyume.Action
             Address inventoryAddress = avatarAddress.Derive(LegacyInventoryKey);
             Address worldInformationAddress = avatarAddress.Derive(LegacyWorldInformationKey);
             Address questListAddress = avatarAddress.Derive(LegacyQuestListKey);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}ClaimMonsterCollection exec started", addressesHex);
 
             if (context.Rehearsal)
             {
@@ -85,6 +89,8 @@ namespace Nekoyume.Action
             }
             monsterCollectionState.Claim(context.BlockIndex);
 
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}ClaimMonsterCollection Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(avatarAddress, avatarState.SerializeV2())
                 .SetState(inventoryAddress, avatarState.inventory.Serialize())

--- a/Lib9c/Action/ClaimRaidReward.cs
+++ b/Lib9c/Action/ClaimRaidReward.cs
@@ -10,6 +10,7 @@ using Nekoyume.Extensions;
 using Nekoyume.Helper;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
+using Serilog;
 
 namespace Nekoyume.Action
 {
@@ -36,6 +37,9 @@ namespace Nekoyume.Action
                 return states;
             }
 
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}ClaimRaidReward exec started", addressesHex);
             Dictionary<Type, (Address, ISheet)> sheets = states.GetSheets(sheetTypes: new[] {
                 typeof(RuneWeightSheet),
                 typeof(WorldBossRankRewardSheet),
@@ -88,6 +92,8 @@ namespace Nekoyume.Action
                 raiderState.LatestRewardRank = rank;
                 raiderState.ClaimedBlockIndex = context.BlockIndex;
                 states = states.SetState(raiderAddress, raiderState.Serialize());
+                var ended = DateTimeOffset.UtcNow;
+                Log.Debug("{AddressesHex}ClaimRaidReward Total Executed Time: {Elapsed}", addressesHex, ended - started);
                 return states;
             }
 

--- a/Lib9c/Action/CombinationConsumable.cs
+++ b/Lib9c/Action/CombinationConsumable.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
@@ -12,6 +13,7 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.Mail;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
+using Serilog;
 using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Action
@@ -74,6 +76,8 @@ namespace Nekoyume.Action
             }
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}Combination exec started", addressesHex);
 
             if (!states.TryGetAvatarStateV2(context.Signer, avatarAddress, out var avatarState, out _))
             {
@@ -229,6 +233,8 @@ namespace Nekoyume.Action
             avatarState.Update(mail);
             // ~Create Mail
 
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}Combination Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(avatarAddress, avatarState.SerializeV2())
                 .SetState(inventoryAddress, avatarState.inventory.Serialize())

--- a/Lib9c/Action/CombinationEquipment.cs
+++ b/Lib9c/Action/CombinationEquipment.cs
@@ -15,6 +15,7 @@ using Nekoyume.Model.Stat;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Nekoyume.TableData.Crystal;
+using Serilog;
 using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Action
@@ -84,6 +85,9 @@ namespace Nekoyume.Action
                 return states;
             }
 
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}CombinationEquipment exec started", addressesHex);
             if (recipeId != 1)
             {
                 var unlockedRecipeIdsAddress = avatarAddress.Derive("recipe_ids");
@@ -99,7 +103,6 @@ namespace Nekoyume.Action
                 }
             }
 
-            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
             if (!states.TryGetAgentAvatarStatesV2(context.Signer, avatarAddress, out var agentState,
                     out var avatarState, out _))
             {
@@ -435,6 +438,8 @@ namespace Nekoyume.Action
             avatarState.Update(mail);
             // ~Create Mail
 
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}CombinationEquipment Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(avatarAddress, avatarState.SerializeV2())
                 .SetState(inventoryAddress, avatarState.inventory.Serialize())

--- a/Lib9c/Action/CreateAvatar.cs
+++ b/Lib9c/Action/CreateAvatar.cs
@@ -99,7 +99,7 @@ namespace Nekoyume.Action
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Verbose("{AddressesHex}CreateAvatar exec started", addressesHex);
+            Log.Debug("{AddressesHex}CreateAvatar exec started", addressesHex);
             AgentState existingAgentState = states.GetAgentState(ctx.Signer);
             var agentState = existingAgentState ?? new AgentState(ctx.Signer);
             var avatarState = states.GetAvatarState(avatarAddress);
@@ -152,7 +152,7 @@ namespace Nekoyume.Action
             sw.Stop();
             Log.Verbose("{AddressesHex}CreateAvatar CreateAvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             var ended = DateTimeOffset.UtcNow;
-            Log.Verbose("{AddressesHex}CreateAvatar Total Executed Time: {Elapsed}", addressesHex, ended - started);
+            Log.Debug("{AddressesHex}CreateAvatar Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(ctx.Signer, agentState.Serialize())
                 .SetState(inventoryAddress, avatarState.inventory.Serialize())

--- a/Lib9c/Action/DailyReward.cs
+++ b/Lib9c/Action/DailyReward.cs
@@ -6,6 +6,7 @@ using Bencodex.Types;
 using Libplanet;
 using Libplanet.Action;
 using Nekoyume.Model.State;
+using Serilog;
 using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Action
@@ -37,7 +38,8 @@ namespace Nekoyume.Action
             }
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
-
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}DailyReward exec started", addressesHex);
             if (!states.TryGetAgentAvatarStatesV2(context.Signer, avatarAddress, out _, out AvatarState avatarState, out _))
             {
                 throw new FailedLoadStateException(
@@ -63,6 +65,8 @@ namespace Nekoyume.Action
             avatarState.dailyRewardReceivedIndex = context.BlockIndex;
             avatarState.actionPoint = gameConfigState.ActionPointMax;
 
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}DailyReward Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(avatarAddress, avatarState.SerializeV2())
                 .SetState(inventoryAddress, avatarState.inventory.Serialize())

--- a/Lib9c/Action/Grinding.cs
+++ b/Lib9c/Action/Grinding.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.Mail;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Nekoyume.TableData.Crystal;
+using Serilog;
 using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Action
@@ -49,6 +50,9 @@ namespace Nekoyume.Action
                     .MarkBalanceChanged(GoldCurrencyMock, context.Signer);
             }
 
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}Grinding exec started", addressesHex);
             if (!EquipmentIds.Any() || EquipmentIds.Count > Limit)
             {
                 throw new InvalidItemCountException();
@@ -160,6 +164,8 @@ namespace Nekoyume.Action
                     .SetState(questListAddress, avatarState.questList.Serialize());
             }
 
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}Grinding Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(AvatarAddress, avatarState.SerializeV2())
                 .SetState(inventoryAddress, avatarState.inventory.Serialize())

--- a/Lib9c/Action/HackAndSlash.cs
+++ b/Lib9c/Action/HackAndSlash.cs
@@ -100,7 +100,7 @@ namespace Nekoyume.Action
 
             var addressesHex = $"[{signer.ToHex()}, {AvatarAddress.ToHex()}]";
             var started = DateTimeOffset.UtcNow;
-            Log.Verbose("{AddressesHex}HAS exec started", addressesHex);
+            Log.Debug("{AddressesHex}HAS exec started", addressesHex);
 
             states.ValidateWorldId(AvatarAddress, WorldId);
 
@@ -387,7 +387,7 @@ namespace Nekoyume.Action
             Log.Verbose("{AddressesHex}HAS Set States: {Elapsed}", addressesHex, sw.Elapsed);
 
             var totalElapsed = DateTimeOffset.UtcNow - started;
-            Log.Verbose("{AddressesHex}HAS Total Executed Time: {Elapsed}", addressesHex, totalElapsed);
+            Log.Debug("{AddressesHex}HAS Total Executed Time: {Elapsed}", addressesHex, totalElapsed);
             return states;
         }
 

--- a/Lib9c/Action/HackAndSlashRandomBuff.cs
+++ b/Lib9c/Action/HackAndSlashRandomBuff.cs
@@ -10,6 +10,7 @@ using Nekoyume.Battle;
 using Nekoyume.Helper;
 using Nekoyume.Model.State;
 using Nekoyume.TableData.Crystal;
+using Serilog;
 
 namespace Nekoyume.Action
 {
@@ -42,6 +43,9 @@ namespace Nekoyume.Action
         {
             var states = context.PreviousStates;
             var gachaStateAddress = Addresses.GetSkillStateAddressFromAvatarAddress(AvatarAddress);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}HackAndSlashRandomBuff exec started", addressesHex);
 
             // Invalid Avatar address, or does not have GachaState.
             if (!states.TryGetState(gachaStateAddress, out List rawGachaState))
@@ -102,6 +106,8 @@ namespace Nekoyume.Action
 
             gachaState.Update(buffIds);
 
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}HackAndSlashRandomBuff Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(gachaStateAddress, gachaState.Serialize())
                 .TransferAsset(context.Signer, Addresses.StageRandomBuff, cost);

--- a/Lib9c/Action/HackAndSlashSweep.cs
+++ b/Lib9c/Action/HackAndSlashSweep.cs
@@ -11,6 +11,7 @@ using Nekoyume.Helper;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
+using Serilog;
 using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Action
@@ -65,6 +66,8 @@ namespace Nekoyume.Action
             }
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}HackAndSlashSweep exec started", addressesHex);
 
             if (apStoneCount > UsableApStoneCount)
             {
@@ -248,6 +251,8 @@ namespace Nekoyume.Action
                     avatarState.worldInformation.Serialize());
             }
 
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}HackAndSlashSweep Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(avatarAddress, avatarState.SerializeV2())
                 .SetState(

--- a/Lib9c/Action/ItemEnhancement.cs
+++ b/Lib9c/Action/ItemEnhancement.cs
@@ -141,7 +141,7 @@ namespace Nekoyume.Action
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Verbose("{AddressesHex}ItemEnhancement exec started", addressesHex);
+            Log.Debug("{AddressesHex}ItemEnhancement exec started", addressesHex);
             if (!states.TryGetAgentAvatarStatesV2(ctx.Signer, avatarAddress, out var agentState, out var avatarState, out _))
             {
                 throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
@@ -378,7 +378,7 @@ namespace Nekoyume.Action
             sw.Stop();
             Log.Verbose("{AddressesHex}ItemEnhancement Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
             var ended = DateTimeOffset.UtcNow;
-            Log.Verbose("{AddressesHex}ItemEnhancement Total Executed Time: {Elapsed}", addressesHex, ended - started);
+            Log.Debug("{AddressesHex}ItemEnhancement Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states.SetState(slotAddress, slotState.Serialize());
         }
 

--- a/Lib9c/Action/JoinArena.cs
+++ b/Lib9c/Action/JoinArena.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model.Arena;
 using Nekoyume.Model.EnumType;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
+using Serilog;
 
 namespace Nekoyume.Action
 {
@@ -59,6 +60,8 @@ namespace Nekoyume.Action
             }
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}JoinArena exec started", addressesHex);
 
             if (!states.TryGetAgentAvatarStatesV2(context.Signer, avatarAddress,
                     out var agentState, out var avatarState, out _))
@@ -173,6 +176,8 @@ namespace Nekoyume.Action
             arenaAvatarState.UpdateCostumes(costumes);
             arenaAvatarState.UpdateEquipment(equipments);
 
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}JoinArena Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(arenaScoreAdr, arenaScore.Serialize())
                 .SetState(arenaInformationAdr, arenaInformation.Serialize())

--- a/Lib9c/Action/MigrateMonsterCollection.cs
+++ b/Lib9c/Action/MigrateMonsterCollection.cs
@@ -39,6 +39,9 @@ namespace Nekoyume.Action
         public override IAccountStateDelta Execute(IActionContext context)
         {
             var states = context.PreviousStates;
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}MigrateMonsterCollection exec started", addressesHex);
             if (states.TryGetStakeState(context.Signer, out StakeState _))
             {
                 throw new InvalidOperationException("The user has already staked.");
@@ -78,6 +81,8 @@ namespace Nekoyume.Action
                 monsterCollectionState.ExpiredBlockIndex,
                 new StakeState.StakeAchievements());
 
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}MigrateMonsterCollection Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states.SetState(monsterCollectionState.address, Null.Value)
                 .SetState(migratedStakeStateAddress, migratedStakeState.SerializeV2())
                 .TransferAsset(

--- a/Lib9c/Action/MimisbrunnrBattle.cs
+++ b/Lib9c/Action/MimisbrunnrBattle.cs
@@ -72,7 +72,7 @@ namespace Nekoyume.Action
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Verbose(
+            Log.Debug(
                 "{AddressesHex}Mimisbrunnr exec started",
                 addressesHex);
 
@@ -369,7 +369,7 @@ namespace Nekoyume.Action
             sw.Restart();
 
             var ended = DateTimeOffset.UtcNow;
-            Log.Verbose(
+            Log.Debug(
                 "{AddressesHex}Mimisbrunnr Total Executed Time: {Elapsed}",
                 addressesHex,
                 ended - started);

--- a/Lib9c/Action/MonsterCollect.cs
+++ b/Lib9c/Action/MonsterCollect.cs
@@ -8,6 +8,7 @@ using Libplanet.Assets;
 using Nekoyume.BlockChain.Policy;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
+using Serilog;
 using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Action
@@ -39,6 +40,9 @@ namespace Nekoyume.Action
                     .MarkBalanceChanged(GoldCurrencyMock, context.Signer, MonsterCollectionState.DeriveAddress(context.Signer, 3));
             }
 
+            var addressesHex = GetSignerAndOtherAddressesHex(context, context.Signer);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}MonsterCollect exec started", addressesHex);
             if (states.TryGetStakeState(context.Signer, out StakeState _))
             {
                 throw new InvalidOperationException(
@@ -112,6 +116,8 @@ namespace Nekoyume.Action
             }
             states = states.TransferAsset(context.Signer, monsterCollectionAddress, requiredGold);
             states = states.SetState(monsterCollectionAddress, monsterCollectionState.Serialize());
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}MonsterCollect Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states;
         }
 

--- a/Lib9c/Action/Raid.cs
+++ b/Lib9c/Action/Raid.cs
@@ -12,6 +12,7 @@ using Nekoyume.Helper;
 using Nekoyume.Model.Arena;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
+using Serilog;
 using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Action
@@ -38,6 +39,9 @@ namespace Nekoyume.Action
                 return states;
             }
 
+            var addressHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressHex}Raid exec started", addressHex);
             if (!states.TryGetAvatarStateV2(context.Signer, AvatarAddress,
                     out AvatarState avatarState,
                     out var migrationRequired))
@@ -255,6 +259,8 @@ namespace Nekoyume.Action
                     .SetState(questListAddress, avatarState.questList.Serialize());
             }
 
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressHex}Raid Total Executed Time: {Elapsed}", addressHex, ended - started);
             return states
                 .SetState(inventoryAddress, avatarState.inventory.Serialize())
                 .SetState(worldBossAddress, bossState.Serialize())

--- a/Lib9c/Action/RankingBattle.cs
+++ b/Lib9c/Action/RankingBattle.cs
@@ -71,7 +71,7 @@ namespace Nekoyume.Action
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Verbose(
+            Log.Debug(
                 "{AddressesHex}RankingBattle exec started. costume: ({CostumeIds}), equipment: ({EquipmentIds})",
                 addressesHex,
                 string.Join(",", costumeIds),
@@ -294,7 +294,7 @@ namespace Nekoyume.Action
             sw.Restart();
 
             var ended = DateTimeOffset.UtcNow;
-            Log.Verbose("{AddressesHex}RankingBattle Total Executed Time: {Elapsed}", addressesHex, ended - started);
+            Log.Debug("{AddressesHex}RankingBattle Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states;
         }
 

--- a/Lib9c/Action/RapidCombination.cs
+++ b/Lib9c/Action/RapidCombination.cs
@@ -10,6 +10,7 @@ using Nekoyume.Extensions;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
+using Serilog;
 using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Action
@@ -48,6 +49,8 @@ namespace Nekoyume.Action
             }
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}RapidCombination exec started", addressesHex);
 
             if (!states.TryGetAgentAvatarStatesV2(
                 context.Signer,
@@ -125,6 +128,8 @@ namespace Nekoyume.Action
                 (RapidCombination5.ResultModel)slotState.Result,
                 context.BlockIndex);
 
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}RapidCombination Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(avatarAddress, avatarState.SerializeV2())
                 .SetState(inventoryAddress, avatarState.inventory.Serialize())

--- a/Lib9c/Action/RedeemCode.cs
+++ b/Lib9c/Action/RedeemCode.cs
@@ -56,6 +56,8 @@ namespace Nekoyume.Action
             }
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}RedeemCode exec started", addressesHex);
 
             if (!states.TryGetAvatarStateV2(context.Signer, AvatarAddress, out AvatarState avatarState, out _))
             {
@@ -115,6 +117,8 @@ namespace Nekoyume.Action
                         break;
                 }
             }
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}RedeemCode Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(AvatarAddress, avatarState.SerializeV2())
                 .SetState(inventoryAddress, avatarState.inventory.Serialize())

--- a/Lib9c/Action/RewardGold.cs
+++ b/Lib9c/Action/RewardGold.cs
@@ -8,6 +8,7 @@ using Libplanet.Action;
 using Libplanet.Assets;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
+using Serilog;
 
 namespace Nekoyume.Action
 {
@@ -35,6 +36,9 @@ namespace Nekoyume.Action
         {
             var states = context.PreviousStates;
             states = GenesisGoldDistribution(context, states);
+            var addressesHex = GetSignerAndOtherAddressesHex(context, context.Signer);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}RewardGold exec started", addressesHex);
 
             // Avoid InvalidBlockStateRootHashException before table patch.
             var arenaSheetAddress = Addresses.GetSheetAddress<ArenaSheet>();
@@ -44,6 +48,8 @@ namespace Nekoyume.Action
                 states = WeeklyArenaRankingBoard2(context, states);
             }
 
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}RewardGold Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return MinerReward(context, states);
         }
 

--- a/Lib9c/Action/Sell.cs
+++ b/Lib9c/Action/Sell.cs
@@ -80,7 +80,7 @@ namespace Nekoyume.Action
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Verbose("{AddressesHex}Sell exec started", addressesHex);
+            Log.Debug("{AddressesHex}Sell exec started", addressesHex);
 
             var ncg = states.GetGoldCurrency();
             if (!price.Currency.Equals(ncg) ||
@@ -172,7 +172,7 @@ namespace Nekoyume.Action
             sw.Stop();
             var ended = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}Sell Set ShopState: {Elapsed}", addressesHex, sw.Elapsed);
-            Log.Verbose(
+            Log.Debug(
                 "{AddressesHex}Sell Total Executed Time: {Elapsed}",
                 addressesHex,
                 ended - started);

--- a/Lib9c/Action/SellCancellation.cs
+++ b/Lib9c/Action/SellCancellation.cs
@@ -105,7 +105,7 @@ namespace Nekoyume.Action
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Verbose("{AddressesHex}Sell Cancel exec started", addressesHex);
+            Log.Debug("{AddressesHex}Sell Cancel exec started", addressesHex);
 
             if (!states.TryGetAvatarStateV2(context.Signer, sellerAvatarAddress, out var avatarState, out _))
             {
@@ -198,7 +198,7 @@ namespace Nekoyume.Action
             sw.Stop();
             var ended = DateTimeOffset.UtcNow;
             Log.Verbose("{AddressesHex}Sell Cancel Set ShopState: {Elapsed}", addressesHex, sw.Elapsed);
-            Log.Verbose("{AddressesHex}Sell Cancel Total Executed Time: {Elapsed}", addressesHex, ended - started);
+            Log.Debug("{AddressesHex}Sell Cancel Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states;
         }
     }

--- a/Lib9c/Action/Stake.cs
+++ b/Lib9c/Action/Stake.cs
@@ -9,6 +9,7 @@ using Libplanet.Action;
 using Nekoyume.Extensions;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
+using Serilog;
 using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Action
@@ -59,6 +60,9 @@ namespace Nekoyume.Action
                         StakeState.DeriveAddress(context.Signer));
             }
 
+            var addressesHex = GetSignerAndOtherAddressesHex(context, context.Signer);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}Stake exec started", addressesHex);
             if (Amount < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(Amount));
@@ -117,6 +121,9 @@ namespace Nekoyume.Action
                         .TransferAsset(stakeState.address, context.Signer, stakedBalance);
                 }
             }
+
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}Stake Total Executed Time: {Elapsed}", addressesHex, ended - started);
 
             // Stake with more or less amount.
             return states.TransferAsset(stakeState.address, context.Signer, stakedBalance)

--- a/Lib9c/Action/TransferAsset.cs
+++ b/Lib9c/Action/TransferAsset.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 using Nekoyume.Model;
+using Serilog;
 
 namespace Nekoyume.Action
 {
@@ -77,6 +78,9 @@ namespace Nekoyume.Action
                 return state.MarkBalanceChanged(Amount.Currency, new[] { Sender, Recipient });
             }
 
+            var addressesHex = GetSignerAndOtherAddressesHex(context, context.Signer);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}TransferAsset3 exec started", addressesHex);
             if (Sender != context.Signer)
             {
                 throw new InvalidTransferSignerException(context.Signer, Sender, Recipient);
@@ -119,6 +123,8 @@ namespace Nekoyume.Action
                );
             }
 
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}TransferAsset3 Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return state.TransferAsset(Sender, Recipient, Amount);
         }
 

--- a/Lib9c/Action/TransferAsset2.cs
+++ b/Lib9c/Action/TransferAsset2.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 using Nekoyume.Model;
+using Serilog;
 
 namespace Nekoyume.Action
 {
@@ -77,6 +78,9 @@ namespace Nekoyume.Action
                 return state.MarkBalanceChanged(Amount.Currency, new[] { Sender, Recipient });
             }
 
+            var addressesHex = GetSignerAndOtherAddressesHex(context, context.Signer);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}TransferAsset2 exec started", addressesHex);
             if (Sender != context.Signer)
             {
                 throw new InvalidTransferSignerException(context.Signer, Sender, Recipient);
@@ -115,6 +119,8 @@ namespace Nekoyume.Action
                );
             }
 
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}TransferAsset2 Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return state.TransferAsset(Sender, Recipient, Amount);
         }
 

--- a/Lib9c/Action/UnlockEquipmentRecipe.cs
+++ b/Lib9c/Action/UnlockEquipmentRecipe.cs
@@ -12,6 +12,7 @@ using Nekoyume.Model;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
+using Serilog;
 using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Action
@@ -40,6 +41,9 @@ namespace Nekoyume.Action
                     .MarkBalanceChanged(GoldCurrencyMock, context.Signer, Addresses.UnlockEquipmentRecipe);
             }
 
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}UnlockEquipmentRecipe exec started", addressesHex);
             if (!RecipeIds.Any() || RecipeIds.Any(i => i < 2))
             {
                 throw new InvalidRecipeIdException();
@@ -91,6 +95,8 @@ namespace Nekoyume.Action
             states = states.SetState(unlockedRecipeIdsAddress,
                     unlockedIds.Aggregate(List.Empty,
                         (current, address) => current.Add(address.Serialize())));
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}UnlockEquipmentRecipe Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states.TransferAsset(context.Signer, Addresses.UnlockEquipmentRecipe,  cost);
         }
 

--- a/Lib9c/Action/UnlockWorld.cs
+++ b/Lib9c/Action/UnlockWorld.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Bencodex.Types;
@@ -9,6 +10,7 @@ using Nekoyume.Helper;
 using Nekoyume.Model;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
+using Serilog;
 using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Action
@@ -38,6 +40,9 @@ namespace Nekoyume.Action
                     .MarkBalanceChanged(GoldCurrencyMock, context.Signer, Addresses.UnlockWorld);
             }
 
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}UnlockWorld exec started", addressesHex);
             if (!WorldIds.Any() || WorldIds.Any(i => i < 2 || i == GameConfig.MimisbrunnrWorldId))
             {
                 throw new InvalidWorldException();
@@ -121,6 +126,8 @@ namespace Nekoyume.Action
                     .SetState(inventoryAddress, avatarState.inventory.Serialize());
             }
 
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}UnlockWorld Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
                 .SetState(unlockedWorldIdsAddress, new List(unlockedIds.Select(i => i.Serialize())))
                 .TransferAsset(context.Signer, Addresses.UnlockWorld, cost);

--- a/Lib9c/Action/UpdateSell.cs
+++ b/Lib9c/Action/UpdateSell.cs
@@ -61,7 +61,7 @@ namespace Nekoyume.Action
             var sw = new Stopwatch();
             sw.Start();
             var started = DateTimeOffset.UtcNow;
-            Log.Verbose("{AddressesHex} updateSell exec started", addressesHex);
+            Log.Debug("{AddressesHex} updateSell exec started", addressesHex);
 
             if (!updateSellInfos.Any())
             {
@@ -196,7 +196,7 @@ namespace Nekoyume.Action
             Log.Verbose("{AddressesHex} UpdateSell Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
 
             var ended = DateTimeOffset.UtcNow;
-            Log.Verbose("{AddressesHex} UpdateSell Total Executed Time: {Elapsed}", addressesHex, ended - started);
+            Log.Debug("{AddressesHex} UpdateSell Total Executed Time: {Elapsed}", addressesHex, ended - started);
 
             return states;
         }


### PR DESCRIPTION
In an effort to better analyze potential `InvalidBlockStateRootHashException` error in future releases, this PR changes the previous `Verbose` level logs of `Lib9c` actions to `Debug` level. This change only applies to the start and end of each action so that it will be easier to assess which action failed when an `InvalidBlockStateRootHashException` occurs.