### PR TITLE
Unify interfaces impl styles in `Lib9c.Abstractions`

### DIFF
--- a/Lib9c.Abstractions/IBattleArenaV1.cs
+++ b/Lib9c.Abstractions/IBattleArenaV1.cs
@@ -2,9 +2,8 @@
 
 using System;
 using System.Collections.Generic;
+using Bencodex.Types;
 using Libplanet;
-
-using BencodexList = Bencodex.Types.List;
 
 namespace Lib9c.Abstractions
 {
@@ -17,6 +16,6 @@ namespace Lib9c.Abstractions
         int Ticket { get; }
         IEnumerable<Guid> Costumes { get; }
         IEnumerable<Guid> Equipments { get; }
-        IEnumerable<BencodexList>? RuneSlotInfos => null;
+        IEnumerable<IValue>? RuneSlotInfos => null;
     }
 }

--- a/Lib9c.Abstractions/ICreatePendingActivationsV1.cs
+++ b/Lib9c.Abstractions/ICreatePendingActivationsV1.cs
@@ -1,9 +1,10 @@
 using System.Collections.Generic;
+using Bencodex.Types;
 
 namespace Lib9c.Abstractions
 {
     public interface ICreatePendingActivationsV1
     {
-        IEnumerable<Bencodex.Types.List> PendingActivations { get; }
+        IEnumerable<IValue> PendingActivations { get; }
     }
 }

--- a/Lib9c.Abstractions/IJoinArenaV1.cs
+++ b/Lib9c.Abstractions/IJoinArenaV1.cs
@@ -2,8 +2,8 @@
 
 using System;
 using System.Collections.Generic;
+using Bencodex.Types;
 using Libplanet;
-using BencodexList = Bencodex.Types.List;
 
 namespace Lib9c.Abstractions
 {
@@ -14,6 +14,6 @@ namespace Lib9c.Abstractions
         int Round { get; }
         IEnumerable<Guid> Costumes { get; }
         IEnumerable<Guid> Equipments { get; }
-        IEnumerable<BencodexList>? RuneSlotInfos => null;
+        IEnumerable<IValue>? RuneSlotInfos => null;
     }
 }

--- a/Lib9c/Action/ActivateAccount.cs
+++ b/Lib9c/Action/ActivateAccount.cs
@@ -18,6 +18,9 @@ namespace Nekoyume.Action
 
         public byte[] Signature { get; private set; }
 
+        Address IActivateAccount.PendingAddress => PendingAddress;
+        byte[] IActivateAccount.Signature => Signature;
+
         public override IValue PlainValue =>
             new Dictionary(
                 new[]

--- a/Lib9c/Action/ActivateAccount0.cs
+++ b/Lib9c/Action/ActivateAccount0.cs
@@ -18,6 +18,9 @@ namespace Nekoyume.Action
 
         public byte[] Signature { get; private set; }
 
+        Address IActivateAccount.PendingAddress => PendingAddress;
+        byte[] IActivateAccount.Signature => Signature;
+
         public override IValue PlainValue =>
             new Dictionary(
                 new[]

--- a/Lib9c/Action/AddActivatedAccount.cs
+++ b/Lib9c/Action/AddActivatedAccount.cs
@@ -24,6 +24,8 @@ namespace Nekoyume.Action
 
         public Address Address { get; private set; }
 
+        Address IAddActivatedAccountV1.Address => Address;
+
         public override IValue PlainValue =>
             new Dictionary(
                 new[]

--- a/Lib9c/Action/AddActivatedAccount0.cs
+++ b/Lib9c/Action/AddActivatedAccount0.cs
@@ -24,6 +24,8 @@ namespace Nekoyume.Action
 
         public Address Address { get; private set; }
 
+        Address IAddActivatedAccountV1.Address => Address;
+
         public override IValue PlainValue =>
             new Dictionary(
                 new[]

--- a/Lib9c/Action/AddRedeemCode.cs
+++ b/Lib9c/Action/AddRedeemCode.cs
@@ -14,7 +14,7 @@ namespace Nekoyume.Action
     {
         public string redeemCsv;
 
-        public string RedeemCsv => redeemCsv;
+        string IAddRedeemCodeV1.RedeemCsv => redeemCsv;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/BattleArena.cs
+++ b/Lib9c/Action/BattleArena.cs
@@ -20,8 +20,6 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
-using BencodexList = Bencodex.Types.List;
-
 namespace Nekoyume.Action
 {
     /// <summary>
@@ -62,8 +60,8 @@ namespace Nekoyume.Action
 
         IEnumerable<Guid> IBattleArenaV1.Equipments => equipments;
 
-        IEnumerable<BencodexList> IBattleArenaV1.RuneSlotInfos => runeInfos
-            .Select(x => (BencodexList)x.Serialize());
+        IEnumerable<IValue> IBattleArenaV1.RuneSlotInfos => runeInfos
+            .Select(x => x.Serialize());
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>()

--- a/Lib9c/Action/BattleArena.cs
+++ b/Lib9c/Action/BattleArena.cs
@@ -48,21 +48,21 @@ namespace Nekoyume.Action
         public ArenaPlayerDigest ExtraEnemyArenaPlayerDigest;
         public int ExtraPreviousMyScore;
 
-        public Address MyAvatarAddress => myAvatarAddress;
+        Address IBattleArenaV1.MyAvatarAddress => myAvatarAddress;
 
-        public Address EnemyAvatarAddress => enemyAvatarAddress;
+        Address IBattleArenaV1.EnemyAvatarAddress => enemyAvatarAddress;
 
-        public int ChampionshipId => championshipId;
+        int IBattleArenaV1.ChampionshipId => championshipId;
 
-        public int Round => round;
+        int IBattleArenaV1.Round => round;
 
-        public int Ticket => ticket;
+        int IBattleArenaV1.Ticket => ticket;
 
-        public IEnumerable<Guid> Costumes => costumes;
+        IEnumerable<Guid> IBattleArenaV1.Costumes => costumes;
 
-        public IEnumerable<Guid> Equipments => equipments;
+        IEnumerable<Guid> IBattleArenaV1.Equipments => equipments;
 
-        public IEnumerable<BencodexList> RuneSlotInfos => runeInfos
+        IEnumerable<BencodexList> IBattleArenaV1.RuneSlotInfos => runeInfos
             .Select(x => (BencodexList)x.Serialize());
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>

--- a/Lib9c/Action/BattleArena1.cs
+++ b/Lib9c/Action/BattleArena1.cs
@@ -43,19 +43,19 @@ namespace Nekoyume.Action
         public int ExtraPreviousMyScore;
 
 
-        public Address MyAvatarAddress => myAvatarAddress;
+        Address IBattleArenaV1.MyAvatarAddress => myAvatarAddress;
 
-        public Address EnemyAvatarAddress => enemyAvatarAddress;
+        Address IBattleArenaV1.EnemyAvatarAddress => enemyAvatarAddress;
 
-        public int ChampionshipId => championshipId;
+        int IBattleArenaV1.ChampionshipId => championshipId;
 
-        public int Round => round;
+        int IBattleArenaV1.Round => round;
 
-        public int Ticket => ticket;
+        int IBattleArenaV1.Ticket => ticket;
 
-        public IEnumerable<Guid> Costumes => costumes;
+        IEnumerable<Guid> IBattleArenaV1.Costumes => costumes;
 
-        public IEnumerable<Guid> Equipments => equipments;
+        IEnumerable<Guid> IBattleArenaV1.Equipments => equipments;
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>()

--- a/Lib9c/Action/BattleArena2.cs
+++ b/Lib9c/Action/BattleArena2.cs
@@ -43,19 +43,19 @@ namespace Nekoyume.Action
         public ArenaPlayerDigest ExtraEnemyArenaPlayerDigest;
         public int ExtraPreviousMyScore;
 
-        public Address MyAvatarAddress => myAvatarAddress;
+        Address IBattleArenaV1.MyAvatarAddress => myAvatarAddress;
 
-        public Address EnemyAvatarAddress => enemyAvatarAddress;
+        Address IBattleArenaV1.EnemyAvatarAddress => enemyAvatarAddress;
 
-        public int ChampionshipId => championshipId;
+        int IBattleArenaV1.ChampionshipId => championshipId;
 
-        public int Round => round;
+        int IBattleArenaV1.Round => round;
 
-        public int Ticket => ticket;
+        int IBattleArenaV1.Ticket => ticket;
 
-        public IEnumerable<Guid> Costumes => costumes;
+        IEnumerable<Guid> IBattleArenaV1.Costumes => costumes;
 
-        public IEnumerable<Guid> Equipments => equipments;
+        IEnumerable<Guid> IBattleArenaV1.Equipments => equipments;
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>()

--- a/Lib9c/Action/BattleArena3.cs
+++ b/Lib9c/Action/BattleArena3.cs
@@ -43,19 +43,19 @@ namespace Nekoyume.Action
         public ArenaPlayerDigest ExtraEnemyArenaPlayerDigest;
         public int ExtraPreviousMyScore;
 
-        public Address MyAvatarAddress => myAvatarAddress;
+        Address IBattleArenaV1.MyAvatarAddress => myAvatarAddress;
 
-        public Address EnemyAvatarAddress => enemyAvatarAddress;
+        Address IBattleArenaV1.EnemyAvatarAddress => enemyAvatarAddress;
 
-        public int ChampionshipId => championshipId;
+        int IBattleArenaV1.ChampionshipId => championshipId;
 
-        public int Round => round;
+        int IBattleArenaV1.Round => round;
 
-        public int Ticket => ticket;
+        int IBattleArenaV1.Ticket => ticket;
 
-        public IEnumerable<Guid> Costumes => costumes;
+        IEnumerable<Guid> IBattleArenaV1.Costumes => costumes;
 
-        public IEnumerable<Guid> Equipments => equipments;
+        IEnumerable<Guid> IBattleArenaV1.Equipments => equipments;
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>()

--- a/Lib9c/Action/BattleArena4.cs
+++ b/Lib9c/Action/BattleArena4.cs
@@ -42,19 +42,19 @@ namespace Nekoyume.Action
         public ArenaPlayerDigest ExtraEnemyArenaPlayerDigest;
         public int ExtraPreviousMyScore;
 
-        public Address MyAvatarAddress => myAvatarAddress;
+        Address IBattleArenaV1.MyAvatarAddress => myAvatarAddress;
 
-        public Address EnemyAvatarAddress => enemyAvatarAddress;
+        Address IBattleArenaV1.EnemyAvatarAddress => enemyAvatarAddress;
 
-        public int ChampionshipId => championshipId;
+        int IBattleArenaV1.ChampionshipId => championshipId;
 
-        public int Round => round;
+        int IBattleArenaV1.Round => round;
 
-        public int Ticket => ticket;
+        int IBattleArenaV1.Ticket => ticket;
 
-        public IEnumerable<Guid> Costumes => costumes;
+        IEnumerable<Guid> IBattleArenaV1.Costumes => costumes;
 
-        public IEnumerable<Guid> Equipments => equipments;
+        IEnumerable<Guid> IBattleArenaV1.Equipments => equipments;
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>()

--- a/Lib9c/Action/BattleArena5.cs
+++ b/Lib9c/Action/BattleArena5.cs
@@ -43,19 +43,19 @@ namespace Nekoyume.Action
         public ArenaPlayerDigest ExtraEnemyArenaPlayerDigest;
         public int ExtraPreviousMyScore;
 
-        public Address MyAvatarAddress => myAvatarAddress;
+        Address IBattleArenaV1.MyAvatarAddress => myAvatarAddress;
 
-        public Address EnemyAvatarAddress => enemyAvatarAddress;
+        Address IBattleArenaV1.EnemyAvatarAddress => enemyAvatarAddress;
 
-        public int ChampionshipId => championshipId;
+        int IBattleArenaV1.ChampionshipId => championshipId;
 
-        public int Round => round;
+        int IBattleArenaV1.Round => round;
 
-        public int Ticket => ticket;
+        int IBattleArenaV1.Ticket => ticket;
 
-        public IEnumerable<Guid> Costumes => costumes;
+        IEnumerable<Guid> IBattleArenaV1.Costumes => costumes;
 
-        public IEnumerable<Guid> Equipments => equipments;
+        IEnumerable<Guid> IBattleArenaV1.Equipments => equipments;
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>()

--- a/Lib9c/Action/BattleArena6.cs
+++ b/Lib9c/Action/BattleArena6.cs
@@ -44,19 +44,19 @@ namespace Nekoyume.Action
         public ArenaPlayerDigest ExtraEnemyArenaPlayerDigest;
         public int ExtraPreviousMyScore;
 
-        public Address MyAvatarAddress => myAvatarAddress;
+        Address IBattleArenaV1.MyAvatarAddress => myAvatarAddress;
 
-        public Address EnemyAvatarAddress => enemyAvatarAddress;
+        Address IBattleArenaV1.EnemyAvatarAddress => enemyAvatarAddress;
 
-        public int ChampionshipId => championshipId;
+        int IBattleArenaV1.ChampionshipId => championshipId;
 
-        public int Round => round;
+        int IBattleArenaV1.Round => round;
 
-        public int Ticket => ticket;
+        int IBattleArenaV1.Ticket => ticket;
 
-        public IEnumerable<Guid> Costumes => costumes;
+        IEnumerable<Guid> IBattleArenaV1.Costumes => costumes;
 
-        public IEnumerable<Guid> Equipments => equipments;
+        IEnumerable<Guid> IBattleArenaV1.Equipments => equipments;
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>()

--- a/Lib9c/Action/BattleArena7.cs
+++ b/Lib9c/Action/BattleArena7.cs
@@ -50,21 +50,21 @@ namespace Nekoyume.Action
         public ArenaPlayerDigest ExtraEnemyArenaPlayerDigest;
         public int ExtraPreviousMyScore;
 
-        public Address MyAvatarAddress => myAvatarAddress;
+        Address IBattleArenaV1.MyAvatarAddress => myAvatarAddress;
 
-        public Address EnemyAvatarAddress => enemyAvatarAddress;
+        Address IBattleArenaV1.EnemyAvatarAddress => enemyAvatarAddress;
 
-        public int ChampionshipId => championshipId;
+        int IBattleArenaV1.ChampionshipId => championshipId;
 
-        public int Round => round;
+        int IBattleArenaV1.Round => round;
 
-        public int Ticket => ticket;
+        int IBattleArenaV1.Ticket => ticket;
 
-        public IEnumerable<Guid> Costumes => costumes;
+        IEnumerable<Guid> IBattleArenaV1.Costumes => costumes;
 
-        public IEnumerable<Guid> Equipments => equipments;
+        IEnumerable<Guid> IBattleArenaV1.Equipments => equipments;
 
-        public IEnumerable<BencodexList> RuneSlotInfos => runeInfos
+        IEnumerable<BencodexList> IBattleArenaV1.RuneSlotInfos => runeInfos
             .Select(x => (BencodexList)x.Serialize());
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>

--- a/Lib9c/Action/BattleArena7.cs
+++ b/Lib9c/Action/BattleArena7.cs
@@ -23,8 +23,6 @@ using Nekoyume.TableData;
 using Serilog;
 using static Lib9c.SerializeKeys;
 
-using BencodexList = Bencodex.Types.List;
-
 namespace Nekoyume.Action
 {
     /// <summary>
@@ -64,8 +62,8 @@ namespace Nekoyume.Action
 
         IEnumerable<Guid> IBattleArenaV1.Equipments => equipments;
 
-        IEnumerable<BencodexList> IBattleArenaV1.RuneSlotInfos => runeInfos
-            .Select(x => (BencodexList)x.Serialize());
+        IEnumerable<IValue> IBattleArenaV1.RuneSlotInfos => runeInfos
+            .Select(x => x.Serialize());
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>()

--- a/Lib9c/Action/CreatePendingActivations.cs
+++ b/Lib9c/Action/CreatePendingActivations.cs
@@ -20,7 +20,7 @@ namespace Nekoyume.Action
     {
         public IList<(byte[] Address, byte[] Nonce, byte[] PublicKey)> PendingActivations { get; internal set; }
 
-        IEnumerable<Bencodex.Types.List> ICreatePendingActivationsV1.PendingActivations =>
+        IEnumerable<IValue> ICreatePendingActivationsV1.PendingActivations =>
             PendingActivations.Select(t =>
                 new List(new Binary[] { t.Address, t.Nonce, t.PublicKey }.Cast<IValue>()));
 

--- a/Lib9c/Action/InitializeStates.cs
+++ b/Lib9c/Action/InitializeStates.cs
@@ -52,6 +52,19 @@ namespace Nekoyume.Action
         // This property can contain null:
         public Dictionary Credits { get; set; }
 
+        Dictionary IInitializeStatesV1.Ranking => Ranking;
+        Dictionary IInitializeStatesV1.Shop => Shop;
+        Dictionary<string, string> IInitializeStatesV1.TableSheets => TableSheets;
+        Dictionary IInitializeStatesV1.GameConfig => GameConfig;
+        Dictionary IInitializeStatesV1.RedeemCode => RedeemCode;
+        Dictionary IInitializeStatesV1.AdminAddressState => AdminAddressState;
+        Dictionary IInitializeStatesV1.ActivatedAccounts => ActivatedAccounts;
+        Dictionary IInitializeStatesV1.GoldCurrency => GoldCurrency;
+        List IInitializeStatesV1.GoldDistributions => GoldDistributions;
+        List IInitializeStatesV1.PendingActivations => PendingActivations;
+        Dictionary IInitializeStatesV1.AuthorizedMiners => AuthorizedMiners;
+        Dictionary IInitializeStatesV1.Credits => Credits;
+
         public InitializeStates()
         {
         }

--- a/Lib9c/Action/ItemEnhancement.cs
+++ b/Lib9c/Action/ItemEnhancement.cs
@@ -44,10 +44,10 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public int slotIndex;
 
-        public Guid ItemId => itemId;
-        public Guid MaterialId => materialId;
-        public Address AvatarAddress => avatarAddress;
-        public int SlotIndex => slotIndex;
+        Guid IItemEnhancementV2.ItemId => itemId;
+        Guid IItemEnhancementV2.MaterialId => materialId;
+        Address IItemEnhancementV2.AvatarAddress => avatarAddress;
+        int IItemEnhancementV2.SlotIndex => slotIndex;
 
         [Serializable]
         public class ResultModel : AttachmentActionResult

--- a/Lib9c/Action/ItemEnhancement0.cs
+++ b/Lib9c/Action/ItemEnhancement0.cs
@@ -31,10 +31,10 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public int slotIndex;
 
-        public Guid ItemId => itemId;
-        public IEnumerable<Guid> MaterialIds => materialIds;
-        public Address AvatarAddress => avatarAddress;
-        public int SlotIndex => slotIndex;
+        Guid IItemEnhancementV1.ItemId => itemId;
+        IEnumerable<Guid> IItemEnhancementV1.MaterialIds => materialIds;
+        Address IItemEnhancementV1.AvatarAddress => avatarAddress;
+        int IItemEnhancementV1.SlotIndex => slotIndex;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/ItemEnhancement10.cs
+++ b/Lib9c/Action/ItemEnhancement10.cs
@@ -40,10 +40,10 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public int slotIndex;
 
-        public Guid ItemId => itemId;
-        public Guid MaterialId => materialId;
-        public Address AvatarAddress => avatarAddress;
-        public int SlotIndex => slotIndex;
+        Guid IItemEnhancementV2.ItemId => itemId;
+        Guid IItemEnhancementV2.MaterialId => materialId;
+        Address IItemEnhancementV2.AvatarAddress => avatarAddress;
+        int IItemEnhancementV2.SlotIndex => slotIndex;
 
         // NOTE: This is equals to [`ItemEnhancement9.ResultModel`].
         [Serializable]

--- a/Lib9c/Action/ItemEnhancement2.cs
+++ b/Lib9c/Action/ItemEnhancement2.cs
@@ -31,10 +31,10 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public int slotIndex;
 
-        public Guid ItemId => itemId;
-        public Guid MaterialId => materialId;
-        public Address AvatarAddress => avatarAddress;
-        public int SlotIndex => slotIndex;
+        Guid IItemEnhancementV2.ItemId => itemId;
+        Guid IItemEnhancementV2.MaterialId => materialId;
+        Address IItemEnhancementV2.AvatarAddress => avatarAddress;
+        int IItemEnhancementV2.SlotIndex => slotIndex;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/ItemEnhancement3.cs
+++ b/Lib9c/Action/ItemEnhancement3.cs
@@ -31,10 +31,10 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public int slotIndex;
 
-        public Guid ItemId => itemId;
-        public Guid MaterialId => materialId;
-        public Address AvatarAddress => avatarAddress;
-        public int SlotIndex => slotIndex;
+        Guid IItemEnhancementV2.ItemId => itemId;
+        Guid IItemEnhancementV2.MaterialId => materialId;
+        Address IItemEnhancementV2.AvatarAddress => avatarAddress;
+        int IItemEnhancementV2.SlotIndex => slotIndex;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/ItemEnhancement4.cs
+++ b/Lib9c/Action/ItemEnhancement4.cs
@@ -29,10 +29,10 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public int slotIndex;
 
-        public Guid ItemId => itemId;
-        public Guid MaterialId => materialId;
-        public Address AvatarAddress => avatarAddress;
-        public int SlotIndex => slotIndex;
+        Guid IItemEnhancementV2.ItemId => itemId;
+        Guid IItemEnhancementV2.MaterialId => materialId;
+        Address IItemEnhancementV2.AvatarAddress => avatarAddress;
+        int IItemEnhancementV2.SlotIndex => slotIndex;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/ItemEnhancement5.cs
+++ b/Lib9c/Action/ItemEnhancement5.cs
@@ -29,10 +29,10 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public int slotIndex;
 
-        public Guid ItemId => itemId;
-        public Guid MaterialId => materialId;
-        public Address AvatarAddress => avatarAddress;
-        public int SlotIndex => slotIndex;
+        Guid IItemEnhancementV2.ItemId => itemId;
+        Guid IItemEnhancementV2.MaterialId => materialId;
+        Address IItemEnhancementV2.AvatarAddress => avatarAddress;
+        int IItemEnhancementV2.SlotIndex => slotIndex;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/ItemEnhancement6.cs
+++ b/Lib9c/Action/ItemEnhancement6.cs
@@ -31,10 +31,10 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public int slotIndex;
 
-        public Guid ItemId => itemId;
-        public Guid MaterialId => materialId;
-        public Address AvatarAddress => avatarAddress;
-        public int SlotIndex => slotIndex;
+        Guid IItemEnhancementV2.ItemId => itemId;
+        Guid IItemEnhancementV2.MaterialId => materialId;
+        Address IItemEnhancementV2.AvatarAddress => avatarAddress;
+        int IItemEnhancementV2.SlotIndex => slotIndex;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/ItemEnhancement7.cs
+++ b/Lib9c/Action/ItemEnhancement7.cs
@@ -32,10 +32,10 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public int slotIndex;
 
-        public Guid ItemId => itemId;
-        public Guid MaterialId => materialId;
-        public Address AvatarAddress => avatarAddress;
-        public int SlotIndex => slotIndex;
+        Guid IItemEnhancementV2.ItemId => itemId;
+        Guid IItemEnhancementV2.MaterialId => materialId;
+        Address IItemEnhancementV2.AvatarAddress => avatarAddress;
+        int IItemEnhancementV2.SlotIndex => slotIndex;
 
         [Serializable]
         public class ResultModel : AttachmentActionResult

--- a/Lib9c/Action/ItemEnhancement8.cs
+++ b/Lib9c/Action/ItemEnhancement8.cs
@@ -32,10 +32,10 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public int slotIndex;
 
-        public Guid ItemId => itemId;
-        public Guid MaterialId => materialId;
-        public Address AvatarAddress => avatarAddress;
-        public int SlotIndex => slotIndex;
+        Guid IItemEnhancementV2.ItemId => itemId;
+        Guid IItemEnhancementV2.MaterialId => materialId;
+        Address IItemEnhancementV2.AvatarAddress => avatarAddress;
+        int IItemEnhancementV2.SlotIndex => slotIndex;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/ItemEnhancement9.cs
+++ b/Lib9c/Action/ItemEnhancement9.cs
@@ -38,10 +38,10 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public int slotIndex;
 
-        public Guid ItemId => itemId;
-        public Guid MaterialId => materialId;
-        public Address AvatarAddress => avatarAddress;
-        public int SlotIndex => slotIndex;
+        Guid IItemEnhancementV2.ItemId => itemId;
+        Guid IItemEnhancementV2.MaterialId => materialId;
+        Address IItemEnhancementV2.AvatarAddress => avatarAddress;
+        int IItemEnhancementV2.SlotIndex => slotIndex;
 
         [Serializable]
         public class ResultModel : AttachmentActionResult

--- a/Lib9c/Action/JoinArena.cs
+++ b/Lib9c/Action/JoinArena.cs
@@ -33,12 +33,12 @@ namespace Nekoyume.Action
         public List<Guid> equipments;
         public List<RuneSlotInfo> runeInfos;
 
-        public Address AvatarAddress => avatarAddress;
-        public int ChampionshipId => championshipId;
-        public int Round => round;
-        public IEnumerable<Guid> Costumes => costumes;
-        public IEnumerable<Guid> Equipments => equipments;
-        public IEnumerable<BencodexList> RuneSlotInfos => runeInfos
+        Address IJoinArenaV1.AvatarAddress => avatarAddress;
+        int IJoinArenaV1.ChampionshipId => championshipId;
+        int IJoinArenaV1.Round => round;
+        IEnumerable<Guid> IJoinArenaV1.Costumes => costumes;
+        IEnumerable<Guid> IJoinArenaV1.Equipments => equipments;
+        IEnumerable<BencodexList> IJoinArenaV1.RuneSlotInfos => runeInfos
             .Select(x => (BencodexList)x.Serialize());
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>

--- a/Lib9c/Action/JoinArena.cs
+++ b/Lib9c/Action/JoinArena.cs
@@ -15,7 +15,6 @@ using Nekoyume.Model.Rune;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
-using BencodexList = Bencodex.Types.List;
 
 namespace Nekoyume.Action
 {
@@ -38,8 +37,8 @@ namespace Nekoyume.Action
         int IJoinArenaV1.Round => round;
         IEnumerable<Guid> IJoinArenaV1.Costumes => costumes;
         IEnumerable<Guid> IJoinArenaV1.Equipments => equipments;
-        IEnumerable<BencodexList> IJoinArenaV1.RuneSlotInfos => runeInfos
-            .Select(x => (BencodexList)x.Serialize());
+        IEnumerable<IValue> IJoinArenaV1.RuneSlotInfos => runeInfos
+            .Select(x => x.Serialize());
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>()

--- a/Lib9c/Action/JoinArena1.cs
+++ b/Lib9c/Action/JoinArena1.cs
@@ -31,11 +31,11 @@ namespace Nekoyume.Action
         public List<Guid> costumes;
         public List<Guid> equipments;
 
-        public Address AvatarAddress => avatarAddress;
-        public int ChampionshipId => championshipId;
-        public int Round => round;
-        public IEnumerable<Guid> Costumes => costumes;
-        public IEnumerable<Guid> Equipments => equipments;
+        Address IJoinArenaV1.AvatarAddress => avatarAddress;
+        int IJoinArenaV1.ChampionshipId => championshipId;
+        int IJoinArenaV1.Round => round;
+        IEnumerable<Guid> IJoinArenaV1.Costumes => costumes;
+        IEnumerable<Guid> IJoinArenaV1.Equipments => equipments;
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>()

--- a/Lib9c/Action/JoinArena2.cs
+++ b/Lib9c/Action/JoinArena2.cs
@@ -35,12 +35,12 @@ namespace Nekoyume.Action
         public List<Guid> equipments;
         public List<RuneSlotInfo> runeInfos;
 
-        public Address AvatarAddress => avatarAddress;
-        public int ChampionshipId => championshipId;
-        public int Round => round;
-        public IEnumerable<Guid> Costumes => costumes;
-        public IEnumerable<Guid> Equipments => equipments;
-        public IEnumerable<BencodexList> RuneSlotInfos => runeInfos
+        Address IJoinArenaV1.AvatarAddress => avatarAddress;
+        int IJoinArenaV1.ChampionshipId => championshipId;
+        int IJoinArenaV1.Round => round;
+        IEnumerable<Guid> IJoinArenaV1.Costumes => costumes;
+        IEnumerable<Guid> IJoinArenaV1.Equipments => equipments;
+        IEnumerable<BencodexList> IJoinArenaV1.RuneSlotInfos => runeInfos
             .Select(x => (BencodexList)x.Serialize());
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>

--- a/Lib9c/Action/JoinArena2.cs
+++ b/Lib9c/Action/JoinArena2.cs
@@ -16,7 +16,6 @@ using Nekoyume.Model.Rune;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
-using BencodexList = Bencodex.Types.List;
 
 namespace Nekoyume.Action
 {
@@ -40,8 +39,8 @@ namespace Nekoyume.Action
         int IJoinArenaV1.Round => round;
         IEnumerable<Guid> IJoinArenaV1.Costumes => costumes;
         IEnumerable<Guid> IJoinArenaV1.Equipments => equipments;
-        IEnumerable<BencodexList> IJoinArenaV1.RuneSlotInfos => runeInfos
-            .Select(x => (BencodexList)x.Serialize());
+        IEnumerable<IValue> IJoinArenaV1.RuneSlotInfos => runeInfos
+            .Select(x => x.Serialize());
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>()

--- a/Lib9c/Action/MigrateMonsterCollection.cs
+++ b/Lib9c/Action/MigrateMonsterCollection.cs
@@ -19,6 +19,8 @@ namespace Nekoyume.Action
     {
         public Address AvatarAddress { get; private set; }
 
+        Address IMigrateMonsterCollectionV1.AvatarAddress => AvatarAddress;
+
         public MigrateMonsterCollection(Address avatarAddress)
         {
             AvatarAddress = avatarAddress;

--- a/Lib9c/Action/RankingBattle.cs
+++ b/Lib9c/Action/RankingBattle.cs
@@ -36,11 +36,11 @@ namespace Nekoyume.Action
         public ArenaInfo PreviousArenaInfo;
         public ArenaInfo PreviousEnemyArenaInfo;
 
-        public Address AvatarAddress => avatarAddress;
-        public Address EnemyAddress => enemyAddress;
-        public Address WeeklyArenaAddress => weeklyArenaAddress;
-        public IEnumerable<Guid> CostumeIds => costumeIds;
-        public IEnumerable<Guid> EquipmentIds => equipmentIds;
+        Address IRankingBattleV2.AvatarAddress => avatarAddress;
+        Address IRankingBattleV2.EnemyAddress => enemyAddress;
+        Address IRankingBattleV2.WeeklyArenaAddress => weeklyArenaAddress;
+        IEnumerable<Guid> IRankingBattleV2.CostumeIds => costumeIds;
+        IEnumerable<Guid> IRankingBattleV2.EquipmentIds => equipmentIds;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/RankingBattle10.cs
+++ b/Lib9c/Action/RankingBattle10.cs
@@ -36,11 +36,11 @@ namespace Nekoyume.Action
         public ArenaInfo ArenaInfo;
         public ArenaInfo EnemyArenaInfo;
 
-        public Address AvatarAddress => avatarAddress;
-        public Address EnemyAddress => enemyAddress;
-        public Address WeeklyArenaAddress => weeklyArenaAddress;
-        public IEnumerable<Guid> CostumeIds => costumeIds;
-        public IEnumerable<Guid> EquipmentIds => equipmentIds;
+        Address IRankingBattleV2.AvatarAddress => avatarAddress;
+        Address IRankingBattleV2.EnemyAddress => enemyAddress;
+        Address IRankingBattleV2.WeeklyArenaAddress => weeklyArenaAddress;
+        IEnumerable<Guid> IRankingBattleV2.CostumeIds => costumeIds;
+        IEnumerable<Guid> IRankingBattleV2.EquipmentIds => equipmentIds;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/RankingBattle11.cs
+++ b/Lib9c/Action/RankingBattle11.cs
@@ -42,11 +42,11 @@ namespace Nekoyume.Action
         public ArenaInfo ArenaInfo;
         public ArenaInfo EnemyArenaInfo;
 
-        public Address AvatarAddress => avatarAddress;
-        public Address EnemyAddress => enemyAddress;
-        public Address WeeklyArenaAddress => weeklyArenaAddress;
-        public IEnumerable<Guid> CostumeIds => costumeIds;
-        public IEnumerable<Guid> EquipmentIds => equipmentIds;
+        Address IRankingBattleV2.AvatarAddress => avatarAddress;
+        Address IRankingBattleV2.EnemyAddress => enemyAddress;
+        Address IRankingBattleV2.WeeklyArenaAddress => weeklyArenaAddress;
+        IEnumerable<Guid> IRankingBattleV2.CostumeIds => costumeIds;
+        IEnumerable<Guid> IRankingBattleV2.EquipmentIds => equipmentIds;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/RankingBattle6.cs
+++ b/Lib9c/Action/RankingBattle6.cs
@@ -33,12 +33,11 @@ namespace Nekoyume.Action
         public List<Guid> consumableIds;
         public BattleLog Result { get; private set; }
 
-        public Address AvatarAddress => avatarAddress;
-        public Address EnemyAddress => enemyAddress;
-        public Address WeeklyArenaAddress => weeklyArenaAddress;
-        public IEnumerable<Guid> CostumeIds => costumeIds;
-        public IEnumerable<Guid> EquipmentIds => equipmentIds;
-        public IEnumerable<Guid> ConsumableIds => consumableIds;
+        Address IRankingBattleV2.AvatarAddress => avatarAddress;
+        Address IRankingBattleV2.EnemyAddress => enemyAddress;
+        Address IRankingBattleV2.WeeklyArenaAddress => weeklyArenaAddress;
+        IEnumerable<Guid> IRankingBattleV2.CostumeIds => costumeIds;
+        IEnumerable<Guid> IRankingBattleV2.EquipmentIds => equipmentIds;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/RankingBattle7.cs
+++ b/Lib9c/Action/RankingBattle7.cs
@@ -33,12 +33,11 @@ namespace Nekoyume.Action
         public List<Guid> consumableIds;
         public BattleLog Result { get; private set; }
 
-        public Address AvatarAddress => avatarAddress;
-        public Address EnemyAddress => enemyAddress;
-        public Address WeeklyArenaAddress => weeklyArenaAddress;
-        public IEnumerable<Guid> CostumeIds => costumeIds;
-        public IEnumerable<Guid> EquipmentIds => equipmentIds;
-        public IEnumerable<Guid> ConsumableIds => consumableIds;
+        Address IRankingBattleV2.AvatarAddress => avatarAddress;
+        Address IRankingBattleV2.EnemyAddress => enemyAddress;
+        Address IRankingBattleV2.WeeklyArenaAddress => weeklyArenaAddress;
+        IEnumerable<Guid> IRankingBattleV2.CostumeIds => costumeIds;
+        IEnumerable<Guid> IRankingBattleV2.EquipmentIds => equipmentIds;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/RankingBattle8.cs
+++ b/Lib9c/Action/RankingBattle8.cs
@@ -36,12 +36,11 @@ namespace Nekoyume.Action
         public ArenaInfo ArenaInfo;
         public ArenaInfo EnemyArenaInfo;
 
-        public Address AvatarAddress => avatarAddress;
-        public Address EnemyAddress => enemyAddress;
-        public Address WeeklyArenaAddress => weeklyArenaAddress;
-        public IEnumerable<Guid> CostumeIds => costumeIds;
-        public IEnumerable<Guid> EquipmentIds => equipmentIds;
-        public IEnumerable<Guid> ConsumableIds => consumableIds;
+        Address IRankingBattleV2.AvatarAddress => avatarAddress;
+        Address IRankingBattleV2.EnemyAddress => enemyAddress;
+        Address IRankingBattleV2.WeeklyArenaAddress => weeklyArenaAddress;
+        IEnumerable<Guid> IRankingBattleV2.CostumeIds => costumeIds;
+        IEnumerable<Guid> IRankingBattleV2.EquipmentIds => equipmentIds;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/RankingBattle9.cs
+++ b/Lib9c/Action/RankingBattle9.cs
@@ -37,12 +37,11 @@ namespace Nekoyume.Action
         public ArenaInfo ArenaInfo;
         public ArenaInfo EnemyArenaInfo;
 
-        public Address AvatarAddress => avatarAddress;
-        public Address EnemyAddress => enemyAddress;
-        public Address WeeklyArenaAddress => weeklyArenaAddress;
-        public IEnumerable<Guid> CostumeIds => costumeIds;
-        public IEnumerable<Guid> EquipmentIds => equipmentIds;
-        public IEnumerable<Guid> ConsumableIds => consumableIds;
+        Address IRankingBattleV2.AvatarAddress => avatarAddress;
+        Address IRankingBattleV2.EnemyAddress => enemyAddress;
+        Address IRankingBattleV2.WeeklyArenaAddress => weeklyArenaAddress;
+        IEnumerable<Guid> IRankingBattleV2.CostumeIds => costumeIds;
+        IEnumerable<Guid> IRankingBattleV2.EquipmentIds => equipmentIds;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/RapidCombination.cs
+++ b/Lib9c/Action/RapidCombination.cs
@@ -26,8 +26,8 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public int slotIndex;
 
-        public Address AvatarAddress => avatarAddress;
-        public int SlotIndex => slotIndex;
+        Address IRapidCombinationV1.AvatarAddress => avatarAddress;
+        int IRapidCombinationV1.SlotIndex => slotIndex;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/RapidCombination0.cs
+++ b/Lib9c/Action/RapidCombination0.cs
@@ -46,8 +46,8 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public int slotIndex;
 
-        public Address AvatarAddress => avatarAddress;
-        public int SlotIndex => slotIndex;
+        Address IRapidCombinationV1.AvatarAddress => avatarAddress;
+        int IRapidCombinationV1.SlotIndex => slotIndex;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/RapidCombination2.cs
+++ b/Lib9c/Action/RapidCombination2.cs
@@ -21,8 +21,8 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public int slotIndex;
 
-        public Address AvatarAddress => avatarAddress;
-        public int SlotIndex => slotIndex;
+        Address IRapidCombinationV1.AvatarAddress => avatarAddress;
+        int IRapidCombinationV1.SlotIndex => slotIndex;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/RapidCombination3.cs
+++ b/Lib9c/Action/RapidCombination3.cs
@@ -21,8 +21,8 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public int slotIndex;
 
-        public Address AvatarAddress => avatarAddress;
-        public int SlotIndex => slotIndex;
+        Address IRapidCombinationV1.AvatarAddress => avatarAddress;
+        int IRapidCombinationV1.SlotIndex => slotIndex;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/RapidCombination4.cs
+++ b/Lib9c/Action/RapidCombination4.cs
@@ -22,8 +22,8 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public int slotIndex;
 
-        public Address AvatarAddress => avatarAddress;
-        public int SlotIndex => slotIndex;
+        Address IRapidCombinationV1.AvatarAddress => avatarAddress;
+        int IRapidCombinationV1.SlotIndex => slotIndex;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/RapidCombination5.cs
+++ b/Lib9c/Action/RapidCombination5.cs
@@ -50,8 +50,8 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public int slotIndex;
 
-        public Address AvatarAddress => avatarAddress;
-        public int SlotIndex => slotIndex;
+        Address IRapidCombinationV1.AvatarAddress => avatarAddress;
+        int IRapidCombinationV1.SlotIndex => slotIndex;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/RapidCombination6.cs
+++ b/Lib9c/Action/RapidCombination6.cs
@@ -28,8 +28,8 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public int slotIndex;
 
-        public Address AvatarAddress => avatarAddress;
-        public int SlotIndex => slotIndex;
+        Address IRapidCombinationV1.AvatarAddress => avatarAddress;
+        int IRapidCombinationV1.SlotIndex => slotIndex;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/RapidCombination7.cs
+++ b/Lib9c/Action/RapidCombination7.cs
@@ -26,8 +26,8 @@ namespace Nekoyume.Action
         public Address avatarAddress;
         public int slotIndex;
 
-        public Address AvatarAddress => avatarAddress;
-        public int SlotIndex => slotIndex;
+        Address IRapidCombinationV1.AvatarAddress => avatarAddress;
+        int IRapidCombinationV1.SlotIndex => slotIndex;
 
         public override IAccountStateDelta Execute(IActionContext context)
         {

--- a/Lib9c/Action/RedeemCode.cs
+++ b/Lib9c/Action/RedeemCode.cs
@@ -27,6 +27,9 @@ namespace Nekoyume.Action
 
         public Address AvatarAddress {get; internal set; }
 
+        string IRedeemCodeV1.Code => Code;
+        Address IRedeemCodeV1.AvatarAddress => AvatarAddress;
+
         public RedeemCode()
         {
         }

--- a/Lib9c/Action/RedeemCode0.cs
+++ b/Lib9c/Action/RedeemCode0.cs
@@ -23,6 +23,9 @@ namespace Nekoyume.Action
 
         public Address AvatarAddress {get; internal set; }
 
+        string IRedeemCodeV1.Code => Code;
+        Address IRedeemCodeV1.AvatarAddress => AvatarAddress;
+
         public RedeemCode0()
         {
         }

--- a/Lib9c/Action/RedeemCode2.cs
+++ b/Lib9c/Action/RedeemCode2.cs
@@ -23,6 +23,9 @@ namespace Nekoyume.Action
 
         public Address AvatarAddress {get; internal set; }
 
+        string IRedeemCodeV1.Code => Code;
+        Address IRedeemCodeV1.AvatarAddress => AvatarAddress;
+
         public RedeemCode2()
         {
         }

--- a/Lib9c/Action/RenewAdminState.cs
+++ b/Lib9c/Action/RenewAdminState.cs
@@ -20,6 +20,8 @@ namespace Nekoyume.Action
         private const string NewValidUntilKey = "new_valid_until";
         public long NewValidUntil {get; internal set; }
 
+        long IRenewAdminStateV1.NewValidUntil => NewValidUntil;
+
         public RenewAdminState()
         {
         }

--- a/Lib9c/Action/Sell.cs
+++ b/Lib9c/Action/Sell.cs
@@ -30,12 +30,12 @@ namespace Nekoyume.Action
         public ItemSubType itemSubType;
         public Guid orderId;
 
-        public Address SellerAvatarAddress => sellerAvatarAddress;
-        public Guid TradableId => tradableId;
-        public int Count => count;
-        public FungibleAssetValue Price => price;
-        public string ItemSubType => itemSubType.ToString();
-        public Guid OrderId => orderId;
+        Address ISellV2.SellerAvatarAddress => sellerAvatarAddress;
+        Guid ISellV2.TradableId => tradableId;
+        int ISellV2.Count => count;
+        FungibleAssetValue ISellV2.Price => price;
+        string ISellV2.ItemSubType => itemSubType.ToString();
+        Guid? ISellV2.OrderId => orderId;
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>

--- a/Lib9c/Action/Sell0.cs
+++ b/Lib9c/Action/Sell0.cs
@@ -23,9 +23,9 @@ namespace Nekoyume.Action
         public Guid itemId;
         public FungibleAssetValue price;
 
-        public Address SellerAvatarAddress => sellerAvatarAddress;
-        public Guid ItemId => itemId;
-        public FungibleAssetValue Price => price;
+        Address ISellV1.SellerAvatarAddress => sellerAvatarAddress;
+        Guid ISellV1.ItemId => itemId;
+        FungibleAssetValue ISellV1.Price => price;
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal => new Dictionary<string, IValue>
         {

--- a/Lib9c/Action/Sell10.cs
+++ b/Lib9c/Action/Sell10.cs
@@ -32,12 +32,12 @@ namespace Nekoyume.Action
         public ItemSubType itemSubType;
         public Guid orderId;
 
-        public Address SellerAvatarAddress => sellerAvatarAddress;
-        public Guid TradableId => tradableId;
-        public int Count => count;
-        public FungibleAssetValue Price => price;
-        public string ItemSubType => itemSubType.ToString();
-        public Guid OrderId => orderId;
+        Address ISellV2.SellerAvatarAddress => sellerAvatarAddress;
+        Guid ISellV2.TradableId => tradableId;
+        int ISellV2.Count => count;
+        FungibleAssetValue ISellV2.Price => price;
+        string ISellV2.ItemSubType => itemSubType.ToString();
+        Guid? ISellV2.OrderId => orderId;
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>

--- a/Lib9c/Action/Sell11.cs
+++ b/Lib9c/Action/Sell11.cs
@@ -32,12 +32,12 @@ namespace Nekoyume.Action
         public ItemSubType itemSubType;
         public Guid orderId;
 
-        public Address SellerAvatarAddress => sellerAvatarAddress;
-        public Guid TradableId => tradableId;
-        public int Count => count;
-        public FungibleAssetValue Price => price;
-        public string ItemSubType => itemSubType.ToString();
-        public Guid OrderId => orderId;
+        Address ISellV2.SellerAvatarAddress => sellerAvatarAddress;
+        Guid ISellV2.TradableId => tradableId;
+        int ISellV2.Count => count;
+        FungibleAssetValue ISellV2.Price => price;
+        string ISellV2.ItemSubType => itemSubType.ToString();
+        Guid? ISellV2.OrderId => orderId;
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>

--- a/Lib9c/Action/Sell2.cs
+++ b/Lib9c/Action/Sell2.cs
@@ -23,9 +23,9 @@ namespace Nekoyume.Action
         public Guid itemId;
         public FungibleAssetValue price;
 
-        public Address SellerAvatarAddress => sellerAvatarAddress;
-        public Guid ItemId => itemId;
-        public FungibleAssetValue Price => price;
+        Address ISellV1.SellerAvatarAddress => sellerAvatarAddress;
+        Guid ISellV1.ItemId => itemId;
+        FungibleAssetValue ISellV1.Price => price;
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal => new Dictionary<string, IValue>
         {

--- a/Lib9c/Action/Sell3.cs
+++ b/Lib9c/Action/Sell3.cs
@@ -23,9 +23,9 @@ namespace Nekoyume.Action
         public Guid itemId;
         public FungibleAssetValue price;
 
-        public Address SellerAvatarAddress => sellerAvatarAddress;
-        public Guid ItemId => itemId;
-        public FungibleAssetValue Price => price;
+        Address ISellV1.SellerAvatarAddress => sellerAvatarAddress;
+        Guid ISellV1.ItemId => itemId;
+        FungibleAssetValue ISellV1.Price => price;
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal => new Dictionary<string, IValue>
         {

--- a/Lib9c/Action/Sell4.cs
+++ b/Lib9c/Action/Sell4.cs
@@ -27,10 +27,10 @@ namespace Nekoyume.Action
         public ItemSubType itemSubType;
         public FungibleAssetValue price;
 
-        public Address SellerAvatarAddress => sellerAvatarAddress;
-        public Guid ItemId => itemId;
-        public FungibleAssetValue Price => price;
-        public string ItemSubType => itemSubType.ToString();
+        Address ISellV1.SellerAvatarAddress => sellerAvatarAddress;
+        Guid ISellV1.ItemId => itemId;
+        FungibleAssetValue ISellV1.Price => price;
+        string ISellV1.ItemSubType => itemSubType.ToString();
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal => new Dictionary<string, IValue>
         {

--- a/Lib9c/Action/Sell7.cs
+++ b/Lib9c/Action/Sell7.cs
@@ -29,12 +29,12 @@ namespace Nekoyume.Action
         public ItemSubType itemSubType;
         public Guid orderId;
 
-        public Address SellerAvatarAddress => sellerAvatarAddress;
-        public Guid TradableId => tradableId;
-        public int Count => count;
-        public FungibleAssetValue Price => price;
-        public string ItemSubType => itemSubType.ToString();
-        public Guid OrderId => orderId;
+        Address ISellV2.SellerAvatarAddress => sellerAvatarAddress;
+        Guid ISellV2.TradableId => tradableId;
+        int ISellV2.Count => count;
+        FungibleAssetValue ISellV2.Price => price;
+        string ISellV2.ItemSubType => itemSubType.ToString();
+        Guid? ISellV2.OrderId => orderId;
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>

--- a/Lib9c/Action/Sell8.cs
+++ b/Lib9c/Action/Sell8.cs
@@ -29,12 +29,12 @@ namespace Nekoyume.Action
         public ItemSubType itemSubType;
         public Guid orderId;
 
-        public Address SellerAvatarAddress => sellerAvatarAddress;
-        public Guid TradableId => tradableId;
-        public int Count => count;
-        public FungibleAssetValue Price => price;
-        public string ItemSubType => itemSubType.ToString();
-        public Guid OrderId => orderId;
+        Address ISellV2.SellerAvatarAddress => sellerAvatarAddress;
+        Guid ISellV2.TradableId => tradableId;
+        int ISellV2.Count => count;
+        FungibleAssetValue ISellV2.Price => price;
+        string ISellV2.ItemSubType => itemSubType.ToString();
+        Guid? ISellV2.OrderId => orderId;
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>

--- a/Lib9c/Action/Sell9.cs
+++ b/Lib9c/Action/Sell9.cs
@@ -28,12 +28,12 @@ namespace Nekoyume.Action
         public ItemSubType itemSubType;
         public Guid orderId;
 
-        public Address SellerAvatarAddress => sellerAvatarAddress;
-        public Guid TradableId => tradableId;
-        public int Count => count;
-        public FungibleAssetValue Price => price;
-        public string ItemSubType => itemSubType.ToString();
-        public Guid OrderId => orderId;
+        Address ISellV2.SellerAvatarAddress => sellerAvatarAddress;
+        Guid ISellV2.TradableId => tradableId;
+        int ISellV2.Count => count;
+        FungibleAssetValue ISellV2.Price => price;
+        string ISellV2.ItemSubType => itemSubType.ToString();
+        Guid? ISellV2.OrderId => orderId;
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>

--- a/Lib9c/Action/TransferAsset.cs
+++ b/Lib9c/Action/TransferAsset.cs
@@ -51,6 +51,11 @@ namespace Nekoyume.Action
         public FungibleAssetValue Amount { get; private set; }
         public string Memo { get; private set; }
 
+        Address ITransferAssetV1.Sender => Sender;
+        Address ITransferAssetV1.Recipient => Recipient;
+        FungibleAssetValue ITransferAssetV1.Amount => Amount;
+        string ITransferAssetV1.Memo => Memo;
+
         public override IValue PlainValue
         {
             get

--- a/Lib9c/Action/TransferAsset0.cs
+++ b/Lib9c/Action/TransferAsset0.cs
@@ -46,6 +46,11 @@ namespace Nekoyume.Action
         public FungibleAssetValue Amount { get; private set; }
         public string Memo { get; private set; }
 
+        Address ITransferAssetV1.Sender => Sender;
+        Address ITransferAssetV1.Recipient => Recipient;
+        FungibleAssetValue ITransferAssetV1.Amount => Amount;
+        string ITransferAssetV1.Memo => Memo;
+
         public override IValue PlainValue
         {
             get

--- a/Lib9c/Action/TransferAsset2.cs
+++ b/Lib9c/Action/TransferAsset2.cs
@@ -51,6 +51,11 @@ namespace Nekoyume.Action
         public FungibleAssetValue Amount { get; private set; }
         public string Memo { get; private set; }
 
+        Address ITransferAssetV1.Sender => Sender;
+        Address ITransferAssetV1.Recipient => Recipient;
+        FungibleAssetValue ITransferAssetV1.Amount => Amount;
+        string ITransferAssetV1.Memo => Memo;
+
         public override IValue PlainValue
         {
             get

--- a/Lib9c/Action/TransferAssets.cs
+++ b/Lib9c/Action/TransferAssets.cs
@@ -50,6 +50,12 @@ namespace Nekoyume.Action
         public List<(Address recipient, FungibleAssetValue amount)> Recipients { get; private set; }
         public string Memo { get; private set; }
 
+        Address ITransferAssetsV1.Sender => Sender;
+
+        List<(Address recipient, FungibleAssetValue amount)> ITransferAssetsV1.Recipients =>
+            Recipients;
+        string ITransferAssetsV1.Memo => Memo;
+
         public override IValue PlainValue
         {
             get


### PR DESCRIPTION
This pull request makes interfaces in `Lib9c.Abstractions` implement interfaces explicitly. And the interfaces doesn't guarantee bencodex types (e.g., `List`, `Dictioanary`), just `IValue`.