### PR TITLE
Mimic Lib9c action structure

### DIFF
--- a/Lib9c.DevExtensions/Action/CreateArenaDummy.cs
+++ b/Lib9c.DevExtensions/Action/CreateArenaDummy.cs
@@ -20,7 +20,7 @@ namespace Lib9c.DevExtensions.Action
 {
     [Serializable]
     [ActionType("create_arena_dummy")]
-    public class CreateArenaDummy : GameAction
+    public class CreateArenaDummy : TestGameAction
     {
         public Address myAvatarAddress;
         public int accountCount;

--- a/Lib9c.DevExtensions/Action/CreateTestbed.cs
+++ b/Lib9c.DevExtensions/Action/CreateTestbed.cs
@@ -22,7 +22,7 @@ namespace Lib9c.DevExtensions.Action
 {
     [Serializable]
     [ActionType("create_testbed")]
-    public class CreateTestbed : GameAction
+    public class CreateTestbed : TestGameAction
     {
         private int _slotIndex = 0;
         private PrivateKey _privateKey = new PrivateKey();

--- a/Lib9c.DevExtensions/Action/FaucetCurrency.cs
+++ b/Lib9c.DevExtensions/Action/FaucetCurrency.cs
@@ -12,7 +12,7 @@ namespace Lib9c.DevExtensions.Action
 {
     [Serializable]
     [ActionType("faucet_currency")]
-    public class FaucetCurrency : GameAction, IFaucetCurrency
+    public class FaucetCurrency : TestGameAction, IFaucetCurrency
     {
         public Libplanet.Address AgentAddress { get; set; }
         public int FaucetNcg { get; set; }

--- a/Lib9c.DevExtensions/Action/FaucetRune.cs
+++ b/Lib9c.DevExtensions/Action/FaucetRune.cs
@@ -15,7 +15,7 @@ namespace Lib9c.DevExtensions.Action;
 
 [Serializable]
 [ActionType("faucet_rune")]
-public class FaucetRune : GameAction, IFaucetRune
+public class FaucetRune : TestGameAction, IFaucetRune
 {
     public Libplanet.Address AvatarAddress { get; set; }
     public List<FaucetRuneInfo> FaucetRuneInfos { get; set; }

--- a/Lib9c.DevExtensions/Action/TestActionBase.cs
+++ b/Lib9c.DevExtensions/Action/TestActionBase.cs
@@ -1,0 +1,20 @@
+using System;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Assets;
+
+namespace Lib9c.DevExtensions.Action;
+
+[Serializable]
+public abstract class TestActionBase : IAction
+{
+    public static readonly IValue MarkChanged = Null.Value;
+
+    // FIXME GoldCurrencyState 에 정의된 것과 다른데 괜찮을지 점검해봐야 합니다.
+    protected static readonly Currency GoldCurrencyMock = new Currency();
+
+    public abstract IValue PlainValue { get; }
+    public abstract void LoadPlainValue(IValue plainValue);
+
+    public abstract IAccountStateDelta Execute(IActionContext context);
+}

--- a/Lib9c.DevExtensions/Action/TestGameAction.cs
+++ b/Lib9c.DevExtensions/Action/TestGameAction.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Bencodex.Types;
+using Nekoyume.Model.State;
+
+namespace Lib9c.DevExtensions.Action
+{
+    [Serializable]
+    public abstract class TestGameAction : TestActionBase
+    {
+        public Guid Id { get; private set; }
+        public override IValue PlainValue =>
+#pragma warning disable LAA1002
+            new Bencodex.Types.Dictionary(
+                PlainValueInternal
+                    .SetItem("id", Id.Serialize())
+                    .Select(kv => new KeyValuePair<IKey, IValue>((Text)kv.Key, kv.Value))
+            );
+#pragma warning restore LAA1002
+        protected abstract IImmutableDictionary<string, IValue> PlainValueInternal { get; }
+
+        protected TestGameAction()
+        {
+            Id = Guid.NewGuid();
+        }
+
+        public override void LoadPlainValue(IValue plainValue)
+        {
+#pragma warning disable LAA1002
+            var dict = ((Bencodex.Types.Dictionary)plainValue)
+                .Select(kv => new KeyValuePair<string, IValue>((Text)kv.Key, kv.Value))
+                .ToImmutableDictionary();
+#pragma warning restore LAA1002
+            Id = dict["id"].ToGuid();
+            LoadPlainValueInternal(dict);
+        }
+
+        protected abstract void LoadPlainValueInternal(
+            IImmutableDictionary<string, IValue> plainValue);
+    }
+}


### PR DESCRIPTION
- To test Lib9c and DevExtensions actions seperately, we need to mimic lib9c structure into DevExtensions.
- Add `TestActionBase` and `TestGameAction` from `ActionBase` and `GameAction`.