### PR TITLE
Fixed tests failing occasionally due to long running time

### DIFF
--- a/.Lib9c.Tests/StagePolicyTest.cs
+++ b/.Lib9c.Tests/StagePolicyTest.cs
@@ -1,5 +1,6 @@
 namespace Lib9c.Tests
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
@@ -51,7 +52,7 @@ namespace Lib9c.Tests
         [Fact]
         public void Stage()
         {
-            StagePolicy stagePolicy = new StagePolicy(default, 2);
+            StagePolicy stagePolicy = new StagePolicy(TimeSpan.FromHours(1), 2);
             BlockChain<NCAction> chain = MakeChainWithStagePolicy(stagePolicy);
 
             stagePolicy.Stage(chain, _txs[_accounts[0].ToAddress()][0]);
@@ -72,7 +73,7 @@ namespace Lib9c.Tests
         [Fact]
         public void StageOverQuota()
         {
-            StagePolicy stagePolicy = new StagePolicy(default, 2);
+            StagePolicy stagePolicy = new StagePolicy(TimeSpan.FromHours(1), 2);
             BlockChain<NCAction> chain = MakeChainWithStagePolicy(stagePolicy);
 
             stagePolicy.Stage(chain, _txs[_accounts[0].ToAddress()][0]);
@@ -91,7 +92,7 @@ namespace Lib9c.Tests
         [Fact]
         public void StageOverQuotaInverseOrder()
         {
-            StagePolicy stagePolicy = new StagePolicy(default, 2);
+            StagePolicy stagePolicy = new StagePolicy(TimeSpan.FromHours(1), 2);
             BlockChain<NCAction> chain = MakeChainWithStagePolicy(stagePolicy);
 
             stagePolicy.Stage(chain, _txs[_accounts[0].ToAddress()][3]);
@@ -110,7 +111,7 @@ namespace Lib9c.Tests
         [Fact]
         public void StageOverQuotaOutOfOrder()
         {
-            StagePolicy stagePolicy = new StagePolicy(default, 2);
+            StagePolicy stagePolicy = new StagePolicy(TimeSpan.FromHours(1), 2);
             BlockChain<NCAction> chain = MakeChainWithStagePolicy(stagePolicy);
 
             stagePolicy.Stage(chain, _txs[_accounts[0].ToAddress()][2]);
@@ -129,7 +130,7 @@ namespace Lib9c.Tests
         [Fact]
         public void StageSameNonce()
         {
-            StagePolicy stagePolicy = new StagePolicy(default, 2);
+            StagePolicy stagePolicy = new StagePolicy(TimeSpan.FromHours(1), 2);
             BlockChain<NCAction> chain = MakeChainWithStagePolicy(stagePolicy);
             var txA = Transaction<NCAction>.Create(0, _accounts[0], default, new NCAction[0]);
             var txB = Transaction<NCAction>.Create(0, _accounts[0], default, new NCAction[0]);
@@ -145,7 +146,7 @@ namespace Lib9c.Tests
         [Fact]
         public async Task StateFromMultiThread()
         {
-            StagePolicy stagePolicy = new StagePolicy(default, 2);
+            StagePolicy stagePolicy = new StagePolicy(TimeSpan.FromHours(1), 2);
             BlockChain<NCAction> chain = MakeChainWithStagePolicy(stagePolicy);
 
             await Task.WhenAll(
@@ -173,7 +174,7 @@ namespace Lib9c.Tests
         [Fact]
         public void IterateAfterUnstage()
         {
-            StagePolicy stagePolicy = new StagePolicy(default, 2);
+            StagePolicy stagePolicy = new StagePolicy(TimeSpan.FromHours(1), 2);
             BlockChain<NCAction> chain = MakeChainWithStagePolicy(stagePolicy);
 
             stagePolicy.Stage(chain, _txs[_accounts[0].ToAddress()][0]);
@@ -201,7 +202,7 @@ namespace Lib9c.Tests
         [Fact]
         public void CalculateNextTxNonceCorrectWhenTxOverQuota()
         {
-            StagePolicy stagePolicy = new StagePolicy(default, 2);
+            StagePolicy stagePolicy = new StagePolicy(TimeSpan.FromHours(1), 2);
             BlockChain<NCAction> chain = MakeChainWithStagePolicy(stagePolicy);
 
             long nextTxNonce = chain.GetNextTxNonce(_accounts[0].ToAddress());


### PR DESCRIPTION
The default `StagePolicy`'s `Transaction<T>` lifetime has reduced to 10 minutes. Because of this change, `StagePolicyTest` fails due to `Transaction<T>` fixtures getting expired.