### PR TITLE
Upgrade Libplanet to 0.45.0-dev.20221202011151+b351ea1

### DIFF
--- a/Lib9c/Policy/DebugPolicy.cs
+++ b/Lib9c/Policy/DebugPolicy.cs
@@ -56,5 +56,7 @@ namespace Nekoyume.BlockChain.Policy
         public int GetMaxTransactionsPerSignerPerBlock(long index) => int.MaxValue;
 
         public IImmutableSet<Currency> NativeTokens => ImmutableHashSet<Currency>.Empty;
+
+        public int GetMinBlockProtocolVersion(long index) => 0;
     }
 }


### PR DESCRIPTION
This basically reverts #1551 again, and recover #1544 (except that it upgrades Libplanet to the slightly later version).  Here's the complete list of changes from Libplanet 0.44.0:

> ### Deprecated APIs
> 
>  -  Removed `BlockChain<T>.MineBlock(PrivateKey, DateTimeOffset, bool, long, int, int, IComparer<Transaction<T>>, CancellationToken?)` by making it `internal`.  [[#2529]]
>  -  Removed `IStore.SetBlockPerceivedTime()` and `IStore.GetBlockPerceivedTime()` methods.  [[#2575]]
>  -  Removed `BlockPerception` struct.  [[#2575]]
>  -  Removed `BlockChain<T>.PerceiveBlock()` method.  [[#2575]]
> 
> ### Backward-incompatible API changes
> 
>  -  Changed `BlockChain<T>.MineBlock(PrivateKey, DateTimeOffset?, bool?, long?, int?, int?, IComparer<Transaction<T>>, CancellationToken?)` to `BlockChain<T>.MineBlock(PrivateKey, DateTimeOffset?, bool?, IComparer<Transaction<T>>, CancellationToken?)` by removing policy controlled parameters.  [[#2529]]
>  -  Changed `BlockPolicy<T>()` constructor to take additional `Func<long, int>` type parameter named `getMinBlockProtocolVersion`.  [[#2593]]
> 
> ### Added APIs
> 
>  -  Added `BlockChainStates<T>` class.  [[#2507]]
>  -  Added new constructors of `BlockChain<T>` takes `IBlockChainStates<T>`
>     and `ActionEvaluator<T>` directly.  [[#2507]]
>  -  Added non-generic interfaces.  [[#2539]]
>      -  Added `IPreEvaluationBlock` interface.
>      -  Added `IBlockContent` interface.
>      -  Added `ITransaction` interface.
>  -  Added `IActionTypeLoader` interface.  [[#2539]]
>  -  Added `StaticActionTypeLoader` class.  [[#2539]]
>  -  (Libplanet.Explorer) Added a new GraphQL endpoint on `/graphql/explorer`.  [[#2562]]
>  -  (Libplanet.Explorer) Added `ConfigureLibplanetExplorerSchema` class.  [[#2572]]
>  -  Added `IBlockPolicy.GetMinBlockProtocolVersion()` interface method.  [[#2593]]
> 
> ### Bug fixes
> 
>  -  (Libplanet.Net) Fixed a bug where `AppProtocolVersion.GetHashCode()` did not work as intended.  [[#2518], [#2520]]
> 
> ### Dependencies
> 
>  -  Replaced *[BouncyCastle.NetCore 1.8.6]* with *[BouncyCastle.Cryptography 2.0.0]*.  [[#2571]]
>  -  (Libplanet.Explorer) Upgraded GraphQL-related dependencies.  [[#2572]]
>      -  *GraphQL*: 4.7.1 → 7.1.1
>      -  *GraphQL.Server.Authorization.AspNetCore*: 5.1.1 → 7.1.1
>      -  *GraphQL.Server.Transports.AspNetCore*: 5.1.1 → 7.1.1
>      -  *GraphQL.Server.Ui.Playground*: 5.1.1 → 7.1.1
>      -  *GraphQL.SystemTextJson*: 4.7.1 → 7.1.1
>      -  *GraphQL.Server.Transports.AspNetCore.SystemTextJson*: 5.1.1 → removed
> 
> ### CLI tools
> 
>  -  Now `planet` can be installed using Homebrew on macOS: `brew install
>     planetarium/brew/planet`.  [[#2555]]
>  -  Now `planet` supports command-line completion for bash and zsh.  See also [Cocona's manual on configuring command-line completion][Cocona command-line completion].  [[#2586]]
>  -  (Libplanet.Explorer) Added `serve` subcommand.  [[#2563]]
>      -  (Libplanet.Explorer) Deprecated primary command.  It will be obsoleted in 0.47.0 release.  You should use `serve` command instead.  [[#2563]]
>  -  (Libplanet.Explorer) Added `schema` subcommand.  [[#2563]]

[BouncyCastle.NetCore 1.8.6]: https://www.nuget.org/packages/BouncyCastle.NetCore/1.8.6
[BouncyCastle.Cryptography 2.0.0]: https://www.nuget.org/packages/BouncyCastle.Cryptography/2.0.0
[Cocona command-line completion]: https://github.com/mayuki/Cocona#shell-command-line-completion
[#2507]: https://github.com/planetarium/libplanet/pull/2507
[#2518]: https://github.com/planetarium/libplanet/issues/2518
[#2520]: https://github.com/planetarium/libplanet/pull/2520
[#2529]: https://github.com/planetarium/libplanet/pull/2529
[#2539]: https://github.com/planetarium/libplanet/pull/2539
[#2555]: https://github.com/planetarium/libplanet/pull/2555
[#2562]: https://github.com/planetarium/libplanet/pull/2562
[#2563]: https://github.com/planetarium/libplanet/pull/2563
[#2571]: https://github.com/planetarium/libplanet/pull/2571
[#2572]: https://github.com/planetarium/libplanet/pull/2572
[#2575]: https://github.com/planetarium/libplanet/pull/2575
[#2586]: https://github.com/planetarium/libplanet/pull/2586
[#2593]: https://github.com/planetarium/libplanet/pull/2593