### PR TITLE
Use linux 8cores GitHub Actions larger runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,8 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ["linux", "8cores"]
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Since the `main` workflow takes about 20~27 minutes, I suggest using high-core GitHub Actions Runners.

There are GitHub Actions larger runners feature and this pull request makes the workflow use them.

## Reviewers

Because GitHub Actions larger runner feature occurs cost issue, I request reviews to @planetarium/devops team.