### PR TITLE
Apply bonus damage on skill based on stat

### DIFF
--- a/Lib9c/Model/Buff/BuffFactory.cs
+++ b/Lib9c/Model/Buff/BuffFactory.cs
@@ -50,7 +50,8 @@ namespace Nekoyume.Model.Buff
             ActionBuffSheet actionBuffSheet)
         {
             var buffs = new List<Buff>();
-            var extraValueBuff = skill is BuffSkill && skill.Power > 0;
+            var extraValueBuff = skill is BuffSkill &&
+                (skill.Power > 0 || skill.SkillRow.ReferencedStatType != StatType.NONE);
 
             if (skillBuffSheet.TryGetValue(skill.SkillRow.Id, out var skillStatBuffRow))
             {
@@ -63,20 +64,15 @@ namespace Nekoyume.Model.Buff
                     if (!customField.HasValue &&
                         extraValueBuff)
                     {
-                        int additionalPower;
+                        var additionalPower = skill.Power;
                         // If ReferencedStatType exists,
-                        // buff value = original value + (referenced stat * (Skill.Power / 10000))
-                        if (buffRow.ReferencedStatType != StatType.NONE)
+                        // buff value = original value + (referenced stat * (SkillRow.StatPowerRatio / 10000))
+                        if (skill.SkillRow.ReferencedStatType != StatType.NONE)
                         {
                             var statMap = stats.StatWithItems;
-                            var multiplier = skill.Power / 10000m;
+                            var multiplier = skill.SkillRow.StatPowerRatio / 10000m;
                             additionalPower = (int)Math.Round(
-                                statMap.GetStat(buffRow.ReferencedStatType) * multiplier);
-                        }
-                        // Else, buff value = original value + Skill.Power
-                        else
-                        {
-                            additionalPower = skill.Power;
+                                statMap.GetStat(skill.SkillRow.ReferencedStatType) * multiplier);
                         }
                         
                         customField = new SkillCustomField()

--- a/Lib9c/Model/Character/ArenaCharacter.cs
+++ b/Lib9c/Model/Character/ArenaCharacter.cs
@@ -30,7 +30,6 @@ namespace Nekoyume.Model
         private readonly SkillActionBuffSheet _skillActionBuffSheet;
         private readonly ActionBuffSheet _actionBuffSheet;
         private readonly IArenaSimulator _simulator;
-        private readonly CharacterStats _stats;
         private readonly ArenaSkills _skills;
 
         public readonly ArenaSkills _runeSkills = new ArenaSkills();
@@ -43,6 +42,7 @@ namespace Nekoyume.Model
 
         public Guid Id { get; } = Guid.NewGuid();
         public BattleStatus.Arena.ArenaSkill SkillLog { get; private set; }
+        public CharacterStats Stats { get; }
         public ElementalType OffensiveElementalType { get; }
         public ElementalType DefenseElementalType { get; }
         public SizeType SizeType { get; }
@@ -61,22 +61,22 @@ namespace Nekoyume.Model
 
         public int Level
         {
-            get => _stats.Level;
-            set => _stats.SetStats(value);
+            get => Stats.Level;
+            set => Stats.SetStats(value);
         }
 
-        public int HP => _stats.HP;
-        public int AdditionalHP => _stats.BuffStats.HP;
-        public int ATK => _stats.ATK;
-        public int DEF => _stats.DEF;
-        public int CRI => _stats.CRI;
-        public int HIT => _stats.HIT;
-        public int SPD => _stats.SPD;
-        public int DRV => _stats.DRV;
-        public int DRR => _stats.DRR;
-        public int CDMG => _stats.CDMG;
-        public int ArmorPenetration => _stats.ArmorPenetration;
-        public int Thorn => _stats.Thorn;
+        public int HP => Stats.HP;
+        public int AdditionalHP => Stats.BuffStats.HP;
+        public int ATK => Stats.ATK;
+        public int DEF => Stats.DEF;
+        public int CRI => Stats.CRI;
+        public int HIT => Stats.HIT;
+        public int SPD => Stats.SPD;
+        public int DRV => Stats.DRV;
+        public int DRR => Stats.DRR;
+        public int CDMG => Stats.CDMG;
+        public int ArmorPenetration => Stats.ArmorPenetration;
+        public int Thorn => Stats.Thorn;
 
         public bool IsDead => CurrentHP <= 0;
         public Dictionary<int, Buff.Buff> Buffs { get; } = new Dictionary<int, Buff.Buff>();
@@ -107,7 +107,7 @@ namespace Nekoyume.Model
             _actionBuffSheet = sheets.ActionBuffSheet;
 
             _simulator = simulator;
-            _stats = GetStat(
+            Stats = GetStat(
                 digest,
                 row,
                 sheets.EquipmentItemSetEffectSheet,
@@ -139,7 +139,7 @@ namespace Nekoyume.Model
             _actionBuffSheet = sheets.ActionBuffSheet;
 
             _simulator = simulator;
-            _stats = GetStat(
+            Stats = GetStat(
                 digest,
                 row,
                 sheets.EquipmentItemSetEffectSheet,
@@ -168,7 +168,7 @@ namespace Nekoyume.Model
             _actionBuffSheet = value._actionBuffSheet;
 
             _simulator = value._simulator;
-            _stats = new CharacterStats(value._stats);
+            Stats = new CharacterStats(value.Stats);
             _skills = value._skills;
             Buffs = new Dictionary<int, Buff.Buff>();
 #pragma warning disable LAA1002
@@ -212,7 +212,7 @@ namespace Nekoyume.Model
 
         protected void ResetCurrentHP()
         {
-            CurrentHP = Math.Max(0, _stats.HP);
+            CurrentHP = Math.Max(0, Stats.HP);
         }
 
         private static CharacterStats GetStat(
@@ -272,8 +272,8 @@ namespace Nekoyume.Model
                             x.stat.StatType,
                             x.operationType,
                             x.stat.TotalValueAsInt)));
-                _stats.AddOptional(statModifiers);
-                _stats.IncreaseHpForArena();
+                Stats.AddOptional(statModifiers);
+                Stats.IncreaseHpForArena();
                 ResetCurrentHP();
 
                 if (optionInfo.SkillId == default ||
@@ -333,8 +333,8 @@ namespace Nekoyume.Model
                             x.stat.StatType,
                             x.operationType,
                             x.stat.TotalValueAsInt)));
-                _stats.AddOptional(statModifiers);
-                _stats.IncreaseHpForArena();
+                Stats.AddOptional(statModifiers);
+                Stats.IncreaseHpForArena();
                 ResetCurrentHP();
 
                 if (optionInfo.SkillId == default ||
@@ -566,7 +566,7 @@ namespace Nekoyume.Model
                 _target,
                 _simulator.Turn,
                 BuffFactory.GetBuffs(
-                    _stats,
+                    Stats,
                     selectedSkill,
                     _skillBuffSheet,
                     _statBuffSheet,
@@ -602,7 +602,7 @@ namespace Nekoyume.Model
                 _target,
                 _simulator.Turn,
                 BuffFactory.GetBuffs(
-                    _stats,
+                    Stats,
                     selectedSkill,
                     _skillBuffSheet,
                     _statBuffSheet,
@@ -637,8 +637,8 @@ namespace Nekoyume.Model
             if (!isBuffRemoved)
                 return;
 
-            _stats.SetBuffs(StatBuffs);
-            _stats.IncreaseHpForArena();
+            Stats.SetBuffs(StatBuffs);
+            Stats.IncreaseHpForArena();
         }
 
         [Obsolete("Use RemoveBuffs")]
@@ -660,7 +660,7 @@ namespace Nekoyume.Model
 
             if (isApply)
             {
-                _stats.SetBuffs(StatBuffs);
+                Stats.SetBuffs(StatBuffs);
             }
         }
 
@@ -700,8 +700,8 @@ namespace Nekoyume.Model
             {
                 var clone = (StatBuff)stat.Clone();
                 Buffs[stat.RowData.GroupId] = clone;
-                _stats.AddBuff(clone, updateImmediate);
-                _stats.IncreaseHpForArena();
+                Stats.AddBuff(clone, updateImmediate);
+                Stats.IncreaseHpForArena();
             }
             else if (buff is ActionBuff action)
             {
@@ -719,7 +719,7 @@ namespace Nekoyume.Model
 
             var clone = (Buff.StatBuff) buff.Clone();
             Buffs[buff.BuffInfo.GroupId] = clone;
-            _stats.AddBuff(clone, updateImmediate);
+            Stats.AddBuff(clone, updateImmediate);
         }
 
         public void RemoveRecentStatBuff()
@@ -752,9 +752,9 @@ namespace Nekoyume.Model
 
             if (removedBuff != null)
             {
-                _stats.RemoveBuff(removedBuff);
+                Stats.RemoveBuff(removedBuff);
                 Buffs.Remove(removedBuff.RowData.GroupId);
-                _stats.IncreaseHpForArena();
+                Stats.IncreaseHpForArena();
             }
         }
 

--- a/Lib9c/Model/Skill/Arena/ArenaAttackSkill.cs
+++ b/Lib9c/Model/Skill/Arena/ArenaAttackSkill.cs
@@ -38,7 +38,7 @@ namespace Nekoyume.Model.Skill.Arena
 
                 if (target.IsHit(caster))
                 {
-                    damage = caster.ATK + Power + statAdditionalPower;                   
+                    damage = caster.ATK + Power + statAdditionalPower;
                     damage = (int) (damage * multiplier);
                     damage = caster.GetDamage(damage, isNormalAttack);
                     damage = elementalType.GetDamage(target.DefenseElementalType, damage);

--- a/Lib9c/Model/Skill/Arena/ArenaAttackSkill.cs
+++ b/Lib9c/Model/Skill/Arena/ArenaAttackSkill.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Nekoyume.Battle;
 using Nekoyume.Model.Elemental;
+using Nekoyume.Model.Stat;
 using Nekoyume.TableData;
 
 namespace Nekoyume.Model.Skill.Arena
@@ -22,6 +23,11 @@ namespace Nekoyume.Model.Skill.Arena
         {
             var infos = new List<BattleStatus.Arena.ArenaSkill.ArenaSkillInfo>();
 
+            // Apply stat power ratio
+            var powerMultiplier = SkillRow.StatPowerRatio / 10000m;
+            var statAdditionalPower = SkillRow.ReferencedStatType != StatType.NONE ?
+                 (int)(caster.Stats.GetStat(SkillRow.ReferencedStatType) * powerMultiplier) : default;
+
             var multipliers = GetMultiplier(SkillRow.HitCount, 1m);
             var elementalType = isNormalAttack ? caster.OffensiveElementalType : SkillRow.ElementalType;
             for (var i = 0; i < SkillRow.HitCount; i++)
@@ -32,7 +38,7 @@ namespace Nekoyume.Model.Skill.Arena
 
                 if (target.IsHit(caster))
                 {
-                    damage = caster.ATK + Power;
+                    damage = caster.ATK + Power + statAdditionalPower;                   
                     damage = (int) (damage * multiplier);
                     damage = caster.GetDamage(damage, isNormalAttack);
                     damage = elementalType.GetDamage(target.DefenseElementalType, damage);

--- a/Lib9c/Model/Skill/Arena/ArenaHealSkill.cs
+++ b/Lib9c/Model/Skill/Arena/ArenaHealSkill.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Nekoyume.Model.Stat;
 using Nekoyume.TableData;
 
 namespace Nekoyume.Model.Skill.Arena
@@ -44,7 +45,13 @@ namespace Nekoyume.Model.Skill.Arena
             int turn)
         {
             var infos = new List<BattleStatus.Arena.ArenaSkill.ArenaSkillInfo>();
-            var healPoint = caster.ATK + Power;
+
+            // Apply stat power ratio
+            var powerMultiplier = SkillRow.StatPowerRatio / 10000m;
+            var statAdditionalPower = SkillRow.ReferencedStatType != StatType.NONE ?
+                (int)(caster.Stats.GetStat(SkillRow.ReferencedStatType) * powerMultiplier) : default;
+
+            var healPoint = caster.ATK + Power + statAdditionalPower;
             caster.Heal(healPoint);
 
             infos.Add(new BattleStatus.Arena.ArenaSkill.ArenaSkillInfo(

--- a/Lib9c/Model/Skill/AttackSkill.cs
+++ b/Lib9c/Model/Skill/AttackSkill.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Nekoyume.Battle;
 using Nekoyume.Model.Elemental;
+using Nekoyume.Model.Stat;
 using Nekoyume.TableData;
 
 namespace Nekoyume.Model.Skill
@@ -28,7 +29,13 @@ namespace Nekoyume.Model.Skill
             var infos = new List<BattleStatus.Skill.SkillInfo>();
             var targets = SkillRow.SkillTargetType.GetTarget(caster).ToList();
             var elementalType = SkillRow.ElementalType;
-            var totalDamage = caster.ATK + Power;
+
+            // Apply stat power ratio
+            var powerMultiplier = SkillRow.StatPowerRatio / 10000m;
+            var statAdditionalPower = SkillRow.ReferencedStatType != StatType.NONE ?
+                (int)(caster.Stats.GetStat(SkillRow.ReferencedStatType) * powerMultiplier) : default;
+
+            var totalDamage = caster.ATK + Power + statAdditionalPower;
             var multipliers = GetMultiplier(SkillRow.HitCount, 1m);
             for (var i = 0; i < SkillRow.HitCount; i++)
             {

--- a/Lib9c/Model/Skill/HealSkill.cs
+++ b/Lib9c/Model/Skill/HealSkill.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Nekoyume.Model.Stat;
 using Nekoyume.TableData;
 
 namespace Nekoyume.Model.Skill
@@ -26,7 +27,13 @@ namespace Nekoyume.Model.Skill
         protected IEnumerable<BattleStatus.Skill.SkillInfo> ProcessHeal(CharacterBase caster, int simulatorWaveTurn)
         {
             var infos = new List<BattleStatus.Skill.SkillInfo>();
-            var healPoint = caster.ATK + Power;
+
+            // Apply stat power ratio
+            var powerMultiplier = SkillRow.StatPowerRatio / 10000m;
+            var statAdditionalPower = SkillRow.ReferencedStatType != StatType.NONE ?
+                (int)(caster.Stats.GetStat(SkillRow.ReferencedStatType) * powerMultiplier) : default;
+
+            var healPoint = caster.ATK + Power + statAdditionalPower;
             foreach (var target in SkillRow.SkillTargetType.GetTarget(caster))
             {
                 target.Heal(healPoint);

--- a/Lib9c/TableCSV/Skill/SkillSheet.csv
+++ b/Lib9c/TableCSV/Skill/SkillSheet.csv
@@ -1,135 +1,135 @@
-id,_name,elemental_type,skill_type,skill_category,skill_target_type,hit_count,cooldown
-100000,기본 공격,Normal,Attack,NormalAttack,Enemy,1,0
-100001,일격,Normal,Attack,BlowAttack,Enemy,1,1
-_100002,일격(전체),Normal,Attack,BlowAttack,Enemies,1,1 // 노멀 속성의 전체 일격은 추가하면 안 됩니다.
-100003,연사,Normal,Attack,DoubleAttack,Enemy,2,1
-100005,광역 난사,Normal,Attack,AreaAttack,Enemies,5,1
-110000,불 공격,Fire,Attack,NormalAttack,Enemy,1,1
-110001,불꽃 일격,Fire,Attack,BlowAttack,Enemy,1,5
-110002,불꽃 일격(전체),Fire,Attack,BlowAttack,Enemies,1,13
-110003,불꽃 연사,Fire,Attack,DoubleAttack,Enemy,2,3
-110004,불꽃 연사(전체),Fire,Attack,DoubleAttack,Enemy,2,13
-110005,용암 해일,Fire,Attack,AreaAttack,Enemies,5,13
-120000,물 공격,Water,Attack,NormalAttack,Enemy,1,1
-120001,얼음 일격,Water,Attack,BlowAttack,Enemy,1,5
-120002,얼음 일격(전체),Water,Attack,BlowAttack,Enemies,1,13
-120003,얼음 연사,Water,Attack,DoubleAttack,Enemy,2,3
-120004,얼음 연사(전체),Water,Attack,DoubleAttack,Enemy,2,13
-120005,얼음 해일,Water,Attack,AreaAttack,Enemies,5,13
-130000,땅 공격,Land,Attack,NormalAttack,Enemy,1,1
-130001,모래 일격,Land,Attack,BlowAttack,Enemy,1,5
-130002,모래 일격(전체),Land,Attack,BlowAttack,Enemies,1,13
-130003,모래 연사,Land,Attack,DoubleAttack,Enemy,2,3
-130004,모래 연사(전체),Land,Attack,DoubleAttack,Enemy,2,13
-130005,모래 폭풍,Land,Attack,AreaAttack,Enemies,5,13
-140000,바람 공격,Wind,Attack,NormalAttack,Enemy,1,1
-140001,바람 일격,Wind,Attack,BlowAttack,Enemy,1,5
-140002,바람 일격(전체),Wind,Attack,BlowAttack,Enemies,1,13
-140003,바람 연사,Wind,Attack,DoubleAttack,Enemy,2,3
-140004,바람 연사(전체),Wind,Attack,DoubleAttack,Enemy,2,13
-140005,거대 태풍,Wind,Attack,AreaAttack,Enemies,5,13
-200000,체력 증가,Normal,Buff,HPBuff,Self,1,10
-_200001,체력 증가(전체),Normal,Buff,HPBuff,Ally,1,1 // 미구현
-210000,공격 강화,Normal,Buff,AttackBuff,Self,1,25
-_210001,공격 강화(전체),Normal,Buff,AttackBuff,Ally,1,1 // 미구현
-210002,공격 약화,Normal,Debuff,AttackBuff,Enemy,1,10
-210003,공격 약화(전체),Normal,Debuff,AttackBuff,Enemies,1,10
-210004,공격 강화,Normal,Buff,AttackBuff,Self,1,10
-220000,방어 강화,Normal,Buff,DefenseBuff,Self,1,25
-_220001,방어 강화(전체),Normal,Buff,DefenseBuff,Ally,1,1 // 미구현
-220002,방어 약화,Normal,Debuff,DefenseBuff,Enemy,1,10
-220003,방어 약화(전체),Normal,Debuff,DefenseBuff,Enemies,1,10
-220004,방어 강화,Normal,Buff,DefenseBuff,Self,1,10
-230000,치명 증가,Normal,Buff,CriticalBuff,Self,1,25
-_230001,치명 증가(전체),Normal,Buff,CriticalBuff,Ally,1,1 // 미구현
-230002,치명 감소,Normal,Debuff,CriticalBuff,Enemy,1,10
-230003,치명 감소(전체),Normal,Debuff,CriticalBuff,Enemies,1,10
-230004,치명 증가,Normal,Buff,CriticalBuff,Self,1,10
-240000,명중 증가,Normal,Buff,HitBuff,Self,1,25
-_240001,명중 증가(전체),Normal,Buff,HitBuff,Ally,1,1 // 미구현
-240002,명중 감소,Normal,Debuff,HitBuff,Enemy,1,10
-240003,명중 감소(전체),Normal,Debuff,HitBuff,Enemies,1,10
-240004,명중 증가,Normal,Buff,HitBuff,Self,1,10
-250000,속도 증가,Normal,Buff,SpeedBuff,Self,1,25
-_250001,속도 증가(전체),Normal,Buff,SpeedBuff,Ally,1,1 // 미구현
-250002,속도 감소,Normal,Debuff,SpeedBuff,Enemy,1,10
-250003,속도 감소(전체),Normal,Debuff,SpeedBuff,Enemies,1,10
-250004,속도 증가,Normal,Buff,SpeedBuff,Self,1,10
-300000,힐,Normal,Heal,Heal,Self,1,10
-_300001,힐(전체),Normal,Heal,Heal,Ally,1,1 // 미구현
-400000,SS 올스텟,Normal,Buff,Buff,Self,1,999
-400001,SS 공격 치명,Normal,Buff,AttackBuff,Self,1,999
-400002,SS 방어 치명,Normal,Buff,DefenseBuff,Self,1,999
-400003,SS 속도 치명,Normal,Buff,SpeedBuff,Self,1,999
-400004,SS 명중 치명,Normal,Buff,HitBuff,Self,1,999
-400005,S 올스텟,Normal,Buff,Buff,Self,1,999
-400006,S 공격 치명,Normal,Buff,AttackBuff,Self,1,999
-400007,S 방어 치명,Normal,Buff,DefenseBuff,Self,1,999
-400008,S 속도 치명,Normal,Buff,SpeedBuff,Self,1,999
-400009,S 명중 치명,Normal,Buff,HitBuff,Self,1,999
-400010,S 공격 방어 치명,Normal,Buff,AttackBuff,Self,1,999
-400011,S 공격 속도 치명,Normal,Buff,AttackBuff,Self,1,999
-400012,S 공격 명중 치명,Normal,Buff,AttackBuff,Self,1,999
-400013,S 방어 속도 치명,Normal,Buff,DefenseBuff,Self,1,999
-400014,S 방어 명중 치명,Normal,Buff,DefenseBuff,Self,1,999
-400015,A 올스텟,Normal,Buff,Buff,Self,1,999
-400016,A 공격,Normal,Buff,AttackBuff,Self,1,999
-400017,A 방어,Normal,Buff,DefenseBuff,Self,1,999
-400018,A 속도,Normal,Buff,SpeedBuff,Self,1,999
-400019,A 명중,Normal,Buff,HitBuff,Self,1,999
-400020,A 공격 방어,Normal,Buff,AttackBuff,Self,1,999
-400021,A 공격 명중,Normal,Buff,AttackBuff,Self,1,999
-400022,A 공격 속도,Normal,Buff,AttackBuff,Self,1,999
-400023,A 방어 명중,Normal,Buff,DefenseBuff,Self,1,999
-400024,A 방어 속도,Normal,Buff,DefenseBuff,Self,1,999
-400025,A 명중 속도,Normal,Buff,HitBuff,Self,1,999
-400026,A 공격 방어 명중,Normal,Buff,AttackBuff,Self,1,999
-400027,A 공격 방어 속도,Normal,Buff,AttackBuff,Self,1,999
-400028,A 공격 명중 속도,Normal,Buff,AttackBuff,Self,1,999
-400029,A 방어 명중 속도,Normal,Buff,DefenseBuff,Self,1,999
-400030,B 올스텟,Normal,Buff,Buff,Self,1,999
-400031,B 공격,Normal,Buff,AttackBuff,Self,1,999
-400032,B 방어,Normal,Buff,DefenseBuff,Self,1,999
-400033,B 속도,Normal,Buff,SpeedBuff,Self,1,999
-400034,B 명중,Normal,Buff,HitBuff,Self,1,999
-400035,B 치명,Normal,Buff,CriticalBuff,Self,1,999
-400036,B 공격 방어,Normal,Buff,AttackBuff,Self,1,999
-400037,B 공격 명중,Normal,Buff,AttackBuff,Self,1,999
-400038,B 공격 속도,Normal,Buff,AttackBuff,Self,1,999
-400039,B 공격 치명,Normal,Buff,AttackBuff,Self,1,999
-400040,B 방어 명중,Normal,Buff,DefenseBuff,Self,1,999
-400041,B 방어 속도,Normal,Buff,DefenseBuff,Self,1,999
-400042,B 방어 치명,Normal,Buff,DefenseBuff,Self,1,999
-400043,B 명중 속도,Normal,Buff,HitBuff,Self,1,999
-400044,B 명중 치명,Normal,Buff,HitBuff,Self,1,999
-400045,B 속도 치명,Normal,Buff,SpeedBuff,Self,1,999
-400046,B 공격 방어 명중,Normal,Buff,AttackBuff,Self,1,999
-400047,B 공격 방어 속도,Normal,Buff,AttackBuff,Self,1,999
-400048,B 공격 방어 치명,Normal,Buff,AttackBuff,Self,1,999
-400049,B 공격 명중 속도,Normal,Buff,AttackBuff,Self,1,999
-400050,B 공격 명중 치명,Normal,Buff,AttackBuff,Self,1,999
-400051,B 공격 속도 치명,Normal,Buff,AttackBuff,Self,1,999
-400052,B 방어 명중 속도,Normal,Buff,DefenseBuff,Self,1,999
-400053,B 방어명중 치명,Normal,Buff,DefenseBuff,Self,1,999
-400054,B 방어 속도 치명,Normal,Buff,DefenseBuff,Self,1,999
-400055,B 명중 속도 치명,Normal,Buff,SpeedBuff,Self,1,999
-500001,분노,Normal,Attack,BlowAttack,Enemy,1,0
-500002,물어뜯기,Normal,Attack,BuffRemovalAttack,Enemy,1,0
-500003,할퀴기,Normal,Attack,BlowAttack,Enemy,1,0
-500004,할퀴기 Wave 4,Normal,Attack,BlowAttack,Enemy,1,0
-500005,할퀴기 Wave 5,Normal,Attack,BlowAttack,Enemy,1,0
-500011,분노,Normal,Attack,BlowAttack,Enemy,1,0
-500012,부식,Normal,Attack,BlowAttack,Enemy,1,0
-500013,연타,Normal,Attack,BlowAttack,Enemy,5,0
-500014,진노,Normal,Buff,CriticalBuff,Self,1,0
-500015,진노 Wave 4,Normal,Buff,CriticalBuff,Self,1,0
-500016,진노 Wave 5,Normal,Buff,CriticalBuff,Self,1,0
-510001,광폭화 Wave 1,Normal,Buff,Buff,Self,1,0
-510002,광폭화 Wave 2,Normal,Buff,Buff,Self,1,0
-510003,광폭화 Wave 3,Normal,Buff,Buff,Self,1,0
-510004,광폭화 Wave 4,Normal,Buff,Buff,Self,1,0
-510005,광폭화 Wave 5,Normal,Buff,Buff,Self,1,0
-600001,출혈,Normal,Debuff,Buff,Enemy,1,15
-700001,피해 감소 (고정),Normal,Buff,DamageReductionBuff,Self,1,15
-700002,피해 감소 (비율),Normal,Buff,DamageReductionBuff,Self,1,15
-700003,치명 데미지 증가,Normal,Buff,CriticalDamageBuff,Self,1,15
+id,_name,elemental_type,skill_type,skill_category,skill_target_type,hit_count,cooldown,stat_power_ratio,referenced_stat_type
+100000,기본 공격,Normal,Attack,NormalAttack,Enemy,1,0,,
+100001,일격,Normal,Attack,BlowAttack,Enemy,1,1,,
+_100002,일격(전체),Normal,Attack,BlowAttack,Enemies,1,1,, // 노멀 속성의 전체 일격은 추가하면 안 됩니다.
+100003,연사,Normal,Attack,DoubleAttack,Enemy,2,1,,
+100005,광역 난사,Normal,Attack,AreaAttack,Enemies,5,1,,
+110000,불 공격,Fire,Attack,NormalAttack,Enemy,1,1,,
+110001,불꽃 일격,Fire,Attack,BlowAttack,Enemy,1,5,,
+110002,불꽃 일격(전체),Fire,Attack,BlowAttack,Enemies,1,13,,
+110003,불꽃 연사,Fire,Attack,DoubleAttack,Enemy,2,3,,
+110004,불꽃 연사(전체),Fire,Attack,DoubleAttack,Enemy,2,13,,
+110005,용암 해일,Fire,Attack,AreaAttack,Enemies,5,13,,
+120000,물 공격,Water,Attack,NormalAttack,Enemy,1,1,,
+120001,얼음 일격,Water,Attack,BlowAttack,Enemy,1,5,,
+120002,얼음 일격(전체),Water,Attack,BlowAttack,Enemies,1,13,,
+120003,얼음 연사,Water,Attack,DoubleAttack,Enemy,2,3,,
+120004,얼음 연사(전체),Water,Attack,DoubleAttack,Enemy,2,13,,
+120005,얼음 해일,Water,Attack,AreaAttack,Enemies,5,13,,
+130000,땅 공격,Land,Attack,NormalAttack,Enemy,1,1,,
+130001,모래 일격,Land,Attack,BlowAttack,Enemy,1,5,,
+130002,모래 일격(전체),Land,Attack,BlowAttack,Enemies,1,13,,
+130003,모래 연사,Land,Attack,DoubleAttack,Enemy,2,3,,
+130004,모래 연사(전체),Land,Attack,DoubleAttack,Enemy,2,13,,
+130005,모래 폭풍,Land,Attack,AreaAttack,Enemies,5,13,,
+140000,바람 공격,Wind,Attack,NormalAttack,Enemy,1,1,,
+140001,바람 일격,Wind,Attack,BlowAttack,Enemy,1,5,,
+140002,바람 일격(전체),Wind,Attack,BlowAttack,Enemies,1,13,,
+140003,바람 연사,Wind,Attack,DoubleAttack,Enemy,2,3,,
+140004,바람 연사(전체),Wind,Attack,DoubleAttack,Enemy,2,13,,
+140005,거대 태풍,Wind,Attack,AreaAttack,Enemies,5,13,,
+200000,체력 증가,Normal,Buff,HPBuff,Self,1,10,,
+_200001,체력 증가(전체),Normal,Buff,HPBuff,Ally,1,1,, // 미구현
+210000,공격 강화,Normal,Buff,AttackBuff,Self,1,25,,
+_210001,공격 강화(전체),Normal,Buff,AttackBuff,Ally,1,1,, // 미구현
+210002,공격 약화,Normal,Debuff,AttackBuff,Enemy,1,10,,
+210003,공격 약화(전체),Normal,Debuff,AttackBuff,Enemies,1,10,,
+210004,공격 강화,Normal,Buff,AttackBuff,Self,1,10,,
+220000,방어 강화,Normal,Buff,DefenseBuff,Self,1,25,,
+_220001,방어 강화(전체),Normal,Buff,DefenseBuff,Ally,1,1,, // 미구현
+220002,방어 약화,Normal,Debuff,DefenseBuff,Enemy,1,10,,
+220003,방어 약화(전체),Normal,Debuff,DefenseBuff,Enemies,1,10,,
+220004,방어 강화,Normal,Buff,DefenseBuff,Self,1,10,,
+230000,치명 증가,Normal,Buff,CriticalBuff,Self,1,25,,
+_230001,치명 증가(전체),Normal,Buff,CriticalBuff,Ally,1,1,, // 미구현
+230002,치명 감소,Normal,Debuff,CriticalBuff,Enemy,1,10,,
+230003,치명 감소(전체),Normal,Debuff,CriticalBuff,Enemies,1,10,,
+230004,치명 증가,Normal,Buff,CriticalBuff,Self,1,10,,
+240000,명중 증가,Normal,Buff,HitBuff,Self,1,25,,
+_240001,명중 증가(전체),Normal,Buff,HitBuff,Ally,1,1,, // 미구현
+240002,명중 감소,Normal,Debuff,HitBuff,Enemy,1,10,,
+240003,명중 감소(전체),Normal,Debuff,HitBuff,Enemies,1,10,,
+240004,명중 증가,Normal,Buff,HitBuff,Self,1,10,,
+250000,속도 증가,Normal,Buff,SpeedBuff,Self,1,25,,
+_250001,속도 증가(전체),Normal,Buff,SpeedBuff,Ally,1,1,, // 미구현
+250002,속도 감소,Normal,Debuff,SpeedBuff,Enemy,1,10,,
+250003,속도 감소(전체),Normal,Debuff,SpeedBuff,Enemies,1,10,,
+250004,속도 증가,Normal,Buff,SpeedBuff,Self,1,10,,
+300000,힐,Normal,Heal,Heal,Self,1,10,,
+_300001,힐(전체),Normal,Heal,Heal,Ally,1,1,, // 미구현
+400000,SS 올스텟,Normal,Buff,Buff,Self,1,999,,
+400001,SS 공격 치명,Normal,Buff,AttackBuff,Self,1,999,,
+400002,SS 방어 치명,Normal,Buff,DefenseBuff,Self,1,999,,
+400003,SS 속도 치명,Normal,Buff,SpeedBuff,Self,1,999,,
+400004,SS 명중 치명,Normal,Buff,HitBuff,Self,1,999,,
+400005,S 올스텟,Normal,Buff,Buff,Self,1,999,,
+400006,S 공격 치명,Normal,Buff,AttackBuff,Self,1,999,,
+400007,S 방어 치명,Normal,Buff,DefenseBuff,Self,1,999,,
+400008,S 속도 치명,Normal,Buff,SpeedBuff,Self,1,999,,
+400009,S 명중 치명,Normal,Buff,HitBuff,Self,1,999,,
+400010,S 공격 방어 치명,Normal,Buff,AttackBuff,Self,1,999,,
+400011,S 공격 속도 치명,Normal,Buff,AttackBuff,Self,1,999,,
+400012,S 공격 명중 치명,Normal,Buff,AttackBuff,Self,1,999,,
+400013,S 방어 속도 치명,Normal,Buff,DefenseBuff,Self,1,999,,
+400014,S 방어 명중 치명,Normal,Buff,DefenseBuff,Self,1,999,,
+400015,A 올스텟,Normal,Buff,Buff,Self,1,999,,
+400016,A 공격,Normal,Buff,AttackBuff,Self,1,999,,
+400017,A 방어,Normal,Buff,DefenseBuff,Self,1,999,,
+400018,A 속도,Normal,Buff,SpeedBuff,Self,1,999,,
+400019,A 명중,Normal,Buff,HitBuff,Self,1,999,,
+400020,A 공격 방어,Normal,Buff,AttackBuff,Self,1,999,,
+400021,A 공격 명중,Normal,Buff,AttackBuff,Self,1,999,,
+400022,A 공격 속도,Normal,Buff,AttackBuff,Self,1,999,,
+400023,A 방어 명중,Normal,Buff,DefenseBuff,Self,1,999,,
+400024,A 방어 속도,Normal,Buff,DefenseBuff,Self,1,999,,
+400025,A 명중 속도,Normal,Buff,HitBuff,Self,1,999,,
+400026,A 공격 방어 명중,Normal,Buff,AttackBuff,Self,1,999,,
+400027,A 공격 방어 속도,Normal,Buff,AttackBuff,Self,1,999,,
+400028,A 공격 명중 속도,Normal,Buff,AttackBuff,Self,1,999,,
+400029,A 방어 명중 속도,Normal,Buff,DefenseBuff,Self,1,999,,
+400030,B 올스텟,Normal,Buff,Buff,Self,1,999,,
+400031,B 공격,Normal,Buff,AttackBuff,Self,1,999,,
+400032,B 방어,Normal,Buff,DefenseBuff,Self,1,999,,
+400033,B 속도,Normal,Buff,SpeedBuff,Self,1,999,,
+400034,B 명중,Normal,Buff,HitBuff,Self,1,999,,
+400035,B 치명,Normal,Buff,CriticalBuff,Self,1,999,,
+400036,B 공격 방어,Normal,Buff,AttackBuff,Self,1,999,,
+400037,B 공격 명중,Normal,Buff,AttackBuff,Self,1,999,,
+400038,B 공격 속도,Normal,Buff,AttackBuff,Self,1,999,,
+400039,B 공격 치명,Normal,Buff,AttackBuff,Self,1,999,,
+400040,B 방어 명중,Normal,Buff,DefenseBuff,Self,1,999,,
+400041,B 방어 속도,Normal,Buff,DefenseBuff,Self,1,999,,
+400042,B 방어 치명,Normal,Buff,DefenseBuff,Self,1,999,,
+400043,B 명중 속도,Normal,Buff,HitBuff,Self,1,999,,
+400044,B 명중 치명,Normal,Buff,HitBuff,Self,1,999,,
+400045,B 속도 치명,Normal,Buff,SpeedBuff,Self,1,999,,
+400046,B 공격 방어 명중,Normal,Buff,AttackBuff,Self,1,999,,
+400047,B 공격 방어 속도,Normal,Buff,AttackBuff,Self,1,999,,
+400048,B 공격 방어 치명,Normal,Buff,AttackBuff,Self,1,999,,
+400049,B 공격 명중 속도,Normal,Buff,AttackBuff,Self,1,999,,
+400050,B 공격 명중 치명,Normal,Buff,AttackBuff,Self,1,999,,
+400051,B 공격 속도 치명,Normal,Buff,AttackBuff,Self,1,999,,
+400052,B 방어 명중 속도,Normal,Buff,DefenseBuff,Self,1,999,,
+400053,B 방어명중 치명,Normal,Buff,DefenseBuff,Self,1,999,,
+400054,B 방어 속도 치명,Normal,Buff,DefenseBuff,Self,1,999,,
+400055,B 명중 속도 치명,Normal,Buff,SpeedBuff,Self,1,999,,
+500001,분노,Normal,Attack,BlowAttack,Enemy,1,0,,
+500002,물어뜯기,Normal,Attack,BuffRemovalAttack,Enemy,1,0,,
+500003,할퀴기,Normal,Attack,BlowAttack,Enemy,1,0,,
+500004,할퀴기 Wave 4,Normal,Attack,BlowAttack,Enemy,1,0,,
+500005,할퀴기 Wave 5,Normal,Attack,BlowAttack,Enemy,1,0,,
+500011,분노,Normal,Attack,BlowAttack,Enemy,1,0,,
+500012,부식,Normal,Attack,BlowAttack,Enemy,1,0,,
+500013,연타,Normal,Attack,BlowAttack,Enemy,5,0,,
+500014,진노,Normal,Buff,CriticalBuff,Self,1,0,,
+500015,진노 Wave 4,Normal,Buff,CriticalBuff,Self,1,0,,
+500016,진노 Wave 5,Normal,Buff,CriticalBuff,Self,1,0,,
+510001,광폭화 Wave 1,Normal,Buff,Buff,Self,1,0,,
+510002,광폭화 Wave 2,Normal,Buff,Buff,Self,1,0,,
+510003,광폭화 Wave 3,Normal,Buff,Buff,Self,1,0,,
+510004,광폭화 Wave 4,Normal,Buff,Buff,Self,1,0,,
+510005,광폭화 Wave 5,Normal,Buff,Buff,Self,1,0,,
+600001,출혈,Normal,Debuff,Buff,Enemy,1,15,,
+700001,피해 감소 (고정),Normal,Buff,DamageReductionBuff,Self,1,15,,
+700002,피해 감소 (비율),Normal,Buff,DamageReductionBuff,Self,1,15,,
+700003,치명 데미지 증가,Normal,Buff,CriticalDamageBuff,Self,1,15,,

--- a/Lib9c/TableCSV/Skill/StatBuffSheet.csv
+++ b/Lib9c/TableCSV/Skill/StatBuffSheet.csv
@@ -1,108 +1,108 @@
-id,group,_name,chance,duration,target_type,stat_type,modify_type,modify_value,referenced_stat_type
-101000,101000,체력 강화,20,10,Self,HP,Percentage,50,
-101001,101000,체력 강화,100,25,Self,HP,Percentage,50,
-102000,102000,공격 강화,20,10,Self,ATK,Percentage,25,
-102001,102000,공격 강화,100,25,Self,ATK,Percentage,50,
-102002,102000,공격 강화,100,10,Self,ATK,Percentage,25,
-103000,103000,방어 강화,20,10,Self,DEF,Percentage,25,
-103001,103000,방어 강화,100,25,Self,DEF,Percentage,50,
-103002,103000,방어 강화,100,10,Self,DEF,Percentage,25,
-104000,104000,치명 증가,20,10,Self,CRI,Percentage,50,
-104001,104000,치명 증가,100,25,Self,CRI,Percentage,75,
-104002,104000,치명 증가,100,10,Self,CRI,Percentage,25,
-105000,105000,회피 증가,20,10,Self,HIT,Percentage,50,
-105001,105000,회피 증가,100,25,Self,HIT,Percentage,75,
-105002,105000,회피 증가,100,10,Self,HIT,Percentage,25,
-106000,106000,속도 증가,20,10,Self,SPD,Percentage,50,
-106001,106000,속도 증가,100,25,Self,SPD,Percentage,75,
-106002,106000,속도 증가,100,10,Self,SPD,Percentage,25,
-202000,202000,공격 약화,20,10,Enemy,ATK,Percentage,-25,
-202001,202000,공격 약화,100,10,Enemy,ATK,Percentage,-25,
-203001,203000,방어 약화,100,10,Enemy,DEF,Percentage,-25,
-204001,204000,치명 감소,100,10,Enemy,CRI,Percentage,-25,
-205001,205000,회피 감소,100,10,Enemy,HIT,Percentage,-25,
-206001,206000,속도 감소,100,10,Enemy,SPD,Percentage,-25,
-301000,301000,체력 강화 (10),100,150,Self,HP,Percentage,10,
-302000,302000,공격 강화 (2),100,150,Self,ATK,Percentage,2,
-302001,302000,공격 강화 (2),100,150,Self,ATK,Percentage,2,
-302002,302000,공격 강화 (3),100,150,Self,ATK,Percentage,3,
-302003,302000,공격 강화 (6),100,150,Self,ATK,Percentage,6,
-302004,302000,공격 강화 (3),100,150,Self,ATK,Percentage,3,
-302005,302000,공격 강화 (5),100,150,Self,ATK,Percentage,5,
-302006,302000,공격 강화 (8),100,150,Self,ATK,Percentage,8,
-302007,302000,S 올스텟,100,150,Self,ATK,Percentage,20,
-302008,302000,S 공격력2,100,150,Self,ATK,Percentage,35,
-302009,302000,공격 강화 (18),100,150,Self,ATK,Percentage,18,
-302010,302000,SS 올스탯,100,150,Self,ATK,Percentage,50,
-302011,302000,S 공격력1,100,150,Self,ATK,Percentage,60,
-302012,302000,SS 공격력,100,150,Self,ATK,Percentage,90,
-303000,303000,방어 강화 (2),100,150,Self,DEF,Percentage,2,
-303001,303000,방어 강화 (2),100,150,Self,DEF,Percentage,2,
-303002,303000,방어 강화 (3),100,150,Self,DEF,Percentage,3,
-303003,303000,방어 강화 (6),100,150,Self,DEF,Percentage,6,
-303004,303000,방어 강화 (3),100,150,Self,DEF,Percentage,3,
-303005,303000,방어 강화 (5),100,150,Self,DEF,Percentage,5,
-303006,303000,방어 강화 (8),100,150,Self,DEF,Percentage,8,
-303007,303000,S 올스텟,100,150,Self,DEF,Percentage,20,
-303008,303000,S 방어력2,100,150,Self,DEF,Percentage,35,
-303009,303000,방어 강화 (18),100,150,Self,DEF,Percentage,18,
-303010,303000,SS 올스탯,100,150,Self,DEF,Percentage,50,
-303011,303000,S 방어력1,100,150,Self,DEF,Percentage,60,
-303012,303000,SS 방어력,100,150,Self,DEF,Percentage,90,
-304000,304000,치명 증가 (100),100,150,Self,CRI,Percentage,100,
-304001,304000,치명 증가 (250),100,150,Self,CRI,Percentage,250,
-305000,305000,명중 강화 (2),100,150,Self,HIT,Percentage,2,
-305001,305000,명중 강화 (2),100,150,Self,HIT,Percentage,2,
-305002,305000,명중 강화 (3),100,150,Self,HIT,Percentage,3,
-305003,305000,명중 강화 (6),100,150,Self,HIT,Percentage,6,
-305004,305000,명중 강화 (3),100,150,Self,HIT,Percentage,3,
-305005,305000,명중 강화 (5),100,150,Self,HIT,Percentage,5,
-305006,305000,명중 강화 (8),100,150,Self,HIT,Percentage,8,
-305007,305000,S 올스텟,100,150,Self,HIT,Percentage,20,
-305008,305000,S 명중2,100,150,Self,HIT,Percentage,35,
-305009,305000,명중 강화 (18),100,150,Self,HIT,Percentage,18,
-305010,305000,SS 올스탯,100,150,Self,HIT,Percentage,50,
-305011,305000,S 명중1,100,150,Self,HIT,Percentage,60,
-305012,305000,SS 명중,100,150,Self,HIT,Percentage,90,
-306000,306000,속도 강화 (2),100,150,Self,SPD,Percentage,2,
-306001,306000,속도 강화 (2),100,150,Self,SPD,Percentage,2,
-306002,306000,속도 강화 (3),100,150,Self,SPD,Percentage,3,
-306003,306000,속도 강화 (6),100,150,Self,SPD,Percentage,6,
-306004,306000,속도 강화 (3),100,150,Self,SPD,Percentage,3,
-306005,306000,속도 강화 (5),100,150,Self,SPD,Percentage,5,
-306006,306000,속도 강화 (8),100,150,Self,SPD,Percentage,8,
-306007,306000,S 올스텟,100,150,Self,SPD,Percentage,20,
-306008,306000,S 속도2,100,150,Self,SPD,Percentage,35,
-306009,306000,속도 강화 (18),100,150,Self,SPD,Percentage,18,
-306010,306000,SS 올스탯,100,150,Self,SPD,Percentage,50,
-306011,306000,S 속도1,100,150,Self,SPD,Percentage,60,
-306012,306000,SS 속도,100,150,Self,SPD,Percentage,90,
-501001,501001,Fenrir Rage ATK,100,5,Self,ATK,Percentage,50,
-502001,502001,Fenrir Rage SPD,100,5,Self,SPD,Percentage,50,
-503011,503011,Berserk ATK(60) Wave 1,100,150,Self,ATK,Percentage,60,
-503012,503012,Berserk DEF(-100) Wave 1,100,150,Self,DEF,Percentage,-100,
-503021,503011,Berserk ATK(80) Wave 2,100,150,Self,ATK,Percentage,80,
-503022,503012,Berserk DEF(-100) Wave 2,100,150,Self,DEF,Percentage,-100,
-503031,503011,Berserk ATK(100) Wave 3,100,150,Self,ATK,Percentage,100,
-503032,503012,Berserk DEF(-100) Wave 3,100,150,Self,DEF,Percentage,-100,
-503041,503011,Berserk ATK(120) Wave 4,100,150,Self,ATK,Percentage,120,
-503042,503012,Berserk DEF(-100) Wave 4,100,150,Self,DEF,Percentage,-100,
-503051,503011,Berserk ATK(150) Wave 5,100,150,Self,ATK,Percentage,150,
-503052,503012,Berserk DEF(-100) Wave 5,100,150,Self,DEF,Percentage,-100,
-503015,503015,Berserk CRI(1500),100,150,Self,CRI,Percentage,1500,
-504001,504001,Serimnir Rage ATK,100,5,Self,ATK,Percentage,50,
-504002,504002,Serimnir Rage SPD,100,5,Self,SPD,Percentage,50,
-504003,504003,Serimnir Corrosion,100,6,Enemy,DEF,Percentage,-50,
-504004,504004,Serimnir a Series Of Hits,100,3,Self,ATK,Percentage,50,
-504005,504005,Serimnir Furious CRI,100,5,Self,CRI,Add,36,
-504006,504005,Serimnir Furious CRI,100,5,Self,CRI,Add,56,
-504007,504005,Serimnir Furious CRI,100,5,Self,CRI,Add,86,
-504008,504008,Serimnir Furious CDMG,100,5,Self,CDMG,Add,5000,
-504009,504008,Serimnir Furious CDMG,100,5,Self,CDMG,Add,10000,
-504010,504008,Serimnir Furious CDMG,100,5,Self,CDMG,Add,20000,
-504011,504011,Serimnir Furious Enemy CDMG,100,8,Enemy,CDMG,Add,10000,
-701000,701000,DRV (Rune),100,0,Self,DRV,Add,0,
-702000,701000,DRR (Rune),100,0,Self,DRR,Add,0,
-703000,703000,CDMG (Rune),100,0,Self,CDMG,Add,0,
-801000,801000,Armor Penetration (Stat conversion),100,10,Self,ArmorPenetration,Add,0,ATK
-802000,802000,Thorn (Stat conversion),100,10,Self,Thorn,Add,0,DEF
+id,group,_name,chance,duration,target_type,stat_type,modify_type,modify_value
+101000,101000,체력 강화,20,10,Self,HP,Percentage,50
+101001,101000,체력 강화,100,25,Self,HP,Percentage,50
+102000,102000,공격 강화,20,10,Self,ATK,Percentage,25
+102001,102000,공격 강화,100,25,Self,ATK,Percentage,50
+102002,102000,공격 강화,100,10,Self,ATK,Percentage,25
+103000,103000,방어 강화,20,10,Self,DEF,Percentage,25
+103001,103000,방어 강화,100,25,Self,DEF,Percentage,50
+103002,103000,방어 강화,100,10,Self,DEF,Percentage,25
+104000,104000,치명 증가,20,10,Self,CRI,Percentage,50
+104001,104000,치명 증가,100,25,Self,CRI,Percentage,75
+104002,104000,치명 증가,100,10,Self,CRI,Percentage,25
+105000,105000,회피 증가,20,10,Self,HIT,Percentage,50
+105001,105000,회피 증가,100,25,Self,HIT,Percentage,75
+105002,105000,회피 증가,100,10,Self,HIT,Percentage,25
+106000,106000,속도 증가,20,10,Self,SPD,Percentage,50
+106001,106000,속도 증가,100,25,Self,SPD,Percentage,75
+106002,106000,속도 증가,100,10,Self,SPD,Percentage,25
+202000,202000,공격 약화,20,10,Enemy,ATK,Percentage,-25
+202001,202000,공격 약화,100,10,Enemy,ATK,Percentage,-25
+203001,203000,방어 약화,100,10,Enemy,DEF,Percentage,-25
+204001,204000,치명 감소,100,10,Enemy,CRI,Percentage,-25
+205001,205000,회피 감소,100,10,Enemy,HIT,Percentage,-25
+206001,206000,속도 감소,100,10,Enemy,SPD,Percentage,-25
+301000,301000,체력 강화 (10),100,150,Self,HP,Percentage,10
+302000,302000,공격 강화 (2),100,150,Self,ATK,Percentage,2
+302001,302000,공격 강화 (2),100,150,Self,ATK,Percentage,2
+302002,302000,공격 강화 (3),100,150,Self,ATK,Percentage,3
+302003,302000,공격 강화 (6),100,150,Self,ATK,Percentage,6
+302004,302000,공격 강화 (3),100,150,Self,ATK,Percentage,3
+302005,302000,공격 강화 (5),100,150,Self,ATK,Percentage,5
+302006,302000,공격 강화 (8),100,150,Self,ATK,Percentage,8
+302007,302000,S 올스텟,100,150,Self,ATK,Percentage,20
+302008,302000,S 공격력2,100,150,Self,ATK,Percentage,35
+302009,302000,공격 강화 (18),100,150,Self,ATK,Percentage,18
+302010,302000,SS 올스탯,100,150,Self,ATK,Percentage,50
+302011,302000,S 공격력1,100,150,Self,ATK,Percentage,60
+302012,302000,SS 공격력,100,150,Self,ATK,Percentage,90
+303000,303000,방어 강화 (2),100,150,Self,DEF,Percentage,2
+303001,303000,방어 강화 (2),100,150,Self,DEF,Percentage,2
+303002,303000,방어 강화 (3),100,150,Self,DEF,Percentage,3
+303003,303000,방어 강화 (6),100,150,Self,DEF,Percentage,6
+303004,303000,방어 강화 (3),100,150,Self,DEF,Percentage,3
+303005,303000,방어 강화 (5),100,150,Self,DEF,Percentage,5
+303006,303000,방어 강화 (8),100,150,Self,DEF,Percentage,8
+303007,303000,S 올스텟,100,150,Self,DEF,Percentage,20
+303008,303000,S 방어력2,100,150,Self,DEF,Percentage,35
+303009,303000,방어 강화 (18),100,150,Self,DEF,Percentage,18
+303010,303000,SS 올스탯,100,150,Self,DEF,Percentage,50
+303011,303000,S 방어력1,100,150,Self,DEF,Percentage,60
+303012,303000,SS 방어력,100,150,Self,DEF,Percentage,90
+304000,304000,치명 증가 (100),100,150,Self,CRI,Percentage,100
+304001,304000,치명 증가 (250),100,150,Self,CRI,Percentage,250
+305000,305000,명중 강화 (2),100,150,Self,HIT,Percentage,2
+305001,305000,명중 강화 (2),100,150,Self,HIT,Percentage,2
+305002,305000,명중 강화 (3),100,150,Self,HIT,Percentage,3
+305003,305000,명중 강화 (6),100,150,Self,HIT,Percentage,6
+305004,305000,명중 강화 (3),100,150,Self,HIT,Percentage,3
+305005,305000,명중 강화 (5),100,150,Self,HIT,Percentage,5
+305006,305000,명중 강화 (8),100,150,Self,HIT,Percentage,8
+305007,305000,S 올스텟,100,150,Self,HIT,Percentage,20
+305008,305000,S 명중2,100,150,Self,HIT,Percentage,35
+305009,305000,명중 강화 (18),100,150,Self,HIT,Percentage,18
+305010,305000,SS 올스탯,100,150,Self,HIT,Percentage,50
+305011,305000,S 명중1,100,150,Self,HIT,Percentage,60
+305012,305000,SS 명중,100,150,Self,HIT,Percentage,90
+306000,306000,속도 강화 (2),100,150,Self,SPD,Percentage,2
+306001,306000,속도 강화 (2),100,150,Self,SPD,Percentage,2
+306002,306000,속도 강화 (3),100,150,Self,SPD,Percentage,3
+306003,306000,속도 강화 (6),100,150,Self,SPD,Percentage,6
+306004,306000,속도 강화 (3),100,150,Self,SPD,Percentage,3
+306005,306000,속도 강화 (5),100,150,Self,SPD,Percentage,5
+306006,306000,속도 강화 (8),100,150,Self,SPD,Percentage,8
+306007,306000,S 올스텟,100,150,Self,SPD,Percentage,20
+306008,306000,S 속도2,100,150,Self,SPD,Percentage,35
+306009,306000,속도 강화 (18),100,150,Self,SPD,Percentage,18
+306010,306000,SS 올스탯,100,150,Self,SPD,Percentage,50
+306011,306000,S 속도1,100,150,Self,SPD,Percentage,60
+306012,306000,SS 속도,100,150,Self,SPD,Percentage,90
+501001,501001,Fenrir Rage ATK,100,5,Self,ATK,Percentage,50
+502001,502001,Fenrir Rage SPD,100,5,Self,SPD,Percentage,50
+503011,503011,Berserk ATK(60) Wave 1,100,150,Self,ATK,Percentage,60
+503012,503012,Berserk DEF(-100) Wave 1,100,150,Self,DEF,Percentage,-100
+503021,503011,Berserk ATK(80) Wave 2,100,150,Self,ATK,Percentage,80
+503022,503012,Berserk DEF(-100) Wave 2,100,150,Self,DEF,Percentage,-100
+503031,503011,Berserk ATK(100) Wave 3,100,150,Self,ATK,Percentage,100
+503032,503012,Berserk DEF(-100) Wave 3,100,150,Self,DEF,Percentage,-100
+503041,503011,Berserk ATK(120) Wave 4,100,150,Self,ATK,Percentage,120
+503042,503012,Berserk DEF(-100) Wave 4,100,150,Self,DEF,Percentage,-100
+503051,503011,Berserk ATK(150) Wave 5,100,150,Self,ATK,Percentage,150
+503052,503012,Berserk DEF(-100) Wave 5,100,150,Self,DEF,Percentage,-100
+503015,503015,Berserk CRI(1500),100,150,Self,CRI,Percentage,1500
+504001,504001,Serimnir Rage ATK,100,5,Self,ATK,Percentage,50
+504002,504002,Serimnir Rage SPD,100,5,Self,SPD,Percentage,50
+504003,504003,Serimnir Corrosion,100,6,Enemy,DEF,Percentage,-50
+504004,504004,Serimnir a Series Of Hits,100,3,Self,ATK,Percentage,50
+504005,504005,Serimnir Furious CRI,100,5,Self,CRI,Add,36
+504006,504005,Serimnir Furious CRI,100,5,Self,CRI,Add,56
+504007,504005,Serimnir Furious CRI,100,5,Self,CRI,Add,86
+504008,504008,Serimnir Furious CDMG,100,5,Self,CDMG,Add,5000
+504009,504008,Serimnir Furious CDMG,100,5,Self,CDMG,Add,10000
+504010,504008,Serimnir Furious CDMG,100,5,Self,CDMG,Add,20000
+504011,504011,Serimnir Furious Enemy CDMG,100,8,Enemy,CDMG,Add,10000
+701000,701000,DRV (Rune),100,0,Self,DRV,Add,0
+702000,701000,DRR (Rune),100,0,Self,DRR,Add,0
+703000,703000,CDMG (Rune),100,0,Self,CDMG,Add,0
+801000,801000,Armor Penetration (Stat conversion),100,10,Self,ArmorPenetration,Add,0
+802000,802000,Thorn (Stat conversion),100,10,Self,Thorn,Add,0

--- a/Lib9c/TableData/Skill/SkillSheet.cs
+++ b/Lib9c/TableData/Skill/SkillSheet.cs
@@ -56,8 +56,12 @@ namespace Nekoyume.TableData
                 SkillTargetType = (SkillTargetType) Enum.Parse(typeof(SkillTargetType), fields[4]);
                 HitCount = ParseInt(fields[5]);
                 Cooldown = ParseInt(fields[6]);
-                StatPowerRatio = TryParseInt(fields[7], out var powerRatio) ? powerRatio : default;
-                ReferencedStatType = Enum.TryParse<StatType>(fields[8], out var statType) ? statType : StatType.NONE;
+
+                if (fields.Count == 9)
+                {
+                    StatPowerRatio = TryParseInt(fields[7], out var powerRatio) ? powerRatio : default;
+                    ReferencedStatType = Enum.TryParse<StatType>(fields[8], out var statType) ? statType : StatType.NONE;
+                }
             }
 
             public IValue Serialize()

--- a/Lib9c/TableData/Skill/StatBuffSheet.cs
+++ b/Lib9c/TableData/Skill/StatBuffSheet.cs
@@ -36,7 +36,6 @@ namespace Nekoyume.TableData
             public StatType StatType { get; private set; }
             public StatModifier.OperationType OperationType { get; private set; }
             public int Value { get; private set; }
-            public StatType ReferencedStatType { get; private set; }
 
             public override void Set(IReadOnlyList<string> fields)
             {
@@ -50,9 +49,6 @@ namespace Nekoyume.TableData
                 StatType = (StatType)Enum.Parse(typeof(StatType), fields[5]);
                 OperationType = (StatModifier.OperationType)Enum.Parse(typeof(StatModifier.OperationType), fields[6]);
                 Value = ParseInt(fields[7]);
-
-                ReferencedStatType = Enum.TryParse<StatType>(fields[8], out var type)
-                    ? type : StatType.NONE;
             }
         }
 


### PR DESCRIPTION
[How to apply (internal document)](https://www.notion.so/planetarium/a48947f47bcc4b1093342d81a1c6a9ae)

## Features
- `StatBuffSheet.Row.ReferencedStatType` is removed.
- Instead, `SkillSheet.Row.StatPowerRatio` decides the additional power of a skill.
- `SkillSheet.Row.ReferencedStatType` specifies the referenced `StatType` of the value.

## How it works
- When referenced `StatType` is specified : `Skill.Power = original power + (referenced stat * (StatPowerRatio / 10000))`
- When referenced `StatType` not specified, nothing happens. Skill will be used with original power.