### PR TITLE
🔧 Fixed index used for policy

### DIFF
--- a/Lib9c.Policy/Policy/BlockPolicySource.cs
+++ b/Lib9c.Policy/Policy/BlockPolicySource.cs
@@ -276,9 +276,7 @@ namespace Nekoyume.BlockChain.Policy
             ImmutableHashSet<Address> allAuthorizedMiners)
         {
             // Avoid NRE when genesis block appended
-            // Here, index is the index of a prospective block that transaction
-            // will be included.
-            long index = blockChain.Count > 0 ? blockChain.Tip.Index : 0;
+            long index = blockChain.Count > 0 ? blockChain.Tip.Index + 1: 0;
 
             if (((ITransaction)transaction).CustomActions?.Count > 1)
             {

--- a/Lib9c/Action/ActionObsoleteAttribute.cs
+++ b/Lib9c/Action/ActionObsoleteAttribute.cs
@@ -1,7 +1,19 @@
 using System;
+using Libplanet.Action;
 
 namespace Nekoyume.Action
 {
+    /// <summary>
+    /// <para>
+    /// An attribute on an <see cref="IAction"/> to indicate that
+    /// such <see cref="IAction"/> is obsoleted after a certain index.
+    /// </para>
+    /// <para>
+    /// Due to a bug introduced earlier and to keep backward compatibility,
+    /// an <see cref="IAction"/> with this attribute is obsoleted, i.e. cannot be included,
+    /// starting from <see cref="ActionObsoleteAttribute.ObsoleteIndex"/> + 2.
+    /// </para>
+    /// </summary>
     public class ActionObsoleteAttribute : Attribute
     {
         public ActionObsoleteAttribute(long obsoleteIndex)


### PR DESCRIPTION
Internally, there are two places using `index`, namely `IsObsolete()` (which also internally uses `IActionTypeLoader.Load()`) and `IActionTypeLoader.Load()`. At a glance, seems like this should be fine.

- ~~`IsObsolete()`: If an action is obsoleted at certain index and permanently onwards, passing in a higher index should be fine, as this results in a more lax condition.~~
  - ~~Suppose some action $X$ was supposed to be obsoleted at block $n$. Before, with **wrong implementation**, action $X$ would've been banned starting from block $n - 1$. Policy is enforced as long as $X$ is not in block $n$.~~
  - As @moreal has pointed out below, this line of reasoning is flawed.
- `IActionTypeLoader.Load()`: This is also used inside `Miner.MineBlockAsync()` with a **proper** block index. So blocks were being mined using the right action. As for policy consideration, seems like inside `ValidateNextBlockTxRaw()` it is only used for account activation check. From what I gather so far, some account activation actions might've failed around the index where the implementation of `IActivateAccount` changed from `activate_account` to `activate_account2`.