### PR TITLE
feat: Introduce `Currencies`

### DIFF
--- a/.Lib9c.DevExtensions.Tests/Action/FaucetRuneTest.cs
+++ b/.Lib9c.DevExtensions.Tests/Action/FaucetRuneTest.cs
@@ -90,10 +90,7 @@ namespace Lib9c.DevExtensions.Tests.Action
             foreach (var rune in faucetRuneInfos)
             {
                 var expectedRune = RuneHelper.ToCurrency(
-                    _runeSheet.OrderedList.First(r => r.Id == rune.RuneId),
-                    0,
-                    null
-                );
+                    _runeSheet.OrderedList.First(r => r.Id == rune.RuneId));
                 Assert.Equal(
                     rune.Amount * expectedRune,
                     states.GetBalance(_avatarAddress, expectedRune)

--- a/.Lib9c.Tests/Action/AccountStateDeltaExtensionsTest.cs
+++ b/.Lib9c.Tests/Action/AccountStateDeltaExtensionsTest.cs
@@ -59,7 +59,7 @@ namespace Lib9c.Tests.Action
             var random = new TestRandom();
             var tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
             var runeSheet = tableSheets.RuneSheet;
-            var runeCurrency = RuneHelper.ToCurrency(runeSheet[10001], 0, null);
+            var runeCurrency = RuneHelper.ToCurrency(runeSheet[10001]);
             var avatarAddress = new PrivateKey().ToAddress();
             var bossState = new WorldBossState(
                 tableSheets.WorldBossListSheet[1],

--- a/.Lib9c.Tests/Action/ClaimRaidRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimRaidRewardTest.cs
@@ -104,7 +104,7 @@ namespace Lib9c.Tests.Action
                         .SelectMany(r => r.RuneInfos.Select(i => i.RuneId)).ToHashSet();
                 foreach (var runeId in runeIds)
                 {
-                    var runeCurrency = RuneHelper.ToCurrency(_tableSheets.RuneSheet[runeId], 0, null);
+                    var runeCurrency = RuneHelper.ToCurrency(_tableSheets.RuneSheet[runeId]);
                     rune += (int)nextState.GetBalance(avatarAddress, runeCurrency).MajorUnit;
                 }
 

--- a/.Lib9c.Tests/Action/ClaimWorldBossKillRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimWorldBossKillRewardTest.cs
@@ -92,7 +92,7 @@ namespace Lib9c.Tests.Action
                     Random = new TestRandom(randomSeed),
                 });
 
-                var runeCurrency = RuneHelper.ToCurrency(tableSheets.RuneSheet[10001], 0, null);
+                var runeCurrency = RuneHelper.ToCurrency(tableSheets.RuneSheet[10001]);
                 Assert.Equal(1 * runeCurrency, nextState.GetBalance(avatarAddress, runeCurrency));
                 Assert.Equal(100 * CrystalCalculator.CRYSTAL, nextState.GetBalance(agentAddress, CrystalCalculator.CRYSTAL));
                 var nextRewardInfo = new WorldBossKillRewardRecord((List)nextState.GetState(worldBossKillRewardRecordAddress));

--- a/.Lib9c.Tests/Action/Scenario/RuneScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/RuneScenarioTest.cs
@@ -63,7 +63,7 @@ namespace Lib9c.Tests.Action.Scenario
 
             var runeId = 30001;
             var runeRow = tableSheets.RuneSheet[runeId];
-            var rune = RuneHelper.ToCurrency(runeRow, 0, null);
+            var rune = RuneHelper.ToCurrency(runeRow);
             initialState = initialState.MintAsset(avatarAddress, rune * 1);
 
             var runeAddress = RuneState.DeriveAddress(avatarAddress, runeId);

--- a/.Lib9c.Tests/CurrenciesTest.cs
+++ b/.Lib9c.Tests/CurrenciesTest.cs
@@ -4,7 +4,6 @@ namespace Lib9c.Tests
 
     using System;
     using System.Linq;
-    using Nekoyume;
     using Nekoyume.TableData;
     using Xunit;
 

--- a/.Lib9c.Tests/CurrenciesTest.cs
+++ b/.Lib9c.Tests/CurrenciesTest.cs
@@ -1,0 +1,133 @@
+namespace Lib9c.Tests
+{
+#nullable enable
+
+    using System;
+    using System.Linq;
+    using Nekoyume;
+    using Nekoyume.TableData;
+    using Xunit;
+
+    public class CurrenciesTest
+    {
+        [Fact]
+        public void GetRune()
+        {
+            var currency = Currencies.GetRune("ticker");
+            Assert.Equal("ticker", currency.Ticker);
+            Assert.Equal(0, currency.DecimalPlaces);
+            Assert.Null(currency.Minters);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void GetRune_Throws_ArgumentNullException(string? ticker)
+        {
+            Assert.Throws<ArgumentNullException>(() => Currencies.GetRune(ticker));
+        }
+
+        [Fact]
+        public void GetRunes_With_Ticker()
+        {
+            var currencies = Currencies.GetRunes("ticker1", "ticker2").ToArray();
+            Assert.Equal(2, currencies.Length);
+            Assert.Equal("ticker1", currencies[0].Ticker);
+            Assert.Equal("ticker2", currencies[1].Ticker);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("ticker1", null)]
+        [InlineData("ticker1", "")]
+        [InlineData(null, "ticker2")]
+        [InlineData("", "ticker2")]
+        public void GetRunes_With_Ticker_Throws_ArgumentNullException(params string?[] tickers)
+        {
+            Assert.Throws<ArgumentNullException>(() => Currencies.GetRunes(tickers).ToArray());
+        }
+
+        [Fact]
+        public void GetRunes_With_Sheet()
+        {
+            Assert.True(TableSheetsImporter.TryGetCsv("RuneSheet", out var csv));
+            var sheet = new RuneSheet();
+            sheet.Set(csv);
+            Assert.NotNull(sheet.OrderedList);
+            var currencies = Currencies.GetRunes(sheet).ToArray();
+            Assert.Equal(sheet.Count, currencies.Length);
+            foreach (var currency in currencies)
+            {
+                Assert.NotNull(sheet.OrderedList!.FirstOrDefault(row =>
+                    row.Ticker == currency.Ticker));
+            }
+        }
+
+        [Fact]
+        public void GetRunes_With_Sheet_Throws_ArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => Currencies.GetRunes((RuneSheet?)null));
+        }
+
+        [Fact]
+        public void GetSoulStone()
+        {
+            var currency = Currencies.GetSoulStone("ticker");
+            Assert.Equal("ticker", currency.Ticker);
+            Assert.Equal(0, currency.DecimalPlaces);
+            Assert.Null(currency.Minters);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void GetSoulStone_Throws_ArgumentNullException(string? ticker)
+        {
+            Assert.Throws<ArgumentNullException>(() => Currencies.GetSoulStone(ticker));
+        }
+
+        [Fact]
+        public void GetSoulStones_With_Ticker()
+        {
+            var currencies = Currencies.GetSoulStones("ticker1", "ticker2").ToArray();
+            Assert.Equal(2, currencies.Length);
+            Assert.Equal("ticker1", currencies[0].Ticker);
+            Assert.Equal("ticker2", currencies[1].Ticker);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("ticker1", null)]
+        [InlineData("ticker1", "")]
+        [InlineData(null, "ticker2")]
+        [InlineData("", "ticker2")]
+        public void GetSoulStones_With_Ticker_Throws_ArgumentNullException(params string?[] tickers)
+        {
+            Assert.Throws<ArgumentNullException>(() => Currencies.GetSoulStones(tickers).ToArray());
+        }
+
+        [Fact]
+        public void GetSoulStones_With_Sheet()
+        {
+            Assert.True(TableSheetsImporter.TryGetCsv("PetSheet", out var csv));
+            var sheet = new PetSheet();
+            sheet.Set(csv);
+            Assert.NotNull(sheet.OrderedList);
+            var currencies = Currencies.GetSoulStones(sheet).ToArray();
+            Assert.Equal(sheet.Count, currencies.Length);
+            foreach (var currency in currencies)
+            {
+                Assert.NotNull(sheet.OrderedList!.FirstOrDefault(row =>
+                    row.SoulStoneTicker == currency.Ticker));
+            }
+        }
+
+        [Fact]
+        public void GetSoulStones_With_Sheet_Throws_ArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => Currencies.GetSoulStones((PetSheet?)null));
+        }
+    }
+}

--- a/Lib9c.sln.DotSettings
+++ b/Lib9c.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=AI/@EntryIndexedValue">AI</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NCG/@EntryIndexedValue">NCG</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Addr/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bencodex/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Equippable/@EntryIndexedValue">True</s:Boolean>

--- a/Lib9c/Currencies.cs
+++ b/Lib9c/Currencies.cs
@@ -1,0 +1,76 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Libplanet;
+using Libplanet.Assets;
+using Nekoyume.TableData;
+
+namespace Nekoyume
+{
+    public static class Currencies
+    {
+        public static readonly Currency NCG = Currency.Legacy(
+            "NCG",
+            2,
+            new Address("0x47D082a115c63E7b58B1532d20E631538eaFADde"));
+
+        public static readonly Currency Crystal = Currency.Legacy(
+            "CRYSTAL",
+            18,
+            minters: null);
+
+        public static readonly Currency StakeRune = Currency.Legacy(
+            "RUNE_GOLDENLEAF",
+            0,
+            minters: null);
+
+        public static readonly Currency DailyRewardRune = Currency.Legacy(
+            "RUNE_ADVENTURER",
+            0,
+            minters: null);
+
+        public static Currency GetRune(string? ticker) =>
+            string.IsNullOrEmpty(ticker)
+                ? throw new ArgumentNullException(nameof(ticker))
+                : Currency.Legacy(
+                    ticker,
+                    0,
+                    minters: null);
+
+        public static IOrderedEnumerable<Currency> GetRunes(params string?[] tickers) =>
+            tickers.Select(GetRune).OrderBy(rune => rune.Hash.GetHashCode());
+
+        public static IOrderedEnumerable<Currency> GetRunes(RuneSheet? sheet) =>
+            sheet?.OrderedList is null
+                ? throw new ArgumentNullException(
+                    nameof(sheet),
+                    "sheet or sheet.OrderedList is null.")
+                : sheet.OrderedList
+                    .Select(row => row.Ticker)
+                    .Select(GetRune)
+                    .OrderBy(rune => rune.Hash.GetHashCode());
+
+        public static Currency GetSoulStone(string? ticker) =>
+            string.IsNullOrEmpty(ticker)
+                ? throw new ArgumentNullException(nameof(ticker))
+                : Currency.Legacy(
+                    ticker,
+                    0,
+                    minters: null);
+
+        public static IOrderedEnumerable<Currency> GetSoulStones(params string?[] tickers) =>
+            tickers.Select(GetSoulStone).OrderBy(soulStone => soulStone.Hash.GetHashCode());
+
+        public static IOrderedEnumerable<Currency> GetSoulStones(PetSheet? sheet) =>
+            sheet?.OrderedList is null
+                ? throw new ArgumentNullException(
+                    nameof(sheet),
+                    "sheet or sheet.OrderedList is null.")
+                : sheet.OrderedList
+                    .Select(row => row.SoulStoneTicker)
+                    .Select(GetSoulStone)
+                    .OrderBy(soulStone => soulStone.Hash.GetHashCode());
+    }
+}

--- a/Lib9c/Currencies.cs
+++ b/Lib9c/Currencies.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Linq;
-using Libplanet;
 using Libplanet.Assets;
 using Nekoyume.TableData;
 
@@ -10,10 +9,17 @@ namespace Lib9c
 {
     public static class Currencies
     {
-        public static readonly Currency NCG = Currency.Legacy(
-            "NCG",
-            2,
-            new Address("0x47D082a115c63E7b58B1532d20E631538eaFADde"));
+        // NOTE: The minters of the NCG are not same between main-net and other networks
+        //       containing local network. So this cannot be defined as a constant.
+        //       After the pluggable-lib9c applied, this will be defined and
+        //       used all of cases(e.g., main-net, unit tests, local network).
+        // NOTE: If there are forked networks and the NCG's minters should be
+        //       different, this should be changed and the migration solution
+        //       should be applied by the forked network.
+        // public static readonly Currency NCG = Currency.Legacy(
+        //     "NCG",
+        //     2,
+        //     new Address("0x47D082a115c63E7b58B1532d20E631538eaFADde"));
 
         public static readonly Currency Crystal = Currency.Legacy(
             "CRYSTAL",

--- a/Lib9c/Currencies.cs
+++ b/Lib9c/Currencies.cs
@@ -1,13 +1,12 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Libplanet;
 using Libplanet.Assets;
 using Nekoyume.TableData;
 
-namespace Nekoyume
+namespace Lib9c
 {
     public static class Currencies
     {

--- a/Lib9c/Helper/CrystalCalculator.cs
+++ b/Lib9c/Helper/CrystalCalculator.cs
@@ -17,7 +17,7 @@ namespace Nekoyume.Helper
     {
 #pragma warning disable CS0618
         // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
-        public static readonly Currency CRYSTAL = Currency.Legacy("CRYSTAL", 18, minters: null);
+        public static readonly Currency CRYSTAL = Currencies.Crystal;
 #pragma warning restore CS0618
 
         public static FungibleAssetValue CalculateRecipeUnlockCost(IEnumerable<int> recipeIds, EquipmentItemRecipeSheet equipmentItemRecipeSheet)

--- a/Lib9c/Helper/CrystalCalculator.cs
+++ b/Lib9c/Helper/CrystalCalculator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using Lib9c;
 using Libplanet;
 using Libplanet.Action;
 using Libplanet.Assets;

--- a/Lib9c/Helper/PetHelper.cs
+++ b/Lib9c/Helper/PetHelper.cs
@@ -12,7 +12,7 @@ namespace Nekoyume.Helper
     public static class PetHelper
     {
         public static Currency GetSoulstoneCurrency(string ticker) =>
-            Currency.Legacy(ticker, 0, minters: null);
+            Currencies.GetSoulStone(ticker);
 
         public static (int ncgQuantity, int soulStoneQuantity) CalculateEnhancementCost(
             PetCostSheet costSheet,

--- a/Lib9c/Helper/PetHelper.cs
+++ b/Lib9c/Helper/PetHelper.cs
@@ -1,11 +1,11 @@
 using System;
+using Lib9c;
 using Libplanet.Assets;
 using Nekoyume.Action;
 using Nekoyume.Model.Pet;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using Nekoyume.TableData.Pet;
-using Serilog;
 
 namespace Nekoyume.Helper
 {

--- a/Lib9c/Helper/RuneHelper.cs
+++ b/Lib9c/Helper/RuneHelper.cs
@@ -13,30 +13,19 @@ namespace Nekoyume.Helper
 {
     public static class RuneHelper
     {
-        public static readonly Currency StakeRune = Currency.Legacy("RUNE_GOLDENLEAF", 0, null);
-        public static readonly Currency DailyRewardRune = Currency.Legacy("RUNE_ADVENTURER", 0, null);
+        public static readonly Currency StakeRune = Currencies.StakeRune;
+        public static readonly Currency DailyRewardRune = Currencies.DailyRewardRune;
 
-        public static Currency ToCurrency(
-            RuneSheet.Row runeRow,
-            byte decimalPlaces,
-            IImmutableSet<Address>? minters
-        )
+        public static Currency ToCurrency(RuneSheet.Row runeRow)
         {
-
-#pragma warning disable CS0618
-            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
-            return Currency.Legacy(runeRow.Ticker, decimalPlaces, minters);
-#pragma warning restore CS0618
+            return Currencies.GetRune(runeRow.Ticker);
         }
 
         public static FungibleAssetValue ToFungibleAssetValue(
             RuneSheet.Row runeRow,
-            int quantity,
-            byte decimalPlaces = 0,
-            IImmutableSet<Address>? minters = null
-        )
+            int quantity)
         {
-            return ToCurrency(runeRow, decimalPlaces, minters) * quantity;
+            return Currencies.GetRune(runeRow.Ticker) * quantity;
         }
 
         public static List<FungibleAssetValue> CalculateReward(

--- a/Lib9c/Helper/RuneHelper.cs
+++ b/Lib9c/Helper/RuneHelper.cs
@@ -1,8 +1,7 @@
 #nullable enable
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
-using Libplanet;
+using Lib9c;
 using Libplanet.Action;
 using Libplanet.Assets;
 using Nekoyume.Action;


### PR DESCRIPTION
## Currencies

- The class `Currencies` summarizes all currencies like `Addresses`.
- Use `Currencies.Crystal` from `CrystalCalculator.CRYSTAL`.
- Use `Currencies.StakeRune` and `Currencies.DailyRewardRune` from `RuneHelper.StakeRune` and `RuneHelper.DailyRewardRune`.
- Use `Currencies.GetRune(ticker)` from `RuneHelper.ToCurrency(runeRow)` and `RuneHelper.ToFungibleAssetValue(runeRow, quantity)`.
- Use `Currencies.GetSoulStone(ticker)` from `PetHelper.GetSoulstoneCurrency(ticker)`.

## RuneHelper

- Remove the `decimalPlaces` and `minters` parameters as they are always `0` and `null`.
