### PR TITLE
fix GetHighestRankSkill

### DIFF
--- a/Lib9c/Model/State/CrystalRandomSkillState.cs
+++ b/Lib9c/Model/State/CrystalRandomSkillState.cs
@@ -79,7 +79,7 @@ namespace Nekoyume.Model.State
             return SkillIds
                 .OrderBy(id => crystalRandomBuffSheet[id].Rank)
                 .ThenBy(id => id)
-                .FirstOrDefault();
+                .First();
         }
     }
 }


### PR DESCRIPTION
use `.First()` for avoid `InvalidBlockStateRootHashException`