### PR TITLE
Fix burn behavior in SecureMiningReward to transferring

### DIFF
--- a/.Lib9c.Tests/Action/SecureMiningRewardTest.cs
+++ b/.Lib9c.Tests/Action/SecureMiningRewardTest.cs
@@ -23,6 +23,9 @@ namespace Lib9c.Tests.Action
         private static readonly Address _treasury =
             new Address("0xB3bCa3b3c6069EF5Bdd6384bAD98F11378Dc360E");
 
+        private static readonly Address _nil =
+            new Address("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF");
+
         private static readonly ImmutableList<Address> _authMiners = new[]
         {
             new Address("ab1dce17dCE1Db1424BB833Af6cC087cd4F5CB6d"),
@@ -66,6 +69,9 @@ namespace Lib9c.Tests.Action
 
             // (1000 + 2000 + 3000 + 4000) * 0.4
             Assert.Equal(NCG * 4000, nextState.GetBalance(_treasury, NCG));
+
+            // (1000 + 2000 + 3000 + 4000) * 0.4
+            Assert.Equal(NCG * 4000, nextState.GetBalance(_nil, NCG));
         }
 
         [Fact]

--- a/Lib9c/Action/SecureMiningReward.cs
+++ b/Lib9c/Action/SecureMiningReward.cs
@@ -26,6 +26,8 @@ namespace Nekoyume.Action
         // https://docs.google.com/document/d/1ErZ5JQia03KqXRG6IRZ7SORfnxMLZfJg4patVKFGX5Y/edit#
         private static readonly Address Treasury = new Address("0xB3bCa3b3c6069EF5Bdd6384bAD98F11378Dc360E");
 
+        private static readonly Address Nil = new Address("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF");
+
         private const int TreasuryRate = 40;
 
         private const int EarnRate = 20;
@@ -72,7 +74,7 @@ namespace Nekoyume.Action
 
                 state = state.TransferAsset(minerAddress, Treasury, toTreasury);
                 state = state.TransferAsset(minerAddress, Recipient, toRecipient);
-                state = state.BurnAsset(minerAddress, toBurn);
+                state = state.TransferAsset(minerAddress, Nil, toBurn);
             }
 
             return state;


### PR DESCRIPTION
Currently, non-minter accounts can't burn FAV (like NCG) due to Libplanet policy, even if they're admin accounts in 9c.  so this PR amends the burning semantic (from `burnAsset` to `transfer` to nil address), on `SecureMiningReward`, introduced by #1720. 

I think it doesn't need a hard fork because no action has been processed on the mainnet by the admin account that would cause state diff.