### PR TITLE
Introduce market models & register action

### DIFF
--- a/.Lib9c.Tests/Action/ActionEvaluationTest.cs
+++ b/.Lib9c.Tests/Action/ActionEvaluationTest.cs
@@ -13,7 +13,9 @@ namespace Lib9c.Tests.Action
     using MessagePack;
     using MessagePack.Resolvers;
     using Nekoyume.Action;
+    using Nekoyume.Helper;
     using Nekoyume.Model.Item;
+    using Nekoyume.Model.Market;
     using Nekoyume.Model.State;
     using Xunit;
 
@@ -83,6 +85,7 @@ namespace Lib9c.Tests.Action
         [InlineData(typeof(ClaimRaidReward))]
         [InlineData(typeof(ClaimWordBossKillReward))]
         [InlineData(typeof(PrepareRewardAssets))]
+        [InlineData(typeof(RegisterProduct))]
         public void Serialize_With_MessagePack(Type actionType)
         {
             var action = GetAction(actionType);
@@ -311,6 +314,27 @@ namespace Lib9c.Tests.Action
                     Assets = new List<FungibleAssetValue>
                     {
                         _currency * 100,
+                    },
+                },
+                RegisterProduct _ => new RegisterProduct
+                {
+                    RegisterInfos = new List<IRegisterInfo>
+                    {
+                        new RegisterInfo
+                        {
+                            AvatarAddress = new PrivateKey().ToAddress(),
+                            ItemCount = 1,
+                            Price = 1 * _currency,
+                            TradableId = Guid.NewGuid(),
+                            Type = ProductType.Fungible,
+                        },
+                        new AssetInfo
+                        {
+                            AvatarAddress = new PrivateKey().ToAddress(),
+                            Price = 1 * _currency,
+                            Asset = 1 * RuneHelper.StakeRune,
+                            Type = ProductType.FungibleAssetValue,
+                        },
                     },
                 },
                 _ => throw new InvalidCastException(),

--- a/.Lib9c.Tests/Action/ExceptionTest.cs
+++ b/.Lib9c.Tests/Action/ExceptionTest.cs
@@ -65,6 +65,8 @@ namespace Lib9c.Tests.Action
         [InlineData(typeof(InvalidClaimException))]
         [InlineData(typeof(RequiredBlockIntervalException))]
         [InlineData(typeof(ActionUnavailableException))]
+        [InlineData(typeof(InvalidCurrencyException))]
+        [InlineData(typeof(InvalidProductTypeException))]
         public void Exception_Serializable(Type excType)
         {
             if (Activator.CreateInstance(excType, "for testing") is Exception exc)

--- a/.Lib9c.Tests/Action/RegisterProductTest.cs
+++ b/.Lib9c.Tests/Action/RegisterProductTest.cs
@@ -1,0 +1,421 @@
+namespace Lib9c.Tests.Action
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Bencodex.Types;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Assets;
+    using Libplanet.Crypto;
+    using Nekoyume;
+    using Nekoyume.Action;
+    using Nekoyume.Helper;
+    using Nekoyume.Model;
+    using Nekoyume.Model.Item;
+    using Nekoyume.Model.Market;
+    using Nekoyume.Model.State;
+    using Xunit;
+
+    public class RegisterProductTest
+    {
+        private readonly Address _agentAddress;
+        private readonly Address _avatarAddress;
+        private readonly AvatarState _avatarState;
+        private readonly TableSheets _tableSheets;
+        private readonly Currency _currency;
+        private IAccountStateDelta _initialState;
+
+        public RegisterProductTest()
+        {
+            _agentAddress = new PrivateKey().ToAddress();
+            var agentState = new AgentState(_agentAddress);
+            _avatarAddress = new PrivateKey().ToAddress();
+            var rankingMapAddress = new PrivateKey().ToAddress();
+            _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
+            _avatarState = new AvatarState(
+                _avatarAddress,
+                _agentAddress,
+                0,
+                _tableSheets.GetAvatarSheets(),
+                new GameConfigState(),
+                rankingMapAddress)
+            {
+                worldInformation = new WorldInformation(
+                    0,
+                    _tableSheets.WorldSheet,
+                    GameConfig.RequireClearedStageLevel.ActionsInShop),
+            };
+            agentState.avatarAddresses[0] = _avatarAddress;
+
+            _currency = Currency.Legacy("NCG", 2, minters: null);
+            _initialState = new State()
+                .SetState(GoldCurrencyState.Address, new GoldCurrencyState(_currency).Serialize())
+                .SetState(_agentAddress, agentState.Serialize())
+                .SetState(_avatarAddress, _avatarState.Serialize());
+        }
+
+        [Fact]
+        public void Execute()
+        {
+            var materialRow = _tableSheets.MaterialItemSheet.Values.First();
+            var equipmentRow = _tableSheets.EquipmentItemSheet.Values.First();
+            var tradableMaterial = ItemFactory.CreateTradableMaterial(materialRow);
+            _avatarState.inventory.AddItem(tradableMaterial);
+            var id = Guid.NewGuid();
+            var equipment = ItemFactory.CreateItemUsable(equipmentRow, id, 0L);
+            _avatarState.inventory.AddItem(equipment);
+            Assert.Equal(2, _avatarState.inventory.Items.Count);
+            var asset = 3 * RuneHelper.DailyRewardRune;
+            _initialState = _initialState
+                .SetState(_avatarAddress, _avatarState.Serialize())
+                .MintAsset(_avatarAddress, asset);
+            var action = new RegisterProduct
+            {
+                RegisterInfos = new List<IRegisterInfo>
+                {
+                    new RegisterInfo
+                    {
+                        AvatarAddress = _avatarAddress,
+                        ItemCount = 1,
+                        Price = 1 * _currency,
+                        TradableId = tradableMaterial.TradableId,
+                        Type = ProductType.Fungible,
+                    },
+                    new RegisterInfo
+                    {
+                        AvatarAddress = _avatarAddress,
+                        ItemCount = 1,
+                        Price = 1 * _currency,
+                        TradableId = equipment.TradableId,
+                        Type = ProductType.NonFungible,
+                    },
+                    new AssetInfo
+                    {
+                        AvatarAddress = _avatarAddress,
+                        Asset = asset,
+                        Price = 1 * _currency,
+                        Type = ProductType.FungibleAssetValue,
+                    },
+                },
+            };
+            var nextState = action.Execute(new ActionContext
+            {
+                BlockIndex = 1L,
+                PreviousStates = _initialState,
+                Random = new TestRandom(),
+                Signer = _agentAddress,
+            });
+
+            var nextAvatarState = nextState.GetAvatarStateV2(_avatarAddress);
+            Assert.Empty(nextAvatarState.inventory.Items);
+
+            var marketState = new MarketState(nextState.GetState(Addresses.Market));
+            Assert.Contains(_avatarAddress, marketState.AvatarAddresses);
+
+            var productsState =
+                new ProductsState((List)nextState.GetState(ProductsState.DeriveAddress(_avatarAddress)));
+            var random = new TestRandom();
+            for (int i = 0; i < 3; i++)
+            {
+                var guid = random.GenerateRandomGuid();
+                Assert.Contains(guid, productsState.ProductIds);
+                var productAddress = Product.DeriveAddress(guid);
+                var product = ProductFactory.Deserialize((List)nextState.GetState(productAddress));
+                Assert.Equal(product.ProductId, guid);
+                Assert.Equal(1 * _currency, product.Price);
+                if (product is ItemProduct itemProduct)
+                {
+                    Assert.Equal(1, itemProduct.ItemCount);
+                    Assert.NotNull(itemProduct.TradableItem);
+                }
+
+                if (product is FavProduct favProduct)
+                {
+                    Assert.Equal(asset, favProduct.Asset);
+                }
+            }
+
+            Assert.Equal(0 * asset.Currency, nextState.GetBalance(_avatarAddress, asset.Currency));
+        }
+
+        [Theory]
+        [InlineData(true, false, typeof(InvalidAddressException))]
+        [InlineData(false, true, typeof(FailedLoadStateException))]
+        public void Execute_Throw_Invalid_Avatar_Addresses(bool multipleAvatarAddress, bool invalidAvatarAddress, Type exc)
+        {
+            var registerInfoList = new List<IRegisterInfo>();
+            if (multipleAvatarAddress)
+            {
+                for (int i = 0; i < 2; i++)
+                {
+                    var avatarAddress = _avatarAddress;
+                    if (i == 0)
+                    {
+                        avatarAddress = new PrivateKey().ToAddress();
+                    }
+
+                    registerInfoList.Add(new AssetInfo
+                    {
+                        AvatarAddress = avatarAddress,
+                        Asset = CrystalCalculator.CRYSTAL * 100,
+                        Price = 1 * _currency,
+                        Type = ProductType.FungibleAssetValue,
+                    });
+                }
+            }
+
+            if (invalidAvatarAddress)
+            {
+                registerInfoList.Add(new AssetInfo
+                {
+                    AvatarAddress = new PrivateKey().ToAddress(),
+                    Asset = CrystalCalculator.CRYSTAL * 100,
+                    Price = 1 * _currency,
+                    Type = ProductType.FungibleAssetValue,
+                });
+            }
+
+            var action = new RegisterProduct
+            {
+                RegisterInfos = registerInfoList,
+            };
+
+            Assert.Throws(exc, () => action.Execute(new ActionContext
+            {
+                PreviousStates = _initialState,
+                Random = new TestRandom(),
+                Signer = _agentAddress,
+            }));
+        }
+
+        [Theory]
+        // ticker is not ncg
+        [InlineData(true, false, false, ProductType.NonFungible)]
+        [InlineData(true, false, false, ProductType.FungibleAssetValue)]
+        // 0.1 ncg
+        [InlineData(false, false, true, ProductType.NonFungible)]
+        // 0 ncg
+        [InlineData(false, true, false, ProductType.Fungible)]
+        [InlineData(false, true, false, ProductType.FungibleAssetValue)]
+        public void Execute_Throw_InvalidPriceException(
+            bool invalidTicker,
+            bool invalidQuantity,
+            bool isDouble,
+            ProductType type
+        )
+        {
+            var currency = invalidTicker ? CrystalCalculator.CRYSTAL : _currency;
+            var quantity = invalidQuantity ? 0 : 2;
+            var price = quantity * currency;
+            if (isDouble)
+            {
+                price = price.DivRem(10, out _);
+            }
+
+            var registerInfos = new List<IRegisterInfo>
+            {
+                new RegisterInfo
+                {
+                    AvatarAddress = _avatarAddress,
+                    ItemCount = 1,
+                    Price = 1 * _currency,
+                    TradableId = Guid.NewGuid(),
+                    Type = ProductType.Fungible,
+                },
+                new RegisterInfo
+                {
+                    AvatarAddress = _avatarAddress,
+                    ItemCount = 1,
+                    Price = 1 * _currency,
+                    TradableId = Guid.NewGuid(),
+                    Type = ProductType.NonFungible,
+                },
+                new AssetInfo
+                {
+                    AvatarAddress = _avatarAddress,
+                    Asset = 1 * RuneHelper.StakeRune,
+                    Price = 1 * _currency,
+                    Type = ProductType.FungibleAssetValue,
+                },
+            };
+
+            if (type == ProductType.FungibleAssetValue)
+            {
+                registerInfos.Add(new AssetInfo
+                {
+                    AvatarAddress = _avatarAddress,
+                    Asset = 1 * RuneHelper.DailyRewardRune,
+                    Price = price,
+                    Type = type,
+                });
+            }
+            else
+            {
+                registerInfos.Add(new RegisterInfo
+                {
+                    AvatarAddress = _avatarAddress,
+                    ItemCount = 1,
+                    Price = price,
+                    TradableId = Guid.NewGuid(),
+                    Type = type,
+                });
+            }
+
+            var action = new RegisterProduct
+            {
+                RegisterInfos = registerInfos,
+            };
+
+            Assert.Throws<InvalidPriceException>(() => action.Execute(new ActionContext
+            {
+                PreviousStates = _initialState,
+            }));
+        }
+
+        [Theory]
+        // not enough block index.
+        [InlineData(ProductType.Fungible, 1, 2L, 1L, false)]
+        // not enough inventory items.
+        [InlineData(ProductType.Fungible, 2, 3L, 3L, false)]
+        // inventory has locked.
+        [InlineData(ProductType.Fungible, 1, 3L, 3L, true)]
+        [InlineData(ProductType.NonFungible, 1, 3L, 3L, true)]
+        public void Execute_Throw_ItemDoesNotExistException(ProductType type, int itemCount, long requiredBlockIndex, long blockIndex, bool lockInventory)
+        {
+            ITradableItem tradableItem = null;
+            switch (type)
+            {
+                case ProductType.Fungible:
+                {
+                    var materialRow = _tableSheets.MaterialItemSheet.Values.First();
+                    var tradableMaterial = ItemFactory.CreateTradableMaterial(materialRow);
+                    tradableMaterial.RequiredBlockIndex = requiredBlockIndex;
+                    tradableItem = tradableMaterial;
+                    break;
+                }
+
+                case ProductType.NonFungible:
+                {
+                    var equipmentRow = _tableSheets.EquipmentItemSheet.Values.First();
+                    var id = Guid.NewGuid();
+                    tradableItem = ItemFactory.CreateItemUsable(equipmentRow, id, requiredBlockIndex);
+                    break;
+                }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type), type, null);
+            }
+
+            if (lockInventory)
+            {
+                _avatarState.inventory.AddItem((ItemBase)tradableItem, iLock: new OrderLock(Guid.NewGuid()));
+            }
+            else
+            {
+                _avatarState.inventory.AddItem((ItemBase)tradableItem);
+            }
+
+            _initialState = _initialState.SetState(_avatarAddress, _avatarState.Serialize());
+            var action = new RegisterProduct
+            {
+                RegisterInfos = new List<IRegisterInfo>
+                {
+                    new RegisterInfo
+                    {
+                        AvatarAddress = _avatarAddress,
+                        ItemCount = itemCount,
+                        Price = 1 * _currency,
+                        TradableId = tradableItem.TradableId,
+                        Type = type,
+                    },
+                },
+            };
+
+            Assert.Throws<ItemDoesNotExistException>(() => action.Execute(new ActionContext
+            {
+                Signer = _agentAddress,
+                BlockIndex = blockIndex,
+                Random = new TestRandom(),
+                PreviousStates = _initialState,
+            }));
+        }
+
+        [Theory]
+        [InlineData(ProductType.Fungible)]
+        [InlineData(ProductType.NonFungible)]
+        [InlineData(ProductType.FungibleAssetValue)]
+        public void Execute_Throw_InvalidProductTypeException(ProductType type)
+        {
+            var registerInfoList = new List<IRegisterInfo>();
+            switch (type)
+            {
+                case ProductType.Fungible:
+                case ProductType.NonFungible:
+                    registerInfoList.Add(new AssetInfo
+                    {
+                        AvatarAddress = _avatarAddress,
+                        Type = type,
+                        Price = 1 * _currency,
+                    });
+                    break;
+                case ProductType.FungibleAssetValue:
+                    registerInfoList.Add(new RegisterInfo
+                    {
+                        AvatarAddress = _avatarAddress,
+                        Type = type,
+                        Price = 1 * _currency,
+                    });
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type), type, null);
+            }
+
+            var action = new RegisterProduct
+            {
+                RegisterInfos = registerInfoList,
+            };
+
+            Assert.Throws<InvalidProductTypeException>(() => action.Execute(new ActionContext
+            {
+                Signer = _agentAddress,
+                PreviousStates = _initialState,
+                Random = new TestRandom(),
+                BlockIndex = 1L,
+            }));
+        }
+
+        [Fact]
+        public void Execute_Throw_InvalidCurrencyException()
+        {
+            _initialState = _initialState.MintAsset(_avatarAddress, RuneHelper.StakeRune * 1);
+            var action = new RegisterProduct
+            {
+                RegisterInfos = new List<IRegisterInfo>
+                {
+                    new AssetInfo
+                    {
+                        AvatarAddress = _avatarAddress,
+                        Asset = 1 * RuneHelper.StakeRune,
+                        Price = 1 * _currency,
+                        Type = ProductType.FungibleAssetValue,
+                    },
+                    new AssetInfo
+                    {
+                        AvatarAddress = _avatarAddress,
+                        Asset = 1 * CrystalCalculator.CRYSTAL,
+                        Price = 1 * _currency,
+                        Type = ProductType.FungibleAssetValue,
+                    },
+                },
+            };
+
+            Assert.Throws<InvalidCurrencyException>(() => action.Execute(new ActionContext
+            {
+                Signer = _agentAddress,
+                PreviousStates = _initialState,
+                Random = new TestRandom(),
+            }));
+        }
+    }
+}

--- a/Lib9c/Action/AssetInfo.cs
+++ b/Lib9c/Action/AssetInfo.cs
@@ -1,0 +1,38 @@
+using System;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Assets;
+using Nekoyume.Model.Market;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Action
+{
+    public class AssetInfo: IRegisterInfo
+    {
+        public Address AvatarAddress { get; set; }
+        public FungibleAssetValue Price { get; set; }
+        public FungibleAssetValue Asset { get; set; }
+        public ProductType Type { get; set; }
+
+        public AssetInfo()
+        {
+        }
+
+        public AssetInfo(List serialized)
+        {
+            AvatarAddress = serialized[0].ToAddress();
+            Price = serialized[1].ToFungibleAssetValue();
+            Type = serialized[2].ToEnum<ProductType>();
+            Asset = serialized[3].ToFungibleAssetValue();
+        }
+
+        public IValue Serialize()
+        {
+            return List.Empty
+                .Add(AvatarAddress.Serialize())
+                .Add(Price.Serialize())
+                .Add(Type.Serialize())
+                .Add(Asset.Serialize());
+        }
+    }
+}

--- a/Lib9c/Action/IRegisterInfo.cs
+++ b/Lib9c/Action/IRegisterInfo.cs
@@ -1,0 +1,16 @@
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Assets;
+using Nekoyume.Model.Market;
+
+namespace Nekoyume.Action
+{
+    public interface IRegisterInfo
+    {
+        public Address AvatarAddress { get; set; }
+        public FungibleAssetValue Price { get; set; }
+        public ProductType Type { get; set; }
+
+        public IValue Serialize();
+    }
+}

--- a/Lib9c/Action/InvalidCurrencyException.cs
+++ b/Lib9c/Action/InvalidCurrencyException.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Nekoyume.Action
+{
+    [Serializable]
+    public class InvalidCurrencyException : InvalidOperationException
+    {
+        public InvalidCurrencyException(string msg) : base(msg)
+        {
+        }
+
+        protected InvalidCurrencyException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Lib9c/Action/InvalidProductTypeException.cs
+++ b/Lib9c/Action/InvalidProductTypeException.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Nekoyume.Action
+{
+    [Serializable]
+    public class InvalidProductTypeException : InvalidOperationException
+    {
+        public InvalidProductTypeException(string msg) : base(msg)
+        {
+        }
+
+        protected InvalidProductTypeException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/Lib9c/Action/ProductInfo.cs
+++ b/Lib9c/Action/ProductInfo.cs
@@ -1,0 +1,44 @@
+using System;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Assets;
+using Nekoyume.Model.Market;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Action
+{
+    public class ProductInfo
+    {
+        public Guid ProductId;
+        public FungibleAssetValue Price;
+        public Address AgentAddress;
+        public Address AvatarAddress;
+        public ProductType Type;
+        public bool Legacy;
+
+        public ProductInfo()
+        {
+        }
+
+        public ProductInfo(List serialized)
+        {
+            ProductId = serialized[0].ToGuid();
+            Price = serialized[1].ToFungibleAssetValue();
+            AgentAddress = serialized[2].ToAddress();
+            AvatarAddress = serialized[3].ToAddress();
+            Type = serialized[4].ToEnum<ProductType>();
+            Legacy = serialized[5].ToBoolean();
+        }
+
+        public IValue Serialize()
+        {
+            return List.Empty
+                .Add(ProductId.Serialize())
+                .Add(Price.Serialize())
+                .Add(AgentAddress.Serialize())
+                .Add(AvatarAddress.Serialize())
+                .Add(Type.Serialize())
+                .Add(Legacy.Serialize());
+        }
+    }
+}

--- a/Lib9c/Action/RegisterInfo.cs
+++ b/Lib9c/Action/RegisterInfo.cs
@@ -1,0 +1,41 @@
+using System;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Assets;
+using Nekoyume.Model.Market;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Action
+{
+    public class RegisterInfo: IRegisterInfo
+    {
+        public Address AvatarAddress { get; set; }
+        public FungibleAssetValue Price { get; set; }
+        public Guid TradableId { get; set; }
+        public int ItemCount { get; set; }
+        public ProductType Type { get; set; }
+
+        public RegisterInfo(List serialized)
+        {
+            AvatarAddress = serialized[0].ToAddress();
+            Price = serialized[1].ToFungibleAssetValue();
+            Type = serialized[2].ToEnum<ProductType>();
+            TradableId = serialized[3].ToGuid();
+            ItemCount = serialized[4].ToInteger();
+        }
+
+        public RegisterInfo()
+        {
+        }
+
+        public IValue Serialize()
+        {
+            return List.Empty
+                .Add(AvatarAddress.Serialize())
+                .Add(Price.Serialize())
+                .Add(Type.Serialize())
+                .Add(TradableId.Serialize())
+                .Add(ItemCount.Serialize());
+        }
+    }
+}

--- a/Lib9c/Action/RegisterProduct.cs
+++ b/Lib9c/Action/RegisterProduct.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Action;
+using Libplanet.Assets;
+using Nekoyume.Helper;
+using Nekoyume.Model.Item;
+using Nekoyume.Model.Market;
+using Nekoyume.Model.State;
+using static Lib9c.SerializeKeys;
+
+namespace Nekoyume.Action
+{
+    [ActionType("register_product")]
+    public class RegisterProduct : GameAction
+    {
+        public IEnumerable<IRegisterInfo> RegisterInfos;
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            var states = context.PreviousStates;
+            if (context.Rehearsal)
+            {
+                return states;
+            }
+
+            if (RegisterInfos.Select(r => r.AvatarAddress).Distinct().Count() != 1)
+            {
+                throw new InvalidAddressException();
+            }
+
+            var ncg = states.GetGoldCurrency();
+            if (RegisterInfos.Any(r => !r.Price.Currency.Equals(ncg) ||
+                !r.Price.MinorUnit.IsZero ||
+                r.Price < 1 * ncg))
+            {
+                throw new InvalidPriceException(
+                    $"product price must be greater than zero.");
+            }
+
+            var avatarAddress = RegisterInfos.First().AvatarAddress;
+            if (!states.TryGetAvatarStateV2(context.Signer, avatarAddress, out var avatarState,
+                    out var migrationRequired))
+            {
+                throw new FailedLoadStateException("");
+            }
+
+            if (!avatarState.worldInformation.IsStageCleared(
+                    GameConfig.RequireClearedStageLevel.ActionsInShop))
+            {
+                avatarState.worldInformation.TryGetLastClearedStageId(out var current);
+                throw new NotEnoughClearedStageLevelException(
+                    avatarAddress.ToHex(),
+                    GameConfig.RequireClearedStageLevel.ActionsInShop,
+                    current);
+            }
+
+            var productsStateAddress = ProductsState.DeriveAddress(avatarAddress);
+            ProductsState productsState;
+            if (states.TryGetState(productsStateAddress, out List rawProducts))
+            {
+                productsState = new ProductsState(rawProducts);
+            }
+            else
+            {
+                productsState = new ProductsState();
+                var marketState = states.TryGetState(Addresses.Market, out List rawMarketList)
+                    ? new MarketState(rawMarketList)
+                    : new MarketState();
+                marketState.AvatarAddresses.Add(avatarAddress);
+                states = states.SetState(Addresses.Market, marketState.Serialize());
+            }
+            foreach (var info in RegisterInfos.OrderBy(r => r.Type).ThenBy(r => r.Price))
+            {
+                states = Register(context, info, avatarState, productsState, states);
+            }
+
+            states = states
+                .SetState(avatarAddress.Derive(LegacyInventoryKey), avatarState.inventory.Serialize())
+                .SetState(productsStateAddress, productsState.Serialize());
+            if (migrationRequired)
+            {
+                states = states
+                    .SetState(avatarAddress, avatarState.SerializeV2())
+                    .SetState(avatarAddress.Derive(LegacyQuestListKey), avatarState.questList.Serialize())
+                    .SetState(avatarAddress.Derive(LegacyWorldInformationKey), avatarState.worldInformation.Serialize());
+            }
+
+            return states;
+        }
+
+        public static IAccountStateDelta Register(IActionContext context, IRegisterInfo info, AvatarState avatarState,
+            ProductsState productsState, IAccountStateDelta states)
+        {
+            switch (info)
+            {
+                case RegisterInfo registerInfo:
+                    switch (info.Type)
+                    {
+                        case ProductType.Fungible:
+                        case ProductType.NonFungible:
+                        {
+                            var tradableId = registerInfo.TradableId;
+                            var itemCount = registerInfo.ItemCount;
+                            var type = registerInfo.Type;
+                            ITradableItem tradableItem = null;
+                            switch (type)
+                            {
+                                case ProductType.Fungible:
+                                {
+                                    if (avatarState.inventory.TryGetTradableItems(tradableId,
+                                            context.BlockIndex, itemCount, out var items))
+                                    {
+                                        int totalCount = itemCount;
+                                        tradableItem = (ITradableItem) items.First().item;
+                                        foreach (var inventoryItem in items)
+                                        {
+                                            int removeCount = Math.Min(totalCount,
+                                                inventoryItem.count);
+                                            ITradableFungibleItem tradableFungibleItem =
+                                                (ITradableFungibleItem) inventoryItem.item;
+                                            if (!avatarState.inventory.RemoveTradableItem(
+                                                    tradableId,
+                                                    tradableFungibleItem.RequiredBlockIndex,
+                                                    removeCount))
+                                            {
+                                                throw new ItemDoesNotExistException(
+                                                    $"failed to remove tradable material {tradableId}/{itemCount}");
+                                            }
+
+                                            totalCount -= removeCount;
+                                            if (totalCount < 1)
+                                            {
+                                                break;
+                                            }
+                                        }
+
+                                        if (totalCount != 0)
+                                        {
+                                            throw new InvalidItemCountException();
+                                        }
+                                    }
+
+                                    break;
+                                }
+                                case ProductType.NonFungible:
+                                {
+                                    if (avatarState.inventory.TryGetNonFungibleItem(tradableId,
+                                            out var item) &&
+                                        avatarState.inventory.RemoveNonFungibleItem(tradableId))
+                                    {
+                                        tradableItem = (ITradableItem) item.item;
+                                    }
+
+                                    break;
+                                }
+                            }
+
+                            if (tradableItem is null)
+                            {
+                                throw new ItemDoesNotExistException($"can't find item: {tradableId}");
+                            }
+
+                            Guid productId = context.Random.GenerateRandomGuid();
+                            var product = new ItemProduct
+                            {
+                                ProductId = productId,
+                                Price = registerInfo.Price,
+                                TradableItem = tradableItem,
+                                ItemCount = itemCount,
+                                RegisteredBlockIndex = context.BlockIndex,
+                                Type = registerInfo.Type,
+                                SellerAgentAddress = context.Signer,
+                                SellerAvatarAddress = registerInfo.AvatarAddress,
+                            };
+                            productsState.ProductIds.Add(productId);
+                            states = states.SetState(Product.DeriveAddress(productId),
+                                product.Serialize());
+                            break;
+                        }
+                        case ProductType.FungibleAssetValue:
+                        default:
+                            throw new InvalidProductTypeException($"register item does not support {ProductType.FungibleAssetValue}");
+                    }
+
+                    break;
+                case AssetInfo assetInfo:
+                {
+                    if (assetInfo.Type == ProductType.FungibleAssetValue)
+                    {
+                        if (assetInfo.Asset.Currency.Equals(CrystalCalculator.CRYSTAL))
+                        {
+                            throw new InvalidCurrencyException($"{CrystalCalculator.CRYSTAL} does not allow register.");
+                        }
+
+                        Guid productId = context.Random.GenerateRandomGuid();
+                        Address productAddress = Product.DeriveAddress(productId);
+                        FungibleAssetValue asset = assetInfo.Asset;
+                        var product = new FavProduct
+                        {
+                            ProductId = productId,
+                            Price = assetInfo.Price,
+                            Asset = asset,
+                            RegisteredBlockIndex = context.BlockIndex,
+                            Type = assetInfo.Type,
+                            SellerAgentAddress = context.Signer,
+                            SellerAvatarAddress = assetInfo.AvatarAddress,
+                        };
+                        states = states
+                            .TransferAsset(avatarState.address, productAddress, asset)
+                            .SetState(productAddress, product.Serialize());
+                        productsState.ProductIds.Add(productId);
+                        break;
+                    }
+                    throw new InvalidProductTypeException($"register asset does not support {assetInfo.Type}");
+                }
+            }
+
+            return states;
+        }
+
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            new Dictionary<string, IValue>
+            {
+                ["r"] = new List(RegisterInfos.Select(r => r.Serialize())),
+            }.ToImmutableDictionary();
+
+        protected override void LoadPlainValueInternal(IImmutableDictionary<string, IValue> plainValue)
+        {
+            var serialized = (List) plainValue["r"];
+            RegisterInfos = serialized.Cast<List>()
+                .Select(registerList =>
+                    registerList[2].ToEnum<ProductType>() == ProductType.FungibleAssetValue
+                        ? (IRegisterInfo) new AssetInfo(registerList)
+                        : new RegisterInfo(registerList)).ToList();
+        }
+    }
+}

--- a/Lib9c/Addresses.cs
+++ b/Lib9c/Addresses.cs
@@ -32,6 +32,7 @@ namespace Nekoyume
         public static readonly Address EventDungeon          = new Address("0000000000000000000000000000000000000014");
         public static readonly Address Raid                  = new Address("0000000000000000000000000000000000000015");
         public static readonly Address Rune                  = new Address("0000000000000000000000000000000000000016");
+        public static readonly Address Market                = new Address("0000000000000000000000000000000000000017");
 
         public static Address GetSheetAddress<T>() where T : ISheet => GetSheetAddress(typeof(T).Name);
 

--- a/Lib9c/Model/Market/FavProduct.cs
+++ b/Lib9c/Model/Market/FavProduct.cs
@@ -1,0 +1,27 @@
+using Bencodex.Types;
+using Libplanet.Assets;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Model.Market
+{
+    public class FavProduct : Product
+    {
+        public FungibleAssetValue Asset;
+
+        public FavProduct()
+        {
+        }
+
+        public FavProduct(List serialized) : base(serialized)
+        {
+            Asset = serialized[6].ToFungibleAssetValue();
+        }
+
+        public override IValue Serialize()
+        {
+            List serialized = (List) base.Serialize();
+            return serialized.Add(Asset.Serialize());
+        }
+
+    }
+}

--- a/Lib9c/Model/Market/ItemProduct.cs
+++ b/Lib9c/Model/Market/ItemProduct.cs
@@ -1,0 +1,30 @@
+using Bencodex.Types;
+using Nekoyume.Model.Item;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Model.Market
+{
+    public class ItemProduct : Product
+    {
+        public ITradableItem TradableItem;
+        public int ItemCount;
+
+        public ItemProduct()
+        {
+        }
+
+        public ItemProduct(List serialized) : base(serialized)
+        {
+            TradableItem = (ITradableItem) ItemFactory.Deserialize((Dictionary)serialized[6]);
+            ItemCount = serialized[7].ToInteger();
+        }
+
+        public override IValue Serialize()
+        {
+            List serialized = (List) base.Serialize();
+            return serialized
+                .Add(TradableItem.Serialize())
+                .Add(ItemCount.Serialize());
+        }
+    }
+}

--- a/Lib9c/Model/Market/Product.cs
+++ b/Lib9c/Model/Market/Product.cs
@@ -1,0 +1,51 @@
+using System;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Assets;
+using Nekoyume.Action;
+using Nekoyume.Model.Item;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Model.Market
+{
+    public class Product
+    {
+        public static Address DeriveAddress(Guid productId)
+        {
+            return Addresses.Market.Derive(productId.ToString());
+        }
+
+
+        public Guid ProductId;
+        public ProductType Type;
+        public FungibleAssetValue Price;
+        public long RegisteredBlockIndex;
+        public Address SellerAvatarAddress;
+        public Address SellerAgentAddress;
+
+        protected Product()
+        {
+        }
+
+        protected Product(List serialized)
+        {
+            ProductId = serialized[0].ToGuid();
+            Type = serialized[1].ToEnum<ProductType>();
+            Price = serialized[2].ToFungibleAssetValue();
+            RegisteredBlockIndex = serialized[3].ToLong();
+            SellerAgentAddress = serialized[4].ToAddress();
+            SellerAvatarAddress = serialized[5].ToAddress();
+        }
+
+        public virtual IValue Serialize()
+        {
+            return List.Empty
+                .Add(ProductId.Serialize())
+                .Add(Type.Serialize())
+                .Add(Price.Serialize())
+                .Add(RegisteredBlockIndex.Serialize())
+                .Add(SellerAgentAddress.Serialize())
+                .Add(SellerAvatarAddress.Serialize());
+        }
+    }
+}

--- a/Lib9c/Model/Market/ProductFactory.cs
+++ b/Lib9c/Model/Market/ProductFactory.cs
@@ -1,0 +1,18 @@
+using Bencodex.Types;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Model.Market
+{
+    public static class ProductFactory
+    {
+        public static Product Deserialize(List serialized)
+        {
+            if (serialized[1].ToEnum<ProductType>() == ProductType.FungibleAssetValue)
+            {
+                return new FavProduct(serialized);
+            }
+
+            return new ItemProduct(serialized);
+        }
+    }
+}

--- a/Lib9c/Model/Market/ProductReceipt.cs
+++ b/Lib9c/Model/Market/ProductReceipt.cs
@@ -1,0 +1,52 @@
+using System;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Assets;
+using Nekoyume.Action;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Model.Market
+{
+    public class ProductReceipt
+    {
+        public static Address DeriveAddress(Guid productId)
+        {
+            return Product.DeriveAddress(productId).Derive(nameof(ProductReceipt));
+        }
+
+        public readonly Guid ProductId;
+        public readonly Address SellerAvatarAddress;
+        public readonly Address BuyerAvatarAddress;
+        public FungibleAssetValue Price;
+        public long PurchasedBlockIndex;
+
+        public ProductReceipt(Guid productId, Address sellerAvatarAddress,
+            Address buyerAvatarAddress, FungibleAssetValue price, long purchasedBlockIndex)
+        {
+            ProductId = productId;
+            SellerAvatarAddress = sellerAvatarAddress;
+            BuyerAvatarAddress = buyerAvatarAddress;
+            Price = price;
+            PurchasedBlockIndex = purchasedBlockIndex;
+        }
+
+        public ProductReceipt(List serialized)
+        {
+            ProductId = serialized[0].ToGuid();
+            SellerAvatarAddress = serialized[1].ToAddress();
+            BuyerAvatarAddress = serialized[2].ToAddress();
+            Price = serialized[3].ToFungibleAssetValue();
+            PurchasedBlockIndex = serialized[4].ToLong();
+        }
+
+        public IValue Serialize()
+        {
+            return List.Empty
+                .Add(ProductId.Serialize())
+                .Add(SellerAvatarAddress.Serialize())
+                .Add(BuyerAvatarAddress.Serialize())
+                .Add(Price.Serialize())
+                .Add(PurchasedBlockIndex.Serialize());
+        }
+    }
+}

--- a/Lib9c/Model/Market/ProductType.cs
+++ b/Lib9c/Model/Market/ProductType.cs
@@ -1,0 +1,9 @@
+namespace Nekoyume.Model.Market
+{
+    public enum ProductType
+    {
+        Fungible,
+        FungibleAssetValue,
+        NonFungible,
+    }
+}

--- a/Lib9c/Model/Market/ProductsState.cs
+++ b/Lib9c/Model/Market/ProductsState.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bencodex.Types;
+using Lib9c;
+using Libplanet;
+using Nekoyume.Action;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Model.Market
+{
+    public class ProductsState
+    {
+        public static Address DeriveAddress(Address avatarAddress) =>
+            avatarAddress.Derive(nameof(ProductsState));
+
+        public List<Guid> ProductIds = new List<Guid>();
+
+        public ProductsState()
+        {
+        }
+
+        public ProductsState(List serialized)
+        {
+            ProductIds = serialized.ToList(StateExtensions.ToGuid);
+        }
+
+        public IValue Serialize()
+        {
+            return ProductIds
+                .Aggregate(
+                    List.Empty,
+                    (current, productId) => current.Add(productId.Serialize())
+                );
+        }
+    }
+}

--- a/Lib9c/Model/State/MarketState.cs
+++ b/Lib9c/Model/State/MarketState.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Linq;
+using Bencodex.Types;
+using Libplanet;
+
+namespace Nekoyume.Model.State
+{
+    public class MarketState
+    {
+        public List<Address> AvatarAddresses = new List<Address>();
+
+        public MarketState(IValue rawList)
+        {
+            AvatarAddresses = rawList.ToList(StateExtensions.ToAddress);
+        }
+
+        public MarketState()
+        {
+        }
+
+        public IValue Serialize()
+        {
+            return AvatarAddresses
+                .Aggregate(
+                    List.Empty,
+                    (current, avatarAddress) => current.Add(avatarAddress.Serialize())
+                );
+        }
+    }
+}


### PR DESCRIPTION
## States
### MarketState
It has the avatar addresses who registered product in the market. It will used when searching for all `ProductsState`.(corresponding to `ShardedShopState`)
### ProductsState
Each AvatarState will have it own a list of registered ProductIds.(corresponding to `OrderDigestListState`)

## Products
registered item, FungibleAssetValue information. (corresponding to `Order, ShopItem`)
### FavProduct
### ItemProduct

## Action
### RegisterProduct
register item or FungibleAssetValue to market. (corresponding to `Sell`)
### RegisterInfo
It is used for registering item to the market. 
### AssetInfo
It is used for registering FungibleAssetValue to the market.
### ProductInfo
It is used for find registered product in the market.

## TL;DR
- The difference with the existing Order model is that instead of copying the item, it completely moves the item (or FungibleAssetValue) to product address.
- IRegisterInfo(RegisterInfo, AssetInfo) & ProductInfo using it action plain values. we can register, cancel, buy, re-register by combining the two models.
- This pr is the divided from #1672 into stages for review convenience. If you need information about the entire action and model, you can check it.