### PR TITLE
Add faucet actions to Lib9c

### DIFF
--- a/.Lib9c.DevExtensions.Tests/Action/FaucetCurrencyTest.cs
+++ b/.Lib9c.DevExtensions.Tests/Action/FaucetCurrencyTest.cs
@@ -1,4 +1,3 @@
-using Lib9c.DevExtensions.Action;
 using Lib9c.Tests.Action;
 using Libplanet;
 using Libplanet.Action;
@@ -28,8 +27,10 @@ namespace Lib9c.DevExtensions.Tests.Action
 
             _initialState = new Lib9c.Tests.Action.State();
 
+#pragma warning disable CS0618
             _ncg = Currency.Legacy("NCG", 2, null);
             _crystal = Currency.Legacy("CRYSTAL", 18, null);
+#pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(_ncg);
             _agentAddress = new PrivateKey().ToAddress();
             var agentState = new AgentState(_agentAddress);
@@ -54,7 +55,7 @@ namespace Lib9c.DevExtensions.Tests.Action
             int expectedCrystal
         )
         {
-            var action = new FaucetCurrency
+            var action = new Lib9c.DevExtensions.Action.FaucetCurrency
             {
                 AgentAddress = _agentAddress,
                 FaucetNcg = faucetNcg,

--- a/.Lib9c.DevExtensions.Tests/Action/FaucetRuneTest.cs
+++ b/.Lib9c.DevExtensions.Tests/Action/FaucetRuneTest.cs
@@ -2,7 +2,6 @@ using Lib9c.Tests;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Lib9c.DevExtensions.Action;
 using Lib9c.Tests.Action;
 using Libplanet;
 using Libplanet.Action;
@@ -81,7 +80,7 @@ namespace Lib9c.DevExtensions.Tests.Action
         [ClassData(typeof(FaucetRuneInfoGenerator))]
         public void Execute_FaucetRune(List<FaucetRuneInfo> faucetRuneInfos)
         {
-            var action = new FaucetRune
+            var action = new Lib9c.DevExtensions.Action.FaucetRune
             {
                 AvatarAddress = _avatarAddress,
                 FaucetRuneInfos = faucetRuneInfos,

--- a/Lib9c/Action/Factory/FaucetFactory.cs
+++ b/Lib9c/Action/Factory/FaucetFactory.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using Libplanet;
+using Nekoyume.Model.Faucet;
+
+namespace Nekoyume.Action.Factory
+{
+    public static class FaucetFactory
+    {
+        public static GameAction CreateFaucetCurrency(
+            Address agentAddress,
+            int faucetNcg,
+            int faucetCrystal
+        )
+        {
+            return new FaucetCurrency
+            {
+                AgentAddress = agentAddress,
+                FaucetNcg = faucetNcg,
+                FaucetCrystal = faucetCrystal,
+            };
+        }
+
+        public static GameAction CreateFaucetRune(
+            Address avatarAddress, List<FaucetRuneInfo> faucetRunes)
+        {
+            return new FaucetRune
+            {
+                AvatarAddress = avatarAddress,
+                FaucetRuneInfos = faucetRunes,
+            };
+        }
+    }
+}

--- a/Lib9c/Action/FaucetCurrency.cs
+++ b/Lib9c/Action/FaucetCurrency.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Assets;
+using Nekoyume.Action.Interface;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Action
+{
+    [Serializable]
+    [ActionType("faucet_currency")]
+    public class FaucetCurrency : GameAction, IFaucetCurrency
+    {
+        public Libplanet.Address AgentAddress { get; set; }
+        public int FaucetNcg { get; set; }
+        public int FaucetCrystal { get; set; }
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            if (context.Rehearsal)
+            {
+                return context.PreviousStates;
+            }
+
+            var states = context.PreviousStates;
+            if (FaucetNcg > 0)
+            {
+                var ncg = states.GetGoldCurrency();
+                states = states.MintAsset(AgentAddress, ncg * FaucetNcg);
+            }
+
+            if (FaucetCrystal > 0)
+            {
+#pragma warning disable CS0618
+                var crystal = Currency.Legacy("CRYSTAL", 18, null);
+#pragma warning restore CS0618
+                states = states.MintAsset(AgentAddress, crystal * FaucetCrystal);
+            }
+
+            return states;
+        }
+
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            new Dictionary<string, IValue>
+            {
+                ["agentAddress"] = AgentAddress.Serialize(),
+                ["faucetNcg"] = FaucetNcg.Serialize(),
+                ["faucetCrystal"] = FaucetCrystal.Serialize()
+            }.ToImmutableDictionary();
+
+        protected override void LoadPlainValueInternal(
+            IImmutableDictionary<string, IValue> plainValue)
+        {
+            AgentAddress = plainValue["agentAddress"].ToAddress();
+            if (plainValue.ContainsKey("faucetNcg"))
+            {
+                FaucetNcg = plainValue["faucetNcg"].ToInteger();
+            }
+
+            if (plainValue.ContainsKey("faucetCrystal"))
+            {
+                FaucetCrystal = plainValue["faucetCrystal"].ToInteger();
+            }
+        }
+    }
+}

--- a/Lib9c/Action/FaucetRune.cs
+++ b/Lib9c/Action/FaucetRune.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Bencodex.Types;
+using Libplanet.Action;
+using Nekoyume.Action.Interface;
+using Nekoyume.Helper;
+using Nekoyume.Model.Faucet;
+using Nekoyume.Model.State;
+using Nekoyume.TableData;
+
+namespace Nekoyume.Action
+{
+    [Serializable]
+    [ActionType("faucet_rune")]
+    public class FaucetRune : GameAction, IFaucetRune
+    {
+        public Libplanet.Address AvatarAddress { get; set; }
+        public List<FaucetRuneInfo> FaucetRuneInfos { get; set; }
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            if (context.Rehearsal)
+            {
+                return context.PreviousStates;
+            }
+
+            var states = context.PreviousStates;
+            if (!(FaucetRuneInfos is null))
+            {
+                RuneSheet runeSheet = states.GetSheet<RuneSheet>();
+                if (runeSheet.OrderedList != null)
+                {
+                    foreach (var rune in FaucetRuneInfos)
+                    {
+                        states = states.MintAsset(AvatarAddress, RuneHelper.ToFungibleAssetValue(
+                            runeSheet.OrderedList.First(r => r.Id == rune.RuneId),
+                            rune.Amount
+                        ));
+                    }
+                }
+            }
+
+            return states;
+        }
+
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            new Dictionary<string, IValue>
+            {
+                ["avatarAddress"] = AvatarAddress.Serialize(),
+                ["faucetRuneInfos"] = FaucetRuneInfos
+                    .OrderBy(x => x.RuneId)
+                    .ThenBy(x => x.Amount)
+                    .Select(x => x.Serialize())
+                    .Serialize()
+            }.ToImmutableDictionary();
+
+        protected override void LoadPlainValueInternal(
+            IImmutableDictionary<string, IValue> plainValue)
+        {
+            AvatarAddress = plainValue["avatarAddress"].ToAddress();
+            FaucetRuneInfos = plainValue["faucetRuneInfos"].ToList(
+                x => new FaucetRuneInfo((List)x)
+            );
+        }
+    }
+}

--- a/Lib9c/Action/Interface/IFaucetCurrency.cs
+++ b/Lib9c/Action/Interface/IFaucetCurrency.cs
@@ -1,0 +1,11 @@
+using Libplanet;
+
+namespace Nekoyume.Action.Interface
+{
+    public interface IFaucetCurrency
+    {
+        Address AgentAddress { get; set; }
+        int FaucetNcg { get; set; }
+        int FaucetCrystal { get; set; }
+    }
+}

--- a/Lib9c/Action/Interface/IFaucetRune.cs
+++ b/Lib9c/Action/Interface/IFaucetRune.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Libplanet;
+using Nekoyume.Model.Faucet;
+
+namespace Nekoyume.Action.Interface
+{
+    public interface IFaucetRune
+    {
+        Address AvatarAddress { get; set; }
+        List<FaucetRuneInfo> FaucetRuneInfos { get; set; }
+    }
+}

--- a/Lib9c/Lib9c.csproj
+++ b/Lib9c/Lib9c.csproj
@@ -9,6 +9,10 @@
     <IntermediateOutputPath>.obj</IntermediateOutputPath>
     <RootNamespace>Nekoyume</RootNamespace>
     <LangVersion>8</LangVersion>
+    <PreBuildEvent Condition="$(ExtraDefineConstants.Contains('TEST_9C'))">
+      echo "TEST_9C: Build Lib9c with test actions"
+    </PreBuildEvent>
+    <DefineConstants Condition="$(ExtraDefineConstants.Contains('TEST_9C'))">$(DefineConstants);TEST_9C</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add dev/test only actions (Faucet~~~) to Lib9c form Lib9c.DevExtensions.

This is because direct import of Lib9c.DevExtensions causes circular dependency.

Faucet actions are only included in the build if the "TEST_9C" DefineConstants is present.
