### PR TITLE
[DevEx]Bug fix of `CreateOrReplaceAvatar`

### DIFF
--- a/.Lib9c.DevExtensions.Tests/Action/CreateOrReplaceAvatarTest.cs
+++ b/.Lib9c.DevExtensions.Tests/Action/CreateOrReplaceAvatarTest.cs
@@ -81,34 +81,6 @@ namespace Lib9c.DevExtensions.Tests.Action
             };
         }
 
-        [Theory]
-        [MemberData(nameof(Get_Execute_Success_MemberData))]
-        public void Execute_Success(
-            long blockIndex,
-            int avatarIndex,
-            string name,
-            int hair,
-            int lens,
-            int ear,
-            int tail,
-            int level,
-            (int itemId, int enhancement)[] equipments)
-        {
-            var agentAddr = new PrivateKey().ToAddress();
-            Execute(
-                _initialStates,
-                blockIndex,
-                agentAddr,
-                avatarIndex,
-                name,
-                hair,
-                lens,
-                ear,
-                tail,
-                level,
-                equipments);
-        }
-
         public static IEnumerable<object[]>
             Get_Execute_Failure_MemberData()
         {
@@ -194,6 +166,69 @@ namespace Lib9c.DevExtensions.Tests.Action
                     (0, -1),
                 },
             };
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Execute_Success_MemberData))]
+        public void Serialize(
+            long blockIndex,
+            int avatarIndex,
+            string name,
+            int hair,
+            int lens,
+            int ear,
+            int tail,
+            int level,
+            (int itemId, int enhancement)[] equipments)
+        {
+            var action = new CreateOrReplaceAvatar(
+                avatarIndex,
+                name,
+                hair,
+                lens,
+                ear,
+                tail,
+                level,
+                equipments);
+            var ser = action.PlainValue;
+            var de = new CreateOrReplaceAvatar();
+            de.LoadPlainValue(ser);
+            Assert.Equal(action.AvatarIndex, de.AvatarIndex);
+            Assert.Equal(action.Name, de.Name);
+            Assert.Equal(action.Hair, de.Hair);
+            Assert.Equal(action.Lens, de.Lens);
+            Assert.Equal(action.Ear, de.Ear);
+            Assert.Equal(action.Tail, de.Tail);
+            Assert.Equal(action.Level, de.Level);
+            Assert.True(action.Equipments.SequenceEqual(de.Equipments));
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Execute_Success_MemberData))]
+        public void Execute_Success(
+            long blockIndex,
+            int avatarIndex,
+            string name,
+            int hair,
+            int lens,
+            int ear,
+            int tail,
+            int level,
+            (int itemId, int enhancement)[] equipments)
+        {
+            var agentAddr = new PrivateKey().ToAddress();
+            Execute(
+                _initialStates,
+                blockIndex,
+                agentAddr,
+                avatarIndex,
+                name,
+                hair,
+                lens,
+                ear,
+                tail,
+                level,
+                equipments);
         }
 
         [Theory]

--- a/Lib9c.DevExtensions/Action/CreateOrReplaceAvatar.cs
+++ b/Lib9c.DevExtensions/Action/CreateOrReplaceAvatar.cs
@@ -60,7 +60,7 @@ namespace Lib9c.DevExtensions.Action
                     }
                 }
 
-                list.Add(equipmentList);
+                list = list.Add(equipmentList);
 
                 return new Dictionary<string, IValue>
                 {
@@ -74,7 +74,7 @@ namespace Lib9c.DevExtensions.Action
         {
             var list = (List)plainValue["l"];
             AvatarIndex = list[0].ToInteger();
-            Name = list[1].ToString();
+            Name = list[1].ToDotnetString();
             Hair = list[2].ToInteger();
             Lens = list[3].ToInteger();
             Ear = list[4].ToInteger();
@@ -91,8 +91,12 @@ namespace Lib9c.DevExtensions.Action
             }
         }
 
+        public CreateOrReplaceAvatar() : this(0)
+        {
+        }
+
         public CreateOrReplaceAvatar(
-            int avatarIndex = 0,
+            int avatarIndex,
             string name = "Avatar",
             int hair = 0,
             int lens = 0,

--- a/Lib9c.DevExtensions/Action/Interface/ICreateOrReplaceAvatar.cs
+++ b/Lib9c.DevExtensions/Action/Interface/ICreateOrReplaceAvatar.cs
@@ -1,6 +1,8 @@
+using Libplanet.Action;
+
 namespace Lib9c.DevExtensions.Action.Interface
 {
-    public interface ICreateOrReplaceAvatar
+    public interface ICreateOrReplaceAvatar : IAction
     {
         int AvatarIndex { get; }
         string Name { get; }


### PR DESCRIPTION
- Fix de/serialization bug.
- Add zero arguments constructor.
- Inherit `IAction` on `ICreateOrReplaceAvatar` interface.