### PR TITLE
Tranfer NCG from minter to faucet instead of unable minting

### DIFF
--- a/Lib9c.DevExtensions/Action/FaucetCurrency.cs
+++ b/Lib9c.DevExtensions/Action/FaucetCurrency.cs
@@ -29,7 +29,7 @@ namespace Lib9c.DevExtensions.Action
             if (FaucetNcg > 0)
             {
                 var ncg = states.GetGoldCurrency();
-                states = states.MintAsset(AgentAddress, ncg * FaucetNcg);
+                states = states.TransferAsset(GoldCurrencyState.Address, AgentAddress, ncg * FaucetNcg);
             }
 
             if (FaucetCrystal > 0)


### PR DESCRIPTION
Direct minting to faucet has several problems:
- Cannot mint when the blockchain already has minter like mainnet-based test.
- The risk of accidentally deploying to production is tooooo great to bear.