### PR TITLE
feat: Upgrade `EventDungeonBattle` from 4 to 5

### DIFF
--- a/.Lib9c.DevExtensions.Tests/Lib9c.DevExtensions.Tests.csproj
+++ b/.Lib9c.DevExtensions.Tests/Lib9c.DevExtensions.Tests.csproj
@@ -13,9 +13,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
-    <PackageReference Include="xunit" Version="2.4.1"/>
-    <PackageReference Include="xunit.assert" Version="2.4.1"/>
-    <PackageReference Include="xunit.extensibility.core" Version="2.4.1"/>
+    <PackageReference Include="xunit" Version="2.4.2"/>
+    <PackageReference Include="xunit.assert" Version="2.4.2"/>
+    <PackageReference Include="xunit.extensibility.core" Version="2.4.2"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"/>
   </ItemGroup>
 

--- a/.Lib9c.Tests/Action/AccountStateViewExtensionsTest.cs
+++ b/.Lib9c.Tests/Action/AccountStateViewExtensionsTest.cs
@@ -6,6 +6,7 @@ namespace Lib9c.Tests.Action
     using System.Linq;
     using Bencodex.Types;
     using Lib9c.Tests.Extensions;
+    using Lib9c.Tests.Fixture.States;
     using Libplanet;
     using Libplanet.Action;
     using Libplanet.Assets;
@@ -30,7 +31,7 @@ namespace Lib9c.Tests.Action
         public AccountStateViewExtensionsTest()
         {
             _agentAddress = default;
-            _avatarAddress = _agentAddress.Derive(string.Format(CultureInfo.InvariantCulture, CreateAvatar2.DeriveFormat, 0));
+            _avatarAddress = Addresses.GetAvatarAddress(_agentAddress, 0);
             _agentState = new AgentState(_agentAddress);
             _agentState.avatarAddresses[0] = _avatarAddress;
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
@@ -50,7 +51,10 @@ namespace Lib9c.Tests.Action
             var states = new State();
             states = (State)states.SetState(_avatarAddress, _avatarState.Serialize());
 
-            Assert.True(states.TryGetAvatarState(_agentAddress, _avatarAddress, out var avatarState2));
+            Assert.True(states.TryGetAvatarState(
+                _agentAddress,
+                _avatarAddress,
+                out var avatarState2));
             Assert.Equal(_avatarAddress, avatarState2.address);
             Assert.Equal(_agentAddress, avatarState2.agentAddress);
         }
@@ -76,10 +80,10 @@ namespace Lib9c.Tests.Action
         {
             var states = new State()
                 .SetState(
-                default,
-                Dictionary.Empty
-                    .Add("agentAddress", default(Address).Serialize())
-            );
+                    default,
+                    Dictionary.Empty
+                        .Add("agentAddress", default(Address).Serialize())
+                );
 
             Assert.False(states.TryGetAvatarState(default, default, out _));
         }
@@ -106,9 +110,15 @@ namespace Lib9c.Tests.Action
             var states = new State();
             states = (State)states
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
-                .SetState(_avatarAddress.Derive(LegacyInventoryKey), _avatarState.inventory.Serialize())
-                .SetState(_avatarAddress.Derive(LegacyWorldInformationKey), _avatarState.worldInformation.Serialize())
-                .SetState(_avatarAddress.Derive(LegacyQuestListKey), _avatarState.questList.Serialize());
+                .SetState(
+                    _avatarAddress.Derive(LegacyInventoryKey),
+                    _avatarState.inventory.Serialize())
+                .SetState(
+                    _avatarAddress.Derive(LegacyWorldInformationKey),
+                    _avatarState.worldInformation.Serialize())
+                .SetState(
+                    _avatarAddress.Derive(LegacyQuestListKey),
+                    _avatarState.questList.Serialize());
 
             var v2 = states.GetAvatarStateV2(_avatarAddress);
             Assert.NotNull(v2.inventory);
@@ -125,11 +135,18 @@ namespace Lib9c.Tests.Action
             var states = new State();
             states = (State)states
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
-                .SetState(_avatarAddress.Derive(LegacyInventoryKey), _avatarState.inventory.Serialize())
-                .SetState(_avatarAddress.Derive(LegacyWorldInformationKey), _avatarState.worldInformation.Serialize())
-                .SetState(_avatarAddress.Derive(LegacyQuestListKey), _avatarState.questList.Serialize());
+                .SetState(
+                    _avatarAddress.Derive(LegacyInventoryKey),
+                    _avatarState.inventory.Serialize())
+                .SetState(
+                    _avatarAddress.Derive(LegacyWorldInformationKey),
+                    _avatarState.worldInformation.Serialize())
+                .SetState(
+                    _avatarAddress.Derive(LegacyQuestListKey),
+                    _avatarState.questList.Serialize());
             states = (State)states.SetState(_avatarAddress.Derive(key), null);
-            var exc = Assert.Throws<FailedLoadStateException>(() => states.GetAvatarStateV2(_avatarAddress));
+            var exc = Assert.Throws<FailedLoadStateException>(() =>
+                states.GetAvatarStateV2(_avatarAddress));
             Assert.Contains(key, exc.Message);
         }
 
@@ -148,12 +165,22 @@ namespace Lib9c.Tests.Action
             {
                 states = (State)states
                     .SetState(_avatarAddress, _avatarState.SerializeV2())
-                    .SetState(_avatarAddress.Derive(LegacyInventoryKey), _avatarState.inventory.Serialize())
-                    .SetState(_avatarAddress.Derive(LegacyWorldInformationKey), _avatarState.worldInformation.Serialize())
-                    .SetState(_avatarAddress.Derive(LegacyQuestListKey), _avatarState.questList.Serialize());
+                    .SetState(
+                        _avatarAddress.Derive(LegacyInventoryKey),
+                        _avatarState.inventory.Serialize())
+                    .SetState(
+                        _avatarAddress.Derive(LegacyWorldInformationKey),
+                        _avatarState.worldInformation.Serialize())
+                    .SetState(
+                        _avatarAddress.Derive(LegacyQuestListKey),
+                        _avatarState.questList.Serialize());
             }
 
-            Assert.True(states.TryGetAvatarStateV2(_agentAddress, _avatarAddress, out _, out bool migrationRequired));
+            Assert.True(states.TryGetAvatarStateV2(
+                _agentAddress,
+                _avatarAddress,
+                out _,
+                out bool migrationRequired));
             Assert.Equal(backward, migrationRequired);
         }
 
@@ -173,12 +200,23 @@ namespace Lib9c.Tests.Action
             {
                 states = (State)states
                     .SetState(_avatarAddress, _avatarState.SerializeV2())
-                    .SetState(_avatarAddress.Derive(LegacyInventoryKey), _avatarState.inventory.Serialize())
-                    .SetState(_avatarAddress.Derive(LegacyWorldInformationKey), _avatarState.worldInformation.Serialize())
-                    .SetState(_avatarAddress.Derive(LegacyQuestListKey), _avatarState.questList.Serialize());
+                    .SetState(
+                        _avatarAddress.Derive(LegacyInventoryKey),
+                        _avatarState.inventory.Serialize())
+                    .SetState(
+                        _avatarAddress.Derive(LegacyWorldInformationKey),
+                        _avatarState.worldInformation.Serialize())
+                    .SetState(
+                        _avatarAddress.Derive(LegacyQuestListKey),
+                        _avatarState.questList.Serialize());
             }
 
-            Assert.True(states.TryGetAgentAvatarStatesV2(_agentAddress, _avatarAddress, out _, out _, out bool avatarMigrationRequired));
+            Assert.True(states.TryGetAgentAvatarStatesV2(
+                _agentAddress,
+                _avatarAddress,
+                out _,
+                out _,
+                out bool avatarMigrationRequired));
             Assert.Equal(backward, avatarMigrationRequired);
         }
 
@@ -264,19 +302,25 @@ namespace Lib9c.Tests.Action
         [InlineData(151_200L, true)]
         public void GetCrystalCostStates(long blockIndex, bool previousWeeklyExist)
         {
-            long interval = _tableSheets.CrystalFluctuationSheet.Values.First(r => r.Type == CrystalFluctuationSheet.ServiceType.Combination).BlockInterval;
+            long interval = _tableSheets.CrystalFluctuationSheet.Values
+                .First(r => r.Type == CrystalFluctuationSheet.ServiceType.Combination)
+                .BlockInterval;
             var weeklyIndex = (int)(blockIndex / interval);
             Address dailyCostAddress =
-                Addresses.GetDailyCrystalCostAddress((int)(blockIndex / CrystalCostState.DailyIntervalIndex));
+                Addresses.GetDailyCrystalCostAddress(
+                    (int)(blockIndex / CrystalCostState.DailyIntervalIndex));
             Address weeklyCostAddress = Addresses.GetWeeklyCrystalCostAddress(weeklyIndex);
             Address previousCostAddress = Addresses.GetWeeklyCrystalCostAddress(weeklyIndex - 1);
-            Address beforePreviousCostAddress = Addresses.GetWeeklyCrystalCostAddress(weeklyIndex - 2);
+            Address beforePreviousCostAddress =
+                Addresses.GetWeeklyCrystalCostAddress(weeklyIndex - 2);
             var crystalCostState = new CrystalCostState(default, 100 * CrystalCalculator.CRYSTAL);
             IAccountStateDelta state = new State()
                 .SetState(dailyCostAddress, crystalCostState.Serialize())
                 .SetState(weeklyCostAddress, crystalCostState.Serialize())
                 .SetState(previousCostAddress, crystalCostState.Serialize())
-                .SetState(Addresses.GetSheetAddress<CrystalFluctuationSheet>(), _tableSheets.CrystalFluctuationSheet.Serialize())
+                .SetState(
+                    Addresses.GetSheetAddress<CrystalFluctuationSheet>(),
+                    _tableSheets.CrystalFluctuationSheet.Serialize())
                 .SetState(beforePreviousCostAddress, crystalCostState.Serialize());
             var (daily, weekly, previousWeekly, beforePreviousWeekly) =
                 state.GetCrystalCostStates(blockIndex, interval);
@@ -297,6 +341,48 @@ namespace Lib9c.Tests.Action
                 Assert.Null(previousWeekly);
                 Assert.Null(beforePreviousWeekly);
             }
+        }
+
+        [Fact]
+        public void GetVersionedState()
+        {
+            IAccountStateDelta states = new State();
+            var addr = new PrivateKey().ToAddress();
+
+            var v1 = new TestStateV1(0);
+            var v1Ser = v1.Serialize();
+            states = states.SetState(addr, v1Ser);
+            var v1Val = states.GetVersionedState(addr);
+            Assert.Equal(v1Ser, v1Val);
+
+            states = states.SetState(addr, "test", 1, v1Ser);
+            v1Val = states.GetVersionedState(addr);
+            Assert.Equal(v1Ser, v1Val);
+
+            states = states.SetState(addr, v1Ser);
+            v1Val = states.GetVersionedState(addr);
+            Assert.Equal(v1Ser, v1Val);
+        }
+
+        [Fact]
+        public void GetVersionedState_With_OutParams()
+        {
+            IAccountStateDelta states = new State();
+            var addr = new PrivateKey().ToAddress();
+
+            var v1 = new TestStateV1(0);
+            var v1Ser = v1.Serialize();
+            states = states.SetState(addr, ITestStateV1.Moniker, ITestStateV1.Version, v1Ser);
+            var v1Val = states.GetVersionedState(addr, out var moniker, out var version);
+            Assert.Equal(v1Ser, v1Val);
+            Assert.Equal(ITestStateV1.Moniker, moniker);
+            Assert.Equal(ITestStateV1.Version, version);
+
+            states = states.SetState(addr, v1Ser);
+            v1Val = states.GetVersionedState(addr, out moniker, out version);
+            Assert.Equal(v1Ser, v1Val);
+            Assert.Null(moniker);
+            Assert.Null(version);
         }
     }
 }

--- a/.Lib9c.Tests/Action/EventDungeonBattleTest.cs
+++ b/.Lib9c.Tests/Action/EventDungeonBattleTest.cs
@@ -1,0 +1,517 @@
+namespace Lib9c.Tests.Action
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using Lib9c.Tests.Util;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Assets;
+    using Nekoyume;
+    using Nekoyume.Action;
+    using Nekoyume.BlockChain.Policy;
+    using Nekoyume.Exceptions;
+    using Nekoyume.Extensions;
+    using Nekoyume.Model.Event;
+    using Nekoyume.Model.Rune;
+    using Nekoyume.Model.State;
+    using Nekoyume.TableData.Event;
+    using Xunit;
+
+    public class EventDungeonBattleTest
+    {
+        private readonly TableSheets _tableSheets;
+        private readonly Address _agentAddress;
+        private readonly Address _avatarAddress;
+        private readonly IAccountStateDelta[] _initialStatesArray;
+        private readonly Currency _ncgCurrency;
+
+        public EventDungeonBattleTest()
+        {
+            IAccountStateDelta initialStatesWithAvatarStateV1;
+            IAccountStateDelta initialStatesWithAvatarStateV2;
+            (
+                _tableSheets,
+                _agentAddress,
+                _avatarAddress,
+                initialStatesWithAvatarStateV1,
+                initialStatesWithAvatarStateV2
+            ) = InitializeUtil.InitializeStates(
+                avatarLevel: 100);
+            _initialStatesArray = new[]
+            {
+                initialStatesWithAvatarStateV1,
+                initialStatesWithAvatarStateV2,
+            };
+            _ncgCurrency = initialStatesWithAvatarStateV1.GetGoldCurrency();
+        }
+
+        [Theory]
+        [InlineData(1001, 10010001, 10010001)]
+        public void Execute_Success_Within_Event_Period(
+            int eventScheduleId,
+            int eventDungeonId,
+            int eventDungeonStageId)
+        {
+            Assert.True(_tableSheets.EventScheduleSheet
+                .TryGetValue(eventScheduleId, out var scheduleRow));
+            var contextBlockIndex = scheduleRow.StartBlockIndex;
+            foreach (var initialStates in _initialStatesArray)
+            {
+                var nextStates = Execute(
+                    initialStates,
+                    eventScheduleId,
+                    eventDungeonId,
+                    eventDungeonStageId,
+                    blockIndex: contextBlockIndex);
+                var ediAddr =
+                    EventDungeonInfo.DeriveAddress(_avatarAddress, eventDungeonId);
+                var edi =
+                    new EventDungeonInfo(nextStates.GetVersionedState(ediAddr));
+                Assert.Equal(
+                    scheduleRow.DungeonTicketsMax - 1,
+                    edi.RemainingTickets);
+
+                contextBlockIndex = scheduleRow.DungeonEndBlockIndex;
+                nextStates = Execute(
+                    initialStates,
+                    eventScheduleId,
+                    eventDungeonId,
+                    eventDungeonStageId,
+                    blockIndex: contextBlockIndex);
+                edi =
+                    new EventDungeonInfo(nextStates.GetVersionedState(ediAddr));
+                Assert.Equal(
+                    scheduleRow.DungeonTicketsMax - 1,
+                    edi.RemainingTickets);
+            }
+        }
+
+        [Theory]
+        [InlineData(1001, 10010001, 10010001, 0, 0, 0)]
+        [InlineData(1001, 10010001, 10010001, 1, 1, 1)]
+        [InlineData(1001, 10010001, 10010001, int.MaxValue, int.MaxValue, int.MaxValue - 1)]
+        public void Execute_Success_With_Ticket_Purchase(
+            int eventScheduleId,
+            int eventDungeonId,
+            int eventDungeonStageId,
+            int dungeonTicketPrice,
+            int dungeonTicketAdditionalPrice,
+            int numberOfTicketPurchases)
+        {
+            foreach (var initialStates in _initialStatesArray)
+            {
+                var previousStates = initialStates;
+                var scheduleSheet = _tableSheets.EventScheduleSheet;
+                Assert.True(scheduleSheet.TryGetValue(eventScheduleId, out var scheduleRow));
+                var sb = new StringBuilder();
+                sb.AppendLine(
+                    "id,_name,start_block_index,dungeon_end_block_index,dungeon_tickets_max,dungeon_tickets_reset_interval_block_range,dungeon_exp_seed_value,recipe_end_block_index,dungeon_ticket_price,dungeon_ticket_additional_price");
+                sb.AppendLine(
+                    $"{eventScheduleId}" +
+                    $",\"2022 Summer Event\"" +
+                    $",{scheduleRow.StartBlockIndex}" +
+                    $",{scheduleRow.DungeonEndBlockIndex}" +
+                    $",{scheduleRow.DungeonTicketsMax}" +
+                    $",{scheduleRow.DungeonTicketsResetIntervalBlockRange}" +
+                    $",{dungeonTicketPrice}" +
+                    $",{dungeonTicketAdditionalPrice}" +
+                    $",{scheduleRow.DungeonExpSeedValue}" +
+                    $",{scheduleRow.RecipeEndBlockIndex}");
+                previousStates = previousStates.SetState(
+                    Addresses.GetSheetAddress<EventScheduleSheet>(),
+                    sb.ToString().Serialize());
+
+                var ediAddr =
+                    EventDungeonInfo.DeriveAddress(_avatarAddress, eventDungeonId);
+                var edi = new EventDungeonInfo(
+                    remainingTickets: 0,
+                    numberOfTicketPurchases: numberOfTicketPurchases);
+                previousStates = previousStates.SetState(
+                    ediAddr,
+                    edi.Serialize());
+
+                Assert.True(previousStates.GetSheet<EventScheduleSheet>()
+                    .TryGetValue(eventScheduleId, out var newScheduleRow));
+                var ncgHas = newScheduleRow.GetDungeonTicketCost(
+                    numberOfTicketPurchases,
+                    _ncgCurrency);
+                previousStates = previousStates.MintAsset(_agentAddress, ncgHas);
+
+                var nextStates = Execute(
+                    previousStates,
+                    eventScheduleId,
+                    eventDungeonId,
+                    eventDungeonStageId,
+                    buyTicketIfNeeded: true,
+                    blockIndex: scheduleRow.StartBlockIndex);
+                var nextEventDungeonInfoList =
+                    (Bencodex.Types.List)nextStates.GetVersionedState(ediAddr)!;
+                Assert.Equal(
+                    numberOfTicketPurchases + 1,
+                    nextEventDungeonInfoList[2].ToInteger());
+                Assert.True(
+                    nextStates.TryGetGoldBalance(
+                        _agentAddress,
+                        _ncgCurrency,
+                        out FungibleAssetValue balance
+                    )
+                );
+                Assert.Equal(0 * _ncgCurrency, balance);
+            }
+        }
+
+        [Theory]
+        [InlineData(10000001, 10010001, 10010001)]
+        [InlineData(10010001, 10010001, 10010001)]
+        public void Execute_Throw_InvalidActionFieldException_By_EventScheduleId(
+            int eventScheduleId,
+            int eventDungeonId,
+            int eventDungeonStageId)
+        {
+            foreach (var initialStates in _initialStatesArray)
+            {
+                Assert.Throws<InvalidActionFieldException>(() =>
+                    Execute(
+                        initialStates,
+                        eventScheduleId,
+                        eventDungeonId,
+                        eventDungeonStageId));
+            }
+        }
+
+        [Theory]
+        [InlineData(1001, 10010001, 10010001)]
+        public void Execute_Throw_InvalidActionFieldException_By_ContextBlockIndex(
+            int eventScheduleId,
+            int eventDungeonId,
+            int eventDungeonStageId)
+        {
+            Assert.True(_tableSheets.EventScheduleSheet
+                .TryGetValue(eventScheduleId, out var scheduleRow));
+            var contextBlockIndex = scheduleRow.StartBlockIndex - 1;
+            foreach (var initialStates in _initialStatesArray)
+            {
+                Assert.Throws<InvalidActionFieldException>(() =>
+                    Execute(
+                        initialStates,
+                        eventScheduleId,
+                        eventDungeonId,
+                        eventDungeonStageId,
+                        blockIndex: contextBlockIndex));
+            }
+
+            contextBlockIndex = scheduleRow.DungeonEndBlockIndex + 1;
+            foreach (var initialStates in _initialStatesArray)
+            {
+                Assert.Throws<InvalidActionFieldException>(() =>
+                    Execute(
+                        initialStates,
+                        eventScheduleId,
+                        eventDungeonId,
+                        eventDungeonStageId,
+                        blockIndex: contextBlockIndex));
+            }
+        }
+
+        [Theory]
+        [InlineData(1001, 10020001, 10010001)]
+        [InlineData(1001, 1001, 10010001)]
+        public void Execute_Throw_InvalidActionFieldException_By_EventDungeonId(
+            int eventScheduleId,
+            int eventDungeonId,
+            int eventDungeonStageId)
+        {
+            Assert.True(_tableSheets.EventScheduleSheet
+                .TryGetValue(eventScheduleId, out var scheduleRow));
+            foreach (var initialStates in _initialStatesArray)
+            {
+                Assert.Throws<InvalidActionFieldException>(() =>
+                    Execute(
+                        initialStates,
+                        eventScheduleId,
+                        eventDungeonId,
+                        eventDungeonStageId,
+                        blockIndex: scheduleRow.StartBlockIndex));
+            }
+        }
+
+        [Theory]
+        [InlineData(1001, 10010001, 10020001)]
+        [InlineData(1001, 10010001, 1001)]
+        public void Execute_Throw_InvalidActionFieldException_By_EventDungeonStageId(
+            int eventScheduleId,
+            int eventDungeonId,
+            int eventDungeonStageId)
+        {
+            Assert.True(_tableSheets.EventScheduleSheet
+                .TryGetValue(eventScheduleId, out var scheduleRow));
+            foreach (var initialStates in _initialStatesArray)
+            {
+                Assert.Throws<InvalidActionFieldException>(() =>
+                    Execute(
+                        initialStates,
+                        eventScheduleId,
+                        eventDungeonId,
+                        eventDungeonStageId,
+                        blockIndex: scheduleRow.StartBlockIndex));
+            }
+        }
+
+        [Theory]
+        [InlineData(1001, 10010001, 10010001)]
+        public void Execute_Throw_NotEnoughEventDungeonTicketsException(
+            int eventScheduleId,
+            int eventDungeonId,
+            int eventDungeonStageId)
+        {
+            foreach (var initialStates in _initialStatesArray)
+            {
+                var previousStates = initialStates;
+                var ediAddr =
+                    EventDungeonInfo.DeriveAddress(_avatarAddress, eventDungeonId);
+                var edi = new EventDungeonInfo();
+                previousStates = previousStates
+                    .SetState(ediAddr, edi.Serialize());
+                Assert.True(_tableSheets.EventScheduleSheet
+                    .TryGetValue(eventScheduleId, out var scheduleRow));
+                Assert.Throws<NotEnoughEventDungeonTicketsException>(() =>
+                    Execute(
+                        previousStates,
+                        eventScheduleId,
+                        eventDungeonId,
+                        eventDungeonStageId,
+                        blockIndex: scheduleRow.StartBlockIndex));
+            }
+        }
+
+        [Theory]
+        [InlineData(1001, 10010001, 10010001, 0)]
+        [InlineData(1001, 10010001, 10010001, int.MaxValue - 1)]
+        public void Execute_Throw_InsufficientBalanceException(
+            int eventScheduleId,
+            int eventDungeonId,
+            int eventDungeonStageId,
+            int numberOfTicketPurchases)
+        {
+            foreach (var initialStates in _initialStatesArray)
+            {
+                var previousStates = initialStates;
+                var ediAddr =
+                    EventDungeonInfo.DeriveAddress(_avatarAddress, eventDungeonId);
+                var edi = new EventDungeonInfo(
+                    remainingTickets: 0,
+                    numberOfTicketPurchases: numberOfTicketPurchases);
+                previousStates = previousStates
+                    .SetState(ediAddr, edi.Serialize());
+
+                Assert.True(_tableSheets.EventScheduleSheet
+                    .TryGetValue(eventScheduleId, out var scheduleRow));
+                var ncgHas = scheduleRow.GetDungeonTicketCost(
+                    numberOfTicketPurchases,
+                    _ncgCurrency) - 1 * _ncgCurrency;
+                previousStates = previousStates.MintAsset(_agentAddress, ncgHas);
+
+                Assert.Throws<InsufficientBalanceException>(() =>
+                    Execute(
+                        previousStates,
+                        eventScheduleId,
+                        eventDungeonId,
+                        eventDungeonStageId,
+                        buyTicketIfNeeded: true,
+                        blockIndex: scheduleRow.StartBlockIndex));
+            }
+        }
+
+        [Theory]
+        [InlineData(1001, 10010001, 10010002)]
+        public void Execute_Throw_StageNotClearedException(
+            int eventScheduleId,
+            int eventDungeonId,
+            int eventDungeonStageId)
+        {
+            Assert.True(_tableSheets.EventScheduleSheet
+                .TryGetValue(eventScheduleId, out var scheduleRow));
+            foreach (var initialStates in _initialStatesArray)
+            {
+                Assert.Throws<StageNotClearedException>(() =>
+                    Execute(
+                        initialStates,
+                        eventScheduleId,
+                        eventDungeonId,
+                        eventDungeonStageId,
+                        blockIndex: scheduleRow.StartBlockIndex));
+            }
+        }
+
+        [Theory]
+        [InlineData(0, 30001, 1, 30001, typeof(DuplicatedRuneIdException))]
+        [InlineData(1, 10002, 1, 30001, typeof(DuplicatedRuneSlotIndexException))]
+        public void Execute_DuplicatedException(
+            int slotIndex,
+            int runeId,
+            int slotIndex2,
+            int runeId2,
+            Type exception)
+        {
+            Assert.True(_tableSheets.EventScheduleSheet
+                .TryGetValue(1001, out var scheduleRow));
+            foreach (var initialStates in _initialStatesArray)
+            {
+                var prevStates =
+                    initialStates.MintAsset(_agentAddress, 99999 * _ncgCurrency);
+
+                var unlockRuneSlot = new UnlockRuneSlot()
+                {
+                    AvatarAddress = _avatarAddress,
+                    SlotIndex = 1,
+                };
+
+                prevStates = unlockRuneSlot.Execute(new ActionContext
+                {
+                    BlockIndex = 1,
+                    PreviousStates = prevStates,
+                    Signer = _agentAddress,
+                    Random = new TestRandom(),
+                });
+
+                Assert.Throws(exception, () =>
+                    Execute(
+                        prevStates,
+                        1001,
+                        10010001,
+                        10010001,
+                        false,
+                        scheduleRow.StartBlockIndex,
+                        slotIndex,
+                        runeId,
+                        slotIndex2,
+                        runeId2));
+            }
+        }
+
+        [Fact]
+        public void Execute_V100301()
+        {
+            const int eventScheduleId = 1001;
+            const int eventDungeonId = 10010001;
+            const int eventDungeonStageId = 10010001;
+            var csv =
+                $@"id,_name,start_block_index,dungeon_end_block_index,dungeon_tickets_max,dungeon_tickets_reset_interval_block_range,dungeon_ticket_price,dungeon_ticket_additional_price,dungeon_exp_seed_value,recipe_end_block_index
+            1001,2022 Summer Event,{BlockPolicySource.V100301ExecutedBlockIndex},{BlockPolicySource.V100301ExecutedBlockIndex + 100},5,7200,5,2,1,5018000";
+            foreach (var initialStates in _initialStatesArray)
+            {
+                var prevStates =
+                    initialStates.SetState(
+                        Addresses.GetSheetAddress<EventScheduleSheet>(),
+                        csv.Serialize());
+                var sheet = new EventScheduleSheet();
+                sheet.Set(csv);
+                Assert.True(sheet.TryGetValue(eventScheduleId, out var scheduleRow));
+                var contextBlockIndex = scheduleRow.StartBlockIndex;
+                var nextStates = Execute(
+                    prevStates,
+                    eventScheduleId,
+                    eventDungeonId,
+                    eventDungeonStageId,
+                    blockIndex: contextBlockIndex);
+                var ediAddr =
+                    EventDungeonInfo.DeriveAddress(_avatarAddress, eventDungeonId);
+                var edi =
+                    new EventDungeonInfo(nextStates.GetVersionedState(ediAddr));
+                Assert.Equal(
+                    scheduleRow.DungeonTicketsMax - 1,
+                    edi.RemainingTickets);
+
+                contextBlockIndex = scheduleRow.DungeonEndBlockIndex;
+                nextStates = Execute(
+                    prevStates,
+                    eventScheduleId,
+                    eventDungeonId,
+                    eventDungeonStageId,
+                    blockIndex: contextBlockIndex);
+                edi =
+                    new EventDungeonInfo(nextStates.GetVersionedState(ediAddr));
+                Assert.Equal(
+                    scheduleRow.DungeonTicketsMax - 1,
+                    edi.RemainingTickets);
+            }
+        }
+
+        private IAccountStateDelta Execute(
+            IAccountStateDelta previousStates,
+            int eventScheduleId,
+            int eventDungeonId,
+            int eventDungeonStageId,
+            bool buyTicketIfNeeded = false,
+            long blockIndex = 0,
+            int slotIndex = 0,
+            int runeId = 10002,
+            int slotIndex2 = 1,
+            int runeId2 = 30001)
+        {
+            Assert.True(previousStates.TryGetAvatarStateV2(
+                _agentAddress,
+                _avatarAddress,
+                out var prevAvatarState,
+                out _));
+            var equipments =
+                Doomfist.GetAllParts(_tableSheets, prevAvatarState.level);
+            foreach (var equipment in equipments)
+            {
+                prevAvatarState.inventory.AddItem(equipment, iLock: null);
+            }
+
+            var action = new EventDungeonBattle
+            {
+                AvatarAddress = _avatarAddress,
+                EventScheduleId = eventScheduleId,
+                EventDungeonId = eventDungeonId,
+                EventDungeonStageId = eventDungeonStageId,
+                Equipments = equipments
+                    .Select(e => e.NonFungibleId)
+                    .ToList(),
+                Costumes = new List<Guid>(),
+                Foods = new List<Guid>(),
+                RuneInfos = new List<RuneSlotInfo>
+                {
+                    new RuneSlotInfo(slotIndex, runeId),
+                    new RuneSlotInfo(slotIndex2, runeId2),
+                },
+                BuyTicketIfNeeded = buyTicketIfNeeded,
+            };
+
+            var nextStates = action.Execute(new ActionContext
+            {
+                PreviousStates = previousStates,
+                Signer = _agentAddress,
+                Random = new TestRandom(),
+                Rehearsal = false,
+                BlockIndex = blockIndex,
+            });
+
+            Assert.True(nextStates.GetSheet<EventScheduleSheet>().TryGetValue(
+                eventScheduleId,
+                out var scheduleRow));
+            var nextAvatarState = nextStates.GetAvatarStateV2(_avatarAddress);
+            var expectExp = scheduleRow.GetStageExp(
+                eventDungeonStageId.ToEventDungeonStageNumber());
+            Assert.Equal(
+                prevAvatarState.exp + expectExp,
+                nextAvatarState.exp);
+            var ediAddr =
+                EventDungeonInfo.DeriveAddress(_avatarAddress, eventDungeonId);
+            var ediVal = nextStates.GetVersionedState(
+                ediAddr,
+                out var moniker,
+                out var version);
+            Assert.NotNull(ediVal);
+            Assert.Equal(IEventDungeonInfo.Moniker, moniker);
+            Assert.Equal(IEventDungeonInfo.Version, version);
+            var edi = new EventDungeonInfo(ediVal);
+
+            return nextStates;
+        }
+    }
+}

--- a/.Lib9c.Tests/Action/EventDungeonBattleV4Test.cs
+++ b/.Lib9c.Tests/Action/EventDungeonBattleV4Test.cs
@@ -448,7 +448,7 @@ namespace Lib9c.Tests.Action
                 previousAvatarState.inventory.AddItem(equipment, iLock: null);
             }
 
-            var action = new EventDungeonBattle
+            var action = new EventDungeonBattleV4
             {
                 AvatarAddress = _avatarAddress,
                 EventScheduleId = eventScheduleId,

--- a/.Lib9c.Tests/Fixture/States/TestState.cs
+++ b/.Lib9c.Tests/Fixture/States/TestState.cs
@@ -1,0 +1,26 @@
+namespace Lib9c.Tests.Fixture.States
+{
+    using Bencodex.Types;
+    using Nekoyume.Model.State;
+
+    // NOTE: Does not attach [VersionedStateImpl] attribute.
+    public class TestState : IState
+    {
+        public int Value { get; }
+
+        public TestState(int value)
+        {
+            Value = value;
+        }
+
+        public TestState(IValue serialized)
+        {
+            Value = (Integer)serialized;
+        }
+
+        public IValue Serialize()
+        {
+            return (Integer)Value;
+        }
+    }
+}

--- a/.Lib9c.Tests/Fixture/States/TestStateV1.cs
+++ b/.Lib9c.Tests/Fixture/States/TestStateV1.cs
@@ -1,0 +1,42 @@
+namespace Lib9c.Tests.Fixture.States
+{
+    using Bencodex.Types;
+    using Nekoyume.Model;
+    using Nekoyume.Model.State;
+
+    [VersionedState(Moniker, Version)]
+    // [VersionedStateType(typeof(Integer))]
+    public interface ITestStateV1
+    {
+        public const string Moniker = "test";
+        public const uint Version = 1;
+
+        // [VersionedStateRootObject]
+        public Integer Value { get; }
+    }
+
+    [VersionedStateImpl(typeof(ITestStateV1))]
+    public class TestStateV1 : IState
+    {
+        public int Value { get; }
+
+        public TestStateV1() : this(0)
+        {
+        }
+
+        public TestStateV1(int value)
+        {
+            Value = value;
+        }
+
+        public TestStateV1(IValue serialized)
+        {
+            Value = (Integer)serialized;
+        }
+
+        public IValue Serialize()
+        {
+            return (Integer)Value;
+        }
+    }
+}

--- a/.Lib9c.Tests/Fixture/States/TestStateV2.cs
+++ b/.Lib9c.Tests/Fixture/States/TestStateV2.cs
@@ -1,0 +1,50 @@
+namespace Lib9c.Tests.Fixture.States
+{
+    using Bencodex.Types;
+    using Nekoyume.Model;
+    using Nekoyume.Model.State;
+
+    // Expand `string Name` from `ITestStateV1`.
+    [VersionedState(Moniker, Version)]
+    // [VersionedStateType(typeof(List))]
+    public interface ITestStateV2
+    {
+        public const string Moniker = "test";
+        public const uint Version = 2;
+
+        // [VersionedStateListElement(0)]
+        public Integer Value { get; }
+
+        // [VersionedStateListElement(1)]
+        public Text Name { get; }
+    }
+
+    [VersionedStateImpl(typeof(ITestStateV2))]
+    public class TestStateV2 : IState
+    {
+        public int Value { get; }
+
+        public string Name { get; }
+
+        public TestStateV2() : this(0, string.Empty)
+        {
+        }
+
+        public TestStateV2(int value, string name)
+        {
+            Value = value;
+            Name = name;
+        }
+
+        public TestStateV2(IValue serialized)
+        {
+            var list = (List)serialized;
+            Value = (Integer)list[0];
+            Name = (Text)list[1];
+        }
+
+        public IValue Serialize() => new List(
+            (Integer)Value,
+            (Text)Name);
+    }
+}

--- a/.Lib9c.Tests/Fixture/States/TestStateV3.cs
+++ b/.Lib9c.Tests/Fixture/States/TestStateV3.cs
@@ -1,0 +1,50 @@
+namespace Lib9c.Tests.Fixture.States
+{
+    using Bencodex.Types;
+    using Nekoyume.Model;
+    using Nekoyume.Model.State;
+
+    // Remove `int Value` and Add `ITestStateV1 Age` from `ITestStateV2`.
+    [VersionedState(Moniker, Version)]
+    // [VersionedStateType(typeof(List))]
+    public interface ITestStateV3
+    {
+        public const string Moniker = "test";
+        public const uint Version = 3;
+
+        // [VersionedStateListElement(0)]
+        public Text Name { get; }
+
+        // [VersionedStateListElement(1)]
+        public ITestStateV1 Age { get; }
+    }
+
+    [VersionedStateImpl(typeof(ITestStateV3))]
+    public class TestStateV3 : IState
+    {
+        public string Name { get; }
+
+        public TestStateV1 Age { get; }
+
+        public TestStateV3() : this(string.Empty, 0)
+        {
+        }
+
+        public TestStateV3(string name, int age)
+        {
+            Name = name;
+            Age = new TestStateV1(age);
+        }
+
+        public TestStateV3(IValue serialized)
+        {
+            var list = (List)serialized;
+            Name = (Text)list[0];
+            Age = new TestStateV1(list[1]);
+        }
+
+        public IValue Serialize() => new List(
+            (Text)Name,
+            Age.Serialize());
+    }
+}

--- a/.Lib9c.Tests/Fixture/States/TestState_InvalidVersionedStateImplType.cs
+++ b/.Lib9c.Tests/Fixture/States/TestState_InvalidVersionedStateImplType.cs
@@ -1,0 +1,36 @@
+// ReSharper disable InconsistentNaming
+namespace Lib9c.Tests.Fixture.States
+{
+    using Bencodex.Types;
+    using Nekoyume.Model;
+    using Nekoyume.Model.State;
+
+    public interface INotAttach_VersionedStateAttribute
+    {
+    }
+
+    [VersionedStateImpl(typeof(INotAttach_VersionedStateAttribute))]
+    public class TestState_InvalidVersionedStateImplType : IState
+    {
+        public int Value { get; }
+
+        public TestState_InvalidVersionedStateImplType() : this(0)
+        {
+        }
+
+        public TestState_InvalidVersionedStateImplType(int value)
+        {
+            Value = value;
+        }
+
+        public TestState_InvalidVersionedStateImplType(IValue serialized)
+        {
+            Value = (Integer)serialized;
+        }
+
+        public IValue Serialize()
+        {
+            return (Integer)Value;
+        }
+    }
+}

--- a/.Lib9c.Tests/Lib9c.Tests.csproj
+++ b/.Lib9c.Tests/Lib9c.Tests.csproj
@@ -7,7 +7,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CS0162;CS8032;CS0618;CS0612;SYSLIB0011;SA1201;SA1649</NoWarn>
+    <NoWarn>$(NoWarn);CS0162;CS8032;CS0618;CS0612;SYSLIB0011;SA1128;SA1201;SA1649</NoWarn>
     <CodeAnalysisRuleSet>.\Lib9c.Tests.ruleset</CodeAnalysisRuleSet>
     <Configurations>Debug;Release;DevEx</Configurations>
     <Platforms>AnyCPU</Platforms>
@@ -32,11 +32,12 @@
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.3" />
     <PackageReference Include="Verify.Xunit" Version="17.2.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
     <PackageReference Include="System.IO.Abstractions" Version="12.2.6" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="12.2.6" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.12.0" />
 
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/.Lib9c.Tests/Lib9c.Tests.csproj
+++ b/.Lib9c.Tests/Lib9c.Tests.csproj
@@ -7,7 +7,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CS0162;CS8032;CS0618;CS0612;SYSLIB0011</NoWarn>
+    <NoWarn>$(NoWarn);CS0162;CS8032;CS0618;CS0612;SYSLIB0011;SA1201;SA1649</NoWarn>
     <CodeAnalysisRuleSet>.\Lib9c.Tests.ruleset</CodeAnalysisRuleSet>
     <Configurations>Debug;Release;DevEx</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/.Lib9c.Tests/Model/Event/EventDungeonInfoTest.cs
+++ b/.Lib9c.Tests/Model/Event/EventDungeonInfoTest.cs
@@ -1,4 +1,4 @@
-namespace Lib9c.Tests.Model
+namespace Lib9c.Tests.Model.Event
 {
     using System;
     using Nekoyume.Model.Event;

--- a/.Lib9c.Tests/Model/VersionedStateAttributeTest.cs
+++ b/.Lib9c.Tests/Model/VersionedStateAttributeTest.cs
@@ -1,0 +1,104 @@
+namespace Lib9c.Tests.Model
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Lib9c.Tests.Fixture.States;
+    using Nekoyume.Model;
+    using Serilog;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class VersionedStateAttributeTest
+    {
+        public VersionedStateAttributeTest(ITestOutputHelper outputHelper)
+        {
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.TestOutput(outputHelper)
+                .CreateLogger();
+        }
+
+        [Fact]
+        public void Constructor()
+        {
+            var attr = new VersionedStateAttribute("moniker", 1);
+            Assert.Equal("moniker", attr.Moniker);
+            Assert.Equal(1u, attr.Version);
+        }
+
+        [Fact]
+        public void TryGetFrom()
+        {
+            var type = typeof(ITestStateV1);
+            Assert.True(VersionedStateAttribute.TryGetFrom(type, out var attr));
+            Assert.Equal(ITestStateV1.Moniker, attr!.Moniker);
+            Assert.Equal(ITestStateV1.Version, attr.Version);
+        }
+
+        [Fact]
+        public void UniqueMonikerAndVersion()
+        {
+            var tuples = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(asm => asm.GetTypes())
+                .Select(type =>
+                {
+                    var attribute = type.GetCustomAttributes(true)
+                        .OfType<VersionedStateAttribute>()
+                        .FirstOrDefault();
+                    return (type, attribute);
+                })
+                .Where(tuple => tuple.attribute is { })
+                .ToArray();
+            var monikerAndVersions = new Dictionary<string, Dictionary<uint, Type>>();
+            var errors = new Dictionary<string, Dictionary<uint, List<Type>>>();
+            foreach (var (type, attribute) in tuples)
+            {
+                Assert.NotNull(attribute);
+                if (!monikerAndVersions.ContainsKey(attribute.Moniker))
+                {
+                    monikerAndVersions[attribute.Moniker] = new Dictionary<uint, Type>
+                    {
+                        { attribute.Version, type },
+                    };
+
+                    continue;
+                }
+
+                if (monikerAndVersions[attribute.Moniker].ContainsKey(attribute.Version))
+                {
+                    var prevType = monikerAndVersions[attribute.Moniker][attribute.Version];
+                    if (!errors.ContainsKey(attribute.Moniker))
+                    {
+                        errors[attribute.Moniker] = new Dictionary<uint, List<Type>>
+                        {
+                            { attribute.Version, new List<Type> { prevType, type } },
+                        };
+
+                        continue;
+                    }
+
+                    if (!errors[attribute.Moniker].ContainsKey(attribute.Version))
+                    {
+                        errors[attribute.Moniker][attribute.Version] = new List<Type> { type };
+
+                        continue;
+                    }
+
+                    errors[attribute.Moniker][attribute.Version].Add(type);
+                }
+
+                monikerAndVersions[attribute.Moniker][attribute.Version] = type;
+            }
+
+            if (errors.Any())
+            {
+                var message = string.Join(
+                    Environment.NewLine,
+                    errors.Select(kv =>
+                        $"\"{kv.Key}\"{string.Join(", ", kv.Value.Select(kv2 => $"({kv2.Key}): {string.Join(", ", kv2.Value)}"))}"));
+                Assert.True(false, message);
+            }
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/VersionedStateFormatterTest.cs
+++ b/.Lib9c.Tests/Model/VersionedStateFormatterTest.cs
@@ -1,0 +1,211 @@
+namespace Lib9c.Tests.Model
+{
+    using System;
+    using System.Collections.Generic;
+    using Bencodex.Types;
+    using Lib9c.Tests.Fixture.States;
+    using Nekoyume.Model;
+    using Xunit;
+
+    public class VersionedStateFormatterTest
+    {
+        public static IEnumerable<object[]> GetMemberData_For_TestStateV1_InvalidSerializedValue()
+        {
+            yield return new object[] { Null.Value };
+            yield return new object[] { new Binary(0x00) };
+            yield return new object[] { new Bencodex.Types.Boolean(false) };
+            yield return new object[] { new Integer(0) };
+            yield return new object[] { new Text("test") };
+            yield return new object[] { List.Empty };
+            yield return new object[]
+            {
+                new List((Text)"test", (Integer)1),
+            };
+            yield return new object[]
+            {
+                new List(Null.Value, (Integer)1, (Integer)0),
+            };
+            yield return new object[]
+            {
+                new List((Text)"test", (Integer)(-1), (Integer)0),
+            };
+            yield return new object[]
+            {
+                new List((Text)"test", (Integer)1, (Integer)0, (Integer)0),
+            };
+            yield return new object[] { Dictionary.Empty };
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            // v1
+            var expected = new List(
+                (Text)ITestStateV1.Moniker,
+                (Integer)ITestStateV1.Version,
+                (Integer)0);
+            var serialized = VersionedStateFormatter.Serialize(
+                (Text)ITestStateV1.Moniker,
+                (Integer)ITestStateV1.Version,
+                new TestStateV1(0).Serialize());
+            Assert.Equal(expected, serialized);
+            serialized = VersionedStateFormatter.Serialize(
+                ITestStateV1.Moniker,
+                ITestStateV1.Version,
+                new TestStateV1(0).Serialize());
+            Assert.Equal(expected, serialized);
+            serialized = VersionedStateFormatter.Serialize(
+                ITestStateV1.Moniker,
+                ITestStateV1.Version,
+                new TestStateV1(0));
+            Assert.Equal(expected, serialized);
+            // v2
+            expected = new List(
+                (Text)ITestStateV2.Moniker,
+                (Integer)ITestStateV2.Version,
+                new List((Integer)0, (Text)"v2"));
+            serialized = VersionedStateFormatter.Serialize(
+                (Text)ITestStateV2.Moniker,
+                (Integer)ITestStateV2.Version,
+                new TestStateV2(0, "v2").Serialize());
+            Assert.Equal(expected, serialized);
+            serialized = VersionedStateFormatter.Serialize(
+                ITestStateV2.Moniker,
+                ITestStateV2.Version,
+                new TestStateV2(0, "v2").Serialize());
+            Assert.Equal(expected, serialized);
+            serialized = VersionedStateFormatter.Serialize(
+                ITestStateV2.Moniker,
+                ITestStateV2.Version,
+                new TestStateV2(0, "v2"));
+            Assert.Equal(expected, serialized);
+            // v3
+            expected = new List(
+                (Text)ITestStateV3.Moniker,
+                (Integer)ITestStateV3.Version,
+                new List((Text)"v3", (Integer)10));
+            serialized = VersionedStateFormatter.Serialize(
+                (Text)ITestStateV3.Moniker,
+                (Integer)ITestStateV3.Version,
+                new TestStateV3("v3", 10).Serialize());
+            Assert.Equal(expected, serialized);
+            serialized = VersionedStateFormatter.Serialize(
+                ITestStateV3.Moniker,
+                ITestStateV3.Version,
+                new TestStateV3("v3", 10).Serialize());
+            Assert.Equal(expected, serialized);
+            serialized = VersionedStateFormatter.Serialize(
+                ITestStateV3.Moniker,
+                ITestStateV3.Version,
+                new TestStateV3("v3", 10));
+            Assert.Equal(expected, serialized);
+        }
+
+        [Fact]
+        public void Deconstruct()
+        {
+            // v1
+            var (moniker, version, data) =
+                VersionedStateFormatter.Deconstruct(
+                    new List(
+                        (Text)ITestStateV1.Moniker,
+                        (Integer)ITestStateV1.Version,
+                        (Integer)0
+                    )
+                );
+            Assert.Equal(ITestStateV1.Moniker, moniker);
+            Assert.Equal(ITestStateV1.Version, (uint)version);
+            Assert.Equal(0, (int)(Integer)data);
+        }
+
+        [Fact]
+        public void Deconstruct_Throws_ArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                VersionedStateFormatter.Deconstruct(null));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetMemberData_For_TestStateV1_InvalidSerializedValue))]
+        public void Deconstruct_Throws_ArgumentException(IValue serialized)
+        {
+            Assert.Throws<ArgumentException>(() =>
+                VersionedStateFormatter.Deconstruct(serialized));
+        }
+
+        [Fact]
+        public void TryDeconstruct()
+        {
+            // v1
+            var v1Val = new List(
+                (Text)ITestStateV1.Moniker,
+                (Integer)ITestStateV1.Version,
+                (Integer)0);
+            Assert.True(VersionedStateFormatter.TryDeconstruct(
+                v1Val,
+                out var result));
+            Assert.True(result.HasValue);
+            Assert.Equal(ITestStateV1.Moniker, result.Value.moniker);
+            Assert.Equal(ITestStateV1.Version, (uint)result.Value.version);
+            Assert.Equal(0, (int)(Integer)result.Value.data);
+        }
+
+        [Fact]
+        public void DeconstructT()
+        {
+            // v1
+            var v1 = new TestStateV1(0);
+            var (moniker, version, data) =
+                VersionedStateFormatter.Deconstruct(v1, out var serialized);
+            Assert.Equal(ITestStateV1.Moniker, moniker);
+            Assert.Equal(ITestStateV1.Version, (uint)version);
+            Assert.Equal(0, (int)(Integer)data);
+            Assert.Equal(v1.Serialize(), serialized);
+            (moniker, version, data) =
+                VersionedStateFormatter.Deconstruct(v1);
+            Assert.Equal(ITestStateV1.Moniker, moniker);
+            Assert.Equal(ITestStateV1.Version, (uint)version);
+            Assert.Equal(0, (int)(Integer)data);
+
+            Assert.Throws<ArgumentNullException>(() =>
+                VersionedStateFormatter.Deconstruct(null));
+            Assert.Throws<ArgumentException>(() =>
+                VersionedStateFormatter.Deconstruct(new TestState(0)));
+            Assert.Throws<ArgumentException>(() =>
+                VersionedStateFormatter.Deconstruct(
+                    new TestState_InvalidVersionedStateImplType(0)));
+        }
+
+        [Fact]
+        public void TryDeconstructT()
+        {
+            // v1
+            Assert.True(VersionedStateFormatter.TryDeconstruct(
+                new TestStateV1(0),
+                out var result));
+            Assert.True(result.HasValue);
+            Assert.Equal(ITestStateV1.Moniker, result.Value.moniker);
+            Assert.Equal(ITestStateV1.Version, (uint)result.Value.version);
+            Assert.Equal(0, (int)(Integer)result.Value.data);
+        }
+
+        [Fact]
+        public void ValidateFormat_Returns_True()
+        {
+            Assert.True(VersionedStateFormatter.ValidateFormat(
+                new List(
+                    (Text)ITestStateV1.Moniker,
+                    (Integer)ITestStateV1.Version,
+                    (Integer)0
+                )
+            ));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetMemberData_For_TestStateV1_InvalidSerializedValue))]
+        public void ValidateFormat_Returns_False(IValue serialized)
+        {
+            Assert.False(VersionedStateFormatter.ValidateFormat(serialized));
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/VersionedStateImplAttributeTest.cs
+++ b/.Lib9c.Tests/Model/VersionedStateImplAttributeTest.cs
@@ -2,10 +2,13 @@ namespace Lib9c.Tests.Model
 {
     using System;
     using System.Linq;
+    using Bencodex.Types;
     using Lib9c.Tests.Fixture.States;
     using Nekoyume.Model;
     using Nekoyume.Model.State;
     using Serilog;
+    using Snapshooter;
+    using Snapshooter.Xunit;
     using Xunit;
     using Xunit.Abstractions;
 
@@ -63,6 +66,37 @@ namespace Lib9c.Tests.Model
             }
 
             Assert.False(hasError);
+        }
+
+        [Fact]
+        public void SnapshotTest()
+        {
+            var tuples = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(a => a.GetTypes())
+                .Select(type =>
+                {
+                    var attr = type.GetCustomAttributes(true)
+                        .OfType<VersionedStateImplAttribute>()
+                        .FirstOrDefault();
+                    return (type, attr);
+                })
+                .Where(tuple => tuple.attr is { })
+                .Select(tuple =>
+                {
+                    var state = (IState)Activator.CreateInstance(tuple.type);
+                    return (
+                        type: tuple.type,
+                        value: state?.Serialize() ?? Null.Value,
+                        versionedStateType: tuple.attr.Type);
+                })
+                .ToArray();
+            foreach (var (type, value, versionedStateType) in tuples)
+            {
+                // Match with implementation type.
+                Snapshot.Match(value, SnapshotNameExtension.Create(type.FullName));
+                // Match with versioned state interface type.
+                Snapshot.Match(value, SnapshotNameExtension.Create(versionedStateType.FullName));
+            }
         }
     }
 }

--- a/.Lib9c.Tests/Model/VersionedStateImplAttributeTest.cs
+++ b/.Lib9c.Tests/Model/VersionedStateImplAttributeTest.cs
@@ -1,0 +1,68 @@
+namespace Lib9c.Tests.Model
+{
+    using System;
+    using System.Linq;
+    using Lib9c.Tests.Fixture.States;
+    using Nekoyume.Model;
+    using Nekoyume.Model.State;
+    using Serilog;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class VersionedStateImplAttributeTest
+    {
+        public VersionedStateImplAttributeTest(ITestOutputHelper outputHelper)
+        {
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.TestOutput(outputHelper)
+                .CreateLogger();
+        }
+
+        [Fact]
+        public void Constructor()
+        {
+            var type = typeof(ITestStateV1);
+            var attr = new VersionedStateImplAttribute(type);
+            Assert.Equal(type, attr.Type);
+        }
+
+        [Fact]
+        public void TryGetFrom()
+        {
+            var type = typeof(TestStateV1);
+            Assert.True(VersionedStateImplAttribute.TryGetFrom(type, out var attr));
+            Assert.Equal(typeof(ITestStateV1), attr!.Type);
+        }
+
+        [Fact]
+        public void CheckInheritIState()
+        {
+            var tuples = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(a => a.GetTypes())
+                .Select(type =>
+                {
+                    var attr = type.GetCustomAttributes(true)
+                        .OfType<VersionedStateImplAttribute>()
+                        .FirstOrDefault();
+                    return (type, attr);
+                })
+                .Where(tuple => tuple.attr is { })
+                .ToArray();
+            var hasError = false;
+            foreach (var (type, _) in tuples)
+            {
+                if (!type.IsAssignableTo(typeof(IState)))
+                {
+                    Log.Debug(
+                        "Type {Type} is not assignable to {AssignableTo}",
+                        type,
+                        typeof(IState));
+                    hasError = true;
+                }
+            }
+
+            Assert.False(hasError);
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Lib9c.Tests.Fixture.States.INotAttach_VersionedStateAttribute.snap
+++ b/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Lib9c.Tests.Fixture.States.INotAttach_VersionedStateAttribute.snap
@@ -1,0 +1,11 @@
+﻿{
+  "Value": 0,
+  "Kind": "Integer",
+  "Fingerprint": {
+    "Kind": 2,
+    "EncodingLength": 3,
+    "Digest": "AA=="
+  },
+  "EncodingLength": 3,
+  "Inspection": "0"
+}

--- a/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Lib9c.Tests.Fixture.States.ITestStateV1.snap
+++ b/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Lib9c.Tests.Fixture.States.ITestStateV1.snap
@@ -1,0 +1,11 @@
+﻿{
+  "Value": 0,
+  "Kind": "Integer",
+  "Fingerprint": {
+    "Kind": 2,
+    "EncodingLength": 3,
+    "Digest": "AA=="
+  },
+  "EncodingLength": 3,
+  "Inspection": "0"
+}

--- a/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Lib9c.Tests.Fixture.States.ITestStateV2.snap
+++ b/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Lib9c.Tests.Fixture.States.ITestStateV2.snap
@@ -1,0 +1,24 @@
+﻿[
+  {
+    "Value": 0,
+    "Kind": "Integer",
+    "Fingerprint": {
+      "Kind": 2,
+      "EncodingLength": 3,
+      "Digest": "AA=="
+    },
+    "EncodingLength": 3,
+    "Inspection": "0"
+  },
+  {
+    "Value": "",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 3,
+      "Digest": ""
+    },
+    "EncodingLength": 3,
+    "Inspection": "\"\""
+  }
+]

--- a/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Lib9c.Tests.Fixture.States.ITestStateV3.snap
+++ b/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Lib9c.Tests.Fixture.States.ITestStateV3.snap
@@ -1,0 +1,24 @@
+﻿[
+  {
+    "Value": "",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 3,
+      "Digest": ""
+    },
+    "EncodingLength": 3,
+    "Inspection": "\"\""
+  },
+  {
+    "Value": 0,
+    "Kind": "Integer",
+    "Fingerprint": {
+      "Kind": 2,
+      "EncodingLength": 3,
+      "Digest": "AA=="
+    },
+    "EncodingLength": 3,
+    "Inspection": "0"
+  }
+]

--- a/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Lib9c.Tests.Fixture.States.TestStateV1.snap
+++ b/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Lib9c.Tests.Fixture.States.TestStateV1.snap
@@ -1,0 +1,11 @@
+﻿{
+  "Value": 0,
+  "Kind": "Integer",
+  "Fingerprint": {
+    "Kind": 2,
+    "EncodingLength": 3,
+    "Digest": "AA=="
+  },
+  "EncodingLength": 3,
+  "Inspection": "0"
+}

--- a/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Lib9c.Tests.Fixture.States.TestStateV2.snap
+++ b/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Lib9c.Tests.Fixture.States.TestStateV2.snap
@@ -1,0 +1,24 @@
+﻿[
+  {
+    "Value": 0,
+    "Kind": "Integer",
+    "Fingerprint": {
+      "Kind": 2,
+      "EncodingLength": 3,
+      "Digest": "AA=="
+    },
+    "EncodingLength": 3,
+    "Inspection": "0"
+  },
+  {
+    "Value": "",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 3,
+      "Digest": ""
+    },
+    "EncodingLength": 3,
+    "Inspection": "\"\""
+  }
+]

--- a/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Lib9c.Tests.Fixture.States.TestStateV3.snap
+++ b/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Lib9c.Tests.Fixture.States.TestStateV3.snap
@@ -1,0 +1,24 @@
+﻿[
+  {
+    "Value": "",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 3,
+      "Digest": ""
+    },
+    "EncodingLength": 3,
+    "Inspection": "\"\""
+  },
+  {
+    "Value": 0,
+    "Kind": "Integer",
+    "Fingerprint": {
+      "Kind": 2,
+      "EncodingLength": 3,
+      "Digest": "AA=="
+    },
+    "EncodingLength": 3,
+    "Inspection": "0"
+  }
+]

--- a/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Lib9c.Tests.Fixture.States.TestState_InvalidVersionedStateImplType.snap
+++ b/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Lib9c.Tests.Fixture.States.TestState_InvalidVersionedStateImplType.snap
@@ -1,0 +1,11 @@
+﻿{
+  "Value": 0,
+  "Kind": "Integer",
+  "Fingerprint": {
+    "Kind": 2,
+    "EncodingLength": 3,
+    "Digest": "AA=="
+  },
+  "EncodingLength": 3,
+  "Inspection": "0"
+}

--- a/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Nekoyume.Model.Event.EventDungeonInfo.snap
+++ b/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Nekoyume.Model.Event.EventDungeonInfo.snap
@@ -1,0 +1,46 @@
+﻿[
+  {
+    "Value": "0",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 4,
+      "Digest": "MA=="
+    },
+    "EncodingLength": 4,
+    "Inspection": "\"0\""
+  },
+  {
+    "Value": "0",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 4,
+      "Digest": "MA=="
+    },
+    "EncodingLength": 4,
+    "Inspection": "\"0\""
+  },
+  {
+    "Value": "0",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 4,
+      "Digest": "MA=="
+    },
+    "EncodingLength": 4,
+    "Inspection": "\"0\""
+  },
+  {
+    "Value": "0",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 4,
+      "Digest": "MA=="
+    },
+    "EncodingLength": 4,
+    "Inspection": "\"0\""
+  }
+]

--- a/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Nekoyume.Model.Event.IEventDungeonInfo.snap
+++ b/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest-Nekoyume.Model.Event.IEventDungeonInfo.snap
@@ -1,0 +1,46 @@
+﻿[
+  {
+    "Value": "0",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 4,
+      "Digest": "MA=="
+    },
+    "EncodingLength": 4,
+    "Inspection": "\"0\""
+  },
+  {
+    "Value": "0",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 4,
+      "Digest": "MA=="
+    },
+    "EncodingLength": 4,
+    "Inspection": "\"0\""
+  },
+  {
+    "Value": "0",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 4,
+      "Digest": "MA=="
+    },
+    "EncodingLength": 4,
+    "Inspection": "\"0\""
+  },
+  {
+    "Value": "0",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 4,
+      "Digest": "MA=="
+    },
+    "EncodingLength": 4,
+    "Inspection": "\"0\""
+  }
+]

--- a/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest_Lib9c.Tests.Fixture.States.INotAttach_VersionedStateAttribute.snap
+++ b/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest_Lib9c.Tests.Fixture.States.INotAttach_VersionedStateAttribute.snap
@@ -1,0 +1,11 @@
+﻿{
+  "Value": 0,
+  "Kind": "Integer",
+  "Fingerprint": {
+    "Kind": 2,
+    "EncodingLength": 3,
+    "Digest": "AA=="
+  },
+  "EncodingLength": 3,
+  "Inspection": "0"
+}

--- a/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest_Lib9c.Tests.Fixture.States.ITestStateV1.snap
+++ b/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest_Lib9c.Tests.Fixture.States.ITestStateV1.snap
@@ -1,0 +1,11 @@
+﻿{
+  "Value": 0,
+  "Kind": "Integer",
+  "Fingerprint": {
+    "Kind": 2,
+    "EncodingLength": 3,
+    "Digest": "AA=="
+  },
+  "EncodingLength": 3,
+  "Inspection": "0"
+}

--- a/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest_Lib9c.Tests.Fixture.States.ITestStateV2.snap
+++ b/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest_Lib9c.Tests.Fixture.States.ITestStateV2.snap
@@ -1,0 +1,24 @@
+﻿[
+  {
+    "Value": 0,
+    "Kind": "Integer",
+    "Fingerprint": {
+      "Kind": 2,
+      "EncodingLength": 3,
+      "Digest": "AA=="
+    },
+    "EncodingLength": 3,
+    "Inspection": "0"
+  },
+  {
+    "Value": "",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 3,
+      "Digest": ""
+    },
+    "EncodingLength": 3,
+    "Inspection": "\"\""
+  }
+]

--- a/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest_Lib9c.Tests.Fixture.States.ITestStateV3.snap
+++ b/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest_Lib9c.Tests.Fixture.States.ITestStateV3.snap
@@ -1,0 +1,24 @@
+﻿[
+  {
+    "Value": "",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 3,
+      "Digest": ""
+    },
+    "EncodingLength": 3,
+    "Inspection": "\"\""
+  },
+  {
+    "Value": 0,
+    "Kind": "Integer",
+    "Fingerprint": {
+      "Kind": 2,
+      "EncodingLength": 3,
+      "Digest": "AA=="
+    },
+    "EncodingLength": 3,
+    "Inspection": "0"
+  }
+]

--- a/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest_Lib9c.Tests.Fixture.States.TestStateV1.snap
+++ b/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest_Lib9c.Tests.Fixture.States.TestStateV1.snap
@@ -1,0 +1,11 @@
+﻿{
+  "Value": 0,
+  "Kind": "Integer",
+  "Fingerprint": {
+    "Kind": 2,
+    "EncodingLength": 3,
+    "Digest": "AA=="
+  },
+  "EncodingLength": 3,
+  "Inspection": "0"
+}

--- a/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest_Lib9c.Tests.Fixture.States.TestStateV2.snap
+++ b/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest_Lib9c.Tests.Fixture.States.TestStateV2.snap
@@ -1,0 +1,24 @@
+﻿[
+  {
+    "Value": 0,
+    "Kind": "Integer",
+    "Fingerprint": {
+      "Kind": 2,
+      "EncodingLength": 3,
+      "Digest": "AA=="
+    },
+    "EncodingLength": 3,
+    "Inspection": "0"
+  },
+  {
+    "Value": "",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 3,
+      "Digest": ""
+    },
+    "EncodingLength": 3,
+    "Inspection": "\"\""
+  }
+]

--- a/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest_Lib9c.Tests.Fixture.States.TestStateV3.snap
+++ b/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest_Lib9c.Tests.Fixture.States.TestStateV3.snap
@@ -1,0 +1,24 @@
+﻿[
+  {
+    "Value": "",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 3,
+      "Digest": ""
+    },
+    "EncodingLength": 3,
+    "Inspection": "\"\""
+  },
+  {
+    "Value": 0,
+    "Kind": "Integer",
+    "Fingerprint": {
+      "Kind": 2,
+      "EncodingLength": 3,
+      "Digest": "AA=="
+    },
+    "EncodingLength": 3,
+    "Inspection": "0"
+  }
+]

--- a/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest_Lib9c.Tests.Fixture.States.TestState_InvalidVersionedStateImplType.snap
+++ b/.Lib9c.Tests/Model/__snapshots__/VersionedStateImplAttributeTest.SnapshotTest_Lib9c.Tests.Fixture.States.TestState_InvalidVersionedStateImplType.snap
@@ -1,0 +1,11 @@
+﻿{
+  "Value": 0,
+  "Kind": "Integer",
+  "Fingerprint": {
+    "Kind": 2,
+    "EncodingLength": 3,
+    "Digest": "AA=="
+  },
+  "EncodingLength": 3,
+  "Inspection": "0"
+}

--- a/.Lib9c.Tests/Util/InitializeUtil.cs
+++ b/.Lib9c.Tests/Util/InitializeUtil.cs
@@ -18,7 +18,8 @@ namespace Lib9c.Tests.Util
             Address agentAddress,
             Address avatarAddress,
             IAccountStateDelta initialStatesWithAvatarStateV1,
-            IAccountStateDelta initialStatesWithAvatarStateV2) InitializeStates()
+            IAccountStateDelta initialStatesWithAvatarStateV2) InitializeStates(
+                int avatarLevel = 1)
         {
             IAccountStateDelta states = new State();
             var sheets = TableSheetsImporter.ImportSheets();
@@ -48,7 +49,10 @@ namespace Lib9c.Tests.Util
                 0,
                 tableSheets.GetAvatarSheets(),
                 new GameConfigState(),
-                avatarAddr.Derive("ranking_map"));
+                avatarAddr.Derive("ranking_map"))
+            {
+                level = avatarLevel,
+            };
             agentState.avatarAddresses.Add(0, avatarAddr);
 
             var initialStatesWithAvatarStateV1 = states

--- a/Lib9c/Action/AccountStateDeltaExtensions.cs
+++ b/Lib9c/Action/AccountStateDeltaExtensions.cs
@@ -1,10 +1,12 @@
 using System.Collections.Generic;
 using System.Linq;
+using Bencodex.Types;
 using Libplanet;
 using Libplanet.Action;
 using Libplanet.Assets;
 using LruCacheNet;
 using Nekoyume.Helper;
+using Nekoyume.Model;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 
@@ -87,6 +89,75 @@ namespace Nekoyume.Action
             }
 
             return states.SetState(rewardInfoAddress, rewardRecord.Serialize());
+        }
+
+        public static IAccountStateDelta SetState(
+            this IAccountStateDelta states,
+            Address address,
+            Text moniker,
+            Integer version,
+            IValue data)
+        {
+            return states.SetState(
+                address,
+                VersionedStateFormatter.Serialize(
+                    moniker,
+                    version,
+                    data));
+        }
+
+        public static IAccountStateDelta SetState(
+            this IAccountStateDelta states,
+            Address address,
+            string moniker,
+            uint version,
+            IValue data)
+        {
+            return states.SetState(
+                address,
+                VersionedStateFormatter.Serialize(
+                    moniker,
+                    version,
+                    data));
+        }
+
+        public static IAccountStateDelta SetState(
+            this IAccountStateDelta states,
+            Address address,
+            string moniker,
+            uint version,
+            IState state)
+        {
+            return states.SetState(
+                address,
+                VersionedStateFormatter.Serialize(
+                    moniker,
+                    version,
+                    state));
+        }
+
+        public static IAccountStateDelta SetState<T>(
+            this IAccountStateDelta states,
+            Address address,
+            T state)
+            where T : IState
+        {
+            if (!VersionedStateFormatter.TryDeconstruct(
+                    state,
+                    out var result,
+                    out var serialized) ||
+                !result.HasValue)
+            {
+                return serialized != null
+                    ? states.SetState(address, serialized)
+                    : states.SetState(address, state.Serialize());
+            }
+
+            return states.SetState(
+                address,
+                result.Value.moniker,
+                result.Value.version,
+                result.Value.data);
         }
     }
 }

--- a/Lib9c/Action/AccountStateViewExtensions.cs
+++ b/Lib9c/Action/AccountStateViewExtensions.cs
@@ -11,6 +11,7 @@ using Libplanet.Assets;
 using LruCacheNet;
 using Nekoyume.Model.Arena;
 using Nekoyume.Helper;
+using Nekoyume.Model;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Serilog;
@@ -1313,6 +1314,50 @@ namespace Nekoyume.Action
             }
 
             return states.GetSheets(sheetTypeList.Distinct().ToArray());
+        }
+
+        /// <summary>
+        /// Returns the versioned state of the given <paramref name="address"/>.
+        /// It returns non-versioned state if the state is not versioned.
+        /// It returns <see cref="IVersionedState.Data"/> part of the versioned state.
+        /// </summary>
+#pragma warning disable CS8632
+        public static IValue? GetVersionedState(
+#pragma warning restore CS8632
+            this IAccountStateView states,
+            Address address)
+        {
+            return GetVersionedState(states, address, out _, out _);
+        }
+
+        /// <summary>
+        /// Returns the versioned state of the given <paramref name="address"/>.
+        /// It returns non-versioned state if the state is not versioned.
+        /// It returns <see cref="IVersionedState.Data"/> part of the versioned state.
+        /// </summary>
+        /// <param name="moniker"><see cref="IVersionedState.Moniker"/></param>
+        /// <param name="version"><see cref="IVersionedState.Version"/></param>
+#pragma warning disable CS8632
+        public static IValue? GetVersionedState(
+#pragma warning restore CS8632
+            this IAccountStateView states,
+            Address address,
+            out string moniker,
+            out uint? version)
+        {
+            var value = states.GetState(address);
+            if (value is null ||
+                !VersionedStateFormatter.TryDeconstruct(value, out var result) ||
+                !result.HasValue)
+            {
+                moniker = null;
+                version = null;
+                return value;
+            }
+
+            moniker = result.Value.moniker;
+            version = result.Value.version;
+            return result.Value.data;
         }
     }
 }

--- a/Lib9c/Action/EventDungeonBattleV1.cs
+++ b/Lib9c/Action/EventDungeonBattleV1.cs
@@ -8,6 +8,7 @@ using Lib9c.Abstractions;
 using Libplanet;
 using Libplanet.Action;
 using Nekoyume.Battle;
+using Nekoyume.BlockChain.Policy;
 using Nekoyume.Exceptions;
 using Nekoyume.Extensions;
 using Nekoyume.Model.Event;
@@ -25,9 +26,12 @@ namespace Nekoyume.Action
     /// </summary>
     [Serializable]
     [ActionType(ActionTypeText)]
+    [ActionObsolete(ObsoleteBlockIndex)]
     public class EventDungeonBattleV1 : GameAction, IEventDungeonBattleV1
     {
-        private const string ActionTypeText = "event_dungeon_battle";
+        public const string ActionTypeText = "event_dungeon_battle";
+        public const long ObsoleteBlockIndex = BlockPolicySource.V100370ObsoleteIndex;
+
         public const int PlayCount = 1;
 
         public Address AvatarAddress;
@@ -113,6 +117,8 @@ namespace Nekoyume.Action
             {
                 return states;
             }
+
+            CheckObsolete(ObsoleteBlockIndex, context);
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
             var started = DateTimeOffset.UtcNow;

--- a/Lib9c/Action/EventDungeonBattleV2.cs
+++ b/Lib9c/Action/EventDungeonBattleV2.cs
@@ -24,11 +24,14 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1321
     /// </summary>
     [Serializable]
-    [ActionObsolete(BlockChain.Policy.BlockPolicySource.V100340ObsoleteIndex)]
     [ActionType(ActionTypeText)]
+    [ActionObsolete(ObsoleteBlockIndex)]
     public class EventDungeonBattleV2 : GameAction, IEventDungeonBattleV1
     {
-        private const string ActionTypeText = "event_dungeon_battle2";
+        public const string ActionTypeText = "event_dungeon_battle2";
+        public const long ObsoleteBlockIndex =
+            BlockChain.Policy.BlockPolicySource.V100340ObsoleteIndex;
+
         public const int PlayCount = 1;
 
         public Address AvatarAddress;
@@ -115,7 +118,7 @@ namespace Nekoyume.Action
                 return states;
             }
 
-            CheckObsolete(BlockChain.Policy.BlockPolicySource.V100340ObsoleteIndex, context);
+            CheckObsolete(ObsoleteBlockIndex, context);
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
             var started = DateTimeOffset.UtcNow;

--- a/Lib9c/Action/EventDungeonBattleV3.cs
+++ b/Lib9c/Action/EventDungeonBattleV3.cs
@@ -26,11 +26,14 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/
     /// </summary>
     [Serializable]
-    [ActionObsolete(BlockChain.Policy.BlockPolicySource.V100360ObsoleteIndex)]
     [ActionType(ActionTypeText)]
+    [ActionObsolete(ObsoleteBlockIndex)]
     public class EventDungeonBattleV3 : GameAction, IEventDungeonBattleV2
     {
-        private const string ActionTypeText = "event_dungeon_battle3";
+        public const string ActionTypeText = "event_dungeon_battle3";
+        public const long ObsoleteBlockIndex =
+            BlockChain.Policy.BlockPolicySource.V100360ObsoleteIndex;
+
         public const int PlayCount = 1;
 
         public Address AvatarAddress;
@@ -123,7 +126,7 @@ namespace Nekoyume.Action
                 return states;
             }
 
-            CheckObsolete(BlockChain.Policy.BlockPolicySource.V100360ObsoleteIndex, context);
+            CheckObsolete(ObsoleteBlockIndex, context);
 
             var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
             var started = DateTimeOffset.UtcNow;

--- a/Lib9c/Model/Event/EventDungeonInfo.cs
+++ b/Lib9c/Model/Event/EventDungeonInfo.cs
@@ -6,6 +6,22 @@ using Nekoyume.Model.State;
 
 namespace Nekoyume.Model.Event
 {
+    [VersionedState(Moniker, Version)]
+    public interface IEventDungeonInfo
+    {
+        public const string Moniker = "event_dungeon_info";
+        public const uint Version = 1;
+
+        Integer ResetTicketsInterval { get; }
+
+        Integer RemainingTickets { get; }
+
+        Integer NumberOfTicketPurchases { get; }
+
+        Integer ClearedStageId { get; }
+    }
+
+    [VersionedStateImpl(typeof(IEventDungeonInfo))]
     public class EventDungeonInfo : IState
     {
         public static Address DeriveAddress(Address address, int dungeonId)

--- a/Lib9c/Model/Event/EventDungeonInfo.cs
+++ b/Lib9c/Model/Event/EventDungeonInfo.cs
@@ -37,6 +37,10 @@ namespace Nekoyume.Model.Event
 
         public int ClearedStageId { get; private set; }
 
+        public EventDungeonInfo() : this(0)
+        {
+        }
+
         public EventDungeonInfo(
             int resetTicketsInterval = 0,
             int remainingTickets = 0,

--- a/Lib9c/Model/IVersionedState.cs
+++ b/Lib9c/Model/IVersionedState.cs
@@ -1,0 +1,14 @@
+using Bencodex.Types;
+
+namespace Nekoyume.Model
+{
+    /// <summary>
+    /// Interface for versioned state.
+    /// </summary>
+    public interface IVersionedState
+    {
+        Text Moniker { get; }
+        Integer Version { get; }
+        IValue Data { get; }
+    }
+}

--- a/Lib9c/Model/VersionedStateAttribute.cs
+++ b/Lib9c/Model/VersionedStateAttribute.cs
@@ -1,0 +1,43 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Nekoyume.Model
+{
+    [AttributeUsage(AttributeTargets.Interface, AllowMultiple = false, Inherited = true)]
+    public class VersionedStateAttribute : Attribute
+    {
+        public string Moniker { get; }
+
+        public uint Version { get; }
+
+        public VersionedStateAttribute(string moniker, uint version)
+        {
+            if (string.IsNullOrEmpty(moniker))
+            {
+                throw new ArgumentException("Moniker must not be null or empty.");
+            }
+
+            Moniker = moniker;
+            Version = version;
+        }
+
+        public static bool TryGetFrom(Type type, out VersionedStateAttribute? attr)
+        {
+            try
+            {
+                attr = type
+                    .GetCustomAttributes()
+                    .OfType<VersionedStateAttribute>()
+                    .First();
+                return true;
+            }
+            catch
+            {
+                attr = null;
+                return false;
+            }
+        }
+    }
+}

--- a/Lib9c/Model/VersionedStateFormatter.cs
+++ b/Lib9c/Model/VersionedStateFormatter.cs
@@ -1,0 +1,203 @@
+#nullable enable
+using System;
+using Bencodex.Types;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Model
+{
+    public static class VersionedStateFormatter
+    {
+        public static IValue Serialize(Text moniker, Integer version, IValue data)
+        {
+            if (string.IsNullOrEmpty(moniker))
+            {
+                throw new ArgumentException(
+                    $"{nameof(moniker)} must not be null or empty.");
+            }
+
+            return new List(
+                moniker,
+                version,
+                data ?? Null.Value);
+        }
+
+        public static IValue Serialize(string moniker, uint version, IValue data) =>
+            Serialize((Text)moniker, (Integer)version, data ?? Null.Value);
+
+        public static IValue Serialize(string moniker, uint version, IState state) =>
+            Serialize((Text)moniker, (Integer)version, state?.Serialize() ?? Null.Value);
+
+        public static (Text moniker, Integer version, IValue data) Deconstruct(IValue serialized)
+        {
+            if (serialized is null)
+            {
+                throw new ArgumentNullException(nameof(serialized));
+            }
+
+            if (!(serialized is List list))
+            {
+                throw new ArgumentException(
+                    "Serialized value must be a 'BenCodex.Types.List'.");
+            }
+
+            if (list.Count != 3)
+            {
+                throw new ArgumentException(
+                    $"Serialized value must have 3 elements, but has {list.Count}.");
+            }
+
+            try
+            {
+                var moniker = (Text)list[0];
+                if (string.IsNullOrEmpty(moniker))
+                {
+                    throw new ArgumentException(
+                        $"Serialized value's moniker must not be" +
+                        $" null or empty, but {moniker}.");
+                }
+
+                var version = (Integer)list[1];
+                if (version < 0)
+                {
+                    throw new ArgumentException(
+                        $"Serialized value's version must be" +
+                        $" greater than or equal to 0, but {version}.");
+                }
+
+                return (moniker, version, list[2]);
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentException("Serialized value is invalid.", e);
+            }
+        }
+
+        public static bool TryDeconstruct(
+            IValue serialized,
+            out (Text moniker, Integer version, IValue data)? result)
+        {
+            try
+            {
+                result = Deconstruct(serialized);
+                return true;
+            }
+            catch
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        public static (Text moniker, Integer version, IValue data) Deconstruct<T>(
+            T state,
+            out IValue? serialized)
+            where T : IState
+        {
+            if (state is null)
+            {
+                throw new ArgumentNullException(nameof(state));
+            }
+
+            serialized = state.Serialize();
+            if (TryDeconstruct(serialized, out var result) &&
+                result.HasValue)
+            {
+                return result.Value;
+            }
+
+            if (!VersionedStateImplAttribute.TryGetFrom(typeof(T), out var attr))
+            {
+                throw new ArgumentException(
+                    $"Type {typeof(T).FullName} must have" +
+                    $" {nameof(VersionedStateImplAttribute)}.",
+                    new DeconstructVersionedStateException(serialized: serialized));
+            }
+
+            if (!VersionedStateAttribute.TryGetFrom(attr!.Type, out var attr2))
+            {
+                throw new ArgumentException(
+                    $"Type {attr.Type.FullName} must have" +
+                    $" {nameof(VersionedStateAttribute)}.",
+                    new DeconstructVersionedStateException(serialized: serialized));
+            }
+
+            return (attr2!.Moniker, attr2.Version, serialized);
+        }
+
+        public static (Text moniker, Integer version, IValue data) Deconstruct<T>(T state)
+            where T : IState
+        {
+            return Deconstruct(state, out _);
+        }
+
+        public static bool TryDeconstruct<T>(
+            T state,
+            out (Text moniker, Integer version, IValue data)? result,
+            out IValue? serialized)
+            where T : IState
+        {
+            try
+            {
+                result = Deconstruct(state, out serialized);
+                return true;
+            }
+            catch (ArgumentException e)
+            {
+                result = null;
+                serialized = e.InnerException is DeconstructVersionedStateException e2
+                    ? e2.Serialized
+                    : null;
+                return false;
+            }
+        }
+
+        public static bool TryDeconstruct<T>(
+            T state,
+            out (Text moniker, Integer version, IValue data)? result)
+            where T : IState
+        {
+            return TryDeconstruct(state, out result, out _);
+        }
+
+        public static bool ValidateFormat(IValue serialized)
+        {
+            if (!(serialized is List list))
+            {
+                return false;
+            }
+
+            if (list.Count != 3)
+            {
+                return false;
+            }
+
+            if (!(list[0] is Text moniker) ||
+                string.IsNullOrEmpty(moniker))
+            {
+                return false;
+            }
+
+            if (!(list[1] is Integer version) ||
+                version < 0)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    public class DeconstructVersionedStateException : Exception
+    {
+        public IValue? Serialized { get; }
+
+        public DeconstructVersionedStateException(
+            string? message = null,
+            Exception? innerException = null,
+            IValue? serialized = null)
+            : base(message, innerException)
+        {
+            Serialized = serialized;
+        }
+    }
+}

--- a/Lib9c/Model/VersionedStateImplAttribute.cs
+++ b/Lib9c/Model/VersionedStateImplAttribute.cs
@@ -1,0 +1,48 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Nekoyume.Model
+{
+    /// <summary>
+    /// Implementation attribute of <see cref="VersionedStateAttribute"/>.
+    /// The class or struct that has this attribute must implement parameterless constructor
+    /// and <see cref="State.IState"/>.
+    /// </summary>
+    [AttributeUsage(
+        AttributeTargets.Class,
+        AllowMultiple = false,
+        Inherited = true)]
+    public class VersionedStateImplAttribute : Attribute
+    {
+        public Type Type { get; }
+
+        public VersionedStateImplAttribute(Type type)
+        {
+            if (type is null)
+            {
+                throw new ArgumentNullException("Type must not be null.");
+            }
+
+            Type = type;
+        }
+
+        public static bool TryGetFrom(Type type, out VersionedStateImplAttribute? attr)
+        {
+            try
+            {
+                attr = type
+                    .GetCustomAttributes()
+                    .OfType<VersionedStateImplAttribute>()
+                    .First();
+                return true;
+            }
+            catch
+            {
+                attr = null;
+                return false;
+            }
+        }
+    }
+}

--- a/Lib9c/Policy/BlockPolicySource.cs
+++ b/Lib9c/Policy/BlockPolicySource.cs
@@ -101,6 +101,9 @@ namespace Nekoyume.BlockChain.Policy
 
         public const long V100360ObsoleteIndex = 6_020_000;
 
+        // FIXME: This value is temporary.
+        public const long V100370ObsoleteIndex = 6_300_000;
+
         public const long PermissionedMiningStartIndex = 2_225_500;
 
         public const long V100301ExecutedBlockIndex = 5_048_399L;


### PR DESCRIPTION
This pull request based on #1717 .

## Changes

- Introduce `IEventDungeonInfo` interface with `VersionedState` attribute.
  - Moniker: "event_dungeon_info"
  - Version: 1
- Use `IAccountStateView.GetVersionedState()` instead of `GetState()` in `EventDungeonBattle` action.
- Use `IAccountStateDelta.SetState()` override method for versioned state in `EventDungeonBattle` action.
