### PR TITLE
Introduce `ClaimStakeReward4` action

### DIFF
--- a/.Lib9c.Tests/Action/ClaimStakeReward2Test.cs
+++ b/.Lib9c.Tests/Action/ClaimStakeReward2Test.cs
@@ -14,7 +14,7 @@ namespace Lib9c.Tests.Action
     using Xunit.Abstractions;
     using static Lib9c.SerializeKeys;
 
-    public class ClaimStakeRewardTest
+    public class ClaimStakeReward2Test
     {
         private readonly IAccountStateDelta _initialState;
         private readonly Currency _currency;
@@ -24,7 +24,7 @@ namespace Lib9c.Tests.Action
         private readonly Address _avatarAddress;
         private readonly Address _avatarAddressForBackwardCompatibility;
 
-        public ClaimStakeRewardTest(ITestOutputHelper outputHelper)
+        public ClaimStakeReward2Test(ITestOutputHelper outputHelper)
         {
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
@@ -102,8 +102,8 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Serialization()
         {
-            var action = new ClaimStakeReward(_avatarAddress);
-            var deserialized = new ClaimStakeReward();
+            var action = new ClaimStakeReward2(_avatarAddress);
+            var deserialized = new ClaimStakeReward2();
             deserialized.LoadPlainValue(action.PlainValue);
             Assert.Equal(action.AvatarAddress, deserialized.AvatarAddress);
         }
@@ -127,12 +127,12 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Execute_Throw_ActionObsoletedException()
         {
-            var action = new ClaimStakeReward(_avatarAddress);
+            var action = new ClaimStakeReward2(_avatarAddress);
             Assert.Throws<ActionObsoletedException>(() => action.Execute(new ActionContext
             {
                 PreviousStates = _initialState,
                 Signer = _signerAddress,
-                BlockIndex = ClaimStakeReward.ObsoletedIndex + 1,
+                BlockIndex = ClaimStakeReward2.ObsoletedIndex + 1,
             }));
         }
 
@@ -155,7 +155,7 @@ namespace Lib9c.Tests.Action
                 state = state.SetState(Addresses.GetSheetAddress<StakeRegularRewardSheet>(), sheet);
             }
 
-            var action = new ClaimStakeReward(avatarAddress);
+            var action = new ClaimStakeReward2(avatarAddress);
             var states = action.Execute(new ActionContext
             {
                 PreviousStates = state,

--- a/.Lib9c.Tests/Action/ClaimStakeReward3Test.cs
+++ b/.Lib9c.Tests/Action/ClaimStakeReward3Test.cs
@@ -107,8 +107,8 @@ namespace Lib9c.Tests.Action
         }
 
         [Theory]
-        [InlineData(ClaimStakeReward.ObsoletedIndex)]
-        [InlineData(ClaimStakeReward.ObsoletedIndex - 1)]
+        [InlineData(ClaimStakeReward2.ObsoletedIndex)]
+        [InlineData(ClaimStakeReward2.ObsoletedIndex - 1)]
         public void Execute_Throw_ActionUnAvailableException(long blockIndex)
         {
             var action = new ClaimStakeReward3(_avatarAddress);
@@ -121,10 +121,10 @@ namespace Lib9c.Tests.Action
         }
 
         [Theory]
-        [InlineData(ClaimStakeReward.ObsoletedIndex, 100, ClaimStakeReward.ObsoletedIndex + StakeState.LockupInterval, 40, 4, 0)]
-        [InlineData(ClaimStakeReward.ObsoletedIndex, 6000, ClaimStakeReward.ObsoletedIndex + StakeState.LockupInterval, 4800, 36, 4)]
+        [InlineData(ClaimStakeReward2.ObsoletedIndex, 100, ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval, 40, 4, 0)]
+        [InlineData(ClaimStakeReward2.ObsoletedIndex, 6000, ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval, 4800, 36, 4)]
         // Calculate rune start from hard fork index
-        [InlineData(0L, 6000, ClaimStakeReward.ObsoletedIndex + StakeState.LockupInterval, 136800, 1026, 4)]
+        [InlineData(0L, 6000, ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval, 136800, 1026, 4)]
         public void Execute_Success(
             long startedBlockIndex,
             int stakeAmount,
@@ -146,7 +146,7 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Execute_With_Old_AvatarState_Success()
         {
-            Execute(_avatarAddressForBackwardCompatibility, ClaimStakeReward.ObsoletedIndex, 100, ClaimStakeReward.ObsoletedIndex + StakeState.LockupInterval, 40, 4, 0);
+            Execute(_avatarAddressForBackwardCompatibility, ClaimStakeReward2.ObsoletedIndex, 100, ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval, 40, 4, 0);
         }
 
         private void Execute(Address avatarAddress, long startedBlockIndex, int stakeAmount, long blockIndex, int expectedHourglass, int expectedApStone, int expectedRune)

--- a/.Lib9c.Tests/Action/ClaimStakeReward4Test.cs
+++ b/.Lib9c.Tests/Action/ClaimStakeReward4Test.cs
@@ -1,0 +1,291 @@
+namespace Lib9c.Tests.Action
+{
+    using System.Linq;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Assets;
+    using Libplanet.Crypto;
+    using Nekoyume;
+    using Nekoyume.Action;
+    using Nekoyume.Helper;
+    using Nekoyume.Model.State;
+    using Nekoyume.TableData;
+    using Serilog;
+    using Xunit;
+    using Xunit.Abstractions;
+    using static Lib9c.SerializeKeys;
+
+    public class ClaimStakeReward4Test
+    {
+        private readonly IAccountStateDelta _initialState;
+        private readonly Currency _currency;
+        private readonly Address _signerAddress;
+        private readonly Address _avatarAddress;
+        private readonly Address _avatarAddressForBackwardCompatibility;
+        private readonly Address _stakeStateAddress;
+
+        public ClaimStakeReward4Test(ITestOutputHelper outputHelper)
+        {
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.TestOutput(outputHelper)
+                .CreateLogger();
+
+            _initialState = new State();
+
+            var sheets = TableSheetsImporter.ImportSheets();
+            foreach (var (key, value) in sheets)
+            {
+                _initialState = _initialState
+                    .SetState(Addresses.TableSheet.Derive(key), value.Serialize());
+            }
+
+            foreach (var (sheetName, sheetValue) in Addresses.TableSheetVersionControlDict)
+            {
+                if (sheets.TryGetValue(sheetName, out var sheet))
+                {
+                    foreach (var (version, blockIndex) in sheetValue)
+                    {
+                        _initialState = _initialState.SetState(
+                            Addresses.DeriveSheetAddress(sheetName, blockIndex), sheet.Serialize());
+                    }
+                }
+            }
+
+            var tableSheets = new TableSheets(sheets);
+
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
+            var goldCurrencyState = new GoldCurrencyState(_currency);
+
+            _signerAddress = new PrivateKey().ToAddress();
+            _stakeStateAddress = StakeState.DeriveAddress(_signerAddress);
+            var agentState = new AgentState(_signerAddress);
+            _avatarAddress = _signerAddress.Derive("0");
+            agentState.avatarAddresses.Add(0, _avatarAddress);
+            var avatarState = new AvatarState(
+                _avatarAddress,
+                _signerAddress,
+                0,
+                tableSheets.GetAvatarSheets(),
+                new GameConfigState(sheets[nameof(GameConfigSheet)]),
+                new PrivateKey().ToAddress()
+            )
+            {
+                level = 100,
+            };
+
+            _avatarAddressForBackwardCompatibility = _signerAddress.Derive("1");
+            agentState.avatarAddresses.Add(1, _avatarAddressForBackwardCompatibility);
+            var avatarStateForBackwardCompatibility = new AvatarState(
+                _avatarAddressForBackwardCompatibility,
+                _signerAddress,
+                0,
+                tableSheets.GetAvatarSheets(),
+                new GameConfigState(sheets[nameof(GameConfigSheet)]),
+                new PrivateKey().ToAddress()
+            )
+            {
+                level = 100,
+            };
+
+            _initialState = _initialState
+                .SetState(_signerAddress, agentState.Serialize())
+                .SetState(_avatarAddress, avatarState.SerializeV2())
+                .SetState(
+                    _avatarAddress.Derive(LegacyInventoryKey),
+                    avatarState.inventory.Serialize())
+                .SetState(
+                    _avatarAddress.Derive(LegacyWorldInformationKey),
+                    avatarState.worldInformation.Serialize())
+                .SetState(
+                    _avatarAddress.Derive(LegacyQuestListKey),
+                    avatarState.questList.Serialize())
+                .SetState(
+                    _avatarAddressForBackwardCompatibility,
+                    avatarStateForBackwardCompatibility.Serialize())
+                .SetState(GoldCurrencyState.Address, goldCurrencyState.Serialize());
+        }
+
+        [Fact]
+        public void Serialization()
+        {
+            var action = new ClaimStakeReward(_avatarAddress);
+            var deserialized = new ClaimStakeReward();
+            deserialized.LoadPlainValue(action.PlainValue);
+            Assert.Equal(action.AvatarAddress, deserialized.AvatarAddress);
+        }
+
+        [Theory]
+        [InlineData(ClaimStakeReward3.ObsoletedIndex)]
+        [InlineData(ClaimStakeReward3.ObsoletedIndex - 1)]
+        public void Execute_Throw_ActionUnAvailableException(long blockIndex)
+        {
+            var action = new ClaimStakeReward(_avatarAddress);
+            Assert.Throws<ActionUnavailableException>(() => action.Execute(new ActionContext
+            {
+                PreviousStates = _initialState,
+                Signer = _signerAddress,
+                BlockIndex = blockIndex,
+            }));
+        }
+
+        [Theory]
+        [InlineData(
+            ClaimStakeReward3.ObsoletedIndex,
+            100,
+            null,
+            ClaimStakeReward3.ObsoletedIndex + StakeState.LockupInterval,
+            40,
+            4,
+            0
+        )]
+        [InlineData(
+            ClaimStakeReward3.ObsoletedIndex,
+            6000,
+            null,
+            ClaimStakeReward3.ObsoletedIndex + StakeState.LockupInterval,
+            4800,
+            36,
+            4
+        )]
+        // Calculate rune start from hard fork index
+        [InlineData(
+            0L,
+            6000,
+            0L,
+            ClaimStakeReward3.ObsoletedIndex + StakeState.LockupInterval,
+            170400,
+            1278,
+            32
+        )]
+        // Stake reward v2
+        // Stake before v2, prev. receive v1, receive v1 & v2
+        [InlineData(
+            TableDataVersionConfig.StakeRewardSheetV2Index - StakeState.RewardInterval * 2,
+            50,
+            TableDataVersionConfig.StakeRewardSheetV2Index - StakeState.RewardInterval,
+            TableDataVersionConfig.StakeRewardSheetV2Index + 1,
+            5,
+            1,
+            0
+        )]
+        // Stake before v2, prev. receive v2, receive v2
+        [InlineData(
+            TableDataVersionConfig.StakeRewardSheetV2Index - StakeState.RewardInterval,
+            50,
+            TableDataVersionConfig.StakeRewardSheetV2Index,
+            TableDataVersionConfig.StakeRewardSheetV2Index + StakeState.RewardInterval,
+            5,
+            1,
+            0
+        )]
+        // Stake after v2, no prev. receive, receive v2
+        [InlineData(
+            TableDataVersionConfig.StakeRewardSheetV2Index,
+            6000,
+            null,
+            TableDataVersionConfig.StakeRewardSheetV2Index + StakeState.RewardInterval,
+            1200,
+            9,
+            1
+        )]
+        // stake after v2, prev. receive v2, receive v2
+        [InlineData(
+            TableDataVersionConfig.StakeRewardSheetV2Index,
+            50,
+            TableDataVersionConfig.StakeRewardSheetV2Index + StakeState.RewardInterval,
+            TableDataVersionConfig.StakeRewardSheetV2Index + StakeState.RewardInterval * 2,
+            5,
+            1,
+            0
+        )]
+        public void Execute_Success(
+            long startedBlockIndex,
+            int stakeAmount,
+            long? previousRewardReceiveIndex,
+            long blockIndex,
+            int expectedHourglass,
+            int expectedApStone,
+            int expectedRune)
+        {
+            Execute(
+                _avatarAddress,
+                startedBlockIndex,
+                stakeAmount,
+                previousRewardReceiveIndex,
+                blockIndex,
+                expectedHourglass,
+                expectedApStone,
+                expectedRune);
+        }
+
+        [Fact]
+        public void Execute_With_Old_AvatarState_Success()
+        {
+            Execute(
+                _avatarAddressForBackwardCompatibility,
+                ClaimStakeReward3.ObsoletedIndex,
+                100,
+                0L,
+                ClaimStakeReward3.ObsoletedIndex + StakeState.LockupInterval,
+                40,
+                4,
+                0
+            );
+        }
+
+        private void Execute(
+            Address avatarAddress,
+            long startedBlockIndex,
+            int stakeAmount,
+            long? previousRewardReceiveIndex,
+            long blockIndex,
+            int expectedHourglass,
+            int expectedApStone,
+            int expectedRune
+        )
+        {
+            var state = _initialState;
+            var initialStakeState = new StakeState(_stakeStateAddress, startedBlockIndex);
+            if (!(previousRewardReceiveIndex is null))
+            {
+                initialStakeState.Claim((long)previousRewardReceiveIndex);
+            }
+
+            state = state
+                .SetState(
+                    _stakeStateAddress,
+                    initialStakeState.Serialize()
+                ).MintAsset(_stakeStateAddress, _currency * stakeAmount);
+
+            var action = new ClaimStakeReward(avatarAddress);
+            var states = action.Execute(new ActionContext
+            {
+                PreviousStates = state,
+                Signer = _signerAddress,
+                BlockIndex = blockIndex,
+            });
+
+            AvatarState avatarState = states.GetAvatarStateV2(avatarAddress);
+            Assert.Equal(
+                expectedHourglass,
+                avatarState.inventory.Items.First(x => x.item.Id == 400000).count
+            );
+            // It must be never added into the inventory if the amount is 0.
+            Assert.Equal(
+                expectedApStone,
+                avatarState.inventory.Items.First(x => x.item.Id == 500000).count
+            );
+            Assert.Equal(
+                expectedRune * RuneHelper.StakeRune,
+                states.GetBalance(avatarAddress, RuneHelper.StakeRune)
+            );
+
+            Assert.True(states.TryGetStakeState(_signerAddress, out StakeState stakeState));
+            Assert.Equal(blockIndex, stakeState.ReceivedBlockIndex);
+        }
+    }
+}

--- a/.Lib9c.Tests/Action/Factory/ClaimStakeRewardFactoryTest.cs
+++ b/.Lib9c.Tests/Action/Factory/ClaimStakeRewardFactoryTest.cs
@@ -10,9 +10,9 @@ namespace Lib9c.Tests.Action.Factory
     public class ClaimStakeRewardFactoryTest
     {
         [Theory]
-        [InlineData(ClaimStakeReward.ObsoletedIndex - 1, typeof(ClaimStakeReward))]
-        [InlineData(ClaimStakeReward.ObsoletedIndex, typeof(ClaimStakeReward))]
-        [InlineData(ClaimStakeReward.ObsoletedIndex + 1, typeof(ClaimStakeReward3))]
+        [InlineData(ClaimStakeReward2.ObsoletedIndex - 1, typeof(ClaimStakeReward))]
+        [InlineData(ClaimStakeReward2.ObsoletedIndex, typeof(ClaimStakeReward))]
+        [InlineData(ClaimStakeReward2.ObsoletedIndex + 1, typeof(ClaimStakeReward3))]
         public void Create_ByBlockIndex_Success(
             long blockIndex,
             Type type)

--- a/.Lib9c.Tests/Action/PatchTableSheetTest.cs
+++ b/.Lib9c.Tests/Action/PatchTableSheetTest.cs
@@ -152,10 +152,10 @@ namespace Lib9c.Tests.Action
 
         [Theory]
         // Addresses.TableSheet.Derive("StakeRegularRewardSheet")
-        [InlineData(TableDataVersionConfig.StakeRegularRewardSheetV2Index - 1, "0x6Cae7459207B0551170b931Cb1D15E286E661646")]
+        [InlineData(TableDataVersionConfig.StakeRewardSheetV2Index - 1, "0x6Cae7459207B0551170b931Cb1D15E286E661646")]
         // Addresses.TableSheet.Derive("StakeRegularRewardSheet-V2")
-        [InlineData(TableDataVersionConfig.StakeRegularRewardSheetV2Index, "0x547c58B88C6B144E0ABc5406f5105ae57E13b10a")]
-        [InlineData(TableDataVersionConfig.StakeRegularRewardSheetV2Index + 1, "0x547c58B88C6B144E0ABc5406f5105ae57E13b10a")]
+        [InlineData(TableDataVersionConfig.StakeRewardSheetV2Index, "0x547c58B88C6B144E0ABc5406f5105ae57E13b10a")]
+        [InlineData(TableDataVersionConfig.StakeRewardSheetV2Index + 1, "0x547c58B88C6B144E0ABc5406f5105ae57E13b10a")]
         public void DeriveAddress(long blockIndex, string targetAddress)
         {
             const string tableName = "StakeRegularRewardSheet";

--- a/.Lib9c.Tests/Action/PatchTableSheetTest.cs
+++ b/.Lib9c.Tests/Action/PatchTableSheetTest.cs
@@ -149,5 +149,34 @@ namespace Lib9c.Tests.Action
 
             Assert.NotNull(nextState.GetSheet<CostumeStatSheet>());
         }
+
+        [Theory]
+        // Addresses.TableSheet.Derive("StakeRegularRewardSheet")
+        [InlineData(TableDataVersionConfig.StakeRegularRewardSheetV2Index - 1, "0x6Cae7459207B0551170b931Cb1D15E286E661646")]
+        // Addresses.TableSheet.Derive("StakeRegularRewardSheet-V2")
+        [InlineData(TableDataVersionConfig.StakeRegularRewardSheetV2Index, "0x547c58B88C6B144E0ABc5406f5105ae57E13b10a")]
+        [InlineData(TableDataVersionConfig.StakeRegularRewardSheetV2Index + 1, "0x547c58B88C6B144E0ABc5406f5105ae57E13b10a")]
+        public void DeriveAddress(long blockIndex, string targetAddress)
+        {
+            const string tableName = "StakeRegularRewardSheet";
+            var adminAddress = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
+            var adminState = new AdminState(adminAddress, 999_999_999_999L);
+            var initialStates = ImmutableDictionary<Address, IValue>.Empty
+                .Add(adminAddress, adminState.Serialize());
+            var state = new State(initialStates, ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty);
+            var action = new PatchTableSheet
+            {
+                TableName = tableName,
+                TableCsv = "level,required_gold,item-id,rate,type\n1,50,400000,10,Item",
+            };
+            var nextState = action.Execute(new ActionContext
+            {
+                PreviousStates = state,
+                Signer = adminAddress,
+                BlockIndex = blockIndex,
+            });
+            Assert.NotNull(nextState.GetState(new Address(targetAddress)));
+            Assert.NotNull(nextState.GetSheet<StakeRegularRewardSheet>(blockIndex));
+        }
     }
 }

--- a/.Lib9c.Tests/Action/Scenario/StakeAndClaimStakeReward2ScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/StakeAndClaimStakeReward2ScenarioTest.cs
@@ -16,7 +16,7 @@ namespace Lib9c.Tests.Action.Scenario
     using static Lib9c.SerializeKeys;
     using State = Lib9c.Tests.Action.State;
 
-    public class StakeAndClaimStakeRewardScenarioTest
+    public class StakeAndClaimStakeReward2ScenarioTest
     {
         private readonly IAccountStateDelta _initialState;
         private readonly Currency _currency;
@@ -25,7 +25,7 @@ namespace Lib9c.Tests.Action.Scenario
         private readonly Address _signerAddress;
         private readonly Address _avatarAddress;
 
-        public StakeAndClaimStakeRewardScenarioTest(ITestOutputHelper outputHelper)
+        public StakeAndClaimStakeReward2ScenarioTest(ITestOutputHelper outputHelper)
         {
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
@@ -643,7 +643,7 @@ namespace Lib9c.Tests.Action.Scenario
             Assert.True(states.TryGetStakeState(_signerAddress, out StakeState stakeState));
             Assert.NotNull(stakeState);
 
-            action = new ClaimStakeReward(_avatarAddress);
+            action = new ClaimStakeReward2(_avatarAddress);
             states = action.Execute(new ActionContext
             {
                 PreviousStates = states,
@@ -699,7 +699,7 @@ namespace Lib9c.Tests.Action.Scenario
                 _currency * stakeAmount,
                 states.GetBalance(stakeState.address, _currency));
 
-            action = new ClaimStakeReward(_avatarAddress);
+            action = new ClaimStakeReward2(_avatarAddress);
             states = action.Execute(new ActionContext
             {
                 PreviousStates = states,
@@ -772,7 +772,7 @@ namespace Lib9c.Tests.Action.Scenario
                 _currency * stakeAmount,
                 states.GetBalance(stakeState.address, _currency));
 
-            action = new ClaimStakeReward(_avatarAddress);
+            action = new ClaimStakeReward2(_avatarAddress);
             states = action.Execute(new ActionContext
             {
                 PreviousStates = states,
@@ -824,7 +824,7 @@ namespace Lib9c.Tests.Action.Scenario
             // 201,600 블록 도달 이후 → 지정된 캐릭터 앞으로 이하 보상의 수령이 가능해야 한다.
             foreach ((long claimBlockIndex, (int itemId, int amount)[] expectedItems) in claimEvents)
             {
-                action = new ClaimStakeReward(_avatarAddress);
+                action = new ClaimStakeReward2(_avatarAddress);
                 states = action.Execute(new ActionContext
                 {
                     PreviousStates = states,
@@ -876,7 +876,7 @@ namespace Lib9c.Tests.Action.Scenario
                 Assert.Throws<RequiredBlockIndexException>(() =>
                 {
                     // 현재 스테이킹된 NCG를 인출할 수 없다
-                    action = new ClaimStakeReward(_avatarAddress);
+                    action = new ClaimStakeReward2(_avatarAddress);
                     states = action.Execute(new ActionContext
                     {
                         PreviousStates = states,
@@ -911,7 +911,7 @@ namespace Lib9c.Tests.Action.Scenario
                 BlockIndex = 0,
             });
 
-            action = new ClaimStakeReward(_avatarAddress);
+            action = new ClaimStakeReward2(_avatarAddress);
             Assert.Throws<RequiredBlockIndexException>(() => states = action.Execute(new ActionContext
             {
                 PreviousStates = states,

--- a/.Lib9c.Tests/Action/Scenario/StakeAndClaimStakeReward3ScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/StakeAndClaimStakeReward3ScenarioTest.cs
@@ -97,7 +97,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 5),
                     (500000, 1),
                 },
-                ClaimStakeReward.ObsoletedIndex + 50400,
+                ClaimStakeReward2.ObsoletedIndex + 50400,
                 0,
             };
             yield return new object[]
@@ -108,7 +108,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 49),
                     (500000, 1),
                 },
-                ClaimStakeReward.ObsoletedIndex + 50400,
+                ClaimStakeReward2.ObsoletedIndex + 50400,
                 0,
             };
 
@@ -124,7 +124,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 62),
                     (500000, 2),
                 },
-                ClaimStakeReward.ObsoletedIndex + 50400,
+                ClaimStakeReward2.ObsoletedIndex + 50400,
                 0,
             };
             yield return new object[]
@@ -135,7 +135,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 99),
                     (500000, 2),
                 },
-                ClaimStakeReward.ObsoletedIndex + 50400,
+                ClaimStakeReward2.ObsoletedIndex + 50400,
                 0,
             };
             yield return new object[]
@@ -146,7 +146,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 624),
                     (500000, 8),
                 },
-                ClaimStakeReward.ObsoletedIndex + 50400,
+                ClaimStakeReward2.ObsoletedIndex + 50400,
                 0,
             };
 
@@ -162,7 +162,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 1000),
                     (500000, 8),
                 },
-                ClaimStakeReward.ObsoletedIndex + 50400,
+                ClaimStakeReward2.ObsoletedIndex + 50400,
                 0,
             };
             yield return new object[]
@@ -173,7 +173,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 9999),
                     (500000, 64),
                 },
-                ClaimStakeReward.ObsoletedIndex + 50400,
+                ClaimStakeReward2.ObsoletedIndex + 50400,
                 8,
             };
 
@@ -189,7 +189,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 10000),
                     (500000, 64),
                 },
-                ClaimStakeReward.ObsoletedIndex + 50400,
+                ClaimStakeReward2.ObsoletedIndex + 50400,
                 8,
             };
             yield return new object[]
@@ -200,7 +200,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 99999),
                     (500000, 626),
                 },
-                ClaimStakeReward.ObsoletedIndex + 50400,
+                ClaimStakeReward2.ObsoletedIndex + 50400,
                 83,
             };
 
@@ -216,7 +216,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 100000),
                     (500000, 627),
                 },
-                ClaimStakeReward.ObsoletedIndex + 50400,
+                ClaimStakeReward2.ObsoletedIndex + 50400,
                 83,
             };
             yield return new object[]
@@ -227,7 +227,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 19999999),
                     (500000, 125001),
                 },
-                ClaimStakeReward.ObsoletedIndex + 50400,
+                ClaimStakeReward2.ObsoletedIndex + 50400,
                 16666,
             };
 
@@ -246,7 +246,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 45),
                     (500000, 9),
                 },
-                ClaimStakeReward.ObsoletedIndex + 500800,
+                ClaimStakeReward2.ObsoletedIndex + 500800,
                 0,
             };
             yield return new object[]
@@ -257,7 +257,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 441),
                     (500000, 9),
                 },
-                ClaimStakeReward.ObsoletedIndex + 500800,
+                ClaimStakeReward2.ObsoletedIndex + 500800,
                 0,
             };
 
@@ -275,7 +275,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 558),
                     (500000, 18),
                 },
-                ClaimStakeReward.ObsoletedIndex + 500800,
+                ClaimStakeReward2.ObsoletedIndex + 500800,
                 0,
             };
             yield return new object[]
@@ -286,7 +286,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 891),
                     (500000, 18),
                 },
-                ClaimStakeReward.ObsoletedIndex + 500800,
+                ClaimStakeReward2.ObsoletedIndex + 500800,
                 0,
             };
             yield return new object[]
@@ -297,7 +297,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 5616),
                     (500000, 72),
                 },
-                ClaimStakeReward.ObsoletedIndex + 500800,
+                ClaimStakeReward2.ObsoletedIndex + 500800,
                 0,
             };
 
@@ -315,7 +315,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 9000),
                     (500000, 72),
                 },
-                ClaimStakeReward.ObsoletedIndex + 500800,
+                ClaimStakeReward2.ObsoletedIndex + 500800,
                 0,
             };
             yield return new object[]
@@ -326,7 +326,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 89991),
                     (500000, 576),
                 },
-                ClaimStakeReward.ObsoletedIndex + 500800,
+                ClaimStakeReward2.ObsoletedIndex + 500800,
                 72,
             };
 
@@ -344,7 +344,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 90000),
                     (500000, 576),
                 },
-                ClaimStakeReward.ObsoletedIndex + 500800,
+                ClaimStakeReward2.ObsoletedIndex + 500800,
                 72,
             };
             yield return new object[]
@@ -355,7 +355,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 899991),
                     (500000, 5634),
                 },
-                ClaimStakeReward.ObsoletedIndex + 500800,
+                ClaimStakeReward2.ObsoletedIndex + 500800,
                 747,
             };
 
@@ -377,7 +377,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 900000),
                     (500000, 5643),
                 },
-                ClaimStakeReward.ObsoletedIndex + 500800,
+                ClaimStakeReward2.ObsoletedIndex + 500800,
                 747,
             };
             yield return new object[]
@@ -388,7 +388,7 @@ namespace Lib9c.Tests.Action.Scenario
                     (400000, 8999991),
                     (500000, 56259),
                 },
-                ClaimStakeReward.ObsoletedIndex + 500800,
+                ClaimStakeReward2.ObsoletedIndex + 500800,
                 7497,
             };
         }
@@ -404,22 +404,22 @@ namespace Lib9c.Tests.Action.Scenario
                 const int hourglassItemId = 400000, apPotionItemId = 500000;
                 return new[]
                 {
-                    (ClaimStakeReward.ObsoletedIndex + StakeState.RewardInterval, new[]
+                    (ClaimStakeReward2.ObsoletedIndex + StakeState.RewardInterval, new[]
                     {
                         (hourglassItemId, (int)(stakeAmount / hourglassRate)),
                         (apPotionItemId, (int)(stakeAmount / apPotionRate + apPotionBonus)),
                     }),
-                    (ClaimStakeReward.ObsoletedIndex + StakeState.RewardInterval * 2, new[]
+                    (ClaimStakeReward2.ObsoletedIndex + StakeState.RewardInterval * 2, new[]
                     {
                         (hourglassItemId, (int)(stakeAmount / hourglassRate)),
                         (apPotionItemId, (int)(stakeAmount / apPotionRate + apPotionBonus)),
                     }),
-                    (ClaimStakeReward.ObsoletedIndex + StakeState.RewardInterval * 3, new[]
+                    (ClaimStakeReward2.ObsoletedIndex + StakeState.RewardInterval * 3, new[]
                     {
                         (hourglassItemId, (int)(stakeAmount / hourglassRate)),
                         (apPotionItemId, (int)(stakeAmount / apPotionRate + apPotionBonus)),
                     }),
-                    (ClaimStakeReward.ObsoletedIndex + StakeState.RewardInterval * 4, new[]
+                    (ClaimStakeReward2.ObsoletedIndex + StakeState.RewardInterval * 4, new[]
                     {
                         (hourglassItemId, (int)(stakeAmount / hourglassRate)),
                         (apPotionItemId, (int)(stakeAmount / apPotionRate + apPotionBonus)),
@@ -649,7 +649,7 @@ namespace Lib9c.Tests.Action.Scenario
             {
                 PreviousStates = states,
                 Signer = _signerAddress,
-                BlockIndex = ClaimStakeReward.ObsoletedIndex,
+                BlockIndex = ClaimStakeReward2.ObsoletedIndex,
             });
 
             Assert.True(states.TryGetStakeState(_signerAddress, out StakeState stakeState));
@@ -690,7 +690,7 @@ namespace Lib9c.Tests.Action.Scenario
         [InlineData(500000000, 500000, 500000000)]
         public void StakeAndStakeMore(long initialBalance, long stakeAmount, long newStakeAmount)
         {
-            long newStakeBlockIndex = ClaimStakeReward.ObsoletedIndex + StakeState.LockupInterval - 1;
+            long newStakeBlockIndex = ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval - 1;
             // Validate testcases
             Assert.True(stakeAmount < newStakeAmount);
 
@@ -701,7 +701,7 @@ namespace Lib9c.Tests.Action.Scenario
             {
                 PreviousStates = states,
                 Signer = _signerAddress,
-                BlockIndex = ClaimStakeReward.ObsoletedIndex,
+                BlockIndex = ClaimStakeReward2.ObsoletedIndex,
             });
 
             Assert.True(states.TryGetStakeState(_signerAddress, out StakeState stakeState));
@@ -774,7 +774,7 @@ namespace Lib9c.Tests.Action.Scenario
             {
                 PreviousStates = states,
                 Signer = _signerAddress,
-                BlockIndex = ClaimStakeReward.ObsoletedIndex,
+                BlockIndex = ClaimStakeReward2.ObsoletedIndex,
             });
 
             Assert.True(states.TryGetStakeState(_signerAddress, out StakeState stakeState));
@@ -791,7 +791,7 @@ namespace Lib9c.Tests.Action.Scenario
             {
                 PreviousStates = states,
                 Signer = _signerAddress,
-                BlockIndex = ClaimStakeReward.ObsoletedIndex + StakeState.LockupInterval - 1,
+                BlockIndex = ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval - 1,
             });
 
             action = new Stake(newStakeAmount);
@@ -800,7 +800,7 @@ namespace Lib9c.Tests.Action.Scenario
             {
                 PreviousStates = states,
                 Signer = _signerAddress,
-                BlockIndex = ClaimStakeReward.ObsoletedIndex + StakeState.LockupInterval - 1,
+                BlockIndex = ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval - 1,
             }));
 
             Assert.True(states.TryGetStakeState(_signerAddress, out stakeState));
@@ -831,7 +831,7 @@ namespace Lib9c.Tests.Action.Scenario
             {
                 PreviousStates = states,
                 Signer = _signerAddress,
-                BlockIndex = ClaimStakeReward.ObsoletedIndex,
+                BlockIndex = ClaimStakeReward2.ObsoletedIndex,
             });
 
             // 1~3회까지 모든 보상을 수령함
@@ -865,7 +865,7 @@ namespace Lib9c.Tests.Action.Scenario
             {
                 PreviousStates = states,
                 Signer = _signerAddress,
-                BlockIndex = ClaimStakeReward.ObsoletedIndex + StakeState.LockupInterval,
+                BlockIndex = ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval,
             });
 
             // Setup staking again.
@@ -874,10 +874,10 @@ namespace Lib9c.Tests.Action.Scenario
                 Assert.True(states.TryGetStakeState(_signerAddress, out stakeState));
                 Assert.NotNull(stakeState);
                 // 쌓여있던 보상 타이머가 정상적으로 리셋되는지
-                Assert.Equal(ClaimStakeReward.ObsoletedIndex + StakeState.LockupInterval, stakeState.StartedBlockIndex);
+                Assert.Equal(ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval, stakeState.StartedBlockIndex);
                 // 락업기간이 새롭게 201,600으로 갱신되는지 확인
                 Assert.Equal(
-                    ClaimStakeReward.ObsoletedIndex + StakeState.LockupInterval + StakeState.LockupInterval,
+                    ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval + StakeState.LockupInterval,
                     stakeState.CancellableBlockIndex);
                 // 기존 deposit - 현재 deposit 만큼의 ncg 인출 상태 확인
                 Assert.Equal(
@@ -895,7 +895,7 @@ namespace Lib9c.Tests.Action.Scenario
                     {
                         PreviousStates = states,
                         Signer = _signerAddress,
-                        BlockIndex = ClaimStakeReward.ObsoletedIndex + StakeState.LockupInterval + 1,
+                        BlockIndex = ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval + 1,
                     });
                 });
                 // 현재 deposit 묶인 상태 확인
@@ -922,7 +922,7 @@ namespace Lib9c.Tests.Action.Scenario
             {
                 PreviousStates = states,
                 Signer = _signerAddress,
-                BlockIndex = ClaimStakeReward.ObsoletedIndex,
+                BlockIndex = ClaimStakeReward2.ObsoletedIndex,
             });
 
             action = new ClaimStakeReward3(_avatarAddress);
@@ -930,7 +930,7 @@ namespace Lib9c.Tests.Action.Scenario
             {
                 PreviousStates = states,
                 Signer = _signerAddress,
-                BlockIndex = ClaimStakeReward.ObsoletedIndex + StakeState.RewardInterval - 1,
+                BlockIndex = ClaimStakeReward2.ObsoletedIndex + StakeState.RewardInterval - 1,
             }));
 
             var avatarState = states.GetAvatarStateV2(_avatarAddress);

--- a/.Lib9c.Tests/Model/State/StakeStateTest.cs
+++ b/.Lib9c.Tests/Model/State/StakeStateTest.cs
@@ -58,8 +58,8 @@ namespace Lib9c.Tests.Model.State
 
         [Theory]
         [InlineData(1L, 1L, -110)]
-        [InlineData(1L, ClaimStakeReward.ObsoletedIndex, 0)]
-        [InlineData(1L, ClaimStakeReward.ObsoletedIndex + StakeState.RewardInterval, 1)]
+        [InlineData(1L, ClaimStakeReward2.ObsoletedIndex, 0)]
+        [InlineData(1L, ClaimStakeReward2.ObsoletedIndex + StakeState.RewardInterval, 1)]
         public void CalculateAccumulateRuneRewards(
             long startedBlockIndex,
             long blockIndex,

--- a/Lib9c.DevExtensions/Action/CreateOrReplaceAvatar.cs
+++ b/Lib9c.DevExtensions/Action/CreateOrReplaceAvatar.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Bencodex.Types;
@@ -458,7 +457,7 @@ namespace Lib9c.DevExtensions.Action
 
             // Set Inventory.
             var inventoryAddr = avatarAddr.Derive(LegacyInventoryKey);
-            var inventory = new Inventory();
+            var inventory = new Nekoyume.Model.Item.Inventory();
             var equipmentItemSheet = sheets.GetSheet<EquipmentItemSheet>();
             var enhancementCostSheetV2 = sheets.GetSheet<EnhancementCostSheetV2>();
             var recipeSheet = sheets.GetSheet<EquipmentItemRecipeSheet>();

--- a/Lib9c/Action/AccountStateViewExtensions.cs
+++ b/Lib9c/Action/AccountStateViewExtensions.cs
@@ -474,13 +474,13 @@ namespace Nekoyume.Action
             }
         }
 
-        public static T GetSheet<T>(this IAccountStateView states) where T : ISheet, new()
+        public static T GetSheet<T>(this IAccountStateView states, long? blockIndex = 0L) where T : ISheet, new()
         {
-            var address = Addresses.GetSheetAddress<T>();
+            var address = Addresses.GetSheetAddress<T>(blockIndex);
 
             try
             {
-                var csv = GetSheetCsv<T>(states);
+                var csv = GetSheetCsv<T>(states, blockIndex);
                 byte[] hash;
                 using (var sha256 = SHA256.Create())
                 {
@@ -710,9 +710,9 @@ namespace Nekoyume.Action
             return result;
         }
 
-        public static string GetSheetCsv<T>(this IAccountStateView states) where T : ISheet, new()
+        public static string GetSheetCsv<T>(this IAccountStateView states, long? blockIndex = 0L) where T : ISheet, new()
         {
-            var address = Addresses.GetSheetAddress<T>();
+            var address = Addresses.GetSheetAddress<T>(blockIndex);
             var value = states.GetState(address);
             if (value is null)
             {

--- a/Lib9c/Action/AccountStateViewExtensions.cs
+++ b/Lib9c/Action/AccountStateViewExtensions.cs
@@ -505,11 +505,11 @@ namespace Nekoyume.Action
             }
         }
 
-        public static bool TryGetSheet<T>(this IAccountStateView states, out T sheet) where T : ISheet, new()
+        public static bool TryGetSheet<T>(this IAccountStateView states, out T sheet, long? blockIndex = 0L) where T : ISheet, new()
         {
             try
             {
-                sheet = states.GetSheet<T>();
+                sheet = states.GetSheet<T>(blockIndex);
                 return true;
             }
             catch (Exception)

--- a/Lib9c/Action/ClaimStakeReward.cs
+++ b/Lib9c/Action/ClaimStakeReward.cs
@@ -1,0 +1,223 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Runtime;
+using Bencodex.Types;
+using Lib9c.Abstractions;
+using Libplanet;
+using Libplanet.Action;
+using Libplanet.Assets;
+using Nekoyume.Extensions;
+using Nekoyume.Helper;
+using Nekoyume.Model.Item;
+using Nekoyume.Model.State;
+using Nekoyume.TableData;
+using Org.BouncyCastle.Tls.Crypto;
+using static Lib9c.SerializeKeys;
+
+namespace Nekoyume.Action
+{
+    // Update hard fork PR URL after creating PR
+    /// <summary>
+    /// Hard forked at
+    /// </summary>
+    [ActionType(ActionTypeText)]
+    public class ClaimStakeReward : GameAction, IClaimStakeReward, IClaimStakeRewardV1
+    {
+        private const string ActionTypeText = "claim_stake_reward4";
+
+        internal Address AvatarAddress { get; private set; }
+
+        Address IClaimStakeRewardV1.AvatarAddress => AvatarAddress;
+
+        public ClaimStakeReward(Address avatarAddress)
+        {
+            AvatarAddress = avatarAddress;
+        }
+
+        public ClaimStakeReward()
+        {
+        }
+
+        private IAccountStateDelta ProcessReward(IActionContext context, IAccountStateDelta states,
+            ref AvatarState avatarState,
+            ItemSheet itemSheet, FungibleAssetValue stakedAmount,
+            int rewardStep, int runeRewardStep,
+            List<StakeRegularFixedRewardSheet.RewardInfo> fixedReward,
+            List<StakeRegularRewardSheet.RewardInfo> regularReward)
+        {
+            var currency = stakedAmount.Currency;
+
+            // Regular Reward
+            foreach (var reward in regularReward)
+            {
+                switch (reward.Type)
+                {
+                    case StakeRegularRewardSheet.StakeRewardType.Item:
+                        var (quantity, _) = stakedAmount.DivRem(currency * reward.Rate);
+                        if (quantity < 1)
+                        {
+                            // If the quantity is zero, it doesn't add the item into inventory.
+                            continue;
+                        }
+
+                        ItemSheet.Row row = itemSheet[reward.ItemId];
+                        ItemBase item = row is MaterialItemSheet.Row materialRow
+                            ? ItemFactory.CreateTradableMaterial(materialRow)
+                            : ItemFactory.CreateItem(row, context.Random);
+                        avatarState.inventory.AddItem(item, (int)quantity * rewardStep);
+                        break;
+                    case StakeRegularRewardSheet.StakeRewardType.Rune:
+                        var runeReward = runeRewardStep *
+                                         RuneHelper.CalculateStakeReward(stakedAmount, reward.Rate);
+                        if (runeReward < 1 * RuneHelper.StakeRune)
+                        {
+                            continue;
+                        }
+
+                        states = states.MintAsset(AvatarAddress, runeReward);
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            // Fixed Reward
+            foreach (var reward in fixedReward)
+            {
+                ItemSheet.Row row = itemSheet[reward.ItemId];
+                ItemBase item = row is MaterialItemSheet.Row materialRow
+                    ? ItemFactory.CreateTradableMaterial(materialRow)
+                    : ItemFactory.CreateItem(row, context.Random);
+                avatarState.inventory.AddItem(item, reward.Count * rewardStep);
+            }
+
+            return states;
+        }
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            if (context.Rehearsal)
+            {
+                return context.PreviousStates;
+            }
+
+            var states = context.PreviousStates;
+            CheckActionAvailable(ClaimStakeReward3.ObsoletedIndex, context);
+            // TODO: Uncomment this when new version of action is created
+            // CheckObsolete(ObsoletedIndex, context);
+
+            // Check condition
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
+            if (!states.TryGetStakeState(context.Signer, out StakeState stakeState))
+            {
+                throw new FailedLoadStateException(
+                    ActionTypeText,
+                    addressesHex,
+                    typeof(StakeState),
+                    StakeState.DeriveAddress(context.Signer));
+            }
+
+            if (!stakeState.IsClaimable(context.BlockIndex, out int v1Step, out int v2Step))
+            {
+                throw new RequiredBlockIndexException(
+                    ActionTypeText,
+                    addressesHex,
+                    context.BlockIndex);
+            }
+
+            // Get data
+            if (!states.TryGetAvatarStateV2(
+                    context.Signer,
+                    AvatarAddress,
+                    out var avatarState,
+                    out var migrationRequired))
+            {
+                throw new FailedLoadStateException(
+                    ActionTypeText,
+                    addressesHex,
+                    typeof(AvatarState),
+                    AvatarAddress);
+            }
+
+            var sheets = states.GetSheets(sheetTypes: new[]
+            {
+                typeof(ConsumableItemSheet),
+                typeof(CostumeItemSheet),
+                typeof(EquipmentItemSheet),
+                typeof(MaterialItemSheet),
+            });
+
+            var currency = states.GetGoldCurrency();
+            var stakedAmount = states.GetBalance(stakeState.address, currency);
+            var stakeRegularRewardSheet =
+                states.GetSheet<StakeRegularRewardSheet>(context.BlockIndex);
+            // var stakeRegularRewardSheet = sheets.GetSheet<StakeRegularRewardSheet>();
+            int level =
+                stakeRegularRewardSheet.FindLevelByStakedAmount(context.Signer, stakedAmount);
+            ItemSheet itemSheet = sheets.GetItemSheet();
+            var accumulatedRewards =
+                stakeState.CalculateAccumulatedRewards(context.BlockIndex, out v1Step,
+                    out v2Step);
+            var accumulatedRuneRewards =
+                stakeState.CalculateAccumulatedRuneRewards(context.BlockIndex, out int runeV1Step,
+                    out int runeV2Step);
+
+            if (v1Step > 0)
+            {
+                var fixedReward =
+                    states.TryGetSheet<StakeRegularFixedRewardSheet>(out var fixedRewardSheet, context.BlockIndex)
+                        ? fixedRewardSheet[level].Rewards
+                        : new List<StakeRegularFixedRewardSheet.RewardInfo>();
+                var regularRewardSheet = states.GetSheet<StakeRegularRewardSheet>();
+                var regularReward = regularRewardSheet[level].Rewards;
+                states = ProcessReward(context, states, ref avatarState, itemSheet,
+                    stakedAmount, v1Step, runeV1Step, fixedReward, regularReward);
+            }
+
+            if (v2Step > 0)
+            {
+                var fixedReward =
+                    states.TryGetSheet<StakeRegularFixedRewardSheet>(
+                        out var fixedRewardSheet, context.BlockIndex
+                    )
+                        ? fixedRewardSheet[level].Rewards
+                        : new List<StakeRegularFixedRewardSheet.RewardInfo>();
+                var regularRewardSheet =
+                    states.GetSheet<StakeRegularRewardSheet>(context.BlockIndex);
+                var regularReward = regularRewardSheet[level].Rewards;
+                states = ProcessReward(context, states, ref avatarState, itemSheet,
+                    stakedAmount, v2Step, runeV2Step, fixedReward, regularReward);
+            }
+
+            stakeState.Claim(context.BlockIndex);
+
+            if (migrationRequired)
+            {
+                states = states
+                    .SetState(avatarState.address, avatarState.SerializeV2())
+                    .SetState(
+                        avatarState.address.Derive(LegacyWorldInformationKey),
+                        avatarState.worldInformation.Serialize())
+                    .SetState(
+                        avatarState.address.Derive(LegacyQuestListKey),
+                        avatarState.questList.Serialize());
+            }
+
+            return states
+                .SetState(stakeState.address, stakeState.Serialize())
+                .SetState(
+                    avatarState.address.Derive(LegacyInventoryKey),
+                    avatarState.inventory.Serialize());
+        }
+
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            ImmutableDictionary<string, IValue>.Empty
+                .Add(AvatarAddressKey, AvatarAddress.Serialize());
+
+        protected override void LoadPlainValueInternal(
+            IImmutableDictionary<string, IValue> plainValue)
+        {
+            AvatarAddress = plainValue[AvatarAddressKey].ToAddress();
+        }
+    }
+}

--- a/Lib9c/Action/ClaimStakeReward2.cs
+++ b/Lib9c/Action/ClaimStakeReward2.cs
@@ -15,7 +15,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1371
     /// </summary>
     [ActionType(ActionTypeText)]
-    public class ClaimStakeReward : GameAction, IClaimStakeReward, IClaimStakeRewardV1
+    public class ClaimStakeReward2 : GameAction, IClaimStakeReward, IClaimStakeRewardV1
     {
         public const long ObsoletedIndex = 5_549_200L;
         private const string ActionTypeText = "claim_stake_reward2";
@@ -24,12 +24,12 @@ namespace Nekoyume.Action
 
         Address IClaimStakeRewardV1.AvatarAddress => AvatarAddress;
 
-        public ClaimStakeReward(Address avatarAddress)
+        public ClaimStakeReward2(Address avatarAddress)
         {
             AvatarAddress = avatarAddress;
         }
 
-        public ClaimStakeReward()
+        public ClaimStakeReward2()
         {
         }
 

--- a/Lib9c/Action/ClaimStakeReward3.cs
+++ b/Lib9c/Action/ClaimStakeReward3.cs
@@ -18,6 +18,8 @@ namespace Nekoyume.Action
     [ActionType(ActionTypeText)]
     public class ClaimStakeReward3 : GameAction, IClaimStakeReward, IClaimStakeRewardV1
     {
+        // FIXME: Change this value when target block height is determined
+        public const long ObsoletedIndex = 7_000_000L;
         private const string ActionTypeText = "claim_stake_reward3";
 
         internal Address AvatarAddress { get; private set; }
@@ -42,6 +44,7 @@ namespace Nekoyume.Action
 
             var states = context.PreviousStates;
             CheckActionAvailable(ClaimStakeReward2.ObsoletedIndex, context);
+            CheckObsolete(ObsoletedIndex, context);
             var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
             if (!states.TryGetStakeState(context.Signer, out StakeState stakeState))
             {

--- a/Lib9c/Action/ClaimStakeReward3.cs
+++ b/Lib9c/Action/ClaimStakeReward3.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Immutable;
 using Bencodex.Types;
 using Lib9c.Abstractions;
@@ -14,7 +13,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     /// <summary>
-    /// Hard forked at https://github.com/planetarium/lib9c/pull/1371
+    /// Hard forked at https://github.com/planetarium/lib9c/pull/1458
     /// </summary>
     [ActionType(ActionTypeText)]
     public class ClaimStakeReward3 : GameAction, IClaimStakeReward, IClaimStakeRewardV1

--- a/Lib9c/Action/ClaimStakeReward3.cs
+++ b/Lib9c/Action/ClaimStakeReward3.cs
@@ -42,7 +42,7 @@ namespace Nekoyume.Action
             }
 
             var states = context.PreviousStates;
-            CheckActionAvailable(ClaimStakeReward.ObsoletedIndex, context);
+            CheckActionAvailable(ClaimStakeReward2.ObsoletedIndex, context);
             var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
             if (!states.TryGetStakeState(context.Signer, out StakeState stakeState))
             {

--- a/Lib9c/Action/Factory/ClaimStakeRewardFactory.cs
+++ b/Lib9c/Action/Factory/ClaimStakeRewardFactory.cs
@@ -11,7 +11,7 @@ namespace Nekoyume.Action.Factory
             long blockIndex,
             Address avatarAddress)
         {
-            if (blockIndex > ClaimStakeReward.ObsoletedIndex)
+            if (blockIndex > ClaimStakeReward2.ObsoletedIndex)
             {
                 return new ClaimStakeReward3(avatarAddress);
             }

--- a/Lib9c/Action/PatchTableSheet.cs
+++ b/Lib9c/Action/PatchTableSheet.cs
@@ -38,7 +38,7 @@ namespace Nekoyume.Action
         {
             IActionContext ctx = context;
             var states = ctx.PreviousStates;
-            var sheetAddress = Addresses.TableSheet.Derive(TableName);
+            var sheetAddress = Addresses.GetSheetAddress(TableName, ctx.BlockIndex);
             if (ctx.Rehearsal)
             {
                 return states

--- a/Lib9c/Addresses.cs
+++ b/Lib9c/Addresses.cs
@@ -42,10 +42,19 @@ namespace Nekoyume
                 new Dictionary<string, ImmutableSortedDictionary<int, long>>
                 {
                     {
-                        "StakeRegularRewardSheet", new Dictionary<int, long>
+                        "StakeRegularFixedRewardSheet",
+                        new Dictionary<int, long>
                         {
-                            // {1, 0},
-                            { 2, TableDataVersionConfig.StakeRegularRewardSheetV2Index },
+                            // {1, 0L},
+                            {2, TableDataVersionConfig.StakeRewardSheetV2Index},
+                        }.ToImmutableSortedDictionary()
+                    },
+                    {
+                        "StakeRegularRewardSheet",
+                        new Dictionary<int, long>
+                        {
+                            // {1, 0L},
+                            { 2, TableDataVersionConfig.StakeRewardSheetV2Index },
                         }.ToImmutableSortedDictionary()
                     },
                 }.ToImmutableDictionary();

--- a/Lib9c/Addresses.cs
+++ b/Lib9c/Addresses.cs
@@ -37,7 +37,7 @@ namespace Nekoyume
         public static readonly Address Rune                  = new Address("0000000000000000000000000000000000000016");
         public static readonly Address Market                = new Address("0000000000000000000000000000000000000017");
 
-        private static readonly ImmutableDictionary<string, ImmutableSortedDictionary<int, long>>
+        public static readonly ImmutableDictionary<string, ImmutableSortedDictionary<int, long>>
             TableSheetVersionControlDict =
                 new Dictionary<string, ImmutableSortedDictionary<int, long>>
                 {
@@ -59,7 +59,7 @@ namespace Nekoyume
                     },
                 }.ToImmutableDictionary();
 
-        private static Address DeriveSheetAddress(string sheetName, long? blockIndex = 0L)
+        public static Address DeriveSheetAddress(string sheetName, long? blockIndex = 0L)
         {
             var derivedAddress = TableSheet.Derive(sheetName);
             if (TableSheetVersionControlDict.ContainsKey(sheetName))

--- a/Lib9c/Model/State/StakeState.cs
+++ b/Lib9c/Model/State/StakeState.cs
@@ -4,9 +4,8 @@ using System.Globalization;
 using System.Linq;
 using Bencodex.Types;
 using Libplanet;
-using Libplanet.Action;
 using Nekoyume.Action;
-
+using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Model.State

--- a/Lib9c/Model/State/StakeState.cs
+++ b/Lib9c/Model/State/StakeState.cs
@@ -99,20 +99,27 @@ namespace Nekoyume.Model.State
         }
 
         public override IValue Serialize() =>
-            new Dictionary(SerializeImpl().Union((Dictionary) base.Serialize()));
+            new Dictionary(SerializeImpl().Union((Dictionary)base.Serialize()));
 
         public override IValue SerializeV2() =>
-            new Dictionary(SerializeImpl().Union((Dictionary) base.SerializeV2()));
+            new Dictionary(SerializeImpl().Union((Dictionary)base.SerializeV2()));
 
         public bool IsCancellable(long blockIndex) => blockIndex >= CancellableBlockIndex;
 
         public bool IsClaimable(long blockIndex)
         {
+            return IsClaimable(blockIndex, out _, out _);
+        }
+
+        public bool IsClaimable(long blockIndex, out int v1Step, out int v2Step)
+        {
             if (blockIndex >= ActionObsoleteConfig.V100290ObsoleteIndex)
             {
-                return CalculateAccumulatedRewards(blockIndex) > 0;
+                return CalculateAccumulatedRewards(blockIndex, out v1Step, out v2Step) > 0;
             }
 
+            v1Step = 0;
+            v2Step = 0;
             if (ReceivedBlockIndex == 0)
             {
                 return StartedBlockIndex + RewardInterval <= blockIndex;
@@ -128,33 +135,58 @@ namespace Nekoyume.Model.State
 
         public int CalculateAccumulatedRewards(long blockIndex)
         {
-            return CalculateStep(blockIndex, StartedBlockIndex);
+            return CalculateAccumulatedRewards(blockIndex, out _, out _);
+        }
+
+        public int CalculateAccumulatedRewards(long blockIndex, out int v1Step, out int v2Step)
+        {
+            return CalculateStep(blockIndex, StartedBlockIndex, out v1Step, out v2Step);
         }
 
         public int CalculateAccumulatedRuneRewards(long blockIndex)
         {
-            long startedBlockIndex = Math.Max(StartedBlockIndex, ClaimStakeReward.ObsoletedIndex);
-            return CalculateStep(blockIndex, startedBlockIndex);
+            return CalculateAccumulatedRuneRewards(blockIndex, out _, out _);
         }
 
-        private int CalculateStep(long blockIndex, long startedBlockIndex)
+        public int CalculateAccumulatedRuneRewards(long blockIndex, out int v1Step, out int v2Step)
         {
-            int step = (int)Math.DivRem(
+            long startedBlockIndex = Math.Max(StartedBlockIndex, ClaimStakeReward2.ObsoletedIndex);
+            return CalculateStep(blockIndex, startedBlockIndex, out v1Step, out v2Step);
+        }
+
+        private int CalculateStep(long blockIndex, long startedBlockIndex, out int v1Step,
+            out int v2Step)
+        {
+            int totalStep = (int)Math.DivRem(
                 blockIndex - startedBlockIndex,
                 RewardInterval,
                 out _
             );
+
+            int previousStep = 0;
             if (ReceivedBlockIndex > 0)
             {
-                int previousStep = (int)Math.DivRem(
+                previousStep = (int)Math.DivRem(
                     ReceivedBlockIndex - startedBlockIndex,
                     RewardInterval,
                     out _
                 );
-                step -= previousStep;
             }
 
-            return step;
+            v1Step = totalStep - previousStep;
+            v2Step = 0;
+
+            if (blockIndex >= TableDataVersionConfig.StakeRewardSheetV2Index)
+            {
+                v1Step = Math.Max((int)Math.DivRem(
+                    TableDataVersionConfig.StakeRewardSheetV2Index - Math.Max(ReceivedBlockIndex, startedBlockIndex),
+                    RewardInterval,
+                    out _
+                ), 0);
+                v2Step = totalStep - previousStep - v1Step;
+            }
+
+            return v1Step + v2Step;
         }
 
         public static Address DeriveAddress(Address agentAddress) => agentAddress.Derive("stake");

--- a/Lib9c/Model/State/StakeState.cs
+++ b/Lib9c/Model/State/StakeState.cs
@@ -24,14 +24,14 @@ namespace Nekoyume.Model.State
             public StakeAchievements(Dictionary serialized)
             {
                 _achievements = serialized.ToDictionary(
-                    pair => int.Parse(((Text) pair.Key).Value, CultureInfo.InvariantCulture),
-                    pair => (int) (Integer) pair.Value);
+                    pair => int.Parse(((Text)pair.Key).Value, CultureInfo.InvariantCulture),
+                    pair => (int)(Integer)pair.Value);
             }
 
             public IValue Serialize() =>
                 new Dictionary(_achievements.ToDictionary(
-                    pair => (IKey)(Text) pair.Key.ToString(CultureInfo.InvariantCulture),
-                    pair => (IValue)(Integer) pair.Value));
+                    pair => (IKey)(Text)pair.Key.ToString(CultureInfo.InvariantCulture),
+                    pair => (IValue)(Integer)pair.Value));
 
             public bool Check(int level, int step)
             {

--- a/Lib9c/TableData/TableDataVersionConfig.cs
+++ b/Lib9c/TableData/TableDataVersionConfig.cs
@@ -1,0 +1,9 @@
+namespace Nekoyume.TableData
+{
+    public static class TableDataVersionConfig
+    {
+        // PatchTableSheet version update without changing model version
+        // FIXME: Set block index to real block index to change reward version
+        public const long StakeRegularRewardSheetV2Index = 7_000_000L;
+    }
+}

--- a/Lib9c/TableData/TableDataVersionConfig.cs
+++ b/Lib9c/TableData/TableDataVersionConfig.cs
@@ -4,6 +4,6 @@ namespace Nekoyume.TableData
     {
         // PatchTableSheet version update without changing model version
         // FIXME: Set block index to real block index to change reward version
-        public const long StakeRegularRewardSheetV2Index = 7_000_000L;
+        public const long StakeRewardSheetV2Index = 7_000_000L;
     }
 }


### PR DESCRIPTION
## This is action hard fork
### :warning: Hard fork block index should be determined

### Breaking changes
- `Addresses` has TableData version control data as Dictionary.
    - Sheet name and block index finalizes target TableData version.
    - All sheet retrieving logic should pass current block index to get latest version of sheet
- Calculates stake reward change with keeping past unclaimed reward
    - Calculate reward steps before/after update as `v1Step`, `v2Step`.
    - Use same `ProcessReward` action to give rewards.