### PR TITLE
Check raw custom actions in `BlockPolicySource`

### DIFF
--- a/Lib9c.Abstractions/IActivateAccount.cs
+++ b/Lib9c.Abstractions/IActivateAccount.cs
@@ -1,0 +1,10 @@
+using Libplanet;
+
+namespace Lib9c.Abstractions
+{
+    public interface IActivateAccount
+    {
+        Address PendingAddress { get; }
+        byte[] Signature { get; }
+    }
+}

--- a/Lib9c.Abstractions/Lib9c.Abstractions.csproj
+++ b/Lib9c.Abstractions/Lib9c.Abstractions.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\.Libplanet\Libplanet\Libplanet.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Lib9c.Miner/Miner.cs
+++ b/Lib9c.Miner/Miner.cs
@@ -54,7 +54,7 @@ namespace Nekoyume.BlockChain
             try
             {
                 // Each validator should return true when the transaction can be mined.
-                var txValidators = new List<Func<ITransaction, bool>>
+                var txValidators = new List<Predicate<ITransaction>>
                 {
                     tx => !_bannedAccounts.Contains(tx.Signer),
                 };

--- a/Lib9c.Miner/Miner.cs
+++ b/Lib9c.Miner/Miner.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Bencodex.Types;
 using Libplanet;
 using Libplanet.Action;
 using Libplanet.Blockchain;
@@ -21,6 +22,9 @@ namespace Nekoyume.BlockChain
         private readonly BlockChain<NCAction> _chain;
         private readonly Swarm<NCAction> _swarm;
         private readonly PrivateKey _privateKey;
+
+        private readonly IActionTypeLoader? _actionTypeLoader;
+
         // TODO we must justify it.
         private static readonly ImmutableHashSet<Address> _bannedAccounts = new[]
         {
@@ -49,12 +53,50 @@ namespace Nekoyume.BlockChain
             Block<NCAction>? block = null;
             try
             {
-                IEnumerable<Transaction<NCAction>> bannedTxs = _chain.GetStagedTransactionIds()
-                    .Select(txId => _chain.GetTransaction(txId))
-                    .Where(tx => _bannedAccounts.Contains(tx.Signer));
-                foreach (Transaction<NCAction> tx in bannedTxs)
+                // Each validator should return true when the transaction can be mined.
+                var txValidators = new List<Func<ITransaction, bool>>
                 {
-                    _chain.UnstageTransaction(tx);
+                    tx => !_bannedAccounts.Contains(tx.Signer),
+                };
+
+                if (_actionTypeLoader is { } actionTypeLoader)
+                {
+                    txValidators.Add(tx =>
+                    {
+                        var fakeMetadata = new BlockMetadata(
+                            _chain.Tip.Header.ProtocolVersion,
+                            _chain.Tip.Header.Index + 1,
+                            _chain.Tip.Header.Timestamp,
+                            _chain.Tip.Header.Miner,
+                            _chain.Tip.Header.PublicKey,
+                            1,
+                            1,
+                            _chain.Tip.Header.Hash,
+                            _chain.Tip.Header.TxHash
+                        );
+                        var fakeHeader =
+                            new PreEvaluationBlockHeader(fakeMetadata, fakeMetadata.MineNonce());
+                        var types = actionTypeLoader.Load(fakeHeader);
+
+                        return tx.CustomActions?.All(ca =>
+                            ca is Dictionary dictionary &&
+                            dictionary.TryGetValue((Text)"type_id", out IValue value) &&
+                            value is Text typeId &&
+                            types.ContainsKey(typeId)) == true;
+                    });
+                }
+
+                foreach (Transaction<NCAction> tx in _chain.GetStagedTransactionIds()
+                             .Select(txId => _chain.GetTransaction(txId)))
+                {
+                    foreach (var validator in txValidators)
+                    {
+                        if (!validator(tx))
+                        {
+                            _chain.UnstageTransaction(tx);
+                            break;
+                        }
+                    }
                 }
 
                 block = await _chain.MineBlock(
@@ -109,12 +151,14 @@ namespace Nekoyume.BlockChain
         public Miner(
             BlockChain<NCAction> chain,
             Swarm<NCAction> swarm,
-            PrivateKey privateKey
+            PrivateKey privateKey,
+            IActionTypeLoader? actionTypeLoader = null
         )
         {
             _chain = chain ?? throw new ArgumentNullException(nameof(chain));
             _swarm = swarm;
             _privateKey = privateKey;
+            _actionTypeLoader = actionTypeLoader;
         }
     }
 }

--- a/Lib9c.Miner/Miner.cs
+++ b/Lib9c.Miner/Miner.cs
@@ -63,20 +63,8 @@ namespace Nekoyume.BlockChain
                 {
                     txValidators.Add(tx =>
                     {
-                        var fakeMetadata = new BlockMetadata(
-                            _chain.Tip.Header.ProtocolVersion,
-                            _chain.Tip.Header.Index + 1,
-                            _chain.Tip.Header.Timestamp,
-                            _chain.Tip.Header.Miner,
-                            _chain.Tip.Header.PublicKey,
-                            1,
-                            1,
-                            _chain.Tip.Header.Hash,
-                            _chain.Tip.Header.TxHash
-                        );
-                        var fakeHeader =
-                            new PreEvaluationBlockHeader(fakeMetadata, fakeMetadata.MineNonce());
-                        var types = actionTypeLoader.Load(fakeHeader);
+                        var nextBlockIndex = _chain.Tip.Header.Index + 1;
+                        var types = actionTypeLoader.Load(new ActionTypeLoaderContext(nextBlockIndex));
 
                         return tx.CustomActions?.All(ca =>
                             ca is Dictionary dictionary &&
@@ -159,6 +147,17 @@ namespace Nekoyume.BlockChain
             _swarm = swarm;
             _privateKey = privateKey;
             _actionTypeLoader = actionTypeLoader;
+        }
+
+
+        private class ActionTypeLoaderContext : IActionTypeLoaderContext
+        {
+            public ActionTypeLoaderContext(long index)
+            {
+                Index = index;
+            }
+
+            public long Index { get; }
         }
     }
 }

--- a/Lib9c.sln
+++ b/Lib9c.sln
@@ -39,6 +39,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Crypto.Secp256k1"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib9c.MessagePack", "Lib9c.MessagePack\Lib9c.MessagePack.csproj", "{64B1F3F2-B554-4FB1-98A5-24AEBB300056}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib9c.Abstractions", "Lib9c.Abstractions\Lib9c.Abstractions.csproj", "{2D8BB275-57B6-4707-A20F-6836F4EB0EE2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -105,6 +107,10 @@ Global
 		{64B1F3F2-B554-4FB1-98A5-24AEBB300056}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{64B1F3F2-B554-4FB1-98A5-24AEBB300056}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{64B1F3F2-B554-4FB1-98A5-24AEBB300056}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2D8BB275-57B6-4707-A20F-6836F4EB0EE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2D8BB275-57B6-4707-A20F-6836F4EB0EE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2D8BB275-57B6-4707-A20F-6836F4EB0EE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2D8BB275-57B6-4707-A20F-6836F4EB0EE2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Lib9c/Action/ActivateAccount.cs
+++ b/Lib9c/Action/ActivateAccount.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Bencodex.Types;
+using Lib9c.Abstractions;
 using Libplanet;
 using Libplanet.Action;
 using Nekoyume.Model;
@@ -11,7 +12,7 @@ namespace Nekoyume.Action
 {
     [Serializable]
     [ActionType("activate_account2")]
-    public class ActivateAccount : ActionBase, IActivateAction
+    public class ActivateAccount : ActionBase, IActivateAccount
     {
         public Address PendingAddress { get; private set; }
 

--- a/Lib9c/Action/ActivateAccount0.cs
+++ b/Lib9c/Action/ActivateAccount0.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Bencodex.Types;
+using Lib9c.Abstractions;
 using Libplanet;
 using Libplanet.Action;
 using Nekoyume.Model.State;
@@ -11,7 +12,7 @@ namespace Nekoyume.Action
     [Serializable]
     [ActionObsolete(BlockChain.Policy.BlockPolicySource.V100080ObsoleteIndex)]
     [ActionType("activate_account")]
-    public class ActivateAccount0 : ActionBase, IActivateAction
+    public class ActivateAccount0 : ActionBase, IActivateAccount
     {
         public Address PendingAddress { get; private set; }
 

--- a/Lib9c/Lib9c.csproj
+++ b/Lib9c/Lib9c.csproj
@@ -33,6 +33,7 @@
       <OutputItemType>Analyzer</OutputItemType>
       <!-- https://github.com/dotnet/roslyn/issues/18093#issuecomment-405702631 -->
     </ProjectReference>
+    <ProjectReference Include="..\Lib9c.Abstractions\Lib9c.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Lib9c/Policy/BlockPolicySource.Utils.cs
+++ b/Lib9c/Policy/BlockPolicySource.Utils.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using Bencodex.Types;
 using Libplanet;
+using Libplanet.Action;
 using Libplanet.Blockchain;
 using Libplanet.Blocks;
 using Libplanet.Tx;
@@ -16,17 +18,30 @@ namespace Nekoyume.BlockChain.Policy
     // Collection of helper methods not directly used as a pluggable component.
     public partial class BlockPolicySource
     {
-        internal static bool IsObsolete(Transaction<NCAction> transaction, long blockIndex) =>
-            transaction.CustomActions is { } customActions &&
-            customActions
-                .Select(action => action.InnerAction.GetType())
-                .Any(
-                    at =>
-                    at.IsDefined(typeof(ActionObsoleteAttribute), false) &&
-                    at.GetCustomAttributes()
+        internal static bool IsObsolete(
+            ITransaction transaction,
+            IActionTypeLoader actionTypeLoader,
+            BlockHeader blockHeader
+        )
+        {
+            long blockIndex = blockHeader.Index;
+            if (!(transaction.CustomActions is { } customActions))
+            {
+                return false;
+            }
+
+            var types = actionTypeLoader.Load(MakeFakeNextBlockHeader(blockHeader));
+            return customActions.Any(
+                ca => ca is Dictionary dictionary
+                    && dictionary.TryGetValue((Text)"type_id", out IValue typeIdValue)
+                    && typeIdValue is Text typeId
+                    && types.TryGetValue(typeId, out Type actionType)
+                    && actionType.IsDefined(typeof(ActionObsoleteAttribute), false)
+                    && actionType.GetCustomAttributes()
                         .OfType<ActionObsoleteAttribute>()
                         .FirstOrDefault()?.ObsoleteIndex < blockIndex
-                );
+            );
+        }
 
         internal static bool IsAdminTransaction(
             BlockChain<NCAction> blockChain, Transaction<NCAction> transaction)

--- a/Lib9c/Policy/BlockPolicySource.Utils.cs
+++ b/Lib9c/Policy/BlockPolicySource.Utils.cs
@@ -21,16 +21,15 @@ namespace Nekoyume.BlockChain.Policy
         internal static bool IsObsolete(
             ITransaction transaction,
             IActionTypeLoader actionTypeLoader,
-            BlockHeader blockHeader
+            long blockIndex
         )
         {
-            long blockIndex = blockHeader.Index;
             if (!(transaction.CustomActions is { } customActions))
             {
                 return false;
             }
 
-            var types = actionTypeLoader.Load(MakeFakeNextBlockHeader(blockHeader));
+            var types = actionTypeLoader.Load(new ActionTypeLoaderContext(blockIndex));
             return customActions.Any(
                 ca => ca is Dictionary dictionary
                     && dictionary.TryGetValue((Text)"type_id", out IValue typeIdValue)

--- a/Lib9c/Policy/BlockPolicySource.cs
+++ b/Lib9c/Policy/BlockPolicySource.cs
@@ -325,11 +325,6 @@ namespace Nekoyume.BlockChain.Policy
             Transaction<NCAction> transaction,
             ImmutableHashSet<Address> allAuthorizedMiners)
         {
-            // Avoid NRE when genesis block appended
-            // Here, index is the index of a prospective block that transaction
-            // will be included.
-            long index = blockChain.Count > 0 ? blockChain.Tip.Index : 0;
-
             if (((ITransaction)transaction).CustomActions?.Count > 1)
             {
                 return new TxPolicyViolationException(
@@ -337,7 +332,7 @@ namespace Nekoyume.BlockChain.Policy
                     $"{((ITransaction)transaction).CustomActions?.Count}",
                     transaction.Id);
             }
-            else if (IsObsolete(transaction, index))
+            else if (IsObsolete(transaction, actionTypeLoader, blockChain.Tip.Header))
             {
                 return new TxPolicyViolationException(
                     $"Transaction {transaction.Id} is obsolete.",


### PR DESCRIPTION
This pull request makes `BlockPolicySource` check actions through `ITransaction.CustomActions`, not been instantiated yet. Also, it makes `Miner` discard (i.e., unstage) transactions not available in the next block when the `IActionTypeLoader` is given.