### PR TITLE
obsolete transfer asset2

### DIFF
--- a/.Lib9c.Tests/Action/TransferAsset2Test.cs
+++ b/.Lib9c.Tests/Action/TransferAsset2Test.cs
@@ -380,5 +380,21 @@ namespace Lib9c.Tests.Action
             Assert.Equal(_currency * 100, deserialized.Amount);
             Assert.Equal(memo, deserialized.Memo);
         }
+
+        [Fact]
+        public void CheckObsolete()
+        {
+            var action = new TransferAsset2(_sender, _recipient, _currency * 1);
+            Assert.Throws<ActionObsoletedException>(() =>
+            {
+                action.Execute(new ActionContext()
+                {
+                    PreviousStates = new State(),
+                    Signer = _sender,
+                    Rehearsal = false,
+                    BlockIndex = TransferAsset.CrystalTransferringRestrictionStartIndex,
+                });
+            });
+        }
     }
 }

--- a/Lib9c/Action/TransferAsset2.cs
+++ b/Lib9c/Action/TransferAsset2.cs
@@ -19,6 +19,7 @@ namespace Nekoyume.Action
     /// Updated at https://github.com/planetarium/lib9c/pull/957
     /// </summary>
     [Serializable]
+    [ActionObsolete(TransferAsset.CrystalTransferringRestrictionStartIndex - 1)]
     [ActionType("transfer_asset2")]
     public class TransferAsset2 : ActionBase, ISerializable, ITransferAsset, ITransferAssetV1
     {
@@ -84,6 +85,7 @@ namespace Nekoyume.Action
                 return state.MarkBalanceChanged(Amount.Currency, new[] { Sender, Recipient });
             }
 
+            CheckObsolete(TransferAsset.CrystalTransferringRestrictionStartIndex - 1, context);
             var addressesHex = GetSignerAndOtherAddressesHex(context, context.Signer);
             var started = DateTimeOffset.UtcNow;
             Log.Debug("{AddressesHex}TransferAsset2 exec started", addressesHex);


### PR DESCRIPTION
- related with #1718 .
- Even if the set block height (622,000) is reached, crystal transfer with TransferAsset2 is still possible. to avoid this problem, prevent the execution of TransferAsset2 from the set height.