### PR TITLE
Fix exception message

### DIFF
--- a/Lib9c/Helper/Validator.cs
+++ b/Lib9c/Helper/Validator.cs
@@ -74,7 +74,7 @@ namespace Nekoyume.Helper
             {
                 throw new InvalidStageException(
                     $"{addressesHex}Aborted as the stage ({worldId}/{stageId - 1}) is not cleared; " +
-                    $"clear the stage first: ({world.Id}/{world.StageBegin})"
+                    $"clear the stage ({world.Id}/{world.StageBegin}) first"
                 );
             }
 
@@ -82,7 +82,8 @@ namespace Nekoyume.Helper
             {
                 throw new InvalidStageException(
                     $"{addressesHex}Aborted as the stage ({worldId}/{stageId - 1}) is not cleared; " +
-                    $"cleared stage: ({world.Id}/{world.StageClearedId})"
+                    $"cleared stage is ({world.Id}/{world.StageClearedId}), so you can play stage " +
+                    $"({world.Id}/{world.StageClearedId + 1})"
                 );
             }
 

--- a/Lib9c/Helper/Validator.cs
+++ b/Lib9c/Helper/Validator.cs
@@ -70,12 +70,19 @@ namespace Nekoyume.Helper
                 worldInformation.UpdateWorld(worldRow);
             }
 
-            if (world.IsStageCleared && stageId - 1 > world.StageClearedId ||
-                !world.IsStageCleared && stageId != world.StageBegin)
+            if (!world.IsStageCleared && stageId != world.StageBegin)
             {
                 throw new InvalidStageException(
                     $"{addressesHex}Aborted as the stage ({worldId}/{stageId - 1}) is not cleared; " +
-                    $"cleared stage: {world.StageClearedId}"
+                    $"clear the stage first: ({world.Id}/{world.StageBegin})"
+                );
+            }
+
+            if (world.IsStageCleared && stageId - 1 > world.StageClearedId)
+            {
+                throw new InvalidStageException(
+                    $"{addressesHex}Aborted as the stage ({worldId}/{stageId - 1}) is not cleared; " +
+                    $"cleared stage: ({world.Id}/{world.StageClearedId})"
                 );
             }
 

--- a/Lib9c/Helper/Validator.cs
+++ b/Lib9c/Helper/Validator.cs
@@ -70,11 +70,11 @@ namespace Nekoyume.Helper
                 worldInformation.UpdateWorld(worldRow);
             }
 
-            if (world.IsStageCleared && stageId > world.StageClearedId + 1 ||
+            if (world.IsStageCleared && stageId - 1 > world.StageClearedId ||
                 !world.IsStageCleared && stageId != world.StageBegin)
             {
                 throw new InvalidStageException(
-                    $"{addressesHex}Aborted as the stage ({worldId}/{stageId}) is not cleared; " +
+                    $"{addressesHex}Aborted as the stage ({worldId}/{stageId - 1}) is not cleared; " +
                     $"cleared stage: {world.StageClearedId}"
                 );
             }


### PR DESCRIPTION
When you play the `HackAndSlash` with world(1) and stage(7) and if your `AvatarState` has cleared the world(1) and stage(5) yet. The `InvalidStageException` will be occurred with some message.
This pull request fix the message. And separates the conditions for readability.

Before
> conditions: !world.IsStageCleared && stageId != world.StageBegin || world.IsStageCleared && stageId - 1 > world.StageClearedId
> format: {addressesHex}Aborted as the stage ({worldId}/{stageId}) is not cleared; cleared stage: {world.StageClearedId}
> output: Aborted as the stage (1/7) is not cleared; cleared stage: 5

The "(1/7)" part is confusing.

After

> condition: !world.IsStageCleared && stageId != world.StageBegin
> format: {addressesHex}Aborted as the stage ({worldId}/{stageId - 1}) is not cleared; clear the stage first: ({world.Id}/{world.StageBegin})
> output: Aborted as the stage (1/6) is not cleared; clear the stage first: (1/1)

> condition: world.IsStageCleared && stageId - 1 > world.StageClearedId
> format: {addressesHex}Aborted as the stage ({worldId}/{stageId - 1}) is not cleared; cleared stage: ({world.Id}/{world.StageClearedId})
> output: Aborted as the stage (1/6) is not cleared; cleared stage: (1/5)
