### PR TITLE
Introduce model versioning(interface-centric)

### DIFF
--- a/.Lib9c.DevExtensions.Tests/Lib9c.DevExtensions.Tests.csproj
+++ b/.Lib9c.DevExtensions.Tests/Lib9c.DevExtensions.Tests.csproj
@@ -13,9 +13,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
-    <PackageReference Include="xunit" Version="2.4.1"/>
-    <PackageReference Include="xunit.assert" Version="2.4.1"/>
-    <PackageReference Include="xunit.extensibility.core" Version="2.4.1"/>
+    <PackageReference Include="xunit" Version="2.4.2"/>
+    <PackageReference Include="xunit.assert" Version="2.4.2"/>
+    <PackageReference Include="xunit.extensibility.core" Version="2.4.2"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"/>
   </ItemGroup>
 

--- a/.Lib9c.Tests/Lib9c.Tests.csproj
+++ b/.Lib9c.Tests/Lib9c.Tests.csproj
@@ -7,7 +7,8 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CS0162;CS8032;CS0618;CS0612;SYSLIB0011</NoWarn>
+    <NoWarn>$(NoWarn);CS0162;CS8032;CS0618;CS0612;SYSLIB0011;
+      SA1128;SA1201;SA1202;SA1402;SA1501;SA1503;SA1512;SA1649</NoWarn>
     <CodeAnalysisRuleSet>.\Lib9c.Tests.ruleset</CodeAnalysisRuleSet>
     <Configurations>Debug;Release;DevEx</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/.Lib9c.Tests/Lib9c.Tests.csproj
+++ b/.Lib9c.Tests/Lib9c.Tests.csproj
@@ -33,11 +33,12 @@
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.3" />
     <PackageReference Include="Verify.Xunit" Version="17.2.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
     <PackageReference Include="System.IO.Abstractions" Version="12.2.6" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="12.2.6" />
+    <PackageReference Include="Snapshooter.Xunit" Version="0.12.0" />
 
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/.Lib9c.Tests/VersionedStates/NonVersionedStateImpl.cs
+++ b/.Lib9c.Tests/VersionedStates/NonVersionedStateImpl.cs
@@ -1,0 +1,44 @@
+namespace Lib9c.Tests.VersionedStates
+{
+    using Bencodex.Types;
+    using Nekoyume.VersionedStates;
+
+    public interface INonVersionedStateImpl : INonVersionedState
+    {
+        IValue INonVersionedState.Data => Value;
+
+        Integer Value { get; }
+
+        static bool TryDeconstruct(
+            IValue serialized,
+            out Integer value)
+        {
+            try
+            {
+                value = (Integer)serialized;
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+    }
+
+    public class NonVersionedStateImpl : INonVersionedStateImpl
+    {
+        Integer INonVersionedStateImpl.Value => Value;
+
+        public int Value { get; private set; }
+
+        public NonVersionedStateImpl() : this(0)
+        {
+        }
+
+        public NonVersionedStateImpl(int value)
+        {
+            Value = value;
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/NonVersionedStateImplFactory.cs
+++ b/.Lib9c.Tests/VersionedStates/NonVersionedStateImplFactory.cs
@@ -1,0 +1,14 @@
+namespace Lib9c.Tests.VersionedStates
+{
+    using Bencodex.Types;
+
+    public static class NonVersionedStateImplFactory
+    {
+        public static NonVersionedStateImpl Create(IValue serialized)
+        {
+            return INonVersionedStateImpl.TryDeconstruct(serialized, out var value)
+                ? new NonVersionedStateImpl(value)
+                : null;
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/NonVersionedStateSnapshotTest.cs
+++ b/.Lib9c.Tests/VersionedStates/NonVersionedStateSnapshotTest.cs
@@ -1,0 +1,37 @@
+namespace Lib9c.Tests.VersionedStates
+{
+    using System;
+    using System.Linq;
+    using Bencodex.Types;
+    using Nekoyume.VersionedStates;
+    using Snapshooter;
+    using Snapshooter.Xunit;
+    using Xunit;
+
+    public class NonVersionedStateSnapshotTest
+    {
+        [Fact]
+        public void SnapshotTest()
+        {
+            var iVersionedStateType = typeof(INonVersionedState);
+            var tuples = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(a => a.GetTypes())
+                .Where(type =>
+                    !type.IsAbstract &&
+                    !type.IsInterface &&
+                    type.IsAssignableTo(iVersionedStateType))
+                .Select(type =>
+                {
+                    var state = (INonVersionedState)Activator.CreateInstance(type);
+                    return (
+                        type: type,
+                        value: state?.Serialize() ?? Null.Value);
+                })
+                .ToArray();
+            foreach (var (type, value) in tuples)
+            {
+                Snapshot.Match(value, SnapshotNameExtension.Create(type.FullName));
+            }
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/NonVersionedStateTest.cs
+++ b/.Lib9c.Tests/VersionedStates/NonVersionedStateTest.cs
@@ -1,0 +1,53 @@
+namespace Lib9c.Tests.VersionedStates
+{
+    using Nekoyume.VersionedStates;
+    using Xunit;
+
+    public class NonVersionedStateTest
+    {
+        [Fact]
+        public void Serialize_As_INonVersionedState()
+        {
+            INonVersionedState nvs = new NonVersionedStateImpl();
+            var serialized = nvs.Serialize();
+            var staticSerialized = INonVersionedState.Serialize(nvs);
+            Assert.Equal(serialized, staticSerialized);
+        }
+
+        [Fact]
+        public void Serialize_And_TryDeconstruct_As_INonVersionedStateImpl()
+        {
+            INonVersionedStateImpl nvsi = new NonVersionedStateImpl();
+            var serialized = nvsi.Serialize();
+            var staticSerialized = INonVersionedState.Serialize(nvsi);
+            Assert.Equal(serialized, staticSerialized);
+            Assert.True(INonVersionedStateImpl.TryDeconstruct(
+                serialized,
+                out var value));
+            Assert.Equal(nvsi.Value, value);
+        }
+
+        [Fact]
+        public void Serialize_And_TryDeconstruct_As_NonVersionedStateImpl()
+        {
+            var obj = new NonVersionedStateImpl();
+            var nvsi = (INonVersionedStateImpl)obj;
+            var serialized = obj.Serialize();
+            var staticSerialized = INonVersionedState.Serialize(obj);
+            Assert.Equal(serialized, staticSerialized);
+            Assert.True(INonVersionedStateImpl.TryDeconstruct(
+                serialized,
+                out var value));
+            Assert.Equal(nvsi.Value, value);
+        }
+
+        [Fact]
+        public void Serialize_And_Create()
+        {
+            var obj = new NonVersionedStateImpl();
+            var serialized = obj.Serialize();
+            var created = NonVersionedStateImplFactory.Create(serialized);
+            Assert.Equal(obj.Value, created.Value);
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene1/TestState.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene1/TestState.cs
@@ -1,0 +1,43 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene1
+{
+    using Bencodex.Types;
+    using Nekoyume.Model.State;
+
+    public class TestState : IState
+    {
+        public int Value { get; }
+
+        public TestState(int value = 0)
+        {
+            Value = value;
+        }
+
+        public TestState(IValue serialized)
+        {
+            Value = serialized.ToInteger();
+        }
+
+        public IValue Serialize()
+        {
+            return Value.Serialize();
+        }
+
+        protected bool Equals(TestState other)
+        {
+            return Value == other.Value;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TestState)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value;
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene1/VersionedStateScene1Test.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene1/VersionedStateScene1Test.cs
@@ -1,0 +1,30 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene1
+{
+    using Lib9c.Tests.Action;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Crypto;
+    using Xunit;
+
+    public class VersionedStateScene1Test
+    {
+        [Fact]
+        public void Test()
+        {
+            // serialize and deserialize
+            var state = new TestState(1);
+            Assert.Equal(1, state.Value);
+            var serialized = state.Serialize();
+            var deserialized = new TestState(serialized);
+            Assert.Equal(state.Value, deserialized.Value);
+            Assert.Equal(serialized, deserialized.Serialize());
+
+            // serialize and deserialize with IAccountStateDelta
+            IAccountStateDelta states = new State();
+            var addr = new PrivateKey().ToAddress();
+            states = states.SetState(addr, serialized);
+            var serializedNext = states.GetState(addr);
+            Assert.Equal(serialized, serializedNext);
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene2/ITestState.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene2/ITestState.cs
@@ -1,0 +1,19 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene2
+{
+    using Bencodex.Types;
+    using Nekoyume.VersionedStates;
+
+    // + Add this interface for non-versioned state.
+    // + Does not inherits `ITestState` interface because it is not a versioned state and
+    //   it does not have a moniker.
+
+    // + Declare a base interface for interfaces that share the same moniker.
+    public interface ITestState : IVersionedState
+    {
+        // + Cache moniker.
+        public static readonly Text MonikerCache = "test";
+
+        // + Override moniker property.
+        Text IVersionedState.Moniker => MonikerCache;
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene2/ITestStateNonVersioned.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene2/ITestStateNonVersioned.cs
@@ -1,0 +1,29 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene2
+{
+    using Bencodex.Types;
+    using Nekoyume.VersionedStates;
+
+    public interface ITestStateNonVersioned : INonVersionedState
+    {
+        // + Override `INonVersionedState.Data` property to return the serialized value of the state.
+        IValue INonVersionedState.Data => Value;
+
+        // + Declare the properties as a bencodex type only.
+        Text Value { get; }
+
+        // + Declare static deconstruct method.
+        static bool TryDeconstruct(IValue serialized, out Text value)
+        {
+            try
+            {
+                value = (Text)serialized;
+                return true;
+            }
+            catch
+            {
+                value = default;
+                return false;
+            }
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene2/ITestStateV1.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene2/ITestStateV1.cs
@@ -1,0 +1,44 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene2
+{
+    using Bencodex.Types;
+    using Nekoyume.VersionedStates;
+
+    // + Declare a versioned state interface.
+    // + Inherits `ITestState` interface to share the same moniker.
+    public interface ITestStateV1 : ITestState
+    {
+        // + Cache version.
+        public static readonly Integer VersionCache = 1;
+
+        // + Override `IVersionedState.Version` property.
+        Integer IVersionedState.Version => VersionCache;
+
+        IValue IVersionedState.Data => Value;
+
+        // + Changed the type of the property from `Text` to `Integer`.
+        public Integer Value { get; }
+
+        // + Declare a static method to deconstruct serialized data.
+        static bool TryDeconstruct(
+            IValue serialized,
+            out Text moniker,
+            out Integer version,
+            out Integer value)
+        {
+            try
+            {
+                IValue data;
+                (moniker, version, data) = Deconstruct(serialized);
+                value = (Integer)data;
+                return true;
+            }
+            catch
+            {
+                moniker = default;
+                version = default;
+                value = default;
+                return false;
+            }
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene2/TestState.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene2/TestState.cs
@@ -1,0 +1,60 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene2
+{
+    using Bencodex.Types;
+    using Nekoyume.Model.State;
+    using Nekoyume.VersionedStates;
+
+    // - Remove `IState` interface.
+    // + Implement `ITestState_NonVersioned` interface.
+    // + Implement `ITestStateV1` interface.
+    public class TestState : /*IState,*/ITestStateNonVersioned, ITestStateV1
+    {
+        // + Implement `ITestStateNonVersioned` property.
+        Text ITestStateNonVersioned.Value => (Text)Value.Serialize();
+
+        // + Implement `ITestStateV1` property.
+        Integer ITestStateV1.Value => Value;
+
+        public int Value { get; }
+
+        // + Add default constructor for deserialization.
+        public TestState() : this(0)
+        {
+        }
+
+        public TestState(int value = 0)
+        {
+            Value = value;
+        }
+
+        // - Remove the constructor that takes `IValue` as a parameter.
+        // public TestState(IValue serialized)
+        // {
+        //     Value = serialized.ToInteger();
+        // }
+
+        // - Remove the `Serialize()` method.
+        // public IValue Serialize()
+        // {
+        //     return Value.Serialize();
+        // }
+
+        protected bool Equals(TestState other)
+        {
+            return Value == other.Value;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TestState)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value;
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene2/TestStateFactory.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene2/TestStateFactory.cs
@@ -1,0 +1,52 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene2
+{
+    using Bencodex.Types;
+    using Nekoyume.Model.State;
+    using Nekoyume.VersionedStates;
+
+    // + Declare a factory class for TestState.
+    public static class TestStateFactory
+    {
+        // + Declare a method to create a TestState instance from serialized value.
+        public static TestState Create(IValue serialized)
+        {
+            // + Use `IVersionedState.TryDeconstruct()` method to check if the serialized value is
+            //   a versioned state.
+            if (!IVersionedState.TryDeconstruct(
+                    serialized,
+                    out var moniker,
+                    out var version,
+                    out _) ||
+                moniker != ITestState.MonikerCache)
+            {
+                // + If the serialized value is not a versioned state, try to deconstruct it as
+                //   a non-versioned state.
+                return ITestStateNonVersioned.TryDeconstruct(
+                    serialized,
+                    out var value)
+                    ? new TestState(value.ToInteger())
+                    : null;
+            }
+
+            // + If the serialized value is a versioned state, try to deconstruct it as a
+            //   versioned state.
+            // + Switch the version of the state and create a new instance.
+            switch ((uint)version)
+            {
+                // + Add a case for the version 1.
+                case 1:
+                {
+                    return ITestStateV1.TryDeconstruct(
+                        serialized,
+                        out _,
+                        out _,
+                        out var value)
+                        ? new TestState(value)
+                        : null;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene2/TestStateFactoryTest.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene2/TestStateFactoryTest.cs
@@ -1,0 +1,54 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene2
+{
+    using Bencodex.Types;
+    using Nekoyume.Model.State;
+    using Nekoyume.VersionedStates;
+    using Xunit;
+
+    public class TestStateFactoryTest
+    {
+        [Fact]
+        public void Create()
+        {
+            var current = new TestState(100);
+            var serialized = ((ITestStateV1)current).Serialize();
+            var backwards = new object[]
+            {
+                new Scene1.TestState(100),
+                current,
+            };
+            foreach (var backward in backwards)
+            {
+                if (backward is IState state)
+                {
+                    var serializedBackward = state.Serialize();
+                    Compare(current, serialized, serializedBackward);
+                }
+
+                if (backward is INonVersionedState nonVersionedState)
+                {
+                    var serializedBackward = nonVersionedState.Serialize();
+                    Compare(current, serialized, serializedBackward);
+                }
+
+                // Note: not IVersionedState,
+                //       only testing the implementation interface of IVersionedState.
+                if (backward is ITestStateV1 testStateV1)
+                {
+                    var serializedBackward = testStateV1.Serialize();
+                    Compare(current, serialized, serializedBackward);
+                }
+            }
+        }
+
+        private static void Compare(
+            TestState current,
+            IValue serialized,
+            IValue serializedBackward)
+        {
+            var created = TestStateFactory.Create(serializedBackward);
+            Assert.Equal(current, created);
+            Assert.Equal(serialized, ((ITestStateV1)created).Serialize());
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene2/VersionedStateScene2Test.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene2/VersionedStateScene2Test.cs
@@ -1,0 +1,37 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene2
+{
+    using Lib9c.Tests.Action;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Crypto;
+    using Nekoyume.VersionedStates;
+    using Xunit;
+
+    public class VersionedStateScene2Test
+    {
+        [Fact]
+        public void States()
+        {
+            // Serialize and deserialize with IAccountStateDelta
+            IAccountStateDelta states = new State();
+            var state = new TestState(1);
+            var addr = new PrivateKey().ToAddress();
+
+            // Use specific Serialize() method of type.(INonVersionedState)
+            var serializedNonVersioned = ((INonVersionedState)state).Serialize();
+            // Use normal SetState() method.
+            states = states.SetState(addr, serializedNonVersioned);
+            // Use GetVersionedState() method.
+            var serializedNext = states.GetState(addr);
+            Assert.Equal(serializedNonVersioned, serializedNext);
+
+            // Use specific Serialize() method of type.(IVersionedState)
+            var serializedV1 = ((IVersionedState)state).Serialize();
+            // Use normal SetState() method.
+            states = states.SetState(addr, serializedV1);
+            // Use GetVersionedState() method.
+            serializedNext = states.GetState(addr);
+            Assert.Equal(serializedV1, serializedNext);
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene3/ITestStateV2.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene3/ITestStateV2.cs
@@ -1,0 +1,51 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene3
+{
+    using Bencodex.Types;
+    using Lib9c.Tests.VersionedStates.Scenario.Scene2;
+    using Nekoyume.VersionedStates;
+
+    public interface ITestStateV2 : ITestState
+    {
+        public static readonly Integer VersionCache = 2;
+
+        Integer IVersionedState.Version => VersionCache;
+
+        // + Change the type from `Integer` to `List`.
+        IValue IVersionedState.Data => new List(
+            Value,
+            // + Serialize `TestStateV1` property. If it is `null`, use `Null.Value`.
+            TestState?.Serialize() ?? Null.Value);
+
+        public Integer Value { get; }
+
+        // + Add a new property.
+        public ITestStateV1 TestState { get; }
+
+        // + Declare a static method to deconstruct serialized data.
+        static bool TryDeconstruct(
+            IValue serialized,
+            out Text moniker,
+            out Integer version,
+            out Integer value,
+            out IValue testState)
+        {
+            try
+            {
+                IValue data;
+                (moniker, version, data) = Deconstruct(serialized);
+                var list = (List)data;
+                value = (Integer)list[0];
+                testState = list[1];
+                return true;
+            }
+            catch
+            {
+                moniker = default;
+                version = default;
+                value = default;
+                testState = default;
+                return false;
+            }
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene3/TestStateFactory.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene3/TestStateFactory.cs
@@ -1,0 +1,94 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene3
+{
+    using Bencodex.Types;
+    using Lib9c.Tests.VersionedStates.Scenario.Scene2;
+    using Nekoyume.Model.State;
+    using Nekoyume.VersionedStates;
+
+    public static class TestStateFactory
+    {
+        // NOTE: Every create method should be handled all versions of the state.
+        //       But this not means upward compatibility.
+        public static TestState Create(IValue serialized)
+        {
+            if (!IVersionedState.TryDeconstruct(
+                    serialized,
+                    out var moniker,
+                    out var version,
+                    out _) ||
+                moniker != ITestState.MonikerCache)
+            {
+                return ITestStateNonVersioned.TryDeconstruct(
+                    serialized,
+                    out var value)
+                    ? new TestState(value.ToInteger())
+                    : null;
+            }
+
+            switch ((uint)version)
+            {
+                case 1:
+                {
+                    return ITestStateV1.TryDeconstruct(
+                        serialized,
+                        out _,
+                        out _,
+                        out var value)
+                        ? new TestState(value)
+                        : null;
+                }
+            }
+
+            return null;
+        }
+
+        // + Declare a method to create a `TestStateV2` instance from serialized value.
+        // NOTE: Every create method should be handled all versions of the state.
+        //       But this not means upward compatibility.
+        public static TestStateV2 CreateV2(IValue serialized)
+        {
+            if (!IVersionedState.TryDeconstruct(
+                    serialized,
+                    out var moniker,
+                    out var version,
+                    out _) ||
+                moniker != ITestState.MonikerCache)
+            {
+                return ITestStateNonVersioned.TryDeconstruct(
+                    serialized,
+                    out var value)
+                    ? new TestStateV2(value.ToInteger())
+                    : null;
+            }
+
+            switch ((uint)version)
+            {
+                case 1:
+                {
+                    return ITestStateV1.TryDeconstruct(
+                        serialized,
+                        out _,
+                        out _,
+                        out var value)
+                        ? new TestStateV2(value)
+                        : null;
+                }
+
+                // + Add a case for the version 2.
+                case 2:
+                {
+                    return ITestStateV2.TryDeconstruct(
+                        serialized,
+                        out _,
+                        out _,
+                        out var value,
+                        out var testState)
+                        ? new TestStateV2(value, Create(testState))
+                        : null;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene3/TestStateFactoryTest.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene3/TestStateFactoryTest.cs
@@ -1,0 +1,118 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene3
+{
+    using Bencodex.Types;
+    using Lib9c.Tests.VersionedStates.Scenario.Scene2;
+    using Nekoyume.Model.State;
+    using Nekoyume.VersionedStates;
+    using Xunit;
+
+    public class TestStateFactoryTest
+    {
+        [Fact]
+        public void Create()
+        {
+            var current = new TestState(100);
+            var serialized = ((ITestStateV1)current).Serialize();
+            var backwards = new object[]
+            {
+                new Scene1.TestState(100),
+                current,
+            };
+            foreach (var backward in backwards)
+            {
+                if (backward is IState state)
+                {
+                    var serializedBackward = state.Serialize();
+                    Compare(current, serialized, serializedBackward);
+                }
+
+                if (backward is INonVersionedState nonVersionedState)
+                {
+                    var serializedBackward = nonVersionedState.Serialize();
+                    Compare(current, serialized, serializedBackward);
+                }
+
+                // Note: not IVersionedState,
+                //       only testing the implementation interface of IVersionedState.
+                if (backward is ITestStateV1 versionedState)
+                {
+                    var serializedBackward = versionedState.Serialize();
+                    Compare(current, serialized, serializedBackward);
+                }
+            }
+        }
+
+        [Fact]
+        public void CreateV2()
+        {
+            var current = new TestStateV2(100);
+            var serialized = ((ITestStateV2)current).Serialize();
+            var backwards = new object[]
+            {
+                new Scene1.TestState(100),
+                new TestState(100),
+                current,
+            };
+            foreach (var backward in backwards)
+            {
+                switch (backward)
+                {
+                    case IState state:
+                    {
+                        var serializedBackward = state.Serialize();
+                        CompareV2(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case INonVersionedState nonVersionedState:
+                    {
+                        var serializedBackward = nonVersionedState.Serialize();
+                        CompareV2(current, serialized, serializedBackward);
+                        break;
+                    }
+                }
+
+                switch (backward)
+                {
+                    case ITestStateV1 testStateV1:
+                    {
+                        var serializedBackward = testStateV1.Serialize();
+                        CompareV2(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case ITestStateV2 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV2(current, serialized, serializedBackward);
+                        break;
+                    }
+                }
+            }
+
+            current = new TestStateV2(100, new TestState(200));
+            serialized = ((ITestStateV2)current).Serialize();
+            CompareV2(current, serialized, serialized);
+        }
+
+        private static void Compare(
+            TestState current,
+            IValue serialized,
+            IValue serializedBackward)
+        {
+            var created = TestStateFactory.Create(serializedBackward);
+            Assert.Equal(current, created);
+            Assert.Equal(serialized, ((ITestStateV1)created).Serialize());
+        }
+
+        private static void CompareV2(
+            TestStateV2 current,
+            IValue serialized,
+            IValue serializedBackward)
+        {
+            var created = TestStateFactory.CreateV2(serializedBackward);
+            Assert.Equal(current, created);
+            Assert.Equal(serialized, ((ITestStateV2)created).Serialize());
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene3/TestStateV2.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene3/TestStateV2.cs
@@ -1,0 +1,46 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene3
+{
+    using System;
+    using Bencodex.Types;
+    using Lib9c.Tests.VersionedStates.Scenario.Scene2;
+
+    // + Implement `ITestStateV2` interface.
+    public class TestStateV2 : ITestStateV2
+    {
+        Integer ITestStateV2.Value => Value;
+
+        ITestStateV1 ITestStateV2.TestState => TestState;
+
+        public int Value { get; }
+
+        public TestState TestState { get; }
+
+        public TestStateV2() : this(0)
+        {
+        }
+
+        public TestStateV2(int value = 0, TestState testState = null)
+        {
+            Value = value;
+            TestState = testState;
+        }
+
+        protected bool Equals(TestStateV2 other)
+        {
+            return Value == other.Value && Equals(TestState, other.TestState);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TestStateV2)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Value, TestState);
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene3/VersionedStateScene3Test.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene3/VersionedStateScene3Test.cs
@@ -1,0 +1,29 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene3
+{
+    using Lib9c.Tests.Action;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Crypto;
+    using Nekoyume.VersionedStates;
+    using Xunit;
+
+    public class VersionedStateScene3Test
+    {
+        [Fact]
+        public void States()
+        {
+            // Serialize and deserialize with IAccountStateDelta
+            IAccountStateDelta states = new State();
+            var v2 = new TestStateV2(1);
+            var addr = new PrivateKey().ToAddress();
+
+            // Use specific Serialize() method of type.(IVersionedState)
+            var serializedV2 = ((IVersionedState)v2).Serialize();
+            // Use normal SetState() method.
+            states = states.SetState(addr, serializedV2);
+            // Use GetVersionedState() method.
+            var serializedNext = states.GetState(addr);
+            Assert.Equal(serializedV2, serializedNext);
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene4/ITestStateV3.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene4/ITestStateV3.cs
@@ -1,0 +1,49 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene4
+{
+    using Bencodex.Types;
+    using Lib9c.Tests.VersionedStates.Scenario.Scene2;
+    using Lib9c.Tests.VersionedStates.Scenario.Scene3;
+    using Nekoyume.VersionedStates;
+
+    public interface ITestStateV3 : ITestState
+    {
+        public static readonly Integer VersionCache = 3;
+
+        Integer IVersionedState.Version => VersionCache;
+
+        IValue IVersionedState.Data => new List(
+            Value,
+            TestState?.Serialize() ?? Null.Value);
+
+        public Integer Value { get; }
+
+        // * Change type of `TestStateV1` to `ITestStateV2`.
+        public ITestStateV2 TestState { get; }
+
+        static bool TryDeconstruct(
+            IValue serialized,
+            out Text moniker,
+            out Integer version,
+            out Integer value,
+            out IValue testState)
+        {
+            try
+            {
+                IValue data;
+                (moniker, version, data) = Deconstruct(serialized);
+                var list = (List)data;
+                value = (Integer)list[0];
+                testState = list[1];
+                return true;
+            }
+            catch
+            {
+                moniker = default;
+                version = default;
+                value = default;
+                testState = default;
+                return false;
+            }
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene4/ITestStateV4.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene4/ITestStateV4.cs
@@ -1,0 +1,49 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene4
+{
+    using Bencodex.Types;
+    using Lib9c.Tests.VersionedStates.Scenario.Scene2;
+    using Lib9c.Tests.VersionedStates.Scenario.Scene3;
+    using Nekoyume.VersionedStates;
+
+    public interface ITestStateV4 : ITestState
+    {
+        public static readonly Integer VersionCache = 4;
+
+        Integer IVersionedState.Version => VersionCache;
+
+        IValue IVersionedState.Data => new List(
+            TestState?.Serialize() ?? Null.Value,
+            OtherTestState?.Serialize() ?? Null.Value);
+
+        public ITestStateV2 TestState { get; }
+
+        // * Add a new property.
+        public ITestStateV3 OtherTestState { get; }
+
+        static bool TryDeconstruct(
+            IValue serialized,
+            out Text moniker,
+            out Integer version,
+            out IValue testState,
+            out IValue otherTestState)
+        {
+            try
+            {
+                IValue data;
+                (moniker, version, data) = Deconstruct(serialized);
+                var list = (List)data;
+                testState = list[0];
+                otherTestState = list[1];
+                return true;
+            }
+            catch
+            {
+                moniker = default;
+                version = default;
+                testState = default;
+                otherTestState = default;
+                return false;
+            }
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene4/ITestStateV5.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene4/ITestStateV5.cs
@@ -1,0 +1,55 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene4
+{
+    using Bencodex.Types;
+    using Lib9c.Tests.VersionedStates.Scenario.Scene2;
+    using Lib9c.Tests.VersionedStates.Scenario.Scene3;
+    using Nekoyume.VersionedStates;
+
+    public interface ITestStateV5 : ITestState
+    {
+        public static readonly Integer VersionCache = 5;
+
+        Integer IVersionedState.Version => VersionCache;
+
+        IValue IVersionedState.Data => new List(
+            TestState?.Serialize() ?? Null.Value,
+            OtherTestState?.Serialize() ?? Null.Value,
+            AnotherTestState?.Serialize() ?? Null.Value);
+
+        public ITestStateV2 TestState { get; }
+
+        public ITestStateV3 OtherTestState { get; }
+
+        // * Add a new property.
+        public ITestStateV4 AnotherTestState { get; }
+
+        static bool TryDeconstruct(
+            IValue serialized,
+            out Text moniker,
+            out Integer version,
+            out IValue testState,
+            out IValue otherTestState,
+            out IValue anotherTestState)
+        {
+            try
+            {
+                IValue data;
+                (moniker, version, data) = Deconstruct(serialized);
+                var list = (List)data;
+                testState = list[0];
+                otherTestState = list[1];
+                anotherTestState = list[2];
+                return true;
+            }
+            catch
+            {
+                moniker = default;
+                version = default;
+                testState = default;
+                otherTestState = default;
+                anotherTestState = default;
+                return false;
+            }
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene4/TestStateFactory.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene4/TestStateFactory.cs
@@ -1,0 +1,327 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene4
+{
+    using Bencodex.Types;
+    using Lib9c.Tests.VersionedStates.Scenario.Scene2;
+    using Lib9c.Tests.VersionedStates.Scenario.Scene3;
+    using Nekoyume.Model.State;
+    using Nekoyume.VersionedStates;
+
+    public static class TestStateFactory
+    {
+        // NOTE: Every create method should be handled all versions of the state.
+        //       But this not means upward compatibility.
+        public static TestState Create(IValue serialized)
+        {
+            if (!IVersionedState.TryDeconstruct(
+                    serialized,
+                    out var moniker,
+                    out var version,
+                    out _) ||
+                moniker != ITestState.MonikerCache)
+            {
+                return ITestStateNonVersioned.TryDeconstruct(
+                    serialized,
+                    out var value)
+                    ? new TestState(value.ToInteger())
+                    : null;
+            }
+
+            switch ((uint)version)
+            {
+                case 1:
+                {
+                    return ITestStateV1.TryDeconstruct(
+                        serialized,
+                        out _,
+                        out _,
+                        out var value)
+                        ? new TestState(value)
+                        : null;
+                }
+            }
+
+            return null;
+        }
+
+        // NOTE: Every create method should be handled all versions of the state.
+        //       But this not means upward compatibility.
+        public static TestStateV2 CreateV2(IValue serialized)
+        {
+            if (!IVersionedState.TryDeconstruct(
+                    serialized,
+                    out var moniker,
+                    out var version,
+                    out _) ||
+                moniker != ITestState.MonikerCache)
+            {
+                return ITestStateNonVersioned.TryDeconstruct(
+                    serialized,
+                    out var value)
+                    ? new TestStateV2(value.ToInteger())
+                    : null;
+            }
+
+            switch ((uint)version)
+            {
+                case 1:
+                {
+                    return ITestStateV1.TryDeconstruct(
+                        serialized,
+                        out _,
+                        out _,
+                        out var value)
+                        ? new TestStateV2(value)
+                        : null;
+                }
+
+                // + Add a case for the version 2.
+                case 2:
+                {
+                    return ITestStateV2.TryDeconstruct(
+                        serialized,
+                        out _,
+                        out _,
+                        out var value,
+                        out var testStateV1)
+                        ? new TestStateV2(value, Create(testStateV1))
+                        : null;
+                }
+            }
+
+            return null;
+        }
+
+        // NOTE: Every create method should be handled all versions of the state.
+        //       But this not means upward compatibility.
+        public static TestStateV3 CreateV3(IValue serialized)
+        {
+            if (!IVersionedState.TryDeconstruct(
+                    serialized,
+                    out var moniker,
+                    out var version,
+                    out _) ||
+                moniker != ITestState.MonikerCache)
+            {
+                return ITestStateNonVersioned.TryDeconstruct(
+                    serialized,
+                    out var value)
+                    ? new TestStateV3(value.ToInteger())
+                    : null;
+            }
+
+            switch ((uint)version)
+            {
+                case 1:
+                {
+                    return ITestStateV1.TryDeconstruct(
+                        serialized,
+                        out _,
+                        out _,
+                        out var value)
+                        ? new TestStateV3(value)
+                        : null;
+                }
+
+                // + Add a case for the version 2.
+                case 2:
+                {
+                    return ITestStateV2.TryDeconstruct(
+                        serialized,
+                        out _,
+                        out _,
+                        out var value,
+                        out var testState)
+                        ? new TestStateV3(value, CreateV2(testState))
+                        : null;
+                }
+
+                // + Add a case for the version 3.
+                case 3:
+                {
+                    return ITestStateV3.TryDeconstruct(
+                        serialized,
+                        out _,
+                        out _,
+                        out var value,
+                        out var testState)
+                        ? new TestStateV3(value, CreateV2(testState))
+                        : null;
+                }
+            }
+
+            return null;
+        }
+
+        // NOTE: Every create method should be handled all versions of the state.
+        //       But this not means upward compatibility.
+        public static TestStateV4 CreateV4(IValue serialized)
+        {
+            if (!IVersionedState.TryDeconstruct(
+                    serialized,
+                    out var moniker,
+                    out var version,
+                    out _) ||
+                moniker != ITestState.MonikerCache)
+            {
+                return ITestStateNonVersioned.TryDeconstruct(
+                    serialized,
+                    out var value)
+                    ? new TestStateV4(new TestStateV2(value.ToInteger()))
+                    : null;
+            }
+
+            switch ((uint)version)
+            {
+                case 1:
+                {
+                    return ITestStateV1.TryDeconstruct(
+                        serialized,
+                        out _,
+                        out _,
+                        out var value)
+                        ? new TestStateV4(new TestStateV2(value))
+                        : null;
+                }
+
+                case 2:
+                {
+                    return ITestStateV2.TryDeconstruct(
+                        serialized,
+                        out _,
+                        out _,
+                        out var value,
+                        out var testState)
+                        ? new TestStateV4(
+                            new TestStateV2(value),
+                            CreateV3(testState))
+                        : null;
+                }
+
+                case 3:
+                {
+                    return ITestStateV3.TryDeconstruct(
+                        serialized,
+                        out _,
+                        out _,
+                        out var value,
+                        out var testState)
+                        ? new TestStateV4(
+                            new TestStateV2(value),
+                            CreateV3(testState))
+                        : null;
+                }
+
+                // + Add a case for the version 4.
+                case 4:
+                {
+                    return ITestStateV4.TryDeconstruct(
+                        serialized,
+                        out _,
+                        out _,
+                        out var otherTestState,
+                        out var anotherTestState)
+                        ? new TestStateV4(
+                            CreateV2(otherTestState),
+                            CreateV3(anotherTestState))
+                        : null;
+                }
+            }
+
+            return null;
+        }
+
+        // NOTE: Every create method should be handled all versions of the state.
+        //       But this not means upward compatibility.
+        public static TestStateV5 CreateV5(IValue serialized)
+        {
+            if (!IVersionedState.TryDeconstruct(
+                    serialized,
+                    out var moniker,
+                    out var version,
+                    out _) ||
+                moniker != ITestState.MonikerCache)
+            {
+                return ITestStateNonVersioned.TryDeconstruct(
+                    serialized,
+                    out var value)
+                    ? new TestStateV5(new TestStateV2(value.ToInteger()))
+                    : null;
+            }
+
+            switch ((uint)version)
+            {
+                case 1:
+                {
+                    return ITestStateV1.TryDeconstruct(
+                        serialized,
+                        out _,
+                        out _,
+                        out var value)
+                        ? new TestStateV5(new TestStateV2(value))
+                        : null;
+                }
+
+                case 2:
+                {
+                    return ITestStateV2.TryDeconstruct(
+                        serialized,
+                        out _,
+                        out _,
+                        out var value,
+                        out var testState)
+                        ? new TestStateV5(
+                            new TestStateV2(value),
+                            CreateV3(testState))
+                        : null;
+                }
+
+                case 3:
+                {
+                    return ITestStateV3.TryDeconstruct(
+                        serialized,
+                        out _,
+                        out _,
+                        out var value,
+                        out var testState)
+                        ? new TestStateV5(
+                            new TestStateV2(value),
+                            CreateV3(testState))
+                        : null;
+                }
+
+                case 4:
+                {
+                    return ITestStateV4.TryDeconstruct(
+                        serialized,
+                        out _,
+                        out _,
+                        out var otherTestState,
+                        out var anotherTestState)
+                        ? new TestStateV5(
+                            CreateV2(otherTestState),
+                            CreateV3(anotherTestState))
+                        : null;
+                }
+
+                // + Add a case for the version 5.
+                case 5:
+                {
+                    return ITestStateV5.TryDeconstruct(
+                        serialized,
+                        out _,
+                        out _,
+                        out var otherTestState,
+                        out var anotherTestState,
+                        out var yetAnotherTestState)
+                        ? new TestStateV5(
+                            CreateV2(otherTestState),
+                            CreateV3(anotherTestState),
+                            CreateV4(yetAnotherTestState))
+                        : null;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene4/TestStateFactoryTest.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene4/TestStateFactoryTest.cs
@@ -1,0 +1,550 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene4
+{
+    using Bencodex.Types;
+    using Lib9c.Tests.VersionedStates.Scenario.Scene2;
+    using Lib9c.Tests.VersionedStates.Scenario.Scene3;
+    using Nekoyume.Model.State;
+    using Nekoyume.VersionedStates;
+    using Xunit;
+
+    public class TestStateFactoryTest
+    {
+        [Fact]
+        public void Create()
+        {
+            var current = new TestState(100);
+            var serialized = ((ITestStateV1)current).Serialize();
+            var backwards = new object[]
+            {
+                new Scene1.TestState(100),
+                current,
+            };
+            foreach (var backward in backwards)
+            {
+                if (backward is IState state)
+                {
+                    var serializedBackward = state.Serialize();
+                    Compare(current, serialized, serializedBackward);
+                }
+
+                if (backward is INonVersionedState nonVersionedState)
+                {
+                    var serializedBackward = nonVersionedState.Serialize();
+                    Compare(current, serialized, serializedBackward);
+                }
+
+                // Note: not IVersionedState,
+                //       only testing the implementation interface of IVersionedState.
+                if (backward is ITestStateV1 versionedState)
+                {
+                    var serializedBackward = versionedState.Serialize();
+                    Compare(current, serialized, serializedBackward);
+                }
+            }
+        }
+
+        [Fact]
+        public void CreateV2()
+        {
+            var current = new TestStateV2(100);
+            var serialized = ((ITestStateV2)current).Serialize();
+            var backwards = new object[]
+            {
+                new Scene1.TestState(100),
+                new TestState(100),
+                current,
+            };
+            foreach (var backward in backwards)
+            {
+                switch (backward)
+                {
+                    case IState state:
+                    {
+                        var serializedBackward = state.Serialize();
+                        CompareV2(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case INonVersionedState nonVersionedState:
+                    {
+                        var serializedBackward = nonVersionedState.Serialize();
+                        CompareV2(current, serialized, serializedBackward);
+                        break;
+                    }
+                }
+
+                switch (backward)
+                {
+                    case ITestStateV1 testStateV1:
+                    {
+                        var serializedBackward = testStateV1.Serialize();
+                        CompareV2(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case ITestStateV2 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV2(current, serialized, serializedBackward);
+                        break;
+                    }
+                }
+            }
+
+            current = new TestStateV2(100, new TestState(200));
+            serialized = ((ITestStateV2)current).Serialize();
+            CompareV2(current, serialized, serialized);
+        }
+
+        [Fact]
+        public void CreateV3()
+        {
+            var current = new TestStateV3(100);
+            var serialized = ((ITestStateV3)current).Serialize();
+            var backwards = new object[]
+            {
+                new Scene1.TestState(100),
+                new TestState(100),
+                new TestStateV2(100),
+                current,
+            };
+            foreach (var backward in backwards)
+            {
+                switch (backward)
+                {
+                    case IState state:
+                    {
+                        var serializedBackward = state.Serialize();
+                        CompareV3(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case INonVersionedState nonVersionedState:
+                    {
+                        var serializedBackward = nonVersionedState.Serialize();
+                        CompareV3(current, serialized, serializedBackward);
+                        break;
+                    }
+                }
+
+                switch (backward)
+                {
+                    case ITestStateV1 testStateV1:
+                    {
+                        var serializedBackward = testStateV1.Serialize();
+                        CompareV3(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case ITestStateV2 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV3(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case ITestStateV3 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV3(current, serialized, serializedBackward);
+                        break;
+                    }
+                }
+            }
+
+            current = new TestStateV3(100, new TestStateV2(200));
+            serialized = ((ITestStateV3)current).Serialize();
+            backwards = new object[]
+            {
+                new TestStateV2(100, new TestState(200)),
+                current,
+            };
+            foreach (var backward in backwards)
+            {
+                switch (backward)
+                {
+                    case ITestStateV2 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV3(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case ITestStateV3 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV3(current, serialized, serializedBackward);
+                        break;
+                    }
+                }
+            }
+
+            current = new TestStateV3(100, new TestStateV2(200, new TestState(201)));
+            serialized = ((ITestStateV3)current).Serialize();
+            CompareV3(current, serialized, serialized);
+        }
+
+        [Fact]
+        public void CreateV4()
+        {
+            var current = new TestStateV4(new TestStateV2(100));
+            var serialized = ((ITestStateV4)current).Serialize();
+            var backwards = new object[]
+            {
+                new Scene1.TestState(100),
+                new TestState(100),
+                new TestStateV2(100),
+                new TestStateV3(100),
+                current,
+            };
+            foreach (var backward in backwards)
+            {
+                switch (backward)
+                {
+                    case IState state:
+                    {
+                        var serializedBackward = state.Serialize();
+                        CompareV4(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case INonVersionedState nonVersionedState:
+                    {
+                        var serializedBackward = nonVersionedState.Serialize();
+                        CompareV4(current, serialized, serializedBackward);
+                        break;
+                    }
+                }
+
+                switch (backward)
+                {
+                    case ITestStateV1 testStateV1:
+                    {
+                        var serializedBackward = testStateV1.Serialize();
+                        CompareV4(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case ITestStateV2 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV4(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case ITestStateV3 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV4(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case ITestStateV4 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV4(current, serialized, serializedBackward);
+                        break;
+                    }
+                }
+            }
+
+            current = new TestStateV4(new TestStateV2(100), new TestStateV3(200));
+            serialized = ((ITestStateV4)current).Serialize();
+            backwards = new object[]
+            {
+                new TestStateV2(100, new TestState(200)),
+                new TestStateV3(100, new TestStateV2(200)),
+                current,
+            };
+            foreach (var backward in backwards)
+            {
+                switch (backward)
+                {
+                    case ITestStateV2 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV4(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case ITestStateV3 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV4(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case ITestStateV4 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV4(current, serialized, serializedBackward);
+                        break;
+                    }
+                }
+            }
+
+            current = new TestStateV4(
+                new TestStateV2(100),
+                new TestStateV3(200, new TestStateV2(201)));
+            serialized = ((ITestStateV4)current).Serialize();
+            backwards = new object[]
+            {
+                new TestStateV3(100, new TestStateV2(200, new TestState(201))),
+                current,
+            };
+            foreach (var backward in backwards)
+            {
+                switch (backward)
+                {
+                    case ITestStateV3 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV4(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case ITestStateV4 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV4(current, serialized, serializedBackward);
+                        break;
+                    }
+                }
+            }
+
+            current = new TestStateV4(
+                new TestStateV2(100, new TestState(101)),
+                new TestStateV3(
+                    200,
+                    new TestStateV2(201, new TestState(203))));
+            serialized = ((ITestStateV4)current).Serialize();
+            CompareV4(current, serialized, serialized);
+        }
+
+        [Fact]
+        public void CreateV5()
+        {
+            var current = new TestStateV5(new TestStateV2(100));
+            var serialized = ((ITestStateV5)current).Serialize();
+            var backwards = new object[]
+            {
+                new Scene1.TestState(100),
+                new TestState(100),
+                new TestStateV2(100),
+                new TestStateV3(100),
+                new TestStateV4(new TestStateV2(100)),
+                current,
+            };
+            foreach (var backward in backwards)
+            {
+                switch (backward)
+                {
+                    case IState state:
+                    {
+                        var serializedBackward = state.Serialize();
+                        CompareV5(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case INonVersionedState nonVersionedState:
+                    {
+                        var serializedBackward = nonVersionedState.Serialize();
+                        CompareV5(current, serialized, serializedBackward);
+                        break;
+                    }
+                }
+
+                switch (backward)
+                {
+                    case ITestStateV1 testStateV1:
+                    {
+                        var serializedBackward = testStateV1.Serialize();
+                        CompareV5(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case ITestStateV2 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV5(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case ITestStateV3 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV5(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case ITestStateV4 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV5(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case ITestStateV5 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV5(current, serialized, serializedBackward);
+                        break;
+                    }
+                }
+            }
+
+            current = new TestStateV5(new TestStateV2(100), new TestStateV3(200));
+            serialized = ((ITestStateV5)current).Serialize();
+            backwards = new object[]
+            {
+                new TestStateV2(100, new TestState(200)),
+                new TestStateV3(100, new TestStateV2(200)),
+                new TestStateV4(new TestStateV2(100), new TestStateV3(200)),
+                current,
+            };
+            foreach (var backward in backwards)
+            {
+                switch (backward)
+                {
+                    case ITestStateV2 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV5(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case ITestStateV3 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV5(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case ITestStateV4 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV5(current, serialized, serializedBackward);
+                        break;
+                    }
+                }
+            }
+
+            current = new TestStateV5(
+                new TestStateV2(100),
+                new TestStateV3(200, new TestStateV2(201)));
+            serialized = ((ITestStateV5)current).Serialize();
+            backwards = new object[]
+            {
+                new TestStateV3(100, new TestStateV2(200, new TestState(201))),
+                new TestStateV4(
+                    new TestStateV2(100),
+                    new TestStateV3(200, new TestStateV2(201))),
+                current,
+            };
+            foreach (var backward in backwards)
+            {
+                switch (backward)
+                {
+                    case ITestStateV3 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV5(current, serialized, serializedBackward);
+                        break;
+                    }
+
+                    case ITestStateV4 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV5(current, serialized, serializedBackward);
+                        break;
+                    }
+                }
+            }
+
+            current = new TestStateV5(
+                new TestStateV2(100, new TestState(101)),
+                new TestStateV3(200));
+            serialized = ((ITestStateV5)current).Serialize();
+            backwards = new object[]
+            {
+                new TestStateV4(
+                    new TestStateV2(100, new TestState(101)),
+                    new TestStateV3(200)),
+                current,
+            };
+            foreach (var backward in backwards)
+            {
+                switch (backward)
+                {
+                    case ITestStateV4 versionedState:
+                    {
+                        var serializedBackward = versionedState.Serialize();
+                        CompareV5(current, serialized, serializedBackward);
+                        break;
+                    }
+                }
+            }
+
+            current = new TestStateV5(
+                new TestStateV2(100, new TestState(101)),
+                new TestStateV3(200, new TestStateV2(201)),
+                new TestStateV4(
+                    new TestStateV2(3010, new TestState(3011)),
+                    new TestStateV3(
+                        3020,
+                        new TestStateV2(3021, new TestState(3022)))));
+            serialized = ((ITestStateV5)current).Serialize();
+            CompareV5(current, serialized, serialized);
+        }
+
+        private static void Compare(
+            TestState current,
+            IValue serialized,
+            IValue serializedBackward)
+        {
+            var created = TestStateFactory.Create(serializedBackward);
+            Assert.Equal(current, created);
+            Assert.Equal(serialized, ((ITestStateV1)created).Serialize());
+        }
+
+        private static void CompareV2(
+            TestStateV2 current,
+            IValue serialized,
+            IValue serializedBackward)
+        {
+            var created = TestStateFactory.CreateV2(serializedBackward);
+            Assert.Equal(current, created);
+            Assert.Equal(serialized, ((ITestStateV2)created).Serialize());
+        }
+
+        private static void CompareV3(
+            TestStateV3 current,
+            IValue serialized,
+            IValue serializedBackward)
+        {
+            var created = TestStateFactory.CreateV3(serializedBackward);
+            Assert.Equal(current, created);
+            Assert.Equal(serialized, ((ITestStateV3)created).Serialize());
+        }
+
+        private static void CompareV4(
+            TestStateV4 current,
+            IValue serialized,
+            IValue serializedBackward)
+        {
+            var created = TestStateFactory.CreateV4(serializedBackward);
+            Assert.Equal(current, created);
+            Assert.Equal(serialized, ((ITestStateV4)created).Serialize());
+        }
+
+        private static void CompareV5(
+            TestStateV5 current,
+            IValue serialized,
+            IValue serializedBackward)
+        {
+            var created = TestStateFactory.CreateV5(serializedBackward);
+            Assert.Equal(current, created);
+            Assert.Equal(serialized, ((ITestStateV5)created).Serialize());
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene4/TestStateV3.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene4/TestStateV3.cs
@@ -1,0 +1,48 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene4
+{
+    using System;
+    using Bencodex.Types;
+    using Lib9c.Tests.VersionedStates.Scenario.Scene2;
+    using Lib9c.Tests.VersionedStates.Scenario.Scene3;
+
+    // + Implement `ITestStateV3` interface.
+    public class TestStateV3 : ITestStateV3
+    {
+        Integer ITestStateV3.Value => Value;
+
+        ITestStateV2 ITestStateV3.TestState => TestState;
+
+        public int Value { get; }
+
+        public TestStateV2 TestState { get; }
+
+        public TestStateV3() : this(0)
+        {
+        }
+
+        public TestStateV3(int value = 0, TestStateV2 testState = null)
+        {
+            Value = value;
+            TestState = testState;
+        }
+
+        protected bool Equals(TestStateV3 other)
+        {
+            return Value == other.Value &&
+                   Equals(TestState, other.TestState);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TestStateV3)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Value, TestState);
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene4/TestStateV4.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene4/TestStateV4.cs
@@ -1,0 +1,48 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene4
+{
+    using System;
+    using Lib9c.Tests.VersionedStates.Scenario.Scene3;
+
+    // + Implement `ITestStateV4` interface.
+    public class TestStateV4 : ITestStateV4
+    {
+        ITestStateV2 ITestStateV4.TestState => TestState;
+
+        ITestStateV3 ITestStateV4.OtherTestState => OtherTestState;
+
+        public TestStateV2 TestState { get; }
+
+        public TestStateV3 OtherTestState { get; }
+
+        public TestStateV4() : this(null)
+        {
+        }
+
+        public TestStateV4(
+            TestStateV2 testState = null,
+            TestStateV3 otherTestState = null)
+        {
+            TestState = testState;
+            OtherTestState = otherTestState;
+        }
+
+        protected bool Equals(TestStateV4 other)
+        {
+            return Equals(TestState, other.TestState) &&
+                   Equals(OtherTestState, other.OtherTestState);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TestStateV4)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(TestState, OtherTestState);
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/Scenario/Scene4/TestStateV5.cs
+++ b/.Lib9c.Tests/VersionedStates/Scenario/Scene4/TestStateV5.cs
@@ -1,0 +1,55 @@
+namespace Lib9c.Tests.VersionedStates.Scenario.Scene4
+{
+    using System;
+    using Lib9c.Tests.VersionedStates.Scenario.Scene3;
+
+    // + Implement `ITestStateV5` interface.
+    public class TestStateV5 : ITestStateV5
+    {
+        ITestStateV2 ITestStateV5.TestState => TestState;
+
+        ITestStateV3 ITestStateV5.OtherTestState => OtherTestState;
+
+        ITestStateV4 ITestStateV5.AnotherTestState => AnotherTestState;
+
+        public TestStateV2 TestState { get; }
+
+        public TestStateV3 OtherTestState { get; }
+
+        public TestStateV4 AnotherTestState { get; }
+
+        public TestStateV5() : this(null)
+        {
+        }
+
+        public TestStateV5(
+            TestStateV2 testState = null,
+            TestStateV3 otherTestState = null,
+            TestStateV4 anotherTestState = null)
+        {
+            TestState = testState;
+            OtherTestState = otherTestState;
+            AnotherTestState = anotherTestState;
+        }
+
+        protected bool Equals(TestStateV5 other)
+        {
+            return Equals(TestState, other.TestState) &&
+                   Equals(OtherTestState, other.OtherTestState) &&
+                   Equals(AnotherTestState, other.AnotherTestState);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TestStateV5)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(TestState, OtherTestState, AnotherTestState);
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/VersionedStateImpl.cs
+++ b/.Lib9c.Tests/VersionedStates/VersionedStateImpl.cs
@@ -1,0 +1,71 @@
+namespace Lib9c.Tests.VersionedStates
+{
+    using Bencodex.Types;
+    using Nekoyume.VersionedStates;
+
+    public interface IVersionedStateImpl : IVersionedState
+    {
+        public static readonly Text MonikerCache = "versioned_state";
+
+        public static readonly Integer VersionCache = 1;
+
+        Text IVersionedState.Moniker => MonikerCache;
+
+        Integer IVersionedState.Version => VersionCache;
+
+        IValue IVersionedState.Data => new List(
+            Value1?.Serialize() ?? Null.Value,
+            Value2);
+
+        INonVersionedStateImpl Value1 { get; }
+
+        Text Value2 { get; }
+
+        static bool TryDeconstruct(
+            IValue serialized,
+            out Text moniker,
+            out Integer version,
+            out IValue value1,
+            out Text value2)
+        {
+            try
+            {
+                IValue data;
+                (moniker, version, data) = Deconstruct(serialized);
+                var list = (List)data;
+                value1 = list[0];
+                value2 = (Text)list[1];
+                return true;
+            }
+            catch
+            {
+                moniker = default;
+                version = default;
+                value1 = default;
+                value2 = default;
+                return false;
+            }
+        }
+    }
+
+    public class VersionedStateImpl : IVersionedStateImpl
+    {
+        INonVersionedStateImpl IVersionedStateImpl.Value1 => Value1;
+
+        Text IVersionedStateImpl.Value2 => Value2;
+
+        public NonVersionedStateImpl Value1 { get; private set; }
+
+        public string Value2 { get; private set; }
+
+        public VersionedStateImpl() : this(null, string.Empty)
+        {
+        }
+
+        public VersionedStateImpl(NonVersionedStateImpl value1, string value2)
+        {
+            Value1 = value1;
+            Value2 = value2;
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/VersionedStateImplFactory.cs
+++ b/.Lib9c.Tests/VersionedStates/VersionedStateImplFactory.cs
@@ -1,0 +1,23 @@
+namespace Lib9c.Tests.VersionedStates
+{
+    using Bencodex.Types;
+
+    public static class VersionedStateImplFactory
+    {
+        public static VersionedStateImpl Create(IValue serialized)
+        {
+            if (!IVersionedStateImpl.TryDeconstruct(
+                    serialized,
+                    out _,
+                    out _,
+                    out var value1,
+                    out var value2))
+            {
+                return null;
+            }
+
+            var value1Obj = NonVersionedStateImplFactory.Create(value1);
+            return new VersionedStateImpl(value1Obj, value2);
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/VersionedStateSnapshotTest.cs
+++ b/.Lib9c.Tests/VersionedStates/VersionedStateSnapshotTest.cs
@@ -1,0 +1,37 @@
+namespace Lib9c.Tests.VersionedStates
+{
+    using System;
+    using System.Linq;
+    using Bencodex.Types;
+    using Nekoyume.VersionedStates;
+    using Snapshooter;
+    using Snapshooter.Xunit;
+    using Xunit;
+
+    public class VersionedStateSnapshotTest
+    {
+        [Fact]
+        public void SnapshotTest()
+        {
+            var iVersionedStateType = typeof(IVersionedState);
+            var tuples = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(a => a.GetTypes())
+                .Where(type =>
+                    !type.IsAbstract &&
+                    !type.IsInterface &&
+                    type.IsAssignableTo(iVersionedStateType))
+                .Select(type =>
+                {
+                    var state = (IVersionedState)Activator.CreateInstance(type);
+                    return (
+                        type: type,
+                        value: state?.Serialize() ?? Null.Value);
+                })
+                .ToArray();
+            foreach (var (type, value) in tuples)
+            {
+                Snapshot.Match(value, SnapshotNameExtension.Create(type.FullName));
+            }
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/VersionedStateTest.cs
+++ b/.Lib9c.Tests/VersionedStates/VersionedStateTest.cs
@@ -1,0 +1,106 @@
+namespace Lib9c.Tests.VersionedStates
+{
+    using Bencodex.Types;
+    using Nekoyume.VersionedStates;
+    using Xunit;
+
+    public class VersionedStateTest
+    {
+        [Fact]
+        public void Serialize_And_Deconstruct_As_IVersionedState()
+        {
+            IVersionedState vs = new VersionedStateImpl();
+            Assert.Equal(IVersionedStateImpl.MonikerCache, vs.Moniker);
+            Assert.Equal(IVersionedStateImpl.VersionCache, vs.Version);
+            var serialized = vs.Serialize();
+            var staticSerialized = IVersionedState.Serialize(
+                vs.Moniker,
+                vs.Version,
+                vs.Data);
+            Assert.Equal(serialized, staticSerialized);
+            var (m, v, d) = IVersionedState.Deconstruct(serialized);
+            Assert.Equal(vs.Moniker, m);
+            Assert.Equal(vs.Version, v);
+            Assert.Equal(vs.Data, d);
+            Assert.True(IVersionedState.TryDeconstruct(
+                serialized,
+                out m,
+                out v,
+                out d));
+            Assert.Equal(vs.Moniker, m);
+            Assert.Equal(vs.Version, v);
+            Assert.Equal(vs.Data, d);
+        }
+
+        [Fact]
+        public void Serialize_And_Deconstruct_As_IVersionedStateImpl()
+        {
+            IVersionedStateImpl vsi = new VersionedStateImpl();
+            Assert.Equal(IVersionedStateImpl.MonikerCache, vsi.Moniker);
+            Assert.Equal(IVersionedStateImpl.VersionCache, vsi.Version);
+            var serialized = vsi.Serialize();
+            var staticSerialized = IVersionedState.Serialize(
+                vsi.Moniker,
+                vsi.Version,
+                vsi.Data);
+            Assert.Equal(serialized, staticSerialized);
+            var (m, v, d) = IVersionedState.Deconstruct(serialized);
+            Assert.Equal(vsi.Moniker, m);
+            Assert.Equal(vsi.Version, v);
+            Assert.Equal(vsi.Data, d);
+            Assert.True(IVersionedStateImpl.TryDeconstruct(
+                serialized,
+                out m,
+                out v,
+                out var value1,
+                out var value2));
+            Assert.Equal(vsi.Moniker, m);
+            Assert.Equal(vsi.Version, v);
+            Assert.Equal(vsi.Value1?.Serialize() ?? Null.Value, value1);
+            Assert.Equal(vsi.Value2, value2);
+        }
+
+        [Fact]
+        public void Serialize_And_Deconstruct_As_VersionedStateImpl()
+        {
+            var obj = new VersionedStateImpl();
+            var vsi = (IVersionedStateImpl)obj;
+            Assert.Equal(IVersionedStateImpl.MonikerCache, vsi.Moniker);
+            Assert.Equal(IVersionedStateImpl.VersionCache, vsi.Version);
+            var serialized = obj.Serialize();
+            var staticSerialized = IVersionedState.Serialize(
+                vsi.Moniker,
+                vsi.Version,
+                vsi.Data);
+            Assert.Equal(serialized, staticSerialized);
+            var (m, v, d) = IVersionedState.Deconstruct(serialized);
+            Assert.Equal(vsi.Moniker, m);
+            Assert.Equal(vsi.Version, v);
+            Assert.Equal(vsi.Data, d);
+            Assert.True(IVersionedStateImpl.TryDeconstruct(
+                serialized,
+                out m,
+                out v,
+                out var value1,
+                out var value2));
+            Assert.Equal(vsi.Moniker, m);
+            Assert.Equal(vsi.Version, v);
+            Assert.Equal(obj.Value1?.Serialize() ?? Null.Value, value1);
+            Assert.Equal(obj.Value2, value2);
+        }
+
+        [Fact]
+        public void Serialize_And_Create()
+        {
+            var obj = new VersionedStateImpl();
+            var serialized = obj.Serialize();
+            var created = VersionedStateImplFactory.Create(serialized);
+            var vsi = (IVersionedStateImpl)obj;
+            var createdVsi = (IVersionedStateImpl)created;
+            Assert.Equal(vsi.Moniker, createdVsi.Moniker);
+            Assert.Equal(vsi.Version, createdVsi.Version);
+            Assert.Equal(obj.Value1, created.Value1);
+            Assert.Equal(obj.Value2, created.Value2);
+        }
+    }
+}

--- a/.Lib9c.Tests/VersionedStates/__snapshots__/NonVersionedStateSnapshotTest.SnapshotTest_Lib9c.Tests.VersionedStates.NonVersionedStateImpl.snap
+++ b/.Lib9c.Tests/VersionedStates/__snapshots__/NonVersionedStateSnapshotTest.SnapshotTest_Lib9c.Tests.VersionedStates.NonVersionedStateImpl.snap
@@ -1,0 +1,11 @@
+﻿{
+  "Value": 0,
+  "Kind": "Integer",
+  "Fingerprint": {
+    "Kind": 2,
+    "EncodingLength": 3,
+    "Digest": "AA=="
+  },
+  "EncodingLength": 3,
+  "Inspection": "0"
+}

--- a/.Lib9c.Tests/VersionedStates/__snapshots__/NonVersionedStateSnapshotTest.SnapshotTest_Lib9c.Tests.VersionedStates.Scenario.Scene2.TestState.snap
+++ b/.Lib9c.Tests/VersionedStates/__snapshots__/NonVersionedStateSnapshotTest.SnapshotTest_Lib9c.Tests.VersionedStates.Scenario.Scene2.TestState.snap
@@ -1,0 +1,11 @@
+﻿{
+  "Value": "0",
+  "Kind": "Text",
+  "Fingerprint": {
+    "Kind": 4,
+    "EncodingLength": 4,
+    "Digest": "MA=="
+  },
+  "EncodingLength": 4,
+  "Inspection": "\"0\""
+}

--- a/.Lib9c.Tests/VersionedStates/__snapshots__/VersionedStateSnapshotTest.SnapshotTest_Lib9c.Tests.VersionedStates.Scenario.Scene2.TestState.snap
+++ b/.Lib9c.Tests/VersionedStates/__snapshots__/VersionedStateSnapshotTest.SnapshotTest_Lib9c.Tests.VersionedStates.Scenario.Scene2.TestState.snap
@@ -1,0 +1,35 @@
+﻿[
+  {
+    "Value": "test",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 7,
+      "Digest": "dGVzdA=="
+    },
+    "EncodingLength": 7,
+    "Inspection": "\"test\""
+  },
+  {
+    "Value": 1,
+    "Kind": "Integer",
+    "Fingerprint": {
+      "Kind": 2,
+      "EncodingLength": 3,
+      "Digest": "AQ=="
+    },
+    "EncodingLength": 3,
+    "Inspection": "1"
+  },
+  {
+    "Value": 0,
+    "Kind": "Integer",
+    "Fingerprint": {
+      "Kind": 2,
+      "EncodingLength": 3,
+      "Digest": "AA=="
+    },
+    "EncodingLength": 3,
+    "Inspection": "0"
+  }
+]

--- a/.Lib9c.Tests/VersionedStates/__snapshots__/VersionedStateSnapshotTest.SnapshotTest_Lib9c.Tests.VersionedStates.Scenario.Scene3.TestStateV2.snap
+++ b/.Lib9c.Tests/VersionedStates/__snapshots__/VersionedStateSnapshotTest.SnapshotTest_Lib9c.Tests.VersionedStates.Scenario.Scene3.TestStateV2.snap
@@ -1,0 +1,47 @@
+﻿[
+  {
+    "Value": "test",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 7,
+      "Digest": "dGVzdA=="
+    },
+    "EncodingLength": 7,
+    "Inspection": "\"test\""
+  },
+  {
+    "Value": 2,
+    "Kind": "Integer",
+    "Fingerprint": {
+      "Kind": 2,
+      "EncodingLength": 3,
+      "Digest": "Ag=="
+    },
+    "EncodingLength": 3,
+    "Inspection": "2"
+  },
+  [
+    {
+      "Value": 0,
+      "Kind": "Integer",
+      "Fingerprint": {
+        "Kind": 2,
+        "EncodingLength": 3,
+        "Digest": "AA=="
+      },
+      "EncodingLength": 3,
+      "Inspection": "0"
+    },
+    {
+      "Kind": "Null",
+      "Fingerprint": {
+        "Kind": 0,
+        "EncodingLength": 1,
+        "Digest": ""
+      },
+      "EncodingLength": 1,
+      "Inspection": "null"
+    }
+  ]
+]

--- a/.Lib9c.Tests/VersionedStates/__snapshots__/VersionedStateSnapshotTest.SnapshotTest_Lib9c.Tests.VersionedStates.Scenario.Scene4.TestStateV3.snap
+++ b/.Lib9c.Tests/VersionedStates/__snapshots__/VersionedStateSnapshotTest.SnapshotTest_Lib9c.Tests.VersionedStates.Scenario.Scene4.TestStateV3.snap
@@ -1,0 +1,47 @@
+﻿[
+  {
+    "Value": "test",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 7,
+      "Digest": "dGVzdA=="
+    },
+    "EncodingLength": 7,
+    "Inspection": "\"test\""
+  },
+  {
+    "Value": 3,
+    "Kind": "Integer",
+    "Fingerprint": {
+      "Kind": 2,
+      "EncodingLength": 3,
+      "Digest": "Aw=="
+    },
+    "EncodingLength": 3,
+    "Inspection": "3"
+  },
+  [
+    {
+      "Value": 0,
+      "Kind": "Integer",
+      "Fingerprint": {
+        "Kind": 2,
+        "EncodingLength": 3,
+        "Digest": "AA=="
+      },
+      "EncodingLength": 3,
+      "Inspection": "0"
+    },
+    {
+      "Kind": "Null",
+      "Fingerprint": {
+        "Kind": 0,
+        "EncodingLength": 1,
+        "Digest": ""
+      },
+      "EncodingLength": 1,
+      "Inspection": "null"
+    }
+  ]
+]

--- a/.Lib9c.Tests/VersionedStates/__snapshots__/VersionedStateSnapshotTest.SnapshotTest_Lib9c.Tests.VersionedStates.Scenario.Scene4.TestStateV4.snap
+++ b/.Lib9c.Tests/VersionedStates/__snapshots__/VersionedStateSnapshotTest.SnapshotTest_Lib9c.Tests.VersionedStates.Scenario.Scene4.TestStateV4.snap
@@ -1,0 +1,46 @@
+﻿[
+  {
+    "Value": "test",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 7,
+      "Digest": "dGVzdA=="
+    },
+    "EncodingLength": 7,
+    "Inspection": "\"test\""
+  },
+  {
+    "Value": 4,
+    "Kind": "Integer",
+    "Fingerprint": {
+      "Kind": 2,
+      "EncodingLength": 3,
+      "Digest": "BA=="
+    },
+    "EncodingLength": 3,
+    "Inspection": "4"
+  },
+  [
+    {
+      "Kind": "Null",
+      "Fingerprint": {
+        "Kind": 0,
+        "EncodingLength": 1,
+        "Digest": ""
+      },
+      "EncodingLength": 1,
+      "Inspection": "null"
+    },
+    {
+      "Kind": "Null",
+      "Fingerprint": {
+        "Kind": 0,
+        "EncodingLength": 1,
+        "Digest": ""
+      },
+      "EncodingLength": 1,
+      "Inspection": "null"
+    }
+  ]
+]

--- a/.Lib9c.Tests/VersionedStates/__snapshots__/VersionedStateSnapshotTest.SnapshotTest_Lib9c.Tests.VersionedStates.Scenario.Scene4.TestStateV5.snap
+++ b/.Lib9c.Tests/VersionedStates/__snapshots__/VersionedStateSnapshotTest.SnapshotTest_Lib9c.Tests.VersionedStates.Scenario.Scene4.TestStateV5.snap
@@ -1,0 +1,56 @@
+﻿[
+  {
+    "Value": "test",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 7,
+      "Digest": "dGVzdA=="
+    },
+    "EncodingLength": 7,
+    "Inspection": "\"test\""
+  },
+  {
+    "Value": 5,
+    "Kind": "Integer",
+    "Fingerprint": {
+      "Kind": 2,
+      "EncodingLength": 3,
+      "Digest": "BQ=="
+    },
+    "EncodingLength": 3,
+    "Inspection": "5"
+  },
+  [
+    {
+      "Kind": "Null",
+      "Fingerprint": {
+        "Kind": 0,
+        "EncodingLength": 1,
+        "Digest": ""
+      },
+      "EncodingLength": 1,
+      "Inspection": "null"
+    },
+    {
+      "Kind": "Null",
+      "Fingerprint": {
+        "Kind": 0,
+        "EncodingLength": 1,
+        "Digest": ""
+      },
+      "EncodingLength": 1,
+      "Inspection": "null"
+    },
+    {
+      "Kind": "Null",
+      "Fingerprint": {
+        "Kind": 0,
+        "EncodingLength": 1,
+        "Digest": ""
+      },
+      "EncodingLength": 1,
+      "Inspection": "null"
+    }
+  ]
+]

--- a/.Lib9c.Tests/VersionedStates/__snapshots__/VersionedStateSnapshotTest.SnapshotTest_Lib9c.Tests.VersionedStates.VersionedStateImpl.snap
+++ b/.Lib9c.Tests/VersionedStates/__snapshots__/VersionedStateSnapshotTest.SnapshotTest_Lib9c.Tests.VersionedStates.VersionedStateImpl.snap
@@ -1,0 +1,47 @@
+﻿[
+  {
+    "Value": "versioned_state",
+    "Kind": "Text",
+    "Fingerprint": {
+      "Kind": 4,
+      "EncodingLength": 19,
+      "Digest": "dmVyc2lvbmVkX3N0YXRl"
+    },
+    "EncodingLength": 19,
+    "Inspection": "\"versioned_state\""
+  },
+  {
+    "Value": 1,
+    "Kind": "Integer",
+    "Fingerprint": {
+      "Kind": 2,
+      "EncodingLength": 3,
+      "Digest": "AQ=="
+    },
+    "EncodingLength": 3,
+    "Inspection": "1"
+  },
+  [
+    {
+      "Kind": "Null",
+      "Fingerprint": {
+        "Kind": 0,
+        "EncodingLength": 1,
+        "Digest": ""
+      },
+      "EncodingLength": 1,
+      "Inspection": "null"
+    },
+    {
+      "Value": "",
+      "Kind": "Text",
+      "Fingerprint": {
+        "Kind": 4,
+        "EncodingLength": 3,
+        "Digest": ""
+      },
+      "EncodingLength": 3,
+      "Inspection": "\"\""
+    }
+  ]
+]

--- a/Lib9c/VersionedStates/INonVersionedState.cs
+++ b/Lib9c/VersionedStates/INonVersionedState.cs
@@ -1,0 +1,27 @@
+using Bencodex.Types;
+
+namespace Nekoyume.VersionedStates
+{
+    /// <summary>
+    /// Interface for non-versioned state.
+    /// </summary>
+    public interface INonVersionedState
+    {
+        /// <summary>
+        /// The state data.
+        /// </summary>
+        IValue Data { get; }
+
+        IValue Serialize() => Serialize(this);
+
+        static IValue Serialize(INonVersionedState nonVersionedState) =>
+            nonVersionedState.Data;
+    }
+
+    public static class NonVersionedStateExtensions
+    {
+        public static IValue Serialize<T>(this T nonVersionedState)
+            where T : INonVersionedState =>
+            nonVersionedState.Serialize();
+    }
+}

--- a/Lib9c/VersionedStates/IVersionedState.cs
+++ b/Lib9c/VersionedStates/IVersionedState.cs
@@ -1,0 +1,153 @@
+using System;
+using Bencodex.Types;
+
+namespace Nekoyume.VersionedStates
+{
+    /// <summary>
+    /// Interface for versioned state.
+    /// </summary>
+    public interface IVersionedState
+    {
+        /// <summary>
+        /// The moniker of the versioned state.
+        /// It is used to identify the versioned state.
+        /// </summary>
+        Text Moniker => string.Empty;
+
+        /// <summary>
+        /// The version of the versioned state.
+        /// It is used to identify the versioned state.
+        /// </summary>
+        Integer Version => -1;
+
+        /// <summary>
+        /// The data of the versioned state.
+        /// It stores the actual data of the versioned state.
+        /// </summary>
+        IValue Data { get; }
+
+        /// <summary>
+        /// The <see cref="IVersionedState"/> implement this method directly.
+        /// It is used to serialize the versioned state to <see cref="IValue"/>.
+        /// It returns <see cref="List"/> of <see cref="Moniker"/>, <see cref="Version"/>,
+        /// <see cref="Data"/>.
+        /// </summary>
+        IValue Serialize() => Serialize(Moniker, Version, Data);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="moniker"></param>
+        /// <param name="version"></param>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
+        static IValue Serialize(Text moniker, Integer version, IValue data)
+        {
+            if (string.IsNullOrEmpty(moniker))
+            {
+                throw new ArgumentException(
+                    $"Serialized value's moniker must not be" +
+                    $" null or empty, but {moniker}.");
+            }
+
+            if (version < 0)
+            {
+                throw new ArgumentException(
+                    $"Serialized value's version must be" +
+                    $" greater than or equal to 0, but {version}.");
+            }
+
+            return new List(
+                moniker,
+                version,
+                data);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="serialized"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        static (Text moniker, Integer version, IValue data) Deconstruct(IValue serialized)
+        {
+            if (serialized is null)
+            {
+                throw new ArgumentNullException(nameof(serialized));
+            }
+
+            if (!(serialized is List list))
+            {
+                throw new ArgumentException(
+                    "Serialized value must be a 'BenCodex.Types.List'.");
+            }
+
+            if (list.Count != 3)
+            {
+                throw new ArgumentException(
+                    $"Serialized value must have 3 elements, but has {list.Count}.");
+            }
+
+            try
+            {
+                var moniker = (Text)list[0];
+                if (string.IsNullOrEmpty(moniker))
+                {
+                    throw new ArgumentException(
+                        $"Serialized value's moniker must not be" +
+                        $" null or empty, but {moniker}.");
+                }
+
+                var version = (Integer)list[1];
+                if (version < 0)
+                {
+                    throw new ArgumentException(
+                        $"Serialized value's version must be" +
+                        $" greater than or equal to 0, but {version}.");
+                }
+
+                var data = list[2];
+                return (moniker, version, data);
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentException("Serialized value is invalid.", e);
+            }
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="serialized"></param>
+        /// <param name="moniker"></param>
+        /// <param name="version"></param>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        static bool TryDeconstruct(
+            IValue serialized,
+            out Text moniker,
+            out Integer version,
+            out IValue data)
+        {
+            try
+            {
+                (moniker, version, data) = Deconstruct(serialized);
+                return true;
+            }
+            catch
+            {
+                (moniker, version, data) = (string.Empty, -1, null);
+                return false;
+            }
+        }
+    }
+
+    public static class VersionedStateExtensions
+    {
+        public static IValue Serialize<T>(this T versionedState)
+            where T : IVersionedState =>
+            versionedState.Serialize();
+    }
+}


### PR DESCRIPTION
> This pull request proposes a way of version control the state model. There is another pull request(#1717) with the same goal as this one, but not the same way.

We know from NineChronicles that the models stored in the blockchain state are frequently modified.
The model versioning method proposed in this pull request makes model modifications and their impact manageable.

## INonVersionedState

Before we could write versioned state, we needed to write a basic interface to handle all the existing state models, and it's `INonVersionedState`.

All existing state models inherit from the `IState` interface, and are always serialized with the `IValue Serialize()` method. Therefore, `INonVersionedState` gave use the single responsibility to handle a serialized values. I didn't use the `IState` interface as is because it's hard to infer the connection to `IVersionedState` and it creates a dependency on how it's utilized.

## IVersionedState

A basic scheme of versioned state. Versioned state is defined by the serialization level, i.e., the Bencodex type.

- `Text Moniker`: versioned state has an own moniker.
- `Integer Version`: versioned state has a version.
- `IValue Data`: versioned state has an inner data.

## Snapshot test for versioned states

With the introduction of versioned state, we need to remind ourselves of the need to ensure that the underlying scheme of each version is immutable, so we've added a new snapshot test.
So when a new versioned state is defined, we need to run VersionedStateSnapshotTest.SnapshotTest() once and commit the resulting snapshot files together.

## Unit tests for default implementation of interfaces

I introduce the default implementation interface feature of C# 8.0.([dotnet doc](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-8.0/default-interface-methods))
I try to test all of default implementations of `IVersionedState` and `INonVersionedState` via [Rocks](https://www.nuget.org/packages/Rocks) package. But there is an issue like below.
```
  The analyzer assembly '/Users/seungmin/.nuget/packages/rocks/7.0.0/analyzers/dotnet/cs/Rocks.dll' references version '4.4.0.0' of the compiler, which is newer than the currently running version '4.3.0.0'.
```

I'll handle this issue separately.([issue](https://github.com/planetarium/lib9c/issues/1758))

## How to use `IVersionedState` and `INonVersionedState`

Please check the scenario tests for this which is contained in this pull request.
- `Lib9c.Tests/VersionedStates/Scenario/`
