### PR TITLE
New coupon system to replace existing redeem code

### DIFF
--- a/.Lib9c.Tests/Action/Coupons/CouponsFixture.cs
+++ b/.Lib9c.Tests/Action/Coupons/CouponsFixture.cs
@@ -13,6 +13,9 @@ namespace Lib9c.Tests.Action.Coupons
         public static Address AgentAddress2 { get; } =
             new Address("0000000000000000000000000000000000000001");
 
+        public static Address AgentAddress3 { get; } =
+            new Address("0000000000000000000000000000000000000002");
+
         public static RewardSet RewardSet1 { get; } =
             new RewardSet(ImmutableDictionary<int, uint>.Empty
                 .Add(302001, 1));

--- a/.Lib9c.Tests/Action/Coupons/CouponsFixture.cs
+++ b/.Lib9c.Tests/Action/Coupons/CouponsFixture.cs
@@ -1,0 +1,28 @@
+namespace Lib9c.Tests.Action.Coupons
+{
+    using System.Collections.Immutable;
+    using Libplanet;
+    using Nekoyume.Model.Coupons;
+
+    public static class CouponsFixture
+    {
+        public static Address AgentAddress1 { get; } =
+            new Address("0000000000000000000000000000000000000000");
+
+        public static Address AgentAddress2 { get; } =
+            new Address("0000000000000000000000000000000000000001");
+
+        public static RewardSet RewardSet1 { get; } =
+            new RewardSet(ImmutableDictionary<int, uint>.Empty
+                .Add(1, 2));
+
+        public static RewardSet RewardSet2 { get; } =
+            new RewardSet(ImmutableDictionary<int, uint>.Empty
+                .Add(1, 2)
+                .Add(3, 4));
+
+        public static RewardSet RewardSet3 { get; } =
+            new RewardSet(ImmutableDictionary<int, uint>.Empty
+                .Add(3, 4));
+    }
+}

--- a/.Lib9c.Tests/Action/Coupons/CouponsFixture.cs
+++ b/.Lib9c.Tests/Action/Coupons/CouponsFixture.cs
@@ -1,5 +1,6 @@
 namespace Lib9c.Tests.Action.Coupons
 {
+    using System;
     using System.Collections.Immutable;
     using Libplanet;
     using Nekoyume.Model.Coupons;
@@ -14,15 +15,21 @@ namespace Lib9c.Tests.Action.Coupons
 
         public static RewardSet RewardSet1 { get; } =
             new RewardSet(ImmutableDictionary<int, uint>.Empty
-                .Add(1, 2));
+                .Add(302001, 1));
 
         public static RewardSet RewardSet2 { get; } =
             new RewardSet(ImmutableDictionary<int, uint>.Empty
-                .Add(1, 2)
-                .Add(3, 4));
+                .Add(302001, 1)
+                .Add(302002, 2));
 
         public static RewardSet RewardSet3 { get; } =
             new RewardSet(ImmutableDictionary<int, uint>.Empty
-                .Add(3, 4));
+                .Add(302002, 2));
+
+        public static Guid Guid1 { get; } = new Guid("9CB96C65-3D47-4BAD-8BE6-18D97042B6C9");
+
+        public static Guid Guid2 { get; } = new Guid("85BECFD9-7F5A-4C14-A2E7-C6EA83A23758");
+
+        public static Guid Guid3 { get; } = new Guid("BC911842-11E3-48EB-BFFC-3719465718A5");
     }
 }

--- a/.Lib9c.Tests/Action/Coupons/IssueCouponsTest.cs
+++ b/.Lib9c.Tests/Action/Coupons/IssueCouponsTest.cs
@@ -17,8 +17,40 @@ namespace Lib9c.Tests.Action.Coupons
         [Fact]
         public void Execute()
         {
-            IAccountStateDelta state = new Lib9c.Tests.Action.State();
+            IAccountStateDelta state = new Lib9c.Tests.Action.State()
+                .SetState(
+                    AdminState.Address,
+                    new AdminState(CouponsFixture.AgentAddress1, 1)
+                        .Serialize());
             IRandom random = new TestRandom();
+
+            Assert.Throws<PolicyExpiredException>(() =>
+                new IssueCoupons(
+                        ImmutableDictionary<RewardSet, uint>.Empty,
+                        CouponsFixture.AgentAddress1)
+                    .Execute(
+                        new ActionContext
+                        {
+                            PreviousStates = state,
+                            Rehearsal = false,
+                            Random = random,
+                            BlockIndex = long.MaxValue,
+                            Signer = CouponsFixture.AgentAddress1,
+                        }));
+
+            Assert.Throws<PermissionDeniedException>(() =>
+                new IssueCoupons(
+                        ImmutableDictionary<RewardSet, uint>.Empty,
+                        CouponsFixture.AgentAddress1)
+                    .Execute(
+                        new ActionContext
+                        {
+                            PreviousStates = state,
+                            Rehearsal = false,
+                            Random = random,
+                            BlockIndex = 0,
+                            Signer = CouponsFixture.AgentAddress2,
+                        }));
 
             Assert.Equal(
                 ImmutableDictionary<Guid, Coupon>.Empty,
@@ -31,6 +63,8 @@ namespace Lib9c.Tests.Action.Coupons
                             PreviousStates = state,
                             Rehearsal = false,
                             Random = random,
+                            BlockIndex = 0,
+                            Signer = CouponsFixture.AgentAddress1,
                         })
                     .GetCouponWallet(CouponsFixture.AgentAddress1));
 
@@ -47,6 +81,8 @@ namespace Lib9c.Tests.Action.Coupons
                             PreviousStates = state,
                             Rehearsal = true,
                             Random = random,
+                            BlockIndex = 0,
+                            Signer = CouponsFixture.AgentAddress1,
                         })
                     .GetState(CouponsFixture.AgentAddress1.Derive(SerializeKeys.CouponWalletKey)));
 
@@ -61,6 +97,8 @@ namespace Lib9c.Tests.Action.Coupons
                         PreviousStates = state,
                         Rehearsal = false,
                         Random = random,
+                        BlockIndex = 0,
+                        Signer = CouponsFixture.AgentAddress1,
                     });
 
             state = new IssueCoupons(
@@ -73,6 +111,8 @@ namespace Lib9c.Tests.Action.Coupons
                         PreviousStates = state,
                         Rehearsal = false,
                         Random = random,
+                        BlockIndex = 0,
+                        Signer = CouponsFixture.AgentAddress1,
                     });
 
             var agent1CouponWallet = state.GetCouponWallet(CouponsFixture.AgentAddress1);

--- a/.Lib9c.Tests/Action/Coupons/IssueCouponsTest.cs
+++ b/.Lib9c.Tests/Action/Coupons/IssueCouponsTest.cs
@@ -1,0 +1,156 @@
+namespace Lib9c.Tests.Action.Coupons
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using Bencodex.Types;
+    using Libplanet.Action;
+    using Nekoyume.Action;
+    using Nekoyume.Action.Coupons;
+    using Nekoyume.Model.Coupons;
+    using Nekoyume.Model.State;
+    using Xunit;
+
+    public class IssueCouponsTest
+    {
+        [Fact]
+        public void Execute()
+        {
+            IAccountStateDelta state = new Lib9c.Tests.Action.State();
+            IRandom random = new TestRandom();
+
+            Assert.Equal(
+                ImmutableDictionary<Guid, Coupon>.Empty,
+                new IssueCoupons(
+                    ImmutableDictionary<RewardSet, uint>.Empty,
+                    CouponsFixture.AgentAddress1)
+                    .Execute(
+                        new ActionContext
+                        {
+                            PreviousStates = state,
+                            Rehearsal = false,
+                            Random = random,
+                        })
+                    .GetCouponWallet(CouponsFixture.AgentAddress1));
+
+            Assert.Equal(
+                Bencodex.Types.Null.Value,
+                new IssueCoupons(
+                        ImmutableDictionary<RewardSet, uint>.Empty
+                            .Add(CouponsFixture.RewardSet1, 1)
+                            .Add(CouponsFixture.RewardSet2, 2),
+                        CouponsFixture.AgentAddress1)
+                    .Execute(
+                        new ActionContext
+                        {
+                            PreviousStates = state,
+                            Rehearsal = true,
+                            Random = random,
+                        })
+                    .GetState(CouponsFixture.AgentAddress1.Derive(SerializeKeys.CouponWalletKey)));
+
+            state = new IssueCoupons(
+                    ImmutableDictionary<RewardSet, uint>.Empty
+                        .Add(CouponsFixture.RewardSet1, 1)
+                        .Add(CouponsFixture.RewardSet2, 2),
+                    CouponsFixture.AgentAddress1)
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Rehearsal = false,
+                        Random = random,
+                    });
+
+            state = new IssueCoupons(
+                    ImmutableDictionary<RewardSet, uint>.Empty
+                        .Add(CouponsFixture.RewardSet3, 3),
+                    CouponsFixture.AgentAddress2)
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Rehearsal = false,
+                        Random = random,
+                    });
+
+            var agent1CouponWallet = state.GetCouponWallet(CouponsFixture.AgentAddress1);
+            var agent2CouponWallet = state.GetCouponWallet(CouponsFixture.AgentAddress2);
+
+            Assert.Equal(3, agent1CouponWallet.Count);
+            Assert.Equal(1, agent1CouponWallet.Count(
+                item => item.Value.Rewards.Equals(CouponsFixture.RewardSet1)));
+            Assert.Equal(2, agent1CouponWallet.Count(
+                item => item.Value.Rewards.Equals(CouponsFixture.RewardSet2)));
+            Assert.Equal(0, agent1CouponWallet.Count(
+                item => item.Value.Rewards.Equals(CouponsFixture.RewardSet3)));
+
+            Assert.Equal(3, agent1CouponWallet.Count);
+            Assert.Equal(0, agent2CouponWallet.Count(
+                item => item.Value.Rewards.Equals(CouponsFixture.RewardSet1)));
+            Assert.Equal(0, agent2CouponWallet.Count(
+                item => item.Value.Rewards.Equals(CouponsFixture.RewardSet2)));
+            Assert.Equal(3, agent2CouponWallet.Count(
+                item => item.Value.Rewards.Equals(CouponsFixture.RewardSet3)));
+        }
+
+        [Fact]
+        public void PlainValue()
+        {
+            var action = new IssueCoupons(
+                ImmutableDictionary<RewardSet, uint>.Empty
+                    .Add(CouponsFixture.RewardSet2, 1)
+                    .Add(CouponsFixture.RewardSet1, 2),
+                CouponsFixture.AgentAddress1);
+
+            Assert.Equal(
+                new Bencodex.Types.Dictionary(
+                    ImmutableDictionary<string, IValue>.Empty
+                        .Add("recipient", new Binary(CouponsFixture.AgentAddress1.ByteArray))
+                        .Add(
+                            "rewards",
+                            Bencodex.Types.List.Empty
+                                .Add(Bencodex.Types.Dictionary.Empty
+                                    .Add("rewardSet", CouponsFixture.RewardSet1.Serialize())
+                                    .Add("quantity", 2))
+                                .Add(Bencodex.Types.Dictionary.Empty
+                                    .Add("rewardSet", CouponsFixture.RewardSet2.Serialize())
+                                    .Add("quantity", 1)))
+                        .Select(kv => new KeyValuePair<IKey, IValue>((Text)kv.Key, kv.Value))),
+                ((Bencodex.Types.Dictionary)action.PlainValue).Remove((Text)"id"));
+        }
+
+        [Fact]
+        public void LoadPlainValue()
+        {
+            var expected = new IssueCoupons(
+                ImmutableDictionary<RewardSet, uint>.Empty
+                    .Add(CouponsFixture.RewardSet2, 1)
+                    .Add(CouponsFixture.RewardSet1, 2),
+                CouponsFixture.AgentAddress1);
+            var actual = new IssueCoupons(
+                ImmutableDictionary<RewardSet, uint>.Empty,
+                CouponsFixture.AgentAddress1);
+            actual.LoadPlainValue(
+                new Bencodex.Types.Dictionary(
+                        ImmutableDictionary<string, IValue>.Empty
+                            .Add("recipient", new Binary(CouponsFixture.AgentAddress1.ByteArray))
+                            .Add(
+                                "rewards",
+                                Bencodex.Types.List.Empty
+                                    .Add(Bencodex.Types.Dictionary.Empty
+                                        .Add("rewardSet", CouponsFixture.RewardSet1.Serialize())
+                                        .Add("quantity", 2))
+                                    .Add(Bencodex.Types.Dictionary.Empty
+                                        .Add("rewardSet", CouponsFixture.RewardSet2.Serialize())
+                                        .Add("quantity", 1)))
+                            .Select(kv => new KeyValuePair<IKey, IValue>((Text)kv.Key, kv.Value)))
+                    .SetItem("id", new Guid("6E69DC55-A0D0-435A-A787-C62356CBE517").Serialize())
+            );
+
+            Assert.Equal(expected.Rewards, actual.Rewards);
+            Assert.Equal(expected.Recipient, actual.Recipient);
+        }
+    }
+}

--- a/.Lib9c.Tests/Action/Coupons/RedeemCouponTest.cs
+++ b/.Lib9c.Tests/Action/Coupons/RedeemCouponTest.cs
@@ -1,0 +1,374 @@
+namespace Lib9c.Tests.Action.Coupons
+{
+    using System;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using Libplanet.Action;
+    using Nekoyume;
+    using Nekoyume.Action;
+    using Nekoyume.Action.Coupons;
+    using Nekoyume.Model.Coupons;
+    using Nekoyume.Model.State;
+    using Nekoyume.TableData;
+    using Xunit;
+
+    public class RedeemCouponTest
+    {
+        [Fact]
+        public void Execute()
+        {
+            IRandom random = new TestRandom();
+            var sheets = TableSheetsImporter.ImportSheets();
+            IAccountStateDelta state = new Lib9c.Tests.Action.State()
+                .SetState(
+                    Addresses.GameConfig,
+                    new GameConfigState(sheets[nameof(GameConfigSheet)]).Serialize()
+                );
+
+            foreach (var (key, value) in sheets)
+            {
+                state = state.SetState(Addresses.TableSheet.Derive(key), value.Serialize());
+            }
+
+            var agent1Avatar0Address = CouponsFixture.AgentAddress1
+                .Derive(SerializeKeys.AvatarAddressKey)
+                .Derive("avatar-states-0");
+            var agent1Avatar1Address = CouponsFixture.AgentAddress1
+                .Derive(SerializeKeys.AvatarAddressKey)
+                .Derive("avatar-states-1");
+            var agent2Avatar0Address = CouponsFixture.AgentAddress2
+                .Derive(SerializeKeys.AvatarAddressKey)
+                .Derive("avatar-states-0");
+
+            var agent1Avatar0State = CreateAvatar0.CreateAvatarState(
+                    "agent1avatar0",
+                    agent1Avatar0Address,
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Signer = CouponsFixture.AgentAddress1,
+                        BlockIndex = 0,
+                    },
+                    state.GetSheet<MaterialItemSheet>(),
+                    default);
+            var agent1Avatar1State = CreateAvatar0.CreateAvatarState(
+                    "agent1avatar1",
+                    agent1Avatar1Address,
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Signer = CouponsFixture.AgentAddress1,
+                        BlockIndex = 0,
+                    },
+                    state.GetSheet<MaterialItemSheet>(),
+                    default);
+            var agent2Avatar0State = CreateAvatar0.CreateAvatarState(
+                    "agent2avatar0",
+                    agent2Avatar0Address,
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Signer = CouponsFixture.AgentAddress2,
+                        BlockIndex = 0,
+                    },
+                    state.GetSheet<MaterialItemSheet>(),
+                    default);
+
+            state = state
+                .SetState(agent1Avatar0Address, agent1Avatar0State.SerializeV2())
+                .SetState(
+                    agent1Avatar0Address.Derive(SerializeKeys.LegacyInventoryKey),
+                    agent1Avatar0State.inventory.Serialize())
+                .SetState(
+                    agent1Avatar0Address.Derive(SerializeKeys.LegacyWorldInformationKey),
+                    agent1Avatar0State.worldInformation.Serialize())
+                .SetState(
+                    agent1Avatar0Address.Derive(SerializeKeys.LegacyQuestListKey),
+                    agent1Avatar0State.questList.Serialize())
+                .SetState(agent1Avatar1Address, agent1Avatar1State.SerializeV2())
+                .SetState(
+                    agent1Avatar1Address.Derive(SerializeKeys.LegacyInventoryKey),
+                    agent1Avatar1State.inventory.Serialize())
+                .SetState(
+                    agent1Avatar1Address.Derive(SerializeKeys.LegacyWorldInformationKey),
+                    agent1Avatar1State.worldInformation.Serialize())
+                .SetState(
+                    agent1Avatar1Address.Derive(SerializeKeys.LegacyQuestListKey),
+                    agent1Avatar1State.questList.Serialize())
+                .SetState(agent2Avatar0Address, agent2Avatar0State.SerializeV2())
+                .SetState(
+                    agent2Avatar0Address.Derive(SerializeKeys.LegacyInventoryKey),
+                    agent2Avatar0State.inventory.Serialize())
+                .SetState(
+                    agent2Avatar0Address.Derive(SerializeKeys.LegacyWorldInformationKey),
+                    agent2Avatar0State.worldInformation.Serialize())
+                .SetState(
+                    agent2Avatar0Address.Derive(SerializeKeys.LegacyQuestListKey),
+                    agent2Avatar0State.questList.Serialize());
+
+            // can't redeem a coupon with an arbitrary guid
+            Assert.Equal(
+                state,
+                new RedeemCoupon(
+                    new Guid("AEB63B38-1850-4003-B549-19D37B37AC89"),
+                    agent1Avatar0Address)
+                    .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Rehearsal = false,
+                        Signer = CouponsFixture.AgentAddress1,
+                        Random = random,
+                    }));
+
+            var agent1CouponWallet = state.GetCouponWallet(CouponsFixture.AgentAddress1);
+            var agent2CouponWallet = state.GetCouponWallet(CouponsFixture.AgentAddress2);
+
+            agent1CouponWallet = agent1CouponWallet
+                .Add(
+                    CouponsFixture.Guid1,
+                    new Coupon(CouponsFixture.Guid1, CouponsFixture.RewardSet1))
+                .Add(
+                    CouponsFixture.Guid2,
+                    new Coupon(CouponsFixture.Guid2, CouponsFixture.RewardSet2));
+            agent2CouponWallet = agent2CouponWallet
+                .Add(
+                    CouponsFixture.Guid3,
+                    new Coupon(CouponsFixture.Guid3, CouponsFixture.RewardSet3));
+
+            state = state
+                .SetCouponWallet(CouponsFixture.AgentAddress1, agent1CouponWallet)
+                .SetCouponWallet(CouponsFixture.AgentAddress2, agent2CouponWallet);
+
+            var rehearsedState = new RedeemCoupon(CouponsFixture.Guid1, agent1Avatar0Address)
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Rehearsal = true,
+                        Signer = CouponsFixture.AgentAddress1,
+                        Random = random,
+                    });
+
+            Assert.Equal(
+                ActionBase.MarkChanged,
+                rehearsedState.GetState(agent1Avatar0Address));
+
+            Assert.Equal(
+                ActionBase.MarkChanged,
+                rehearsedState.GetState(
+                    agent1Avatar0Address.Derive(SerializeKeys.LegacyInventoryKey)));
+
+            Assert.Equal(
+                ActionBase.MarkChanged,
+                rehearsedState.GetState(
+                    agent1Avatar0Address.Derive(SerializeKeys.LegacyWorldInformationKey)));
+
+            Assert.Equal(
+                ActionBase.MarkChanged,
+                rehearsedState.GetState(
+                    agent1Avatar0Address.Derive(SerializeKeys.LegacyQuestListKey)));
+
+            Assert.Equal(
+                ActionBase.MarkChanged,
+                rehearsedState.GetState(
+                    CouponsFixture.AgentAddress1.Derive(SerializeKeys.CouponWalletKey)));
+
+            // can't redeem other person's coupon
+            var expected = state.GetAvatarStateV2(agent1Avatar0Address);
+            state = new RedeemCoupon(CouponsFixture.Guid3, agent1Avatar0Address)
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Rehearsal = false,
+                        Signer = CouponsFixture.AgentAddress1,
+                        Random = random,
+                    });
+            Assert.Equal(
+                expected.SerializeV2(),
+                state.GetAvatarStateV2(agent1Avatar0Address).SerializeV2());
+            Assert.Equal(agent2CouponWallet, state.GetCouponWallet(CouponsFixture.AgentAddress2));
+
+            // can't redeem other person's coupon to their account
+            expected = state.GetAvatarStateV2(agent2Avatar0Address);
+            state = new RedeemCoupon(CouponsFixture.Guid3, agent2Avatar0Address)
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Rehearsal = false,
+                        Signer = CouponsFixture.AgentAddress1,
+                        Random = random,
+                    });
+            Assert.Equal(
+                expected.SerializeV2(),
+                state.GetAvatarStateV2(agent2Avatar0Address).SerializeV2());
+            Assert.Equal(agent2CouponWallet, state.GetCouponWallet(CouponsFixture.AgentAddress2));
+
+            // can't redeem to a nonexistent avatar
+            state = new RedeemCoupon(
+                    CouponsFixture.Guid1,
+                    CouponsFixture.AgentAddress1
+                        .Derive(SerializeKeys.AvatarAddressKey)
+                        .Derive("avatar-states-2"))
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Rehearsal = false,
+                        Signer = CouponsFixture.AgentAddress1,
+                        Random = random,
+                    });
+            Assert.Null(
+                state.GetAvatarStateV2(
+                    CouponsFixture.AgentAddress1
+                        .Derive(SerializeKeys.AvatarAddressKey)
+                        .Derive("avatar-states-2")));
+            Assert.Equal(agent1CouponWallet, state.GetCouponWallet(CouponsFixture.AgentAddress1));
+
+            expected = state.GetAvatarStateV2(agent2Avatar0Address);
+            // can't redeem to an avatar of different agent
+            state = new RedeemCoupon(
+                    CouponsFixture.Guid1,
+                    agent2Avatar0Address)
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Rehearsal = false,
+                        Signer = CouponsFixture.AgentAddress1,
+                        Random = random,
+                    });
+            Assert.Equal(
+                expected.SerializeV2(),
+                state.GetAvatarStateV2(agent2Avatar0Address).SerializeV2());
+            Assert.Equal(agent1CouponWallet, state.GetCouponWallet(CouponsFixture.AgentAddress1));
+
+            // redeem a coupon
+            expected = state.GetAvatarStateV2(agent1Avatar0Address);
+            state = new RedeemCoupon(
+                    CouponsFixture.Guid1,
+                    agent1Avatar0Address)
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Rehearsal = false,
+                        Signer = CouponsFixture.AgentAddress1,
+                        Random = random,
+                    });
+            var actual = state.GetAvatarStateV2(agent1Avatar0Address);
+            Assert.Equal(
+                CouponsFixture.RewardSet1.Select(kv => kv.Key).ToImmutableSortedSet(),
+                actual.inventory.Items
+                    .Select(item => item.item.Id)
+                    .ToImmutableSortedSet());
+            expected.inventory = actual.inventory;
+            Assert.Equal(expected.SerializeV2(), actual.SerializeV2());
+
+            // can't redeem a coupon twice
+            expected = state.GetAvatarStateV2(agent1Avatar1Address);
+            state = new RedeemCoupon(
+                    CouponsFixture.Guid1,
+                    agent1Avatar1Address)
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Rehearsal = false,
+                        Signer = CouponsFixture.AgentAddress1,
+                        Random = random,
+                    });
+            actual = state.GetAvatarStateV2(agent1Avatar1Address);
+            Assert.Equal(0, state.GetAvatarStateV2(agent1Avatar1Address).inventory.Items.Count);
+            Assert.Empty(actual.inventory.Items);
+            Assert.Equal(expected.SerializeV2(), actual.SerializeV2());
+
+            expected = state.GetAvatarStateV2(agent1Avatar1Address);
+            state = new RedeemCoupon(
+                    CouponsFixture.Guid2,
+                    agent1Avatar1Address)
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Rehearsal = false,
+                        Signer = CouponsFixture.AgentAddress1,
+                        Random = random,
+                    });
+            actual = state.GetAvatarStateV2(agent1Avatar1Address);
+            Assert.Equal(
+                CouponsFixture.RewardSet2.Select(kv => kv.Key).ToImmutableSortedSet(),
+                actual.inventory.Items
+                    .Select(item => item.item.Id)
+                    .ToImmutableSortedSet());
+            Assert.Equal(expected.SerializeV2(), actual.SerializeV2());
+
+            expected = state.GetAvatarStateV2(agent2Avatar0Address);
+            state = new RedeemCoupon(
+                    CouponsFixture.Guid3,
+                    agent2Avatar0Address)
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Rehearsal = false,
+                        Signer = CouponsFixture.AgentAddress2,
+                        Random = random,
+                    });
+            actual = state.GetAvatarStateV2(agent2Avatar0Address);
+            Assert.Equal(
+                CouponsFixture.RewardSet3.Select(kv => kv.Key).ToImmutableSortedSet(),
+                actual.inventory.Items
+                    .Select(item => item.item.Id)
+                    .ToImmutableSortedSet());
+            Assert.Equal(expected.SerializeV2(), actual.SerializeV2());
+
+            state = state
+                .SetCouponWallet(CouponsFixture.AgentAddress1, agent1CouponWallet);
+            expected = state.GetAvatarStateV2(agent1Avatar0Address);
+            state = new RedeemCoupon(
+                    CouponsFixture.Guid2,
+                    agent1Avatar0Address)
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Rehearsal = false,
+                        Signer = CouponsFixture.AgentAddress1,
+                        Random = random,
+                    });
+            actual = state.GetAvatarStateV2(agent1Avatar0Address);
+            var aggregateRewardSet = CouponsFixture.RewardSet1.Aggregate(
+                CouponsFixture.RewardSet2, (rewardSet, kv) =>
+                {
+                    if (rewardSet.TryGetValue(kv.Key, out var val))
+                    {
+                        rewardSet = new RewardSet(
+                            rewardSet.ToImmutableDictionary().SetItem(kv.Key, val + kv.Value));
+                    }
+                    else
+                    {
+                        rewardSet = new RewardSet(
+                            rewardSet.ToImmutableDictionary().SetItem(kv.Key, kv.Value));
+                    }
+
+                    return rewardSet;
+                });
+            Assert.Equal(
+                aggregateRewardSet.Select(kv => kv.Key).ToImmutableSortedSet(),
+                actual.inventory.Items
+                    .Select(item => item.item.Id)
+                    .ToImmutableSortedSet());
+            foreach (var kv in aggregateRewardSet)
+            {
+                var item = actual.inventory.Items.Single(item => item.item.Id.Equals(kv.Key));
+                Assert.Equal((int)kv.Value, item.count);
+            }
+
+            expected.inventory = actual.inventory;
+            Assert.Equal(expected.SerializeV2(), actual.SerializeV2());
+        }
+    }
+}

--- a/.Lib9c.Tests/Action/Coupons/TransferCouponsTest.cs
+++ b/.Lib9c.Tests/Action/Coupons/TransferCouponsTest.cs
@@ -1,0 +1,279 @@
+namespace Lib9c.Tests.Action.Coupons
+{
+    using System;
+    using System.Collections.Immutable;
+    using Bencodex.Types;
+    using Libplanet;
+    using Libplanet.Action;
+    using Nekoyume.Action;
+    using Nekoyume.Action.Coupons;
+    using Nekoyume.Model.Coupons;
+    using Nekoyume.Model.State;
+    using Xunit;
+
+    public class TransferCouponsTest
+    {
+        [Fact]
+        public void Execute()
+        {
+            IAccountStateDelta state = new Lib9c.Tests.Action.State();
+            IRandom random = new TestRandom();
+
+            var coupon1 = new Coupon(CouponsFixture.Guid1, CouponsFixture.RewardSet1);
+            var coupon2 = new Coupon(CouponsFixture.Guid2, CouponsFixture.RewardSet2);
+            var coupon3 = new Coupon(CouponsFixture.Guid3, CouponsFixture.RewardSet3);
+
+            state = state
+                .SetCouponWallet(
+                    CouponsFixture.AgentAddress1,
+                    state.GetCouponWallet(CouponsFixture.AgentAddress1)
+                        .Add(CouponsFixture.Guid1, coupon1)
+                        .Add(CouponsFixture.Guid2, coupon2)
+                        .Add(CouponsFixture.Guid3, coupon3));
+
+            // can't transfer a nonexistent coupon
+            Assert.Throws<FailedLoadStateException>(() => new TransferCoupons(
+                    ImmutableDictionary<Address, IImmutableSet<Guid>>.Empty
+                        .Add(CouponsFixture.AgentAddress2, ImmutableHashSet<Guid>.Empty.Add(
+                            new Guid("97529656-CB7F-45C6-8466-A072DD2DBFBD"))))
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Signer = CouponsFixture.AgentAddress1,
+                        Rehearsal = false,
+                    }));
+
+            // can't transfer coupon that's not mine
+            Assert.Throws<FailedLoadStateException>(() => new TransferCoupons(
+                    ImmutableDictionary<Address, IImmutableSet<Guid>>.Empty
+                        .Add(CouponsFixture.AgentAddress1, ImmutableHashSet<Guid>.Empty
+                            .Add(CouponsFixture.Guid1)))
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Signer = CouponsFixture.AgentAddress2,
+                        Rehearsal = false,
+                    }));
+
+            // can't transfer a coupon to two different people
+            Assert.Throws<FailedLoadStateException>(() => new TransferCoupons(
+                    ImmutableDictionary<Address, IImmutableSet<Guid>>.Empty
+                        .Add(CouponsFixture.AgentAddress2, ImmutableHashSet<Guid>.Empty
+                            .Add(CouponsFixture.Guid1))
+                        .Add(CouponsFixture.AgentAddress3, ImmutableHashSet<Guid>.Empty
+                            .Add(CouponsFixture.Guid1)))
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Signer = CouponsFixture.AgentAddress1,
+                        Rehearsal = false,
+                    }));
+
+            // transfer to self
+            var expected = state.GetCouponWallet(CouponsFixture.AgentAddress1);
+            state = new TransferCoupons(
+                    ImmutableDictionary<Address, IImmutableSet<Guid>>.Empty
+                        .Add(CouponsFixture.AgentAddress1, ImmutableHashSet<Guid>.Empty
+                            .Add(CouponsFixture.Guid1)))
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Signer = CouponsFixture.AgentAddress1,
+                        Rehearsal = false,
+                    });
+            Assert.Equal(expected, state.GetCouponWallet(CouponsFixture.AgentAddress1));
+
+            // transfer nothing
+            state = new TransferCoupons(
+                    ImmutableDictionary<Address, IImmutableSet<Guid>>.Empty
+                        .Add(CouponsFixture.AgentAddress2, ImmutableHashSet<Guid>.Empty))
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Signer = CouponsFixture.AgentAddress1,
+                        Rehearsal = false,
+                    });
+            Assert.Equal(expected, state.GetCouponWallet(CouponsFixture.AgentAddress1));
+
+            // single transfer
+            expected = state.GetCouponWallet(CouponsFixture.AgentAddress1);
+            state = new TransferCoupons(
+                    ImmutableDictionary<Address, IImmutableSet<Guid>>.Empty
+                        .Add(CouponsFixture.AgentAddress2, ImmutableHashSet<Guid>.Empty
+                            .Add(CouponsFixture.Guid1)))
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Signer = CouponsFixture.AgentAddress1,
+                        Rehearsal = false,
+                    });
+            Assert.Equal(
+                expected.Remove(CouponsFixture.Guid1),
+                state.GetCouponWallet(CouponsFixture.AgentAddress1));
+            Assert.Equal(
+                ImmutableDictionary<Guid, Coupon>.Empty
+                    .Add(CouponsFixture.Guid1, coupon1),
+                state.GetCouponWallet(CouponsFixture.AgentAddress2));
+
+            // can't transfer a coupon twice
+            Assert.Throws<FailedLoadStateException>(() => new TransferCoupons(
+                    ImmutableDictionary<Address, IImmutableSet<Guid>>.Empty
+                        .Add(CouponsFixture.AgentAddress2, ImmutableHashSet<Guid>.Empty
+                            .Add(CouponsFixture.Guid1)))
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Signer = CouponsFixture.AgentAddress1,
+                        Rehearsal = false,
+                    }));
+
+            state = state
+                .SetCouponWallet(
+                    CouponsFixture.AgentAddress1,
+                    ImmutableDictionary<Guid, Coupon>.Empty
+                        .Add(CouponsFixture.Guid1, coupon1)
+                        .Add(CouponsFixture.Guid2, coupon2)
+                        .Add(CouponsFixture.Guid3, coupon3))
+                .SetCouponWallet(
+                    CouponsFixture.AgentAddress2,
+                    ImmutableDictionary<Guid, Coupon>.Empty)
+                .SetCouponWallet(
+                    CouponsFixture.AgentAddress3,
+                    ImmutableDictionary<Guid, Coupon>.Empty);
+
+            var rehearsedState = new TransferCoupons(
+                    ImmutableDictionary<Address, IImmutableSet<Guid>>.Empty
+                        .Add(CouponsFixture.AgentAddress2, ImmutableHashSet<Guid>.Empty
+                            .Add(CouponsFixture.Guid1)
+                            .Add(CouponsFixture.Guid2))
+                        .Add(CouponsFixture.AgentAddress3, ImmutableHashSet<Guid>.Empty
+                            .Add(CouponsFixture.Guid3)))
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Signer = CouponsFixture.AgentAddress1,
+                        Rehearsal = true,
+                    });
+            Assert.Equal(
+                ActionBase.MarkChanged,
+                rehearsedState.GetState(
+                    CouponsFixture.AgentAddress1.Derive(SerializeKeys.CouponWalletKey)));
+            Assert.Equal(
+                ActionBase.MarkChanged,
+                rehearsedState.GetState(
+                    CouponsFixture.AgentAddress2.Derive(SerializeKeys.CouponWalletKey)));
+            Assert.Equal(
+                ActionBase.MarkChanged,
+                rehearsedState.GetState(
+                    CouponsFixture.AgentAddress3.Derive(SerializeKeys.CouponWalletKey)));
+
+            // multiple transfer
+            state = new TransferCoupons(
+                    ImmutableDictionary<Address, IImmutableSet<Guid>>.Empty
+                        .Add(CouponsFixture.AgentAddress2, ImmutableHashSet<Guid>.Empty
+                            .Add(CouponsFixture.Guid1)
+                            .Add(CouponsFixture.Guid2))
+                        .Add(CouponsFixture.AgentAddress3, ImmutableHashSet<Guid>.Empty
+                            .Add(CouponsFixture.Guid3)))
+                .Execute(
+                    new ActionContext
+                    {
+                        PreviousStates = state,
+                        Signer = CouponsFixture.AgentAddress1,
+                        Rehearsal = false,
+                    });
+            Assert.Equal(
+                ImmutableDictionary<Guid, Coupon>.Empty,
+                state.GetCouponWallet(CouponsFixture.AgentAddress1));
+            Assert.Equal(
+                ImmutableDictionary<Guid, Coupon>.Empty
+                    .Add(CouponsFixture.Guid1, coupon1)
+                    .Add(CouponsFixture.Guid2, coupon2),
+                state.GetCouponWallet(CouponsFixture.AgentAddress2));
+            Assert.Equal(
+                ImmutableDictionary<Guid, Coupon>.Empty
+                    .Add(CouponsFixture.Guid3, coupon3),
+                state.GetCouponWallet(CouponsFixture.AgentAddress3));
+        }
+
+        [Fact]
+        public void PlainValue()
+        {
+            var action = new TransferCoupons(
+                ImmutableDictionary<Address, IImmutableSet<Guid>>.Empty
+                    .Add(CouponsFixture.AgentAddress1, ImmutableHashSet<Guid>.Empty
+                        .Add(CouponsFixture.Guid1))
+                    .Add(CouponsFixture.AgentAddress2, ImmutableHashSet<Guid>.Empty
+                        .Add(CouponsFixture.Guid3)
+                        .Add(CouponsFixture.Guid2))
+                    .Add(CouponsFixture.AgentAddress3, ImmutableHashSet<Guid>.Empty));
+
+            var expected = new Bencodex.Types.Dictionary(
+                ImmutableDictionary<string, IValue>.Empty
+                    .Add(
+                        "couponsPerRecipient",
+                        Bencodex.Types.Dictionary.Empty
+                            .Add(
+                                (Bencodex.Types.Binary)CouponsFixture.AgentAddress1.ByteArray,
+                                Bencodex.Types.List.Empty
+                                    .Add(CouponsFixture.Guid1.ToByteArray()))
+                            .Add(
+                                (Bencodex.Types.Binary)CouponsFixture.AgentAddress2.ByteArray,
+                                Bencodex.Types.List.Empty
+                                    .Add(CouponsFixture.Guid2.ToByteArray())
+                                    .Add(CouponsFixture.Guid3.ToByteArray()))
+                            .Add(
+                                (Bencodex.Types.Binary)CouponsFixture.AgentAddress3.ByteArray,
+                                Bencodex.Types.List.Empty)));
+
+            Assert.Equal(
+                expected,
+                ((Bencodex.Types.Dictionary)action.PlainValue).Remove((Text)"id"));
+        }
+
+        [Fact]
+        public void LoadPlainValue()
+        {
+            var expected = new TransferCoupons(
+                ImmutableDictionary<Address, IImmutableSet<Guid>>.Empty
+                    .Add(CouponsFixture.AgentAddress1, ImmutableHashSet<Guid>.Empty
+                        .Add(CouponsFixture.Guid1))
+                    .Add(CouponsFixture.AgentAddress2, ImmutableHashSet<Guid>.Empty
+                        .Add(CouponsFixture.Guid3)
+                        .Add(CouponsFixture.Guid2))
+                    .Add(CouponsFixture.AgentAddress3, ImmutableHashSet<Guid>.Empty));
+
+            var actual =
+                new TransferCoupons(ImmutableDictionary<Address, IImmutableSet<Guid>>.Empty);
+
+            actual.LoadPlainValue(
+                new Bencodex.Types.Dictionary(
+                    ImmutableDictionary<string, IValue>.Empty
+                        .Add(
+                            "couponsPerRecipient",
+                            Bencodex.Types.Dictionary.Empty
+                                .Add(
+                                    (Bencodex.Types.Binary)CouponsFixture.AgentAddress1.ByteArray,
+                                    Bencodex.Types.List.Empty
+                                .Add(CouponsFixture.Guid1.ToByteArray()))
+                                .Add(
+                                    (Bencodex.Types.Binary)CouponsFixture.AgentAddress2.ByteArray,
+                                    Bencodex.Types.List.Empty
+                                        .Add(CouponsFixture.Guid2.ToByteArray())
+                                        .Add(CouponsFixture.Guid3.ToByteArray()))
+                                .Add(
+                                    (Bencodex.Types.Binary)CouponsFixture.AgentAddress3.ByteArray,
+                                    Bencodex.Types.List.Empty)))
+                    .SetItem("id", new Guid("AE3FA099-B97C-480F-9E3A-4E1FEF1EA783").Serialize()));
+            Assert.Equal(expected.CouponsPerRecipient, actual.CouponsPerRecipient);
+        }
+    }
+}

--- a/.Lib9c.Tests/Action/TransferAsset2Test.cs
+++ b/.Lib9c.Tests/Action/TransferAsset2Test.cs
@@ -380,5 +380,21 @@ namespace Lib9c.Tests.Action
             Assert.Equal(_currency * 100, deserialized.Amount);
             Assert.Equal(memo, deserialized.Memo);
         }
+
+        [Fact]
+        public void CheckObsolete()
+        {
+            var action = new TransferAsset2(_sender, _recipient, _currency * 1);
+            Assert.Throws<ActionObsoletedException>(() =>
+            {
+                action.Execute(new ActionContext()
+                {
+                    PreviousStates = new State(),
+                    Signer = _sender,
+                    Rehearsal = false,
+                    BlockIndex = TransferAsset.CrystalTransferringRestrictionStartIndex,
+                });
+            });
+        }
     }
 }

--- a/.Lib9c.Tests/Model/Coupons/CouponTest.cs
+++ b/.Lib9c.Tests/Model/Coupons/CouponTest.cs
@@ -1,0 +1,162 @@
+#nullable enable
+namespace Lib9c.Tests.Model.Coupons
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Libplanet;
+    using Nekoyume.Model.Coupons;
+    using Xunit;
+
+    public class CouponTest
+    {
+        [Fact]
+        public void Constructors()
+        {
+            var emptyCoupon = new Coupon(
+                Guid.Parse("8b899e82-1918-4d72-83c8-83407f8d6dc0"),
+                default(RewardSet)
+            );
+            Assert.Equal(
+                emptyCoupon,
+                new Coupon(
+                    Guid.Parse("8b899e82-1918-4d72-83c8-83407f8d6dc0"),
+                    Enumerable.Empty<(int, uint)>()
+                )
+            );
+            Assert.Equal(
+                emptyCoupon,
+                new Coupon(
+                    Guid.Parse("8b899e82-1918-4d72-83c8-83407f8d6dc0"),
+                    new (int, uint)[0]
+                )
+            );
+
+            var coupon = new Coupon(
+                Guid.Parse("4a09d5d1-d702-45d5-aa6f-44e19bdab42d"),
+                new RewardSet((1, 2U), (3, 4U))
+            );
+            Assert.Equal(
+                coupon,
+                new Coupon(
+                    Guid.Parse("4a09d5d1-d702-45d5-aa6f-44e19bdab42d"),
+                    new List<(int, uint)> { (1, 2U), (3, 4U) }
+                )
+            );
+            Assert.Equal(
+                coupon,
+                new Coupon(
+                    Guid.Parse("4a09d5d1-d702-45d5-aa6f-44e19bdab42d"),
+                    (1, 2U),
+                    (3, 4U)
+                )
+            );
+        }
+
+        [Fact]
+        public void Equality()
+        {
+            var emptyCoupon = new Coupon(
+                Guid.Parse("8b899e82-1918-4d72-83c8-83407f8d6dc0"),
+                default(RewardSet)
+            );
+            var coupon = new Coupon(
+                Guid.Parse("4a09d5d1-d702-45d5-aa6f-44e19bdab42d"),
+                new RewardSet((1, 2U), (3, 4U))
+            );
+            var coupon2 = new Coupon(
+                Guid.Parse("4a09d5d1-d702-45d5-aa6f-44e19bdab42d"),
+                new RewardSet((1, 2U), (3, 5U))
+            );
+            var coupon3 = new Coupon(
+                Guid.Parse("4a09d5d1-d702-45d5-aa6f-44e19bdab42d"),
+                new RewardSet((1, 2U), (2, 4U))
+            );
+            var coupon4 = new Coupon(
+                Guid.Parse("4a09d5d1-d702-45d5-aa6f-44e19bdab42d"),
+                new RewardSet((1, 2U))
+            );
+            var coupon5 = new Coupon(
+                Guid.Parse("8b899e82-1918-4d72-83c8-83407f8d6dc0"),
+                new RewardSet((1, 2U), (3, 4U))
+            );
+            Assert.False(coupon.Equals(emptyCoupon));
+            Assert.True(coupon.Equals(coupon));
+            Assert.False(coupon.Equals(coupon2));
+            Assert.False(coupon.Equals(coupon3));
+            Assert.False(coupon.Equals(coupon4));
+            Assert.False(coupon.Equals(coupon5));
+            Assert.False(emptyCoupon.Equals(coupon5));
+            Assert.False(coupon.Equals((object)emptyCoupon));
+            Assert.True(coupon.Equals((object)coupon));
+            Assert.False(coupon.Equals((object)coupon2));
+            Assert.False(coupon.Equals((object)coupon3));
+            Assert.False(coupon.Equals((object)coupon4));
+            Assert.False(coupon.Equals((object)coupon5));
+            Assert.False(emptyCoupon.Equals((object)coupon5));
+            Assert.False(coupon.Equals((object?)null));
+            Assert.False(emptyCoupon.Equals((object?)null));
+            Assert.NotEqual(coupon.GetHashCode(), emptyCoupon.GetHashCode());
+            Assert.Equal(coupon.GetHashCode(), coupon.GetHashCode());
+            Assert.NotEqual(coupon.GetHashCode(), coupon2.GetHashCode());
+            Assert.NotEqual(coupon.GetHashCode(), coupon3.GetHashCode());
+            Assert.NotEqual(coupon.GetHashCode(), coupon4.GetHashCode());
+            Assert.NotEqual(coupon.GetHashCode(), coupon5.GetHashCode());
+            Assert.NotEqual(emptyCoupon.GetHashCode(), coupon5.GetHashCode());
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            var emptyCoupon = new Coupon(
+                Guid.Parse("8b899e82-1918-4d72-83c8-83407f8d6dc0"),
+                default(RewardSet)
+            );
+            var emptySerialized = emptyCoupon.Serialize();
+            Assert.Equal(
+                Bencodex.Types.Dictionary.Empty
+                    .Add("id", ByteUtil.ParseHex("829e898b1819724d83c883407f8d6dc0"))
+                    .Add("rewards", Bencodex.Types.Dictionary.Empty),
+                emptySerialized
+            );
+
+            var coupon = new Coupon(
+                Guid.Parse("4a09d5d1-d702-45d5-aa6f-44e19bdab42d"),
+                new RewardSet((1, 2U), (3, 4U))
+            );
+            var serialized = coupon.Serialize();
+            Assert.Equal(
+                Bencodex.Types.Dictionary.Empty
+                    .Add("id", ByteUtil.ParseHex("d1d5094a02d7d545aa6f44e19bdab42d"))
+                    .Add("rewards", Bencodex.Types.Dictionary.Empty.Add("1", 2).Add("3", 4)),
+                serialized
+            );
+        }
+
+        [Fact]
+        public void Deserialize()
+        {
+            var deserializedEmptyCoupon = new Coupon(
+                Bencodex.Types.Dictionary.Empty
+                    .Add("id", ByteUtil.ParseHex("829e898b1819724d83c883407f8d6dc0"))
+                    .Add("rewards", Bencodex.Types.Dictionary.Empty)
+            );
+            var expectedEmptyCoupon = new Coupon(
+                Guid.Parse("8b899e82-1918-4d72-83c8-83407f8d6dc0"),
+                default(RewardSet)
+            );
+            Assert.Equal(expectedEmptyCoupon, deserializedEmptyCoupon);
+
+            var deserializedCoupon = new Coupon(
+                Bencodex.Types.Dictionary.Empty
+                    .Add("id", ByteUtil.ParseHex("d1d5094a02d7d545aa6f44e19bdab42d"))
+                    .Add("rewards", Bencodex.Types.Dictionary.Empty.Add("1", 2).Add("3", 4))
+            );
+            var expectedCoupon = new Coupon(
+                Guid.Parse("4a09d5d1-d702-45d5-aa6f-44e19bdab42d"),
+                new RewardSet((1, 2U), (3, 4U))
+            );
+            Assert.Equal(expectedCoupon, deserializedCoupon);
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/Coupons/RewardSetTest.cs
+++ b/.Lib9c.Tests/Model/Coupons/RewardSetTest.cs
@@ -1,0 +1,79 @@
+#nullable enable
+namespace Lib9c.Tests.Action.Coupons
+{
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using Nekoyume.Model.Coupons;
+    using Xunit;
+
+    public class RewardSetTest
+    {
+        [Fact]
+        public void Constructors()
+        {
+            var emptySet = default(RewardSet);
+            Assert.Equal(emptySet, new RewardSet(ImmutableDictionary<int, uint>.Empty));
+            Assert.Equal(emptySet, new RewardSet(Enumerable.Empty<(int, uint)>()));
+            Assert.Equal(emptySet, new RewardSet(new (int, uint)[0]));
+
+            var set = new RewardSet(ImmutableDictionary<int, uint>.Empty.Add(1, 2).Add(3, 4));
+            Assert.Equal(set, new RewardSet(new List<(int, uint)> { (1, 2U), (3, 4U) }));
+            Assert.Equal(set, new RewardSet((1, 2U), (3, 4U)));
+        }
+
+        [Fact]
+        public void Equality()
+        {
+            var emptySet = default(RewardSet);
+            var set = new RewardSet((1, 2U), (3, 4U));
+            var set2 = new RewardSet((1, 2U), (3, 5U));
+            var set3 = new RewardSet((1, 2U), (2, 4U));
+            var set4 = new RewardSet((1, 2U));
+            Assert.False(set.Equals(emptySet));
+            Assert.True(set.Equals(set));
+            Assert.False(set.Equals(set2));
+            Assert.False(set.Equals(set3));
+            Assert.False(set.Equals(set4));
+            Assert.False(set.Equals((object)emptySet));
+            Assert.True(set.Equals((object)set));
+            Assert.False(set.Equals((object)set2));
+            Assert.False(set.Equals((object)set3));
+            Assert.False(set.Equals((object)set4));
+            Assert.False(set.Equals((object?)null));
+            Assert.NotEqual(set.GetHashCode(), emptySet.GetHashCode());
+            Assert.Equal(set.GetHashCode(), set.GetHashCode());
+            Assert.NotEqual(set.GetHashCode(), set2.GetHashCode());
+            Assert.NotEqual(set.GetHashCode(), set3.GetHashCode());
+            Assert.NotEqual(set.GetHashCode(), set4.GetHashCode());
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            var emptySet = default(RewardSet);
+            var emptySerialized = emptySet.Serialize();
+            Assert.Equal(Bencodex.Types.Dictionary.Empty, emptySerialized);
+
+            var set = new RewardSet((1, 2U), (3, 4U));
+            var serialized = set.Serialize();
+            Assert.Equal(
+                Bencodex.Types.Dictionary.Empty.Add("1", 2).Add("3", 4),
+                serialized
+            );
+        }
+
+        [Fact]
+        public void Deserialize()
+        {
+            var deserializedEmptySet = new RewardSet(Bencodex.Types.Dictionary.Empty);
+            var expectedEmptySet = default(RewardSet);
+            Assert.Equal(expectedEmptySet, deserializedEmptySet);
+
+            var deserializedSet =
+                new RewardSet(Bencodex.Types.Dictionary.Empty.Add("1", 2).Add("3", 4));
+            var expectedSet = new RewardSet((1, 2U), (3, 4U));
+            Assert.Equal(expectedSet, deserializedSet);
+        }
+    }
+}

--- a/Lib9c/Action/AccountStateViewExtensions.cs
+++ b/Lib9c/Action/AccountStateViewExtensions.cs
@@ -15,6 +15,8 @@ using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
+using System.Collections.Immutable;
+using Nekoyume.Model.Coupons;
 
 namespace Nekoyume.Action
 {
@@ -432,6 +434,23 @@ namespace Nekoyume.Action
                 throw;
             }
         }
+
+#nullable enable
+        public static IImmutableDictionary<Guid, Coupon> GetCouponWallet(this IAccountStateView states, Address agentAddress)
+        {
+            Address walletAddress = agentAddress.Derive(CouponWalletKey);
+            IValue? serialized = states.GetState(walletAddress);
+            if (!(serialized is { } serializedValue))
+            {
+                return ImmutableDictionary<Guid, Coupon>.Empty;
+            }
+
+             var serializedWallet = (Bencodex.Types.List)serializedValue;
+             return serializedWallet
+                .Select(serializedCoupon => new Coupon(serializedCoupon))
+                .ToImmutableDictionary(v => v.Id, v => v);
+        }
+#nullable disable
 
         public static IEnumerable<GoldDistribution> GetGoldDistribution(
             this IAccountStateView states)

--- a/Lib9c/Action/Coupons/IssueCoupons.cs
+++ b/Lib9c/Action/Coupons/IssueCoupons.cs
@@ -71,7 +71,7 @@ namespace Nekoyume.Action.Coupons
             Rewards = ((Bencodex.Types.List)plainValue["rewards"])
                 .OfType<Bencodex.Types.Dictionary>()
                 .ToImmutableDictionary(
-                    d => new RewardSet((Dictionary)d["rewordSet"]),
+                    d => new RewardSet((Dictionary)d["rewardSet"]),
                     d => (uint)(Integer)d["quantity"]
                 );
         }

--- a/Lib9c/Action/Coupons/IssueCoupons.cs
+++ b/Lib9c/Action/Coupons/IssueCoupons.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Action;
+using Nekoyume.Model.Coupons;
+
+namespace Nekoyume.Action.Coupons
+{
+    [Serializable]
+    [ActionType("issue_coupons")]
+    public sealed class IssueCoupons : GameAction
+    {
+        public IssueCoupons(IImmutableDictionary<RewardSet, uint> rewards, Address recipient)
+        {
+            Rewards = rewards;
+            Recipient = recipient;
+        }
+
+        public IImmutableDictionary<RewardSet, uint> Rewards { get; private set; }
+
+        public Address Recipient { get; private set; }
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            var states = context.PreviousStates;
+            if (context.Rehearsal)
+            {
+                return states.SetCouponWallet(
+                    Recipient,
+                    ImmutableDictionary.Create<Guid, Coupon>(),
+                    rehearsal: true);
+            }
+
+            var wallet = states.GetCouponWallet(Recipient);
+            var random = context.Random;
+            var idBytes = new byte[16];
+            var orderedRewards = Rewards.OrderBy(kv => kv.Key, default(RewardSet.Comparer));
+            foreach (var (rewardSet, quantity) in orderedRewards)
+            {
+                for (uint i = 0U; i < quantity; i++)
+                {
+                    random.NextBytes(idBytes);
+                    var id = new Guid(idBytes);
+                    var coupon = new Coupon(id, rewardSet);
+                    wallet = wallet.Add(coupon.Id, coupon);
+                }
+            }
+
+            return states.SetCouponWallet(Recipient, wallet);
+        }
+
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            ImmutableDictionary<string, IValue>.Empty
+                .Add("recipient", new Binary(Recipient.ByteArray))
+                .Add(
+                    "rewards",
+                    new Bencodex.Types.List(
+                        Rewards
+                            .OrderBy(kv => kv.Key, default(RewardSet.Comparer))
+                            .Select(kv => Bencodex.Types.Dictionary.Empty
+                                .Add("rewardSet", kv.Key.Serialize())
+                                .Add("quantity", kv.Value))
+                    )
+                );
+
+        protected override void LoadPlainValueInternal(IImmutableDictionary<string, IValue> plainValue)
+        {
+            Recipient = new Address(plainValue["recipient"]);
+            Rewards = ((Bencodex.Types.List)plainValue["rewards"])
+                .OfType<Bencodex.Types.Dictionary>()
+                .ToImmutableDictionary(
+                    d => new RewardSet((Dictionary)d["rewordSet"]),
+                    d => (uint)(Integer)d["quantity"]
+                );
+        }
+    }
+}

--- a/Lib9c/Action/Coupons/IssueCoupons.cs
+++ b/Lib9c/Action/Coupons/IssueCoupons.cs
@@ -33,6 +33,8 @@ namespace Nekoyume.Action.Coupons
                     rehearsal: true);
             }
 
+            CheckPermission(context);
+
             var wallet = states.GetCouponWallet(Recipient);
             var random = context.Random;
             var idBytes = new byte[16];

--- a/Lib9c/Action/Coupons/RedeemCoupon.cs
+++ b/Lib9c/Action/Coupons/RedeemCoupon.cs
@@ -1,0 +1,87 @@
+#nullable enable
+using System;
+using System.Collections.Immutable;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Action;
+using Nekoyume.Model.Coupons;
+using Nekoyume.Model.Item;
+using Nekoyume.Model.State;
+using static Lib9c.SerializeKeys;
+
+namespace Nekoyume.Action.Coupons
+{
+    [Serializable]
+    [ActionType("redeem_coupon")]
+    public sealed class RedeemCoupon : GameAction
+    {
+        public Guid CouponId { get; private set; }
+        public Address AvatarAddress { get; private set; }
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            var states = context.PreviousStates;
+            var inventoryAddress = AvatarAddress.Derive(LegacyInventoryKey);
+            var worldInformationAddress = AvatarAddress.Derive(LegacyWorldInformationKey);
+            var questListAddress = AvatarAddress.Derive(LegacyQuestListKey);
+            if (context.Rehearsal)
+            {
+                return states
+                    .SetState(AvatarAddress, MarkChanged)
+                    .SetState(inventoryAddress, MarkChanged)
+                    .SetState(worldInformationAddress, MarkChanged)
+                    .SetState(questListAddress, MarkChanged)
+                    .SetCouponWallet(
+                        context.Signer,
+                        ImmutableDictionary.Create<Guid, Coupon>(),
+                        rehearsal: true);
+            }
+
+            if (!states.TryGetAvatarStateV2(
+                    context.Signer,
+                    AvatarAddress,
+                    out AvatarState avatarState,
+                    out _))
+            {
+                return states;
+            }
+
+            var wallet = states.GetCouponWallet(context.Signer);
+            if (!wallet.TryGetValue(CouponId, out var coupon))
+            {
+                return states;
+            }
+
+            wallet = wallet.Remove(CouponId);
+            var itemSheets = states.GetItemSheet();
+            foreach ((int itemId, uint q) in coupon)
+            {
+                for (uint i = 0U; i < q; i++)
+                {
+                    ItemBase item = ItemFactory.CreateItem(itemSheets[itemId], context.Random);
+                    // XXX: Inventory.AddItem() method silently ignores count if the item is
+                    // non-fungible.
+                    avatarState.inventory.AddItem(item, count: 1);
+                }
+            }
+
+            return states
+                .SetState(AvatarAddress, avatarState.SerializeV2())
+                .SetState(inventoryAddress, avatarState.inventory.Serialize())
+                .SetState(worldInformationAddress, avatarState.worldInformation.Serialize())
+                .SetState(questListAddress, avatarState.questList.Serialize())
+                .SetCouponWallet(context.Signer, wallet);
+        }
+
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            ImmutableDictionary<string, IValue>.Empty
+                .Add("coupon_id", new Binary(CouponId.ToByteArray()))
+                .Add("avatar_address", new Binary(AvatarAddress.ByteArray));
+
+        protected override void LoadPlainValueInternal(IImmutableDictionary<string, IValue> plainValue)
+        {
+            CouponId = new Guid((Binary)plainValue["coupon_id"]);
+            AvatarAddress = new Address(plainValue["avatar_address"]);
+        }
+    }
+}

--- a/Lib9c/Action/Coupons/RedeemCoupon.cs
+++ b/Lib9c/Action/Coupons/RedeemCoupon.cs
@@ -18,6 +18,12 @@ namespace Nekoyume.Action.Coupons
         public Guid CouponId { get; private set; }
         public Address AvatarAddress { get; private set; }
 
+        public RedeemCoupon(Guid couponId, Address avatarAddress)
+        {
+            CouponId = couponId;
+            AvatarAddress = avatarAddress;
+        }
+
         public override IAccountStateDelta Execute(IActionContext context)
         {
             var states = context.PreviousStates;

--- a/Lib9c/Action/Coupons/TransferCoupons.cs
+++ b/Lib9c/Action/Coupons/TransferCoupons.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Action;
+
+namespace Nekoyume.Action.Coupons
+{
+    [Serializable]
+    [ActionType("transfer_coupons")]
+    public sealed class TransferCoupons : GameAction
+    {
+        public TransferCoupons(
+            IImmutableDictionary<Address, IImmutableSet<Guid>> couponsPerRecipient)
+        {
+            CouponsPerRecipient = couponsPerRecipient;
+        }
+
+        public IImmutableDictionary<Address, IImmutableSet<Guid>> CouponsPerRecipient
+        {
+            get;
+            private set;
+        }
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            var states = context.PreviousStates;
+            var signerWallet = states.GetCouponWallet(context.Signer);
+            var orderedRecipients = CouponsPerRecipient.OrderBy(pair => pair.Key);
+            foreach ((Address recipient, IImmutableSet<Guid> couponIds) in orderedRecipients)
+            {
+                var recipientWallet = states.GetCouponWallet(recipient);
+                foreach (Guid id in couponIds)
+                {
+                    if (!signerWallet.TryGetValue(id, out var coupon))
+                    {
+                        throw new FailedLoadStateException(
+                            $"Failed to load a coupon (id: {id})."
+                        );
+                    }
+
+                    signerWallet = signerWallet.Remove(id);
+                    recipientWallet = recipientWallet.Add(id, coupon);
+                }
+
+                states = states.SetCouponWallet(recipient, recipientWallet, context.Rehearsal);
+            }
+
+            states = states.SetCouponWallet(context.Signer, signerWallet, context.Rehearsal);
+            return states;
+        }
+
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            CouponsPerRecipient.ToImmutableDictionary(
+                pair => pair.Key.ToHex(),
+                pair => (IValue)new Bencodex.Types.List(
+                    pair.Value.OrderBy(id => id).Select(id => id.ToByteArray()))
+            );
+
+        protected override void LoadPlainValueInternal(IImmutableDictionary<string, IValue> plainValue) =>
+            CouponsPerRecipient = plainValue.ToImmutableDictionary(
+                pair => new Address(pair.Key),
+                pair => (IImmutableSet<Guid>)((Bencodex.Types.List)pair.Value).Select(
+                    value => new Guid((Binary)value)
+                ).ToImmutableHashSet()
+            );
+    }
+}

--- a/Lib9c/Action/TransferAsset2.cs
+++ b/Lib9c/Action/TransferAsset2.cs
@@ -19,6 +19,7 @@ namespace Nekoyume.Action
     /// Updated at https://github.com/planetarium/lib9c/pull/957
     /// </summary>
     [Serializable]
+    [ActionObsolete(TransferAsset.CrystalTransferringRestrictionStartIndex - 1)]
     [ActionType("transfer_asset2")]
     public class TransferAsset2 : ActionBase, ISerializable, ITransferAsset, ITransferAssetV1
     {
@@ -84,6 +85,7 @@ namespace Nekoyume.Action
                 return state.MarkBalanceChanged(Amount.Currency, new[] { Sender, Recipient });
             }
 
+            CheckObsolete(TransferAsset.CrystalTransferringRestrictionStartIndex - 1, context);
             var addressesHex = GetSignerAndOtherAddressesHex(context, context.Signer);
             var started = DateTimeOffset.UtcNow;
             Log.Debug("{AddressesHex}TransferAsset2 exec started", addressesHex);

--- a/Lib9c/Model/Coupons/Coupon.cs
+++ b/Lib9c/Model/Coupons/Coupon.cs
@@ -1,0 +1,77 @@
+#nullable enable
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Bencodex.Types;
+
+namespace Nekoyume.Model.Coupons
+{
+    public readonly struct Coupon
+        : IOrderedEnumerable<(int ItemId, uint Quantity)>, IEquatable<Coupon>
+    {
+        public readonly Guid Id;
+
+        public readonly RewardSet Rewards;
+
+        public Coupon(Guid id, params (int ItemId, uint Quantity)[] rewards)
+            : this(id, (IEnumerable<(int ItemId, uint Quantity)>)rewards)
+        {
+        }
+
+        public Coupon(Guid id, IEnumerable<(int ItemId, uint Quantity)> rewards)
+            : this(id, new RewardSet(rewards))
+        {
+        }
+
+        public Coupon(Guid id, in RewardSet rewards)
+        {
+            Id = id;
+            Rewards = rewards;
+        }
+
+        public Coupon(IValue serialized)
+        {
+            if (!(serialized is Bencodex.Types.Dictionary dict))
+            {
+                throw new ArgumentException(
+                    $"Expected {nameof(Bencodex.Types.Dictionary)} but {serialized} was given.",
+                    nameof(serialized)
+                );
+            }
+
+            Id = new Guid(dict.GetValue<Binary>("id"));
+            Rewards = new RewardSet((Bencodex.Types.Dictionary)dict["rewards"]);
+        }
+
+        public IValue Serialize() => Bencodex.Types.Dictionary.Empty
+            .Add("id", Id.ToByteArray())
+            .Add("rewards", Rewards.Serialize());
+
+        public override bool Equals(object? obj) => obj is Coupon { } o && o.Equals(this);
+
+        public override int GetHashCode() =>
+            HashCode.Combine(Id, Rewards);
+
+        public bool Equals(Coupon other) => Id == other.Id && Rewards.Equals(other.Rewards);
+
+        IOrderedEnumerable<(int ItemId, uint Quantity)> IOrderedEnumerable<(int ItemId, uint Quantity)>.CreateOrderedEnumerable<TKey>(
+            Func<(int ItemId, uint Quantity), TKey> keySelector,
+            IComparer<TKey>? comparer,
+            bool descending)
+        {
+#pragma warning disable LAA1002
+            var pairs = Rewards.Select(pair => (pair.Key, pair.Value));
+#pragma warning restore LAA1002
+            return descending
+                ? pairs.OrderByDescending(keySelector, comparer)
+                : pairs.OrderBy(keySelector, comparer);
+        }
+
+        IEnumerator<(int ItemId, uint Quantity)> IEnumerable<(int ItemId, uint Quantity)>.GetEnumerator() =>
+            this.Rewards.OrderBy(pair => pair.Key).Select(pair => (pair.Key, pair.Value)).GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() =>
+            this.Rewards.OrderBy(pair => pair.Key).Select(pair => (pair.Key, pair.Value)).GetEnumerator();
+    }
+}

--- a/Lib9c/Model/Coupons/RewardSet.cs
+++ b/Lib9c/Model/Coupons/RewardSet.cs
@@ -1,0 +1,160 @@
+#nullable enable
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using Bencodex.Types;
+
+namespace Nekoyume.Model.Coupons
+{
+    public readonly struct RewardSet : IImmutableDictionary<int, uint>, IEquatable<RewardSet>
+    {
+        private readonly ImmutableDictionary<int, uint> _rewards;
+
+        private IImmutableDictionary<int, uint> Rewards =>
+            _rewards ?? ImmutableDictionary<int, uint>.Empty;
+
+        public RewardSet(in ImmutableDictionary<int, uint> rewards)
+        {
+            _rewards = rewards;
+        }
+
+        public RewardSet(IEnumerable<(int ItemId, uint Quantity)> rewards)
+            : this(rewards.ToImmutableDictionary(
+                pair => pair.ItemId,
+                pair => pair.Quantity
+            ))
+        {
+        }
+
+        public RewardSet(params (int ItemId, uint Quantity)[] rewards)
+            : this((IEnumerable<(int ItemId, uint Quantity)>)rewards)
+        {
+        }
+
+        public RewardSet(Bencodex.Types.Dictionary serialized)
+            : this(
+#pragma warning disable LAA1002
+                serialized.ToImmutableDictionary(
+                    pair => int.Parse((Text)pair.Key, CultureInfo.InvariantCulture),
+                    pair => (uint)(Bencodex.Types.Integer)pair.Value
+                )
+#pragma warning restore LAA1002
+            )
+        {
+        }
+
+        public Bencodex.Types.Dictionary Serialize() =>
+            new Bencodex.Types.Dictionary(
+#pragma warning disable LAA1002
+                Rewards.Select(pair =>
+                    KeyValuePair.Create<string, IValue>(
+                        pair.Key.ToString(CultureInfo.InvariantCulture),
+                        (Bencodex.Types.Integer)pair.Value
+                    )
+                )
+#pragma warning restore LAA1002
+            );
+
+        public uint this[int key] => Rewards[key];
+
+        public IEnumerable<int> Keys => Rewards.Keys;
+
+        public IEnumerable<uint> Values => Rewards.Values;
+
+        public int Count => Rewards.Count;
+
+        public IImmutableDictionary<int, uint> Add(int key, uint value) =>
+            Rewards.Add(key, value);
+
+        public IImmutableDictionary<int, uint> AddRange(IEnumerable<KeyValuePair<int, uint>> pairs) =>
+            Rewards.AddRange(pairs);
+
+        public IImmutableDictionary<int, uint> Clear() =>
+            Rewards.Clear();
+
+        public bool Contains(KeyValuePair<int, uint> pair) =>
+            Rewards.Contains(pair);
+
+        public bool ContainsKey(int key) =>
+            Rewards.ContainsKey(key);
+
+        public IEnumerator<KeyValuePair<int, uint>> GetEnumerator() =>
+            Rewards.GetEnumerator();
+
+        public IImmutableDictionary<int, uint> Remove(int key) =>
+            Rewards.Remove(key);
+
+        public IImmutableDictionary<int, uint> RemoveRange(IEnumerable<int> keys) =>
+            Rewards.RemoveRange(keys);
+
+        public IImmutableDictionary<int, uint> SetItem(int key, uint value) =>
+            Rewards.SetItem(key, value);
+
+        public IImmutableDictionary<int, uint> SetItems(IEnumerable<KeyValuePair<int, uint>> items) =>
+            Rewards.SetItems(items);
+
+        public bool TryGetKey(int equalKey, out int actualKey) =>
+            Rewards.TryGetKey(equalKey, out actualKey);
+
+        public bool TryGetValue(int key, [MaybeNullWhen(false)] out uint value) =>
+            Rewards.TryGetValue(key, out value);
+
+        IEnumerator IEnumerable.GetEnumerator() =>
+            ((IEnumerable)Rewards.OrderBy(pair => pair.Key)).GetEnumerator();
+
+        public bool Equals(RewardSet other) =>
+            Rewards.Count == other.Rewards.Count &&
+#pragma warning disable LAA1002
+            Rewards.All(pair =>
+                other.Rewards.TryGetValue(pair.Key, out uint v) && v == pair.Value);
+#pragma warning restore LAA1002
+
+        public override bool Equals([NotNullWhen(true)] object? obj) =>
+            obj is RewardSet other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            int hash = Count.GetHashCode();
+            foreach (var pair in Rewards.OrderBy(pair => pair.Key))
+            {
+                unchecked
+                {
+                    hash = hash * 31 + pair.Key.GetHashCode();
+                    hash = hash * 31 + pair.Value.GetHashCode();
+                }
+            }
+
+            return hash;
+        }
+
+        public struct Comparer : IComparer<RewardSet>
+        {
+            public int Compare(RewardSet x, RewardSet y)
+            {
+                if (x.Count != y.Count)
+                {
+                    return x.Count.CompareTo(y.Count);
+                }
+
+                foreach (var pair in x.OrderBy(pair => pair.Key))
+                {
+                    if (!y.TryGetValue(pair.Key, out uint v))
+                    {
+                        return 1;
+                    }
+
+                    if (pair.Value != v)
+                    {
+                        return pair.Value.CompareTo(v);
+                    }
+                }
+
+                return 0;
+            }
+        }
+    }
+}

--- a/Lib9c/SerializeKeys.cs
+++ b/Lib9c/SerializeKeys.cs
@@ -152,6 +152,7 @@ namespace Lib9c
         public const string TradableIdKey = "ti";
         public const string OrderReceiptListKey = "orl";
         public const string BuyerAgentAddressKey = "bga";
+        public const string CouponWalletKey = "coupon_wallet";
 
         // QuestList
         public const string QuestsKeyDeprecated = "quests";


### PR DESCRIPTION
A `Coupon` is non-fungible (interpretation: having a unique identifier) and consists of `RewardSet`, a list of `ItemId`s with their quantities.

Every `Agent` has their own coupon wallet to store `Coupon`s that are not redeemed yet.  An `IssueCoupon` action, which takes a `RewardSet` and a recipient, creates a new `Coupon` and then places it inside the recipient's wallet.  Once a `Coupon` is redeemed using a `RedeemCoupon` action, it's destroyed in the agent's wallet and then the promised rewards become added in their inventory.

If necessary `Coupon`s can be transferred to another recipient using a `TransferCoupon` action.  However, once redeemed `Coupon`s cannot be transferred of course.

Actions `IssueCoupon` and `TransferCoupon` can deal with multiple `Coupon`s at a time.  However, different `RewardSet`s of `Coupon`s need to be issued using multiple `IssueCoupon` actions, as a single `IssueCoupon` can produce only `Coupon`s having the same set of rewards.  Note that `TransferCoupon` does not have such limitation, however.