### PR TITLE
Check whether the build passed or failed in several configurations and frameworks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,26 @@ jobs:
     - name: Test
       run: dotnet test --no-restore --verbosity normal --configuration ${{ matrix.configuration }}
 
+  build-for-unity:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.100
+      - name: Enforce netstandard2.1 target with custom patch
+        run: |
+          set -e
+
+          sed -i -E 's|<TargetFramework>.*</TargetFramework>|<TargetFramework>netstandard2.1</TargetFramework>|' Lib9c*/*.csproj Libplanet*/*.csproj
+          sed -i -E 's|<ImplicitUsings>.*</ImplicitUsings>|<ImplicitUsings>disable</ImplicitUsings>|' Lib9c*/*.csproj Libplanet*/*.csproj
+          sed -i -E 's|\[MaybeNullWhen\(false\)] out TValue value|out TValue value|' Lib9c/TableData/Sheet.cs
+          sed -i -E 's|public bool TryGetValue\(TKey key, out TValue value, bool throwException\)|public bool TryGetValue\(TKey key, out TValue? value, bool throwException\)|' Lib9c/TableData/Sheet.cs
+      - name: build
+        run: dotnet build
+
   release:
     if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,11 @@ on:
 
 jobs:
   build-and-test:
+    name: "build-and-test (${{ matrix.configuration }})"
+    strategy:
+      matrix:
+        configuration: ["Release", "DevEx"]
+      fail-fast: false
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -42,9 +47,9 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release
+      run: dotnet build --no-restore --configuration ${{ matrix.configuration }}
     - name: Test
-      run: dotnet test --no-restore --verbosity normal
+      run: dotnet test --no-restore --verbosity normal --configuration ${{ matrix.configuration }}
 
   release:
     if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')

--- a/Lib9c.DevExtensions/Utils.cs
+++ b/Lib9c.DevExtensions/Utils.cs
@@ -155,10 +155,13 @@ namespace Lib9c.DevExtensions
             if (dir is null)
             {
                 dir = Path
-                    .GetFullPath($"..{Path.DirectorySeparatorChar}")
-                    .Replace(
-                        $".Lib9c.DevExtensions.Tests{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}Debug{Path.DirectorySeparatorChar}",
-                        $"Lib9c{Path.DirectorySeparatorChar}TableCSV{Path.DirectorySeparatorChar}");
+                    .GetFullPath(
+                        $"..{Path.DirectorySeparatorChar}" +
+                        $"..{Path.DirectorySeparatorChar}" +
+                        $"..{Path.DirectorySeparatorChar}" +
+                        $"..{Path.DirectorySeparatorChar}" +
+                        $"Lib9c{Path.DirectorySeparatorChar}" +
+                        $"TableCSV{Path.DirectorySeparatorChar}");
             }
             var files = Directory.GetFiles(dir, "*.csv", SearchOption.AllDirectories);
             var sheets = new Dictionary<string, string>();


### PR DESCRIPTION
I opened this pull request to check it is compatible with Unity and the `DevEx` environment automatically without a situation to hold developers accountable. 🙄 

## Check ***Unity*** compatibility

The job enforces the `netstandard2.1` target for the `Lib9c*/*.csproj` and `Libplanet*/*.csproj` projects. It became a .net 6 project but the planetarium/NineChronicles project is still using `Lib9c` as a submodule. So it should check Unity(netstandard2.1) compatibility. See #1752 case.

## Check "DevEx" build also

Maybe, since #1734, the `LIb9c` build with the `DevEx` configuration was broken but not caught in CI. This pull request makes CI do it.