### PR TITLE
Turn on `TreatWarningsAsErrors` feature

### DIFF
--- a/Lib9c.MessagePack/Action/NCActionEvaluation.cs
+++ b/Lib9c.MessagePack/Action/NCActionEvaluation.cs
@@ -28,7 +28,7 @@ namespace Nekoyume.Action
         public IAccountStateDelta OutputStates { get; set; }
 
         [Key(4)]
-        public Exception Exception { get; set; }
+        public Exception? Exception { get; set; }
 
         [Key(5)]
         public IAccountStateDelta PreviousStates { get; set; }

--- a/Lib9c.MessagePack/Formatters/ExceptionFormatter.cs
+++ b/Lib9c.MessagePack/Formatters/ExceptionFormatter.cs
@@ -9,9 +9,9 @@ namespace Lib9c.Formatters
 {
     // FIXME: This class must be removed and replaced with other way for serialization.
     // https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md
-    public class ExceptionFormatter<T> : IMessagePackFormatter<T> where T : Exception
+    public class ExceptionFormatter<T> : IMessagePackFormatter<T?> where T : Exception
     {
-        public void Serialize(ref MessagePackWriter writer, T value,
+        public void Serialize(ref MessagePackWriter writer, T? value,
             MessagePackSerializerOptions options)
         {
             if (value is null)
@@ -30,7 +30,7 @@ namespace Lib9c.Formatters
             }
         }
 
-        T IMessagePackFormatter<T>.Deserialize(ref MessagePackReader reader,
+        T? IMessagePackFormatter<T?>.Deserialize(ref MessagePackReader reader,
             MessagePackSerializerOptions options)
         {
             if (reader.TryReadNil())
@@ -40,7 +40,8 @@ namespace Lib9c.Formatters
 
             options.Security.DepthStep(ref reader);
             var formatter = new BinaryFormatter();
-            byte[] bytes = reader.ReadBytes()?.ToArray();
+            byte[] bytes = reader.ReadBytes()?.ToArray()
+                ?? throw new MessagePackSerializationException();
             using (var stream = new MemoryStream(bytes))
             {
 #pragma warning disable SYSLIB0011

--- a/Lib9c.MessagePack/Formatters/NineChroniclesResolver.cs
+++ b/Lib9c.MessagePack/Formatters/NineChroniclesResolver.cs
@@ -13,14 +13,14 @@ namespace Lib9c.Formatters
         }
 
         // GetFormatter<T>'s get cost should be minimized so use type cache.
-        public IMessagePackFormatter<T> GetFormatter<T>()
+        public IMessagePackFormatter<T>? GetFormatter<T>()
         {
             return FormatterCache<T>.Formatter;
         }
 
         private static class FormatterCache<T>
         {
-            public static readonly IMessagePackFormatter<T> Formatter;
+            public static readonly IMessagePackFormatter<T>? Formatter;
 
             // generic's static constructor should be minimized for reduce type generation size!
             // use outer helper method.
@@ -28,8 +28,8 @@ namespace Lib9c.Formatters
             static FormatterCache()
             {
                 Formatter =
-                    (IMessagePackFormatter<T>)NineChroniclesResolverGetFormatterHelper.GetFormatter(
-                        typeof(T));
+                    (IMessagePackFormatter<T>?)(NineChroniclesResolverGetFormatterHelper
+                        .GetFormatter(typeof(T)));
             }
 #pragma warning restore S3963
         }

--- a/Lib9c.MessagePack/Formatters/NineChroniclesResolverGetFormatterHelper.cs
+++ b/Lib9c.MessagePack/Formatters/NineChroniclesResolverGetFormatterHelper.cs
@@ -26,7 +26,7 @@ namespace Lib9c.Formatters
             // add more your own custom serializers.
         };
 
-        internal static object GetFormatter(Type t)
+        internal static object? GetFormatter(Type t)
         {
             if (FormatterMap.TryGetValue(t, out var formatter))
             {

--- a/Lib9c.MessagePack/Lib9c.MessagePack.csproj
+++ b/Lib9c.MessagePack/Lib9c.MessagePack.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Lib9c.Miner/Lib9c.Miner.csproj
+++ b/Lib9c.Miner/Lib9c.Miner.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Lib9c.Miner/Miner.cs
+++ b/Lib9c.Miner/Miner.cs
@@ -40,13 +40,13 @@ namespace Nekoyume.BlockChain
 
         public Address Address => _privateKey.ToAddress();
 
-        public async Task<Block<NCAction>> MineBlockAsync(
+        public async Task<Block<NCAction>?> MineBlockAsync(
             CancellationToken cancellationToken)
         {
             var txs = new HashSet<Transaction<NCAction>>();
             var invalidTxs = txs;
 
-            Block<NCAction> block = null;
+            Block<NCAction>? block = null;
             try
             {
                 IEnumerable<Transaction<NCAction>> bannedTxs = _chain.GetStagedTransactionIds()

--- a/Lib9c.Miner/ReorgMiner.cs
+++ b/Lib9c.Miner/ReorgMiner.cs
@@ -43,15 +43,15 @@ namespace Nekoyume.BlockChain
         }
 
         public async Task<(
-                Block<PolymorphicAction<ActionBase>> MainBlock,
-                Block<PolymorphicAction<ActionBase>> SubBlock)>
+                Block<PolymorphicAction<ActionBase>>? MainBlock,
+                Block<PolymorphicAction<ActionBase>>? SubBlock)>
             MineBlockAsync(CancellationToken cancellationToken)
         {
             var txs = new HashSet<Transaction<PolymorphicAction<ActionBase>>>();
 
             var invalidTxs = txs;
-            Block<PolymorphicAction<ActionBase>> mainBlock = null;
-            Block<PolymorphicAction<ActionBase>> subBlock = null;
+            Block<PolymorphicAction<ActionBase>>? mainBlock = null;
+            Block<PolymorphicAction<ActionBase>>? subBlock = null;
             try
             {
                 mainBlock = await _mainChain.MineBlock(


### PR DESCRIPTION
This pull request turns on `TreatWarningsAsErrors` in the below projects:

 - Lib9c.Miner
 - Lib9c.MessagePack