### PR TITLE
Suppress warnings while collecting action type ids

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,7 @@ jobs:
     - name: Collect available action type ids
       run: |
         mkdir publish
-        dotnet run --project .Lib9c.Tools/Lib9c.Tools.csproj -- action list > publish/all_action_type_ids.txt
+        dotnet run --property WarningLevel=0 --project .Lib9c.Tools/Lib9c.Tools.csproj -- action list > publish/all_action_type_ids.txt
     - name: Publish available action type ids
       uses: peaceiris/actions-gh-pages@v3
       with:


### PR DESCRIPTION
Since v100370, the `v*/all_action_type_ids.txt` begins to include a .NET command warning message. (I'm not sure why the warning messages are in stdout, not stderr 🙄 ...) This pull request makes the job suppress the warning message by controlling the [`WarningLevel`][warning-level] property as zero.

(I asked for reviews from those who know this context.)

[warning-level]: https://learn.microsoft.com/ko-kr/dotnet/api/microsoft.build.tasks.csc.warninglevel?view=netframework-4.8.1#microsoft-build-tasks-csc-warninglevel