### PR TITLE
Introduce `ManipulateState` action for easier test environment setting

### DIFF
--- a/.Lib9c.DevExtensions.Tests/Action/Craft/UnlocakCraftActionTest.cs
+++ b/.Lib9c.DevExtensions.Tests/Action/Craft/UnlocakCraftActionTest.cs
@@ -1,0 +1,64 @@
+using Bencodex.Types;
+using Lib9c.DevExtensions.Action.Craft;
+using Lib9c.Tests;
+using Lib9c.Tests.Action;
+using Lib9c.Tests.Util;
+using Libplanet;
+using Libplanet.Action;
+using Nekoyume;
+using Nekoyume.Action;
+using Nekoyume.Model;
+using Xunit;
+using static Lib9c.SerializeKeys;
+
+namespace Lib9c.DevExtensions.Tests.Action.Craft
+{
+    public class UnlockCraftActionTest
+    {
+        private readonly TableSheets _tableSheets;
+        private readonly Address _agentAddress;
+        private readonly Address _avatarAddress;
+        private readonly IAccountStateDelta _initialStateV2;
+        private readonly Address _worldInformationAddress;
+
+        public UnlockCraftActionTest()
+        {
+            (_tableSheets, _agentAddress, _avatarAddress, _, _initialStateV2) =
+                InitializeUtil.InitializeStates(true);
+            _worldInformationAddress = _avatarAddress.Derive(LegacyWorldInformationKey);
+        }
+
+        [Theory]
+        [InlineData("combination_equipment",
+            GameConfig.RequireClearedStageLevel.CombinationEquipmentAction)]
+        [InlineData("combination_equipment14",
+            GameConfig.RequireClearedStageLevel.CombinationEquipmentAction)]
+        [InlineData("combination_consumable",
+            GameConfig.RequireClearedStageLevel.CombinationConsumableAction)]
+        [InlineData("combination_consumable8",
+            GameConfig.RequireClearedStageLevel.CombinationConsumableAction)]
+        [InlineData("item_enhancement",
+            GameConfig.RequireClearedStageLevel.ItemEnhancementAction)]
+        [InlineData("item_enhancement11",
+            GameConfig.RequireClearedStageLevel.ItemEnhancementAction)]
+        public void StageUnlockTest(string typeIdentifier, int expectedStage)
+        {
+            var action = new UnlockCraftAction
+            {
+                AvatarAddress = _avatarAddress,
+                ActionType = new ActionTypeAttribute(typeIdentifier)
+            };
+
+            var state = action.Execute(new ActionContext
+            {
+                PreviousStates = _initialStateV2,
+                Signer = _agentAddress,
+                BlockIndex = 0L
+            });
+
+            var worldInformation =
+                new WorldInformation((Dictionary)state.GetState(_worldInformationAddress));
+            Assert.True(worldInformation.IsStageCleared(expectedStage));
+        }
+    }
+}

--- a/.Lib9c.DevExtensions.Tests/Action/Craft/UnlockRecipeTest.cs
+++ b/.Lib9c.DevExtensions.Tests/Action/Craft/UnlockRecipeTest.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Linq;
+using Bencodex.Types;
+using Lib9c.DevExtensions.Action.Craft;
+using Lib9c.Tests;
+using Lib9c.Tests.Action;
+using Lib9c.Tests.Util;
+using Libplanet;
+using Libplanet.Action;
+using Nekoyume.Action;
+using Nekoyume.Model.Item;
+using Nekoyume.Model.State;
+using Xunit;
+
+namespace Lib9c.DevExtensions.Tests.Action.Craft
+{
+    public class UnlockRecipeTest
+    {
+        private readonly TableSheets _tableSheets;
+        private readonly Address _agentAddress;
+        private readonly Address _avatarAddress;
+        private readonly IAccountStateDelta _initialStateV2;
+        private readonly Address _recipeAddress;
+
+        public UnlockRecipeTest()
+        {
+            (_tableSheets, _agentAddress, _avatarAddress, _, _initialStateV2) =
+                InitializeUtil.InitializeStates(isDevEx: true);
+            _recipeAddress = _avatarAddress.Derive("recipe_ids");
+        }
+
+        [Theory]
+        [InlineData(ItemSubType.Weapon)]
+        [InlineData(ItemSubType.Armor)]
+        [InlineData(ItemSubType.Belt)]
+        [InlineData(ItemSubType.Necklace)]
+        [InlineData(ItemSubType.Ring)]
+        public void UnlockRecipeTest_Equipment(ItemSubType targetType)
+        {
+            var random = new Random();
+            var equipmentList = _tableSheets.EquipmentItemSheet.Values.Where(
+                eq => eq.ItemSubType == targetType
+            ).ToList();
+            var equipment = equipmentList[random.Next(equipmentList.Count)];
+
+            var recipeRow = _tableSheets.EquipmentItemRecipeSheet.Values.First(
+                recipe => recipe.ResultEquipmentId == equipment.Id
+            );
+            var action = new UnlockRecipe
+            {
+                AvatarAddress = _avatarAddress,
+                TargetStage = recipeRow.UnlockStage,
+            };
+
+            var stateV2 = action.Execute(new ActionContext
+            {
+                PreviousStates = _initialStateV2,
+                Signer = _agentAddress,
+                BlockIndex = 0L,
+            });
+
+            Assert.True(stateV2.TryGetState(_recipeAddress, out List rawIds));
+            var unlockedRecipeIds = rawIds.ToList(StateExtensions.ToInteger);
+            Assert.Contains(recipeRow.UnlockStage, unlockedRecipeIds);
+        }
+
+        [Theory]
+        [InlineData(ItemSubType.Food)]
+        public void UnlockRecipeTest_Consumable(ItemSubType targetType)
+        {
+            const int targetStage = 6;
+            var random = new Random();
+            var foodList = _tableSheets.ConsumableItemSheet.Values.Where(
+                con => con.ItemSubType == targetType
+            ).ToList();
+            var targetConsumable = foodList[random.Next(foodList.Count)];
+            var recipeRow = _tableSheets.ConsumableItemRecipeSheet.Values.First(
+                recipe => recipe.ResultConsumableItemId == targetConsumable.Id
+            );
+            var action = new UnlockRecipe
+            {
+                AvatarAddress = _avatarAddress,
+                TargetStage = targetStage,
+            };
+
+            var stateV2 = action.Execute(new ActionContext
+            {
+                PreviousStates = _initialStateV2,
+                Signer = _agentAddress,
+                BlockIndex = 0L,
+            });
+
+            Assert.True(stateV2.TryGetState(_recipeAddress, out List _));
+        }
+    }
+}

--- a/.Lib9c.DevExtensions.Tests/Action/Craft/UnlockRecipeTest.cs
+++ b/.Lib9c.DevExtensions.Tests/Action/Craft/UnlockRecipeTest.cs
@@ -38,8 +38,11 @@ namespace Lib9c.DevExtensions.Tests.Action.Craft
         public void UnlockRecipeTest_Equipment(ItemSubType targetType)
         {
             var random = new Random();
+            var recipeResultList = _tableSheets.EquipmentItemRecipeSheet.Values.Select(
+                recipe => recipe.ResultEquipmentId
+            );
             var equipmentList = _tableSheets.EquipmentItemSheet.Values.Where(
-                eq => eq.ItemSubType == targetType
+                eq => eq.ItemSubType == targetType && recipeResultList.Contains(eq.Id)
             ).ToList();
             var equipment = equipmentList[random.Next(equipmentList.Count)];
 
@@ -70,11 +73,14 @@ namespace Lib9c.DevExtensions.Tests.Action.Craft
         {
             const int targetStage = 6;
             var random = new Random();
+            var recipeResultList = _tableSheets.ConsumableItemRecipeSheet.Values.Select(
+                recipe => recipe.ResultConsumableItemId
+            );
             var foodList = _tableSheets.ConsumableItemSheet.Values.Where(
-                con => con.ItemSubType == targetType
+                con => con.ItemSubType == targetType && recipeResultList.Contains(con.Id)
             ).ToList();
             var targetConsumable = foodList[random.Next(foodList.Count)];
-            var recipeRow = _tableSheets.ConsumableItemRecipeSheet.Values.First(
+            var _ = _tableSheets.ConsumableItemRecipeSheet.Values.First(
                 recipe => recipe.ResultConsumableItemId == targetConsumable.Id
             );
             var action = new UnlockRecipe
@@ -90,7 +96,9 @@ namespace Lib9c.DevExtensions.Tests.Action.Craft
                 BlockIndex = 0L,
             });
 
-            Assert.True(stateV2.TryGetState(_recipeAddress, out List _));
+            Assert.True(stateV2.TryGetState(_recipeAddress, out List rawIds));
+            var unlockedRecipeIds = rawIds.ToList(StateExtensions.ToInteger);
+            Assert.Contains(targetStage, unlockedRecipeIds);
         }
     }
 }

--- a/.Lib9c.DevExtensions.Tests/Action/ManipulateStateTest.cs
+++ b/.Lib9c.DevExtensions.Tests/Action/ManipulateStateTest.cs
@@ -1,0 +1,468 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using Bencodex.Types;
+using Lib9c.DevExtensions.Action;
+using Lib9c.Tests;
+using Lib9c.Tests.Action;
+using Lib9c.Tests.Util;
+using Libplanet;
+using Libplanet.Action;
+using Nekoyume.Action;
+using Nekoyume.Model;
+using Nekoyume.Model.EnumType;
+using Nekoyume.Model.Item;
+using Nekoyume.Model.Quest;
+using Nekoyume.Model.State;
+using Nekoyume.TableData;
+using Xunit;
+
+namespace Lib9c.DevExtensions.Tests.Action
+{
+    public class ManipulateStateTest
+    {
+        private readonly TableSheets _tableSheets;
+        private readonly Address _agentAddress;
+        private readonly Address _avatarAddress;
+        private readonly IAccountStateDelta _initialStateV2;
+        private readonly Address _inventoryAddress;
+        private readonly Address _worldInformationAddress;
+        private readonly Address _questListAddress;
+        private readonly Address _recipeAddress;
+        private readonly AvatarState _avatarState;
+
+        public ManipulateStateTest()
+        {
+            (_tableSheets, _agentAddress, _avatarAddress, _, _initialStateV2) =
+                InitializeUtil.InitializeStates(isDevEx: true);
+            _inventoryAddress = _avatarAddress.Derive(SerializeKeys.LegacyInventoryKey);
+            _worldInformationAddress =
+                _avatarAddress.Derive(SerializeKeys.LegacyWorldInformationKey);
+            _questListAddress = _avatarAddress.Derive(SerializeKeys.LegacyQuestListKey);
+            _recipeAddress = _avatarAddress.Derive("recipe_ids");
+            _avatarState = _initialStateV2.GetAvatarStateV2(_avatarAddress);
+        }
+
+        // MemberData
+        public static IEnumerable<object[]> FetchAvatarState()
+        {
+            var random = new Random();
+            var blockIndex = random.Next(1, 100);
+
+            /* name, level, exp, actionPoint,
+             dailyRewardReceivedIndex, blockIndex,
+             hair, lens, ear, tail */
+
+            // Change name
+            yield return new object[]
+            {
+                "newAvatar", null, null, null,
+                null, null,
+                null, null, null, null
+            };
+            // Change level and exp
+            yield return new object[]
+            {
+                null, random.Next(1, 300), random.Next(0, 100), null,
+                null, null,
+                null, null, null, null
+            };
+            // Change AP
+            yield return new object[]
+            {
+                null, null, null, random.Next(0, 120),
+                null, null,
+                null, null, null, null
+            };
+            // Change block indexes
+            yield return new object[]
+            {
+                null, null, null, null,
+                blockIndex + 1700, blockIndex, // Get another daily reward
+                null, null, null, null
+            };
+            // Change outfit
+            yield return new object[]
+            {
+                null, null, null, null,
+                null, null,
+                random.Next(0, 4), random.Next(0, 4), random.Next(0, 4), random.Next(0, 4)
+            };
+            // Change multiple things
+            yield return new object[]
+            {
+                "newAvatar", random.Next(1, 300), random.Next(0, 100), null,
+                blockIndex + 1700, blockIndex,
+                random.Next(0, 4), random.Next(0, 4), random.Next(0, 4), random.Next(0, 4)
+            };
+        }
+
+        public static IEnumerable<object[]> FetchInventory()
+        {
+            var random = new TestRandom();
+            var (tableSheets, _, _, _, _) = InitializeUtil.InitializeStates(isDevEx: true);
+            var equipmentList = tableSheets.EquipmentItemSheet.Values.ToList();
+            var consumableList = tableSheets.ConsumableItemSheet.Values.ToList();
+            var materialList = tableSheets.MaterialItemSheet.Values.ToList();
+
+            var equipment = ItemFactory.CreateItem(
+                equipmentList[random.Next(0, equipmentList.Count)],
+                random
+            );
+            var consumable = ItemFactory.CreateItem(
+                consumableList[random.Next(consumableList.Count)],
+                random
+            );
+            var material = ItemFactory.CreateItem(
+                materialList[random.Next(0, materialList.Count)],
+                random
+            );
+            // Clear Inventory
+            yield return new object[]
+            {
+                new Inventory()
+            };
+
+            // Equipment
+            var equipmentInventory = new Inventory();
+            equipmentInventory.AddItem(equipment);
+            yield return new object[]
+            {
+                equipmentInventory
+            };
+
+            // Material
+            var materialInventory = new Inventory();
+            materialInventory.AddItem(material);
+            yield return new object[]
+            {
+                materialInventory
+            };
+            // Consumable
+            var consumableInventory = new Inventory();
+            consumableInventory.AddItem(equipment);
+            yield return new object[]
+            {
+                consumableInventory
+            };
+            // Mixed
+            var inventory = new Inventory();
+            inventory.AddItem(equipment);
+            inventory.AddItem(consumable);
+            inventory.AddItem(material);
+            yield return new object[]
+            {
+                inventory
+            };
+        }
+
+        public static IEnumerable<object[]> FetchWorldInfo()
+        {
+            var random = new Random();
+            var (tableSheets, _, _, _, _) = InitializeUtil.InitializeStates(isDevEx: true);
+            var worldSheet = tableSheets.WorldSheet;
+            yield return new object[]
+            {
+                0,
+                new WorldInformation(0L, worldSheet, 0)
+            };
+
+            var targetStage = random.Next(1, 300);
+            yield return new object[]
+            {
+                targetStage,
+                new WorldInformation(0L, worldSheet, targetStage)
+            };
+
+            yield return new object[]
+            {
+                tableSheets.WorldSheet.OrderedList.Last(world => world.Id < 100).StageEnd,
+                new WorldInformation(0L, worldSheet, true)
+            };
+        }
+
+        public static IEnumerable<object[]> FetchQuest()
+        {
+            var random = new Random();
+            var (tableSheets, _, _, _, stateV2) = InitializeUtil.InitializeStates(isDevEx: true);
+            // Empty QuestList
+            yield return new object[]
+            {
+                new List<int>(),
+                new QuestList(
+                    new QuestSheet(),
+                    new QuestRewardSheet(),
+                    new QuestItemRewardSheet(),
+                    new EquipmentItemRecipeSheet(),
+                    new EquipmentItemSubRecipeSheet()
+                )
+            };
+
+            // QuestList
+            yield return new object[]
+            {
+                new List<int>(),
+                new QuestList(
+                    tableSheets.QuestSheet,
+                    tableSheets.QuestRewardSheet,
+                    tableSheets.QuestItemRewardSheet,
+                    tableSheets.EquipmentItemRecipeSheet,
+                    tableSheets.EquipmentItemSubRecipeSheet
+                )
+            };
+
+            // Clear combination quest
+            var combinationQuestList = new QuestList(
+                tableSheets.QuestSheet,
+                tableSheets.QuestRewardSheet,
+                tableSheets.QuestItemRewardSheet,
+                tableSheets.EquipmentItemRecipeSheet,
+                tableSheets.EquipmentItemSubRecipeSheet
+            );
+            var equipmentList = tableSheets.EquipmentItemSheet.Values.ToList();
+            var equipmentRow = equipmentList[random.Next(0, equipmentList.Count)];
+            var item = ItemFactory.CreateItemUsable(equipmentRow, Guid.NewGuid(), 0);
+            combinationQuestList.UpdateCombinationQuest(item);
+            yield return new object[]
+            {
+                combinationQuestList.completedQuestIds,
+                combinationQuestList
+            };
+
+            // Clear trade quest
+            var tradeQuestList = new QuestList(
+                tableSheets.QuestSheet,
+                tableSheets.QuestRewardSheet,
+                tableSheets.QuestItemRewardSheet,
+                tableSheets.EquipmentItemRecipeSheet,
+                tableSheets.EquipmentItemSubRecipeSheet
+            );
+            tradeQuestList.UpdateTradeQuest(TradeType.Sell, stateV2.GetGoldCurrency() * 1);
+
+            yield return new object[]
+            {
+                tradeQuestList.completedQuestIds,
+                tradeQuestList
+            };
+
+            // Clear stage quest
+            var stageQuestList = new QuestList(
+                tableSheets.QuestSheet,
+                tableSheets.QuestRewardSheet,
+                tableSheets.QuestItemRewardSheet,
+                tableSheets.EquipmentItemRecipeSheet,
+                tableSheets.EquipmentItemSubRecipeSheet
+            );
+            var targetStage = random.Next(1, 300);
+            var stageMap = new CollectionMap();
+            for (var i = 1; i <= targetStage; i++)
+            {
+                stageMap.Add(new KeyValuePair<int, int>(i, 1));
+            }
+
+            stageQuestList.UpdateStageQuest(stageMap);
+            yield return new object[]
+            {
+                stageQuestList.completedQuestIds,
+                stageQuestList
+            };
+
+            // Clear multiple
+            var questList = new QuestList(
+                tableSheets.QuestSheet,
+                tableSheets.QuestRewardSheet,
+                tableSheets.QuestItemRewardSheet,
+                tableSheets.EquipmentItemRecipeSheet,
+                tableSheets.EquipmentItemSubRecipeSheet
+            );
+            combinationQuestList.UpdateCombinationQuest(item);
+            tradeQuestList.UpdateTradeQuest(TradeType.Sell, stateV2.GetGoldCurrency() * 1);
+            stageMap = new CollectionMap();
+            for (var i = 1; i <= targetStage; i++)
+            {
+                stageMap.Add(new KeyValuePair<int, int>(i, 1));
+            }
+
+            yield return new object[]
+            {
+                questList.completedQuestIds,
+                questList
+            };
+        }
+        // ~MemberData
+
+        [Theory]
+        [MemberData(nameof(FetchAvatarState))]
+        public void SetAvatarState(
+            string? name, int? level, long? exp, int? actionPoint,
+            long? blockIndex, long? dailyRewardReceivedIndex,
+            int? hair, int? lens, int? ear, int? tail
+        )
+        {
+            var newAvatarState = (AvatarState)_avatarState.Clone();
+            newAvatarState.name = name ?? _avatarState.name;
+            newAvatarState.level = level ?? _avatarState.level;
+            newAvatarState.exp = exp ?? _avatarState.exp;
+            newAvatarState.actionPoint = actionPoint ?? _avatarState.actionPoint;
+            newAvatarState.blockIndex = blockIndex ?? _avatarState.blockIndex;
+            newAvatarState.dailyRewardReceivedIndex =
+                dailyRewardReceivedIndex ?? _avatarState.dailyRewardReceivedIndex;
+            newAvatarState.hair = hair ?? _avatarState.hair;
+            newAvatarState.lens = lens ?? _avatarState.lens;
+            newAvatarState.ear = ear ?? _avatarState.ear;
+            newAvatarState.tail = tail ?? _avatarState.tail;
+
+            var action = new ManipulateState
+            {
+                StateList = new List<(Address, IValue)>
+                {
+                    (_avatarAddress, newAvatarState.SerializeV2())
+                }
+            };
+
+            var state = action.Execute(new ActionContext
+            {
+                PreviousStates = _initialStateV2,
+                Signer = _agentAddress,
+                BlockIndex = blockIndex ?? _avatarState.blockIndex
+            });
+            var targetAvatarState = state.GetAvatarStateV2(_avatarAddress);
+
+            if (name != null)
+            {
+                Assert.Equal(name, targetAvatarState.name);
+            }
+
+            if (level != null)
+            {
+                Assert.Equal(level, targetAvatarState.level);
+            }
+
+            if (exp != null)
+            {
+                Assert.Equal(exp, targetAvatarState.exp);
+            }
+
+            if (actionPoint != null)
+            {
+                Assert.Equal(actionPoint, targetAvatarState.actionPoint);
+            }
+
+            if (blockIndex != null)
+            {
+                Assert.Equal(blockIndex, targetAvatarState.blockIndex);
+            }
+
+            if (dailyRewardReceivedIndex != null)
+            {
+                Assert.Equal(dailyRewardReceivedIndex, targetAvatarState.dailyRewardReceivedIndex);
+            }
+
+            if (hair != null)
+            {
+                Assert.Equal(hair, targetAvatarState.hair);
+            }
+
+            if (lens != null)
+            {
+                Assert.Equal(lens, targetAvatarState.lens);
+            }
+
+            if (ear != null)
+            {
+                Assert.Equal(ear, targetAvatarState.ear);
+            }
+
+            if (tail != null)
+            {
+                Assert.Equal(tail, targetAvatarState.tail);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(FetchInventory))]
+        public void SetInventoryState(Inventory targetInventory)
+        {
+            var action = new ManipulateState
+            {
+                StateList = new List<(Address, IValue)>
+                {
+                    (_inventoryAddress, targetInventory.Serialize()),
+                }
+            };
+
+            var state = action.Execute(new ActionContext
+            {
+                PreviousStates = _initialStateV2,
+                Signer = _agentAddress,
+                BlockIndex = 0L,
+            });
+
+            var avatarState = state.GetAvatarStateV2(_avatarAddress);
+            var inventoryState = avatarState.inventory;
+            Assert.Equal(targetInventory.Items.Count, inventoryState.Items.Count);
+            foreach (var item in targetInventory.Items)
+            {
+                Assert.Contains(item, inventoryState.Items);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(FetchWorldInfo))]
+        public void SetWorldInformation(int lastClearedStage, WorldInformation targetInfo)
+        {
+            var action = new ManipulateState
+            {
+                StateList = new List<(Address, IValue)>
+                {
+                    (_worldInformationAddress, targetInfo.Serialize()),
+                }
+            };
+
+            var state = action.Execute(new ActionContext
+            {
+                PreviousStates = _initialStateV2,
+                Signer = _agentAddress,
+                BlockIndex = 0L,
+            });
+
+            var avatarState = state.GetAvatarStateV2(_avatarAddress);
+            var worldInformation = avatarState.worldInformation;
+
+            for (var i = 0; i < lastClearedStage; i++)
+            {
+                Assert.True(worldInformation.IsStageCleared(i));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(FetchQuest))]
+        public void SetQuestState(List<int> targetList, QuestList questList)
+        {
+            var action = new ManipulateState
+            {
+                StateList = new List<(Address, IValue)>
+                {
+                    (_questListAddress, questList.Serialize())
+                }
+            };
+
+            var state = action.Execute(new ActionContext
+            {
+                PreviousStates = _initialStateV2,
+                Signer = _agentAddress,
+                BlockIndex = 0L,
+            });
+
+            var avatarState = state.GetAvatarStateV2(_avatarAddress);
+            var questState = avatarState.questList;
+            foreach (var target in targetList)
+            {
+                Assert.Contains(target, questState.completedQuestIds);
+            }
+        }
+    }
+}

--- a/.Lib9c.DevExtensions.Tests/Action/ManipulateStateTest.cs
+++ b/.Lib9c.DevExtensions.Tests/Action/ManipulateStateTest.cs
@@ -191,13 +191,7 @@ namespace Lib9c.DevExtensions.Tests.Action
             yield return new object[]
             {
                 new List<int>(),
-                new QuestList(
-                    new QuestSheet(),
-                    new QuestRewardSheet(),
-                    new QuestItemRewardSheet(),
-                    new EquipmentItemRecipeSheet(),
-                    new EquipmentItemSubRecipeSheet()
-                )
+                new QuestList(Dictionary.Empty),
             };
 
             // QuestList

--- a/.Lib9c.DevExtensions.Tests/Action/Stage/ClearStageTest.cs
+++ b/.Lib9c.DevExtensions.Tests/Action/Stage/ClearStageTest.cs
@@ -1,0 +1,54 @@
+using System;
+using Lib9c.DevExtensions.Action.Stage;
+using Lib9c.Tests;
+using Lib9c.Tests.Action;
+using Lib9c.Tests.Util;
+using Libplanet;
+using Libplanet.Action;
+using Nekoyume.Action;
+using Xunit;
+
+namespace Lib9c.DevExtensions.Tests.Action.Stage
+{
+    public class ClearStageTest
+    {
+        private readonly TableSheets _tableSheets;
+        private readonly Address _agentAddress;
+        private readonly Address _avatarAddress;
+        private readonly IAccountStateDelta _initialStateV2;
+        private readonly Address _worldInfoAddress;
+
+        public ClearStageTest()
+        {
+            (_tableSheets, _agentAddress, _avatarAddress, _, _initialStateV2) =
+                InitializeUtil.InitializeStates(isDevEx: true);
+            _worldInfoAddress = _avatarAddress.Derive(SerializeKeys.LegacyWorldInformationKey);
+        }
+
+        [Fact]
+        public void ClearStage()
+        {
+            var random = new Random();
+            var targetStage = random.Next(1, 300 + 1);
+
+            var action = new ClearStage
+            {
+                AvatarAddress = _avatarAddress,
+                TargetStage = targetStage,
+            };
+
+            var state = action.Execute(new ActionContext
+            {
+                PreviousStates = _initialStateV2,
+                Signer = _agentAddress,
+                BlockIndex = 0L,
+            });
+
+            var avatarState = state.GetAvatarStateV2(_avatarAddress);
+            for (var i = 1; i <= targetStage; i++)
+            {
+                Assert.True(avatarState.worldInformation.IsStageCleared(i));
+            }
+        }
+    }
+}

--- a/.Lib9c.Tests/Util/InitializeUtil.cs
+++ b/.Lib9c.Tests/Util/InitializeUtil.cs
@@ -1,5 +1,6 @@
 namespace Lib9c.Tests.Util
 {
+    using System.IO;
     using Libplanet;
     using Libplanet.Action;
     using Libplanet.Assets;
@@ -18,10 +19,19 @@ namespace Lib9c.Tests.Util
             Address agentAddress,
             Address avatarAddress,
             IAccountStateDelta initialStatesWithAvatarStateV1,
-            IAccountStateDelta initialStatesWithAvatarStateV2) InitializeStates()
+            IAccountStateDelta initialStatesWithAvatarStateV2
+            ) InitializeStates(
+                bool isDevEx = false
+            )
         {
             IAccountStateDelta states = new State();
-            var sheets = TableSheetsImporter.ImportSheets();
+            var sheets = TableSheetsImporter.ImportSheets(
+                isDevEx
+                    ? Path.GetFullPath("../../").Replace(
+                        Path.Combine(".Lib9c.DevExtensions.Tests", "bin"),
+                        Path.Combine("Lib9c", "TableCSV"))
+                    : null
+            );
             foreach (var (key, value) in sheets)
             {
                 states = states.SetState(

--- a/Lib9c.DevExtensions/Action/Craft/UnlockCraftAction.cs
+++ b/Lib9c.DevExtensions/Action/Craft/UnlockCraftAction.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Action;
+using Nekoyume;
+using Nekoyume.Action;
+using Nekoyume.Exceptions;
+using Nekoyume.Model;
+using Nekoyume.Model.State;
+using Nekoyume.TableData;
+using static Lib9c.SerializeKeys;
+
+namespace Lib9c.DevExtensions.Action.Craft
+{
+    [Serializable]
+    [ActionType("unlock_craft_action")]
+    public class UnlockCraftAction : GameAction
+    {
+        public Address AvatarAddress { get; set; }
+        public ActionTypeAttribute ActionType { get; set; }
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            if (context.Rehearsal)
+            {
+                return context.PreviousStates;
+            }
+
+            var states = context.PreviousStates;
+            int targetStage;
+
+            if (ActionType.TypeIdentifier.Contains("combination_equipment"))
+            {
+                targetStage = GameConfig.RequireClearedStageLevel.CombinationEquipmentAction;
+            }
+            else if (ActionType.TypeIdentifier.Contains("combination_consumable"))
+            {
+                targetStage = GameConfig.RequireClearedStageLevel.CombinationConsumableAction;
+            }
+            else if (ActionType.TypeIdentifier.Contains("item_enhancement"))
+            {
+                targetStage = GameConfig.RequireClearedStageLevel.ItemEnhancementAction;
+            }
+            else
+            {
+                throw new InvalidActionFieldException(
+                    $"{ActionType.TypeIdentifier} is not valid action");
+            }
+
+            var worldInformation = new WorldInformation(
+                context.BlockIndex,
+                states.GetSheet<WorldSheet>(),
+                targetStage
+            );
+            return states.SetState(
+                AvatarAddress.Derive(LegacyWorldInformationKey),
+                worldInformation.Serialize()
+            );
+        }
+
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            new Dictionary<string, IValue>
+            {
+                ["avatarAddress"] = AvatarAddress.Serialize(),
+                ["typeIdentifier"] = ActionType.TypeIdentifier.Serialize()
+            }.ToImmutableDictionary();
+
+        protected override void LoadPlainValueInternal(
+            IImmutableDictionary<string, IValue> plainValue
+            )
+        {
+            AvatarAddress = plainValue["avatarAddress"].ToAddress();
+            ActionType = new ActionTypeAttribute(plainValue["typeIdentifier"].ToDotnetString());
+        }
+    }
+}

--- a/Lib9c.DevExtensions/Action/Craft/UnlockRecipe.cs
+++ b/Lib9c.DevExtensions/Action/Craft/UnlockRecipe.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Action;
+using Nekoyume.Action;
+using Nekoyume.Model.State;
+
+namespace Lib9c.DevExtensions.Action.Craft
+{
+    [Serializable]
+    [ActionType("unlock_recipe")]
+    public class UnlockRecipe : GameAction
+    {
+        public Address AvatarAddress { get; set; }
+        public int TargetStage { get; set; }
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            if (context.Rehearsal)
+            {
+                return context.PreviousStates;
+            }
+
+            var states = context.PreviousStates;
+            var recipeIdList = List.Empty;
+            for (var i = 1; i <= TargetStage; i++)
+            {
+                recipeIdList = recipeIdList.Add(i.Serialize());
+            }
+
+            return states.SetState(
+                AvatarAddress.Derive("recipe_ids"),
+                recipeIdList
+            );
+        }
+
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            new Dictionary<string, IValue>
+            {
+                ["avatarAddress"] = AvatarAddress.Serialize(),
+                ["targetStage"] = TargetStage.Serialize()
+            }.ToImmutableDictionary();
+
+        protected override void LoadPlainValueInternal(IImmutableDictionary<string, IValue> plainValue)
+        {
+            AvatarAddress = plainValue["avatarAddress"].ToAddress();
+            TargetStage = plainValue["targetStage"].ToInteger();
+        }
+    }
+}

--- a/Lib9c.DevExtensions/Action/CreateOrReplaceAvatar.cs
+++ b/Lib9c.DevExtensions/Action/CreateOrReplaceAvatar.cs
@@ -282,7 +282,7 @@ namespace Lib9c.DevExtensions.Action
 
             // Set Inventory.
             var inventoryAddr = avatarAddr.Derive(LegacyInventoryKey);
-            var inventory = new Inventory();
+            var inventory = new Nekoyume.Model.Item.Inventory();
             var equipmentItemSheet = sheets.GetSheet<EquipmentItemSheet>();
             var enhancementCostSheetV2 = sheets.GetSheet<EnhancementCostSheetV2>();
             var recipeSheet = sheets.GetSheet<EquipmentItemRecipeSheet>();

--- a/Lib9c.DevExtensions/Action/ManipulateState.cs
+++ b/Lib9c.DevExtensions/Action/ManipulateState.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Action;
+using Nekoyume.Action;
+using Nekoyume.Model.State;
+
+namespace Lib9c.DevExtensions.Action
+{
+    [Serializable]
+    [ActionType("manipulate_state")]
+    public class ManipulateState : GameAction
+    {
+        public List<(Address, IValue)> StateList { get; set; }
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            var state = context.PreviousStates;
+            foreach (var (address, value) in StateList)
+            {
+                state = state.SetState(address, value);
+            }
+
+            return state;
+        }
+
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            new Dictionary<string, IValue>
+            {
+                ["stateList"] = StateList.Serialize()
+            }.ToImmutableDictionary();
+
+        protected override void LoadPlainValueInternal(
+            IImmutableDictionary<string, IValue> plainValue)
+        {
+            StateList = plainValue["stateList"].ToStateList();
+        }
+    }
+}

--- a/Lib9c.DevExtensions/Action/ManipulateState.cs
+++ b/Lib9c.DevExtensions/Action/ManipulateState.cs
@@ -17,6 +17,11 @@ namespace Lib9c.DevExtensions.Action
 
         public override IAccountStateDelta Execute(IActionContext context)
         {
+            if (context.Rehearsal)
+            {
+                return context.PreviousStates;
+            }
+
             var state = context.PreviousStates;
             foreach (var (address, value) in StateList)
             {

--- a/Lib9c.DevExtensions/Action/Stage/ClearStage.cs
+++ b/Lib9c.DevExtensions/Action/Stage/ClearStage.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Action;
+using Nekoyume.Action;
+using Nekoyume.Model;
+using Nekoyume.Model.State;
+using Nekoyume.TableData;
+
+namespace Lib9c.DevExtensions.Action.Stage
+{
+    [Serializable]
+    [ActionType("clear_stage")]
+    public class ClearStage : GameAction
+    {
+        public Address AvatarAddress { get; set; }
+        public int TargetStage { get; set; }
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            if (context.Rehearsal)
+            {
+                return context.PreviousStates;
+            }
+
+            var states = context.PreviousStates;
+            var worldInformation = new WorldInformation(
+                context.BlockIndex,
+                states.GetSheet<WorldSheet>(),
+                TargetStage
+            );
+            return states.SetState(AvatarAddress.Derive(SerializeKeys.LegacyWorldInformationKey),
+                worldInformation.Serialize()
+            );
+        }
+
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            new Dictionary<string, IValue>
+            {
+                ["avatarAddress"] = AvatarAddress.Serialize(),
+                ["targetStage"] = TargetStage.Serialize(),
+            }.ToImmutableDictionary();
+
+        protected override void LoadPlainValueInternal(
+            IImmutableDictionary<string, IValue> plainValue
+        )
+        {
+            AvatarAddress = plainValue["avatarAddress"].ToAddress();
+            TargetStage = plainValue["targetStage"].ToInteger();
+        }
+    }
+}

--- a/Lib9c/Model/Quest/QuestList.cs
+++ b/Lib9c/Model/Quest/QuestList.cs
@@ -82,27 +82,23 @@ namespace Nekoyume.Model.Quest
         )
         {
             _quests = new List<Quest>();
-            if (questSheet.Count > 0)
+            foreach (var questData in questSheet.OrderedList)
             {
-                foreach (var questData in questSheet.OrderedList ?? new List<QuestSheet.Row>())
+                var reward = GetQuestReward(
+                    questData.QuestRewardId,
+                    questRewardSheet,
+                    questItemRewardSheet
+                );
+
+                var quest = CreateQuest(questData, reward, equipmentItemRecipeSheet);
+                if (quest is null)
                 {
-                    var reward = GetQuestReward(
-                        questData.QuestRewardId,
-                        questRewardSheet,
-                        questItemRewardSheet
-                    );
-
-                    var quest = CreateQuest(questData, reward, equipmentItemRecipeSheet);
-                    if (quest is null)
-                    {
-                        continue;
-                    }
-
-                    _quests.Add(quest);
+                    continue;
                 }
+
+                _quests.Add(quest);
             }
         }
-
 
         public QuestList(Dictionary serialized)
         {

--- a/Lib9c/Model/Quest/QuestList.cs
+++ b/Lib9c/Model/Quest/QuestList.cs
@@ -82,21 +82,24 @@ namespace Nekoyume.Model.Quest
         )
         {
             _quests = new List<Quest>();
-            foreach (var questData in questSheet.OrderedList ?? new List<QuestSheet.Row>())
+            if (questSheet.Count > 0)
             {
-                var reward = GetQuestReward(
-                    questData.QuestRewardId,
-                    questRewardSheet,
-                    questItemRewardSheet
-                );
-
-                var quest = CreateQuest(questData, reward, equipmentItemRecipeSheet);
-                if (quest is null)
+                foreach (var questData in questSheet.OrderedList ?? new List<QuestSheet.Row>())
                 {
-                    continue;
-                }
+                    var reward = GetQuestReward(
+                        questData.QuestRewardId,
+                        questRewardSheet,
+                        questItemRewardSheet
+                    );
 
-                _quests.Add(quest);
+                    var quest = CreateQuest(questData, reward, equipmentItemRecipeSheet);
+                    if (quest is null)
+                    {
+                        continue;
+                    }
+
+                    _quests.Add(quest);
+                }
             }
         }
 

--- a/Lib9c/Model/Quest/QuestList.cs
+++ b/Lib9c/Model/Quest/QuestList.cs
@@ -82,7 +82,7 @@ namespace Nekoyume.Model.Quest
         )
         {
             _quests = new List<Quest>();
-            foreach (var questData in questSheet.OrderedList)
+            foreach (var questData in questSheet.OrderedList ?? new List<QuestSheet.Row>())
             {
                 var reward = GetQuestReward(
                     questData.QuestRewardId,

--- a/Lib9c/Model/State/StateExtensions.cs
+++ b/Lib9c/Model/State/StateExtensions.cs
@@ -250,6 +250,42 @@ namespace Nekoyume.Model.State
                 );
         }
 
+        public static IValue Serialize(this List<(Address, IValue)> value)
+        {
+            var result = new Bencodex.Types.List();
+            foreach (var v in value)
+            {
+                result = result.Add(new Bencodex.Types.List
+                    {
+                        v.Item1.Serialize(),
+                        v.Item2 // Already IValue
+                    }
+                );
+            }
+
+            return result;
+        }
+
+        public static List<(Address, IValue)> ToStateList(this IValue serialized)
+        {
+            if (!(serialized is Bencodex.Types.List serializedList))
+            {
+                throw new InvalidCastException();
+            }
+
+            var result = new List<(Address, IValue)>();
+            foreach (var value in serializedList)
+            {
+                var list = (List)value;
+                result.Add((
+                    list.ElementAt(0).ToAddress(),
+                    list.ElementAt(1) // Already IValue
+                ));
+            }
+
+            return result;
+        }
+
         #endregion
 
         #region Bencodex.Types.Dictionary Getter

--- a/Lib9c/Model/State/StateExtensions.cs
+++ b/Lib9c/Model/State/StateExtensions.cs
@@ -250,17 +250,16 @@ namespace Nekoyume.Model.State
                 );
         }
 
-        public static IValue Serialize(this List<(Address, IValue)> value)
+        public static IValue Serialize(this IEnumerable<(Address, IValue)> value)
         {
-            var result = new Bencodex.Types.List();
-            foreach (var v in value)
+            var result = new List();
+            foreach (var v in value
+                         .OrderBy(tuple => tuple.Item1)
+                         .ThenBy(tuple => tuple.Item2))
             {
-                result = result.Add(new Bencodex.Types.List
-                    {
-                        v.Item1.Serialize(),
-                        v.Item2 // Already IValue
-                    }
-                );
+                result = result.Add(new List(
+                    v.Item1.Serialize(),
+                    v.Item2)); // Already IValue
             }
 
             return result;
@@ -268,7 +267,7 @@ namespace Nekoyume.Model.State
 
         public static List<(Address, IValue)> ToStateList(this IValue serialized)
         {
-            if (!(serialized is Bencodex.Types.List serializedList))
+            if (!(serialized is List serializedList))
             {
                 throw new InvalidCastException();
             }


### PR DESCRIPTION
## Update
- `ManipulateState` action force sets given state to given address.
- This function assumes given address and state are in pair.
- This function assumes given state is valid.

### Further work
- Add state editor to unity editor and use this action to save changed state

---

## Features
- `InitializeUtil` now can handle and create inits for DevEx tests.
- `UnlockCraftAction` can unlock craft related action by clearing required stage.
- `UnlockRecipe` can unlock Item reipe to craft.
- `UnlockStage` can unlock stages to test specific stage easily.

### Comment Needed
I wonder I did right thing to set new WorldInformation to clear stage at `ClearStage.cs` workaround.
