### PR TITLE
Calculate UpdatedAddresses on Lib9c side

### DIFF
--- a/.Lib9c.Tests/Action/ActionBaseExtensionsTest.cs
+++ b/.Lib9c.Tests/Action/ActionBaseExtensionsTest.cs
@@ -1,0 +1,33 @@
+namespace Lib9c.Tests.Action
+{
+    using System.Collections.Immutable;
+    using Libplanet;
+    using Libplanet.Action;
+    using Nekoyume.Action;
+    using Xunit;
+
+    public class ActionBaseExtensionsTest
+    {
+        [Fact]
+        public void CalculateUpdateAddresses()
+        {
+            var actions = new PolymorphicAction<ActionBase>[]
+            {
+                new TransferAsset(
+                    sender: default,
+                    recipient: default,
+                    amount: Currencies.DailyRewardRune * 1
+                ),
+            };
+
+            IImmutableSet<Address> actual = actions.CalculateUpdateAddresses();
+            Assert.Equal(
+                new Address[]
+                {
+                    default,
+                },
+                actual
+            );
+        }
+    }
+}

--- a/Lib9c/Action/ActionBaseExtensions.cs
+++ b/Lib9c/Action/ActionBaseExtensions.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Security.Cryptography;
+using Bencodex.Types;
+using Libplanet;
+using Libplanet.Action;
+using Libplanet.Assets;
+using Libplanet.Blocks;
+using Libplanet.Tx;
+
+namespace Nekoyume.Action
+{
+    public static class ActionBaseExtensions
+    {
+        public static IImmutableSet<Address> CalculateUpdateAddresses(
+            this IEnumerable<PolymorphicAction<ActionBase>> actions
+        ) => CalculateUpdateAddresses(actions.Select(pa => pa.InnerAction));
+
+        public static IImmutableSet<Address> CalculateUpdateAddresses(this IEnumerable<ActionBase> actions)
+        {
+            IImmutableSet<Address> addresses = ImmutableHashSet<Address>.Empty;
+            IActionContext rehearsalContext = new RehearsalActionContext();
+
+            foreach (ActionBase action in actions)
+            {
+                IAccountStateDelta nextStates = action.Execute(rehearsalContext);
+                addresses = addresses.Union(nextStates.UpdatedAddresses);
+            }
+
+            return addresses;
+        }
+
+        private class RehearsalActionContext : IActionContext
+        {
+            public BlockHash? GenesisHash => default;
+
+            public Address Signer => default;
+
+            public TxId? TxId => default;
+
+            public Address Miner => default;
+
+            public long BlockIndex => default;
+
+            public bool Rehearsal => true;
+
+            public IAccountStateDelta PreviousStates => new AddressTraceStateDelta();
+
+            public IRandom Random => default;
+
+            public HashDigest<SHA256>? PreviousStateRootHash => default;
+
+            public bool BlockAction => default;
+
+            public IActionContext GetUnconsumedContext() => null;
+
+            public bool IsNativeToken(Currency currency) => false;
+
+            public void PutLog(string log)
+            {
+                // Method intentionally left empty.
+            }
+        }
+
+        private class AddressTraceStateDelta : IAccountStateDelta
+        {
+            private ImmutableHashSet<Address> _updatedAddresses;
+
+            public AddressTraceStateDelta()
+                : this(ImmutableHashSet<Address>.Empty)
+            {
+            }
+
+            public AddressTraceStateDelta(ImmutableHashSet<Address> updatedAddresses)
+            {
+                _updatedAddresses = updatedAddresses;
+            }
+
+            public IImmutableSet<Address> UpdatedAddresses => _updatedAddresses;
+
+            public IImmutableSet<Address> StateUpdatedAddresses => _updatedAddresses;
+
+            public IImmutableDictionary<Address, IImmutableSet<Currency>> UpdatedFungibleAssets
+                => ImmutableDictionary<Address, IImmutableSet<Currency>>.Empty;
+
+            public IImmutableSet<Currency> TotalSupplyUpdatedCurrencies
+                => ImmutableHashSet<Currency>.Empty;
+
+            public IAccountStateDelta BurnAsset(Address owner, FungibleAssetValue value)
+            {
+                return new AddressTraceStateDelta(_updatedAddresses.Union(new [] { owner }));
+            }
+
+            public FungibleAssetValue GetBalance(Address address, Currency currency)
+            {
+                throw new NotSupportedException();
+            }
+
+            public IValue GetState(Address address)
+            {
+                throw new NotSupportedException();
+            }
+
+            public IReadOnlyList<IValue> GetStates(IReadOnlyList<Address> addresses)
+            {
+                throw new NotSupportedException();
+            }
+
+            public FungibleAssetValue GetTotalSupply(Currency currency)
+            {
+                throw new NotSupportedException();
+            }
+
+            public IAccountStateDelta MintAsset(Address recipient, FungibleAssetValue value)
+            {
+                return new AddressTraceStateDelta(_updatedAddresses.Union(new[] { recipient }));
+            }
+
+            public IAccountStateDelta SetState(Address address, IValue state)
+            {
+                return new AddressTraceStateDelta(_updatedAddresses.Union(new[] { address }));
+            }
+
+            public IAccountStateDelta TransferAsset(
+                Address sender,
+                Address recipient,
+                FungibleAssetValue value,
+                bool allowNegativeBalance = false
+            )
+            {
+                return new AddressTraceStateDelta(
+                    _updatedAddresses.Union(new[] { sender, recipient })
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Summary

This PR adds `.CalculateUpdatedAddresses()` to `IEnumerable<PolymorphicAction<ActionBase>>` and `IEnumerable<ActionBase>` to get updated addresses handy.

# Background

## `Transaction<T>.UpdatedAddresses` is no longer auto-calculated.

- This feature isn't necessary for Libplanet 1.0.* yet, because [it will be calculated on `Transaction<T>.Create()`](https://github.com/planetarium/libplanet/blob/1.0.0/Libplanet/Tx/Transaction.cs#L431-L432). 
- But also, Libplanet has planned to remove auto calculation since it isn't realistic to compute all through previous states to make a transaction, and complicates the implementation. 
- see also: 
  - https://github.com/planetarium/libplanet/issues/368
  - https://github.com/planetarium/libplanet/pull/3122
 
## Then, why do we still need it?

- However even now, 'UpdatedAddresses' are automatically written in transactions on 9c mainnet. 
  - This is possible because most of the actions so far are writing compatible code assuming the simple state base based on the `IActionContext.Rehearsal`.
  - E.g., https://github.com/planetarium/lib9c/blob/6912e58ceb7cc29d3ac9ef9fa4b5667af0158192/Lib9c/Action/TransferAsset.cs#L92-L98
- Sadly, related systems in 9c mainnet already seems to be relying `Transaction<T>.UpdatedAddresses`.
  - E.g., https://github.com/planetarium/9cscan-cloud/blob/0760e14f4ed07997d96784fcbc3841cd6790083f/project/sync/src/sync.js#L34-L40
- Thus, even if Libplanet decides to make the block layout compatible, the related system compatibility may be broken against empty `UpdatedAddresses`.
- As one of Libplanet devs, I really want to (re)organize tx/action evaluation flow without the auto-filling assumption of updated addresses. 
- but also as one of 9c devs, I don't want to face an ironic situation like, updating Libplanet (having "good design") kills related services in the ecosystem.

# Plan (9c side only)

- [ ] Add methods to calculate `.UpdatedAddresses` leveraging existing `Rehearsal` related codes to Lib9c (this PR)
- [ ] Add `updatedAddresses` argument explicitly for `Transaction<T>.Create()` when creating transactions (NineChronicles / NineChronicles.Headless).
- [ ] (Optional) Provide a migration path from relying on `Transaction<T>.UpdatedAddresses` to using `ActionEvaluation.UpdatedAddresses` for systems involving 9c mainnet.