### PR TITLE
Shift previous action obsolete indexes

### DIFF
--- a/Lib9c/Action/ActivateAccount0.cs
+++ b/Lib9c/Action/ActivateAccount0.cs
@@ -11,7 +11,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("activate_account")]
     public class ActivateAccount0 : ActionBase, IActivateAccount
     {

--- a/Lib9c/Action/AddActivatedAccount0.cs
+++ b/Lib9c/Action/AddActivatedAccount0.cs
@@ -10,7 +10,7 @@ using Nekoyume.Model.State;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("add_activated_account")]
     public class AddActivatedAccount0 : ActionBase, IAddActivatedAccountV1
     {

--- a/Lib9c/Action/BattleArena1.cs
+++ b/Lib9c/Action/BattleArena1.cs
@@ -26,7 +26,7 @@ namespace Nekoyume.Action
     /// Introduced at https://github.com/planetarium/lib9c/pull/1156
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100290ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("battle_arena")]
     public class BattleArena1 : GameAction, IBattleArenaV1
     {

--- a/Lib9c/Action/BattleArena10.cs
+++ b/Lib9c/Action/BattleArena10.cs
@@ -29,7 +29,7 @@ namespace Nekoyume.Action
     /// Updated at https://github.com/planetarium/lib9c/pull/1679
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V200020ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("battle_arena10")]
     public class BattleArena10 : GameAction, IBattleArenaV1
     {

--- a/Lib9c/Action/BattleArena11.cs
+++ b/Lib9c/Action/BattleArena11.cs
@@ -27,7 +27,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1930
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V200020ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("battle_arena11")]
     public class BattleArena11 : GameAction, IBattleArenaV1
     {

--- a/Lib9c/Action/BattleArena2.cs
+++ b/Lib9c/Action/BattleArena2.cs
@@ -27,7 +27,7 @@ namespace Nekoyume.Action
     /// Introduced at https://github.com/planetarium/lib9c/pull/1190
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100290ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("battle_arena2")]
     public class BattleArena2 : GameAction, IBattleArenaV1
     {

--- a/Lib9c/Action/BattleArena3.cs
+++ b/Lib9c/Action/BattleArena3.cs
@@ -27,7 +27,7 @@ namespace Nekoyume.Action
     /// Introduced at https://github.com/planetarium/lib9c/pull/1190
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100290ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("battle_arena3")]
     public class BattleArena3 : GameAction, IBattleArenaV1
     {

--- a/Lib9c/Action/BattleArena4.cs
+++ b/Lib9c/Action/BattleArena4.cs
@@ -26,7 +26,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1330
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100320ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("battle_arena4")]
     public class BattleArena4 : GameAction, IBattleArenaV1
     {

--- a/Lib9c/Action/BattleArena5.cs
+++ b/Lib9c/Action/BattleArena5.cs
@@ -27,7 +27,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1370
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100320ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("battle_arena5")]
     public class BattleArena5 : GameAction, IBattleArenaV1
     {

--- a/Lib9c/Action/BattleArena6.cs
+++ b/Lib9c/Action/BattleArena6.cs
@@ -27,7 +27,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1464
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100340ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("battle_arena6")]
     public class BattleArena6 : GameAction, IBattleArenaV1
     {

--- a/Lib9c/Action/BattleArena7.cs
+++ b/Lib9c/Action/BattleArena7.cs
@@ -29,7 +29,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1495
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100360ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("battle_arena7")]
     public class BattleArena7 : GameAction, IBattleArenaV1
     {

--- a/Lib9c/Action/BattleArena8.cs
+++ b/Lib9c/Action/BattleArena8.cs
@@ -29,7 +29,7 @@ namespace Nekoyume.Action
     /// Updated at https://github.com/planetarium/lib9c/pull/1679
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V200020ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("battle_arena8")]
     public class BattleArena8 : GameAction, IBattleArenaV1
     {

--- a/Lib9c/Action/BattleGrandFinale.cs
+++ b/Lib9c/Action/BattleGrandFinale.cs
@@ -28,7 +28,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1930
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V200020ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType(ActionTypeName)]
     public class BattleGrandFinale : GameAction, IBattleGrandFinaleV1
     {

--- a/Lib9c/Action/BattleGrandFinale1.cs
+++ b/Lib9c/Action/BattleGrandFinale1.cs
@@ -28,7 +28,7 @@ namespace Nekoyume.Action
     /// Introduced at ...
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V200020ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType(ActionTypeName)]
     public class BattleGrandFinale1 : GameAction, IBattleGrandFinaleV1
     {

--- a/Lib9c/Action/BattleGrandFinale2.cs
+++ b/Lib9c/Action/BattleGrandFinale2.cs
@@ -28,7 +28,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1679
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V200020ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType(ActionTypeName)]
     public class BattleGrandFinale2 : GameAction, IBattleGrandFinaleV1
     {

--- a/Lib9c/Action/Buy0.cs
+++ b/Lib9c/Action/Buy0.cs
@@ -19,7 +19,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("buy")]
     public class Buy0 : GameAction, IBuy0, IBuyV1
     {

--- a/Lib9c/Action/Buy10.cs
+++ b/Lib9c/Action/Buy10.cs
@@ -20,7 +20,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100220ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("buy10")]
     public class Buy10 : GameAction, IBuy5, IBuyV2
     {

--- a/Lib9c/Action/Buy2.cs
+++ b/Lib9c/Action/Buy2.cs
@@ -19,7 +19,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("buy2")]
     public class Buy2 : GameAction, IBuy0, IBuyV1
     {

--- a/Lib9c/Action/Buy3.cs
+++ b/Lib9c/Action/Buy3.cs
@@ -18,7 +18,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("buy3")]
     public class Buy3 : GameAction, IBuy0, IBuyV1
     {

--- a/Lib9c/Action/Buy4.cs
+++ b/Lib9c/Action/Buy4.cs
@@ -18,7 +18,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("buy4")]
     public class Buy4 : GameAction, IBuy0, IBuyV1
     {

--- a/Lib9c/Action/Buy5.cs
+++ b/Lib9c/Action/Buy5.cs
@@ -20,7 +20,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("buy5")]
     public class Buy5 : GameAction, IBuy5, IBuyV2
     {

--- a/Lib9c/Action/Buy6.cs
+++ b/Lib9c/Action/Buy6.cs
@@ -20,7 +20,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("buy6")]
     public class Buy6 : GameAction, IBuy5, IBuyV2
     {

--- a/Lib9c/Action/Buy7.cs
+++ b/Lib9c/Action/Buy7.cs
@@ -20,7 +20,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("buy7")]
     public class Buy7 : GameAction, IBuy5, IBuyV2
     {

--- a/Lib9c/Action/Buy8.cs
+++ b/Lib9c/Action/Buy8.cs
@@ -21,7 +21,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("buy8")]
     public class Buy8 : GameAction, IBuy5, IBuyV2
     {

--- a/Lib9c/Action/Buy9.cs
+++ b/Lib9c/Action/Buy9.cs
@@ -21,7 +21,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("buy9")]
     public class Buy9 : GameAction, IBuy5, IBuyV2
     {

--- a/Lib9c/Action/BuyMultiple.cs
+++ b/Lib9c/Action/BuyMultiple.cs
@@ -26,7 +26,7 @@ namespace Nekoyume.Action
     /// Updated at https://github.com/planetarium/lib9c/pull/957
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("buy_multiple")]
     public class BuyMultiple : GameAction, IBuyMultipleV1
     {

--- a/Lib9c/Action/CancelMonsterCollect.cs
+++ b/Lib9c/Action/CancelMonsterCollect.cs
@@ -22,7 +22,7 @@ namespace Nekoyume.Action
     /// Updated at https://github.com/planetarium/lib9c/pull/957
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("cancel_monster_collect")]
     public class CancelMonsterCollect : GameAction, ICancelMonsterCollectV1
     {

--- a/Lib9c/Action/ChargeActionPoint0.cs
+++ b/Lib9c/Action/ChargeActionPoint0.cs
@@ -15,7 +15,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("charge_action_point")]
     public class ChargeActionPoint0 : GameAction, IChargeActionPointV1
     {

--- a/Lib9c/Action/ChargeActionPoint2.cs
+++ b/Lib9c/Action/ChargeActionPoint2.cs
@@ -14,7 +14,7 @@ using Nekoyume.TableData;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("charge_action_point2")]
     public class ChargeActionPoint2 : GameAction, IChargeActionPointV1
     {

--- a/Lib9c/Action/ClaimMonsterCollectionReward.cs
+++ b/Lib9c/Action/ClaimMonsterCollectionReward.cs
@@ -22,7 +22,7 @@ namespace Nekoyume.Action
     /// </summary>
     [Serializable]
     [ActionType("claim_monster_collection_reward3")]
-    [ActionObsolete(ActionObsoleteConfig.V100220ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     public class ClaimMonsterCollectionReward : GameAction, IClaimMonsterCollectionRewardV2
     {
         public const long MonsterCollectionRewardEndBlockIndex = 4_481_909;

--- a/Lib9c/Action/ClaimMonsterCollectionReward0.cs
+++ b/Lib9c/Action/ClaimMonsterCollectionReward0.cs
@@ -16,7 +16,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("claim_monster_collection_reward")]
     public class ClaimMonsterCollectionReward0 : GameAction, IClaimMonsterCollectionRewardV1
     {

--- a/Lib9c/Action/ClaimMonsterCollectionReward2.cs
+++ b/Lib9c/Action/ClaimMonsterCollectionReward2.cs
@@ -16,7 +16,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("claim_monster_collection_reward2")]
     public class ClaimMonsterCollectionReward2 : GameAction, IClaimMonsterCollectionRewardV2
     {

--- a/Lib9c/Action/ClaimStakeReward1.cs
+++ b/Lib9c/Action/ClaimStakeReward1.cs
@@ -13,7 +13,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [ActionType("claim_stake_reward")]
-    [ActionObsolete(ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     public class ClaimStakeReward1 : GameAction, IClaimStakeReward, IClaimStakeRewardV1
     {
         public const long ObsoleteIndex = ActionObsoleteConfig.V200030ObsoleteIndex;

--- a/Lib9c/Action/ClaimStakeReward2.cs
+++ b/Lib9c/Action/ClaimStakeReward2.cs
@@ -16,7 +16,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1371
     /// </summary>
     [ActionType(ActionTypeText)]
-    [ActionObsolete(ObsoletedIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     public class ClaimStakeReward2 : GameAction, IClaimStakeReward, IClaimStakeRewardV1
     {
         public const long ObsoletedIndex = 5_549_200L;

--- a/Lib9c/Action/CombinationConsumable0.cs
+++ b/Lib9c/Action/CombinationConsumable0.cs
@@ -20,7 +20,7 @@ using Material = Nekoyume.Model.Item.Material;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("combination_consumable")]
     public class CombinationConsumable0 : GameAction, ICombinationConsumableV1
     {

--- a/Lib9c/Action/CombinationConsumable2.cs
+++ b/Lib9c/Action/CombinationConsumable2.cs
@@ -20,7 +20,7 @@ using Material = Nekoyume.Model.Item.Material;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("combination_consumable2")]
     public class CombinationConsumable2 : GameAction, ICombinationConsumableV1
     {

--- a/Lib9c/Action/CombinationConsumable3.cs
+++ b/Lib9c/Action/CombinationConsumable3.cs
@@ -20,7 +20,7 @@ using Material = Nekoyume.Model.Item.Material;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("combination_consumable3")]
     public class CombinationConsumable3 : GameAction, ICombinationConsumableV1
     {

--- a/Lib9c/Action/CombinationConsumable4.cs
+++ b/Lib9c/Action/CombinationConsumable4.cs
@@ -20,7 +20,7 @@ using Material = Nekoyume.Model.Item.Material;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("combination_consumable4")]
     public class CombinationConsumable4 : GameAction, ICombinationConsumableV1
     {

--- a/Lib9c/Action/CombinationConsumable5.cs
+++ b/Lib9c/Action/CombinationConsumable5.cs
@@ -20,7 +20,7 @@ using Material = Nekoyume.Model.Item.Material;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("combination_consumable5")]
     public class CombinationConsumable5 : GameAction, ICombinationConsumableV1
     {

--- a/Lib9c/Action/CombinationConsumable6.cs
+++ b/Lib9c/Action/CombinationConsumable6.cs
@@ -20,7 +20,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("combination_consumable6")]
     public class CombinationConsumable6 : GameAction, ICombinationConsumableV1
     {

--- a/Lib9c/Action/CombinationConsumable7.cs
+++ b/Lib9c/Action/CombinationConsumable7.cs
@@ -21,7 +21,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("combination_consumable7")]
     public class CombinationConsumable7 : GameAction, ICombinationConsumableV1
     {

--- a/Lib9c/Action/CombinationEquipment0.cs
+++ b/Lib9c/Action/CombinationEquipment0.cs
@@ -21,7 +21,7 @@ using Nekoyume.TableData;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("combination_equipment")]
     public class CombinationEquipment0 : GameAction, ICombinationEquipmentV1
     {

--- a/Lib9c/Action/CombinationEquipment10.cs
+++ b/Lib9c/Action/CombinationEquipment10.cs
@@ -18,7 +18,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100220ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("combination_equipment10")]
     public class CombinationEquipment10 : GameAction, ICombinationEquipmentV1
     {

--- a/Lib9c/Action/CombinationEquipment11.cs
+++ b/Lib9c/Action/CombinationEquipment11.cs
@@ -21,7 +21,7 @@ namespace Nekoyume.Action
     /// Updated at https://github.com/planetarium/lib9c/pull/1176
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100270ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("combination_equipment11")]
     public class CombinationEquipment11 : GameAction, ICombinationEquipmentV1
     {

--- a/Lib9c/Action/CombinationEquipment13.cs
+++ b/Lib9c/Action/CombinationEquipment13.cs
@@ -25,7 +25,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1264
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100282ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("combination_equipment13")]
     public class CombinationEquipment13 : GameAction, ICombinationEquipmentV3
     {

--- a/Lib9c/Action/CombinationEquipment2.cs
+++ b/Lib9c/Action/CombinationEquipment2.cs
@@ -21,7 +21,7 @@ using Nekoyume.TableData;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("combination_equipment2")]
     public class CombinationEquipment2 : GameAction, ICombinationEquipmentV1
     {

--- a/Lib9c/Action/CombinationEquipment3.cs
+++ b/Lib9c/Action/CombinationEquipment3.cs
@@ -21,7 +21,7 @@ using Nekoyume.TableData;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("combination_equipment3")]
     public class CombinationEquipment3 : GameAction, ICombinationEquipmentV1
     {

--- a/Lib9c/Action/CombinationEquipment4.cs
+++ b/Lib9c/Action/CombinationEquipment4.cs
@@ -21,7 +21,7 @@ using Nekoyume.TableData;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("combination_equipment4")]
     public class CombinationEquipment4 : GameAction, ICombinationEquipmentV1
     {

--- a/Lib9c/Action/CombinationEquipment5.cs
+++ b/Lib9c/Action/CombinationEquipment5.cs
@@ -21,7 +21,7 @@ using Nekoyume.TableData;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("combination_equipment5")]
     public class CombinationEquipment5 : GameAction, ICombinationEquipmentV1
     {

--- a/Lib9c/Action/CombinationEquipment6.cs
+++ b/Lib9c/Action/CombinationEquipment6.cs
@@ -22,7 +22,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("combination_equipment6")]
     public class CombinationEquipment6 : GameAction, ICombinationEquipmentV1
     {

--- a/Lib9c/Action/CombinationEquipment7.cs
+++ b/Lib9c/Action/CombinationEquipment7.cs
@@ -21,7 +21,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("combination_equipment7")]
     public class CombinationEquipment7 : GameAction, ICombinationEquipmentV1
     {

--- a/Lib9c/Action/CombinationEquipment8.cs
+++ b/Lib9c/Action/CombinationEquipment8.cs
@@ -18,7 +18,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100086ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("combination_equipment8")]
     public class CombinationEquipment8 : GameAction, ICombinationEquipmentV1
     {

--- a/Lib9c/Action/CreateAvatar0.cs
+++ b/Lib9c/Action/CreateAvatar0.cs
@@ -26,7 +26,7 @@ using Lib9c.DevExtensions.Model;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("create_avatar")]
     public class CreateAvatar0 : GameAction, ICreateAvatarV1
     {

--- a/Lib9c/Action/CreateAvatar2.cs
+++ b/Lib9c/Action/CreateAvatar2.cs
@@ -19,7 +19,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("create_avatar2")]
     public class CreateAvatar2 : GameAction, ICreateAvatarV2
     {

--- a/Lib9c/Action/CreateAvatar3.cs
+++ b/Lib9c/Action/CreateAvatar3.cs
@@ -16,7 +16,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("create_avatar3")]
     public class CreateAvatar3 : GameAction, ICreateAvatarV2
     {

--- a/Lib9c/Action/CreateAvatar4.cs
+++ b/Lib9c/Action/CreateAvatar4.cs
@@ -16,7 +16,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100095ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("create_avatar4")]
     public class CreateAvatar4 : GameAction, ICreateAvatarV2
     {

--- a/Lib9c/Action/CreateAvatar5.cs
+++ b/Lib9c/Action/CreateAvatar5.cs
@@ -16,7 +16,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100096ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("create_avatar5")]
     public class CreateAvatar5 : GameAction, ICreateAvatarV2
     {

--- a/Lib9c/Action/DailyReward0.cs
+++ b/Lib9c/Action/DailyReward0.cs
@@ -11,7 +11,7 @@ using Nekoyume.Model.State;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("daily_reward")]
     public class DailyReward0 : GameAction, IDailyRewardV1
     {

--- a/Lib9c/Action/DailyReward2.cs
+++ b/Lib9c/Action/DailyReward2.cs
@@ -15,7 +15,7 @@ using Nekoyume.TableData;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("daily_reward2")]
     public class DailyReward2 : GameAction, IDailyRewardV1
     {

--- a/Lib9c/Action/DailyReward3.cs
+++ b/Lib9c/Action/DailyReward3.cs
@@ -14,7 +14,7 @@ using Nekoyume.TableData;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("daily_reward3")]
     public class DailyReward3 : GameAction, IDailyRewardV1
     {

--- a/Lib9c/Action/DailyReward4.cs
+++ b/Lib9c/Action/DailyReward4.cs
@@ -15,7 +15,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("daily_reward4")]
     public class DailyReward4 : GameAction, IDailyRewardV1
     {

--- a/Lib9c/Action/DailyReward5.cs
+++ b/Lib9c/Action/DailyReward5.cs
@@ -12,7 +12,7 @@ using Nekoyume.Model.State;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("daily_reward5")]
     public class DailyReward5 : GameAction, IDailyRewardV1
     {

--- a/Lib9c/Action/EventDungeonBattleV2.cs
+++ b/Lib9c/Action/EventDungeonBattleV2.cs
@@ -25,7 +25,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1321
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100340ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType(ActionTypeText)]
     public class EventDungeonBattleV2 : GameAction, IEventDungeonBattleV1
     {

--- a/Lib9c/Action/EventDungeonBattleV3.cs
+++ b/Lib9c/Action/EventDungeonBattleV3.cs
@@ -27,7 +27,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100360ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType(ActionTypeText)]
     public class EventDungeonBattleV3 : GameAction, IEventDungeonBattleV2
     {

--- a/Lib9c/Action/EventDungeonBattleV4.cs
+++ b/Lib9c/Action/EventDungeonBattleV4.cs
@@ -26,7 +26,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1663
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V200020ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType(ActionTypeText)]
     public class EventDungeonBattleV4 : GameAction, IEventDungeonBattleV2
     {

--- a/Lib9c/Action/HackAndSlash0.cs
+++ b/Lib9c/Action/HackAndSlash0.cs
@@ -18,7 +18,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash")]
     public class HackAndSlash0 : GameAction, IHackAndSlashV1
     {

--- a/Lib9c/Action/HackAndSlash10.cs
+++ b/Lib9c/Action/HackAndSlash10.cs
@@ -18,7 +18,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100170ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash10")]
     public class HackAndSlash10 : GameAction, IHackAndSlashV4
     {

--- a/Lib9c/Action/HackAndSlash11.cs
+++ b/Lib9c/Action/HackAndSlash11.cs
@@ -17,7 +17,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100190ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash11")]
     public class HackAndSlash11 : GameAction, IHackAndSlashV5
     {

--- a/Lib9c/Action/HackAndSlash12.cs
+++ b/Lib9c/Action/HackAndSlash12.cs
@@ -18,7 +18,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100260ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash12")]
     public class HackAndSlash12 : GameAction, IHackAndSlashV5
     {

--- a/Lib9c/Action/HackAndSlash13.cs
+++ b/Lib9c/Action/HackAndSlash13.cs
@@ -24,7 +24,7 @@ namespace Nekoyume.Action
     /// </summary>
     [Serializable]
     [ActionType("hack_and_slash13")]
-    [ActionObsolete(ObsoletedBlockIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     public class HackAndSlash13 : GameAction, IHackAndSlashV6
     {
         private const long ObsoletedBlockIndex =

--- a/Lib9c/Action/HackAndSlash14.cs
+++ b/Lib9c/Action/HackAndSlash14.cs
@@ -25,7 +25,7 @@ namespace Nekoyume.Action
     /// </summary>
     [Serializable]
     [ActionType("hack_and_slash14")]
-    [ActionObsolete(ObsoletedBlockIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     public class HackAndSlash14 : GameAction, IHackAndSlashV7
     {
         private const long ObsoletedBlockIndex =

--- a/Lib9c/Action/HackAndSlash18.cs
+++ b/Lib9c/Action/HackAndSlash18.cs
@@ -26,7 +26,7 @@ namespace Nekoyume.Action
     /// </summary>
     [Serializable]
     [ActionType("hack_and_slash18")]
-    [ActionObsolete(ActionObsoleteConfig.V100340ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     public class HackAndSlash18 : GameAction, IHackAndSlashV8
     {
         public List<Guid> Costumes;

--- a/Lib9c/Action/HackAndSlash19.cs
+++ b/Lib9c/Action/HackAndSlash19.cs
@@ -25,7 +25,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1495
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100360ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash19")]
     public class HackAndSlash19 : GameAction, IHackAndSlashV9
     {

--- a/Lib9c/Action/HackAndSlash2.cs
+++ b/Lib9c/Action/HackAndSlash2.cs
@@ -17,7 +17,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash2")]
     public class HackAndSlash2 : GameAction, IHackAndSlashV1
     {

--- a/Lib9c/Action/HackAndSlash20.cs
+++ b/Lib9c/Action/HackAndSlash20.cs
@@ -26,7 +26,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1663
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V200020ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash20")]
     public class HackAndSlash20 : GameAction, IHackAndSlashV10
     {

--- a/Lib9c/Action/HackAndSlash3.cs
+++ b/Lib9c/Action/HackAndSlash3.cs
@@ -17,7 +17,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash3")]
     public class HackAndSlash3 : GameAction, IHackAndSlashV1
     {

--- a/Lib9c/Action/HackAndSlash4.cs
+++ b/Lib9c/Action/HackAndSlash4.cs
@@ -17,7 +17,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash4")]
     public class HackAndSlash4 : GameAction, IHackAndSlashV2
     {

--- a/Lib9c/Action/HackAndSlash5.cs
+++ b/Lib9c/Action/HackAndSlash5.cs
@@ -17,7 +17,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash5")]
     public class HackAndSlash5 : GameAction, IHackAndSlashV2
     {

--- a/Lib9c/Action/HackAndSlash6.cs
+++ b/Lib9c/Action/HackAndSlash6.cs
@@ -18,7 +18,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash6")]
     public class HackAndSlash6 : GameAction, IHackAndSlashV2
     {

--- a/Lib9c/Action/HackAndSlash7.cs
+++ b/Lib9c/Action/HackAndSlash7.cs
@@ -18,7 +18,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash7")]
     public class HackAndSlash7 : GameAction, IHackAndSlashV2
     {

--- a/Lib9c/Action/HackAndSlash8.cs
+++ b/Lib9c/Action/HackAndSlash8.cs
@@ -18,7 +18,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100081ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash8")]
     public class HackAndSlash8 : GameAction, IHackAndSlashV3
     {

--- a/Lib9c/Action/HackAndSlash9.cs
+++ b/Lib9c/Action/HackAndSlash9.cs
@@ -18,7 +18,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100086ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash9")]
     public class HackAndSlash9 : GameAction, IHackAndSlashV4
     {

--- a/Lib9c/Action/HackAndSlashSweep1.cs
+++ b/Lib9c/Action/HackAndSlashSweep1.cs
@@ -18,7 +18,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100193ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash_sweep")]
     public class HackAndSlashSweep1 : GameAction, IHackAndSlashSweepV1
     {

--- a/Lib9c/Action/HackAndSlashSweep2.cs
+++ b/Lib9c/Action/HackAndSlashSweep2.cs
@@ -18,7 +18,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100200ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash_sweep2")]
     public class HackAndSlashSweep2 : GameAction, IHackAndSlashSweepV1
     {

--- a/Lib9c/Action/HackAndSlashSweep3.cs
+++ b/Lib9c/Action/HackAndSlashSweep3.cs
@@ -22,7 +22,7 @@ namespace Nekoyume.Action
     /// Updated at https://github.com/planetarium/lib9c/pull/1176
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100210ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash_sweep3")]
     public class HackAndSlashSweep3 : GameAction, IHackAndSlashSweepV2
     {

--- a/Lib9c/Action/HackAndSlashSweep4.cs
+++ b/Lib9c/Action/HackAndSlashSweep4.cs
@@ -22,7 +22,7 @@ namespace Nekoyume.Action
     /// Updated at https://github.com/planetarium/lib9c/pull/1176
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100300ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash_sweep4")]
     public class HackAndSlashSweep4 : GameAction, IHackAndSlashSweepV2
     {

--- a/Lib9c/Action/HackAndSlashSweep5.cs
+++ b/Lib9c/Action/HackAndSlashSweep5.cs
@@ -21,7 +21,7 @@ namespace Nekoyume.Action
     /// Introduced at https://github.com/planetarium/lib9c/pull/1173
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100300ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash_sweep5")]
     public class HackAndSlashSweep5 : GameAction, IHackAndSlashSweepV2
     {

--- a/Lib9c/Action/HackAndSlashSweep7.cs
+++ b/Lib9c/Action/HackAndSlashSweep7.cs
@@ -23,7 +23,7 @@ namespace Nekoyume.Action
     /// </summary>
     [Serializable]
     [ActionType("hack_and_slash_sweep7")]
-    [ActionObsolete(ActionObsoleteConfig.V100340ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     public class HackAndSlashSweep7 : GameAction, IHackAndSlashSweepV2
     {
         public const int UsableApStoneCount = 10;

--- a/Lib9c/Action/HackAndSlashSweep8.cs
+++ b/Lib9c/Action/HackAndSlashSweep8.cs
@@ -23,7 +23,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1495
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100360ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("hack_and_slash_sweep8")]
     public class HackAndSlashSweep8 : GameAction, IHackAndSlashSweepV3
     {

--- a/Lib9c/Action/ItemEnhancement0.cs
+++ b/Lib9c/Action/ItemEnhancement0.cs
@@ -19,7 +19,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("item_enhancement")]
     public class ItemEnhancement0 : GameAction, IItemEnhancementV1
     {

--- a/Lib9c/Action/ItemEnhancement2.cs
+++ b/Lib9c/Action/ItemEnhancement2.cs
@@ -19,7 +19,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("item_enhancement2")]
     public class ItemEnhancement2 : GameAction, IItemEnhancementV2
     {

--- a/Lib9c/Action/ItemEnhancement3.cs
+++ b/Lib9c/Action/ItemEnhancement3.cs
@@ -19,7 +19,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("item_enhancement3")]
     public class ItemEnhancement3 : GameAction, IItemEnhancementV2
     {

--- a/Lib9c/Action/ItemEnhancement4.cs
+++ b/Lib9c/Action/ItemEnhancement4.cs
@@ -17,7 +17,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("item_enhancement4")]
     public class ItemEnhancement4 : GameAction, IItemEnhancementV2
     {

--- a/Lib9c/Action/ItemEnhancement5.cs
+++ b/Lib9c/Action/ItemEnhancement5.cs
@@ -17,7 +17,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("item_enhancement5")]
     public class ItemEnhancement5 : GameAction, IItemEnhancementV2
     {

--- a/Lib9c/Action/ItemEnhancement6.cs
+++ b/Lib9c/Action/ItemEnhancement6.cs
@@ -19,7 +19,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("item_enhancement6")]
     public class ItemEnhancement6 : GameAction, IItemEnhancementV2
     {

--- a/Lib9c/Action/ItemEnhancement7.cs
+++ b/Lib9c/Action/ItemEnhancement7.cs
@@ -20,7 +20,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("item_enhancement7")]
     public class ItemEnhancement7 : GameAction, IItemEnhancementV2
     {

--- a/Lib9c/Action/ItemEnhancement8.cs
+++ b/Lib9c/Action/ItemEnhancement8.cs
@@ -20,7 +20,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("item_enhancement8")]
     public class ItemEnhancement8 : GameAction, IItemEnhancementV2
     {

--- a/Lib9c/Action/ItemEnhancement9.cs
+++ b/Lib9c/Action/ItemEnhancement9.cs
@@ -21,7 +21,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100220ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("item_enhancement9")]
     public class ItemEnhancement9 : GameAction, IItemEnhancementV2
     {

--- a/Lib9c/Action/JoinArena1.cs
+++ b/Lib9c/Action/JoinArena1.cs
@@ -22,7 +22,7 @@ namespace Nekoyume.Action
     /// Introduced at https://github.com/planetarium/lib9c/pull/1495
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100340ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("join_arena")]
     public class JoinArena1 : GameAction, IJoinArenaV1
     {

--- a/Lib9c/Action/JoinArena2.cs
+++ b/Lib9c/Action/JoinArena2.cs
@@ -23,7 +23,7 @@ namespace Nekoyume.Action
     /// Introduced at https://github.com/planetarium/lib9c/pull/1495
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100360ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("join_arena2")]
     public class JoinArena2 : GameAction, IJoinArenaV1
     {

--- a/Lib9c/Action/MigrationLegacyShop0.cs
+++ b/Lib9c/Action/MigrationLegacyShop0.cs
@@ -12,7 +12,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("migration_legacy_shop")]
     public class MigrationLegacyShop0 : GameAction, IMigrationLegacyShopV1
     {

--- a/Lib9c/Action/MimisbrunnrBattle0.cs
+++ b/Lib9c/Action/MimisbrunnrBattle0.cs
@@ -18,7 +18,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("mimisbrunnr_battle")]
     public class MimisbrunnrBattle0 : GameAction, IMimisbrunnrBattleV1
     {

--- a/Lib9c/Action/MimisbrunnrBattle11.cs
+++ b/Lib9c/Action/MimisbrunnrBattle11.cs
@@ -28,7 +28,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1495
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100360ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("mimisbrunnr_battle11")]
     public class MimisbrunnrBattle11 : GameAction, IMimisbrunnrBattleV5
     {

--- a/Lib9c/Action/MimisbrunnrBattle12.cs
+++ b/Lib9c/Action/MimisbrunnrBattle12.cs
@@ -29,7 +29,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1663
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V200020ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("mimisbrunnr_battle12")]
     public class MimisbrunnrBattle12 : GameAction, IMimisbrunnrBattleV5
     {

--- a/Lib9c/Action/MimisbrunnrBattle2.cs
+++ b/Lib9c/Action/MimisbrunnrBattle2.cs
@@ -18,7 +18,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("mimisbrunnr_battle2")]
     public class MimisbrunnrBattle2 : GameAction, IMimisbrunnrBattleV1
     {

--- a/Lib9c/Action/MimisbrunnrBattle3.cs
+++ b/Lib9c/Action/MimisbrunnrBattle3.cs
@@ -18,7 +18,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("mimisbrunnr_battle3")]
     public class MimisbrunnrBattle3 : GameAction, IMimisbrunnrBattleV1
     {

--- a/Lib9c/Action/MimisbrunnrBattle4.cs
+++ b/Lib9c/Action/MimisbrunnrBattle4.cs
@@ -18,7 +18,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("mimisbrunnr_battle4")]
     public class MimisbrunnrBattle4 : GameAction, IMimisbrunnrBattleV1
     {

--- a/Lib9c/Action/MimisbrunnrBattle5.cs
+++ b/Lib9c/Action/MimisbrunnrBattle5.cs
@@ -18,7 +18,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100083ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("mimisbrunnr_battle5")]
     public class MimisbrunnrBattle5 : GameAction, IMimisbrunnrBattleV2
     {

--- a/Lib9c/Action/MimisbrunnrBattle6.cs
+++ b/Lib9c/Action/MimisbrunnrBattle6.cs
@@ -18,7 +18,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100086ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("mimisbrunnr_battle6")]
     public class MimisbrunnrBattle6 : GameAction, IMimisbrunnrBattleV3
     {

--- a/Lib9c/Action/MimisbrunnrBattle7.cs
+++ b/Lib9c/Action/MimisbrunnrBattle7.cs
@@ -18,7 +18,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100170ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("mimisbrunnr_battle7")]
     public class MimisbrunnrBattle7 : GameAction, IMimisbrunnrBattleV3
     {

--- a/Lib9c/Action/MimisbrunnrBattle8.cs
+++ b/Lib9c/Action/MimisbrunnrBattle8.cs
@@ -22,7 +22,7 @@ namespace Nekoyume.Action
     /// </summary>
     [Serializable]
     [ActionType("mimisbrunnr_battle8")]
-    [ActionObsolete(ObsoletedBlockIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     public class MimisbrunnrBattle8 : GameAction, IMimisbrunnrBattleV4
     {
         private const long ObsoletedBlockIndex =

--- a/Lib9c/Action/MimisbrunnrBattle9.cs
+++ b/Lib9c/Action/MimisbrunnrBattle9.cs
@@ -23,7 +23,7 @@ namespace Nekoyume.Action
     /// Updated at https://github.com/planetarium/lib9c/pull/1241
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100340ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("mimisbrunnr_battle9")]
     public class MimisbrunnrBattle9 : GameAction, IMimisbrunnrBattleV4
     {

--- a/Lib9c/Action/MonsterCollect.cs
+++ b/Lib9c/Action/MonsterCollect.cs
@@ -20,7 +20,7 @@ namespace Nekoyume.Action
     /// </summary>
     [Serializable]
     [ActionType("monster_collect3")]
-    [ActionObsolete(ActionObsoleteConfig.V100220ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     public class MonsterCollect : GameAction, IMonsterCollectV2
     {
         public int level;

--- a/Lib9c/Action/MonsterCollect0.cs
+++ b/Lib9c/Action/MonsterCollect0.cs
@@ -14,7 +14,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("monster_collect")]
     public class MonsterCollect0 : GameAction, IMonsterCollectV1
     {

--- a/Lib9c/Action/MonsterCollect2.cs
+++ b/Lib9c/Action/MonsterCollect2.cs
@@ -14,7 +14,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("monster_collect2")]
     public class MonsterCollect2 : GameAction, IMonsterCollectV2
     {

--- a/Lib9c/Action/Raid1.cs
+++ b/Lib9c/Action/Raid1.cs
@@ -19,7 +19,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100360ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("raid")]
     public class Raid1 : GameAction, IRaidV1
     {

--- a/Lib9c/Action/Raid2.cs
+++ b/Lib9c/Action/Raid2.cs
@@ -23,7 +23,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1419
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100340ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("raid2")]
     public class Raid2 : GameAction, IRaidV1
     {

--- a/Lib9c/Action/Raid3.cs
+++ b/Lib9c/Action/Raid3.cs
@@ -25,7 +25,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1495
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100360ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("raid3")]
     public class Raid3 : GameAction, IRaidV2
     {

--- a/Lib9c/Action/Raid4.cs
+++ b/Lib9c/Action/Raid4.cs
@@ -25,7 +25,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1663
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V200010ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("raid4")]
     public class Raid4 : GameAction, IRaidV2
     {

--- a/Lib9c/Action/Raid5.cs
+++ b/Lib9c/Action/Raid5.cs
@@ -25,7 +25,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1858
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V200020ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("raid5")]
     public class Raid5 : GameAction, IRaidV2
     {

--- a/Lib9c/Action/RankingBattle0.cs
+++ b/Lib9c/Action/RankingBattle0.cs
@@ -18,7 +18,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("ranking_battle")]
     public class RankingBattle0 : GameAction, IRankingBattleV1
     {

--- a/Lib9c/Action/RankingBattle10.cs
+++ b/Lib9c/Action/RankingBattle10.cs
@@ -20,7 +20,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100190ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("ranking_battle10")]
     public class RankingBattle10 : GameAction, IRankingBattleV2
     {

--- a/Lib9c/Action/RankingBattle2.cs
+++ b/Lib9c/Action/RankingBattle2.cs
@@ -18,7 +18,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("ranking_battle2")]
     public class RankingBattle2 : GameAction, IRankingBattleV1
     {

--- a/Lib9c/Action/RankingBattle3.cs
+++ b/Lib9c/Action/RankingBattle3.cs
@@ -18,7 +18,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("ranking_battle3")]
     public class RankingBattle3 : GameAction, IRankingBattleV2
     {

--- a/Lib9c/Action/RankingBattle4.cs
+++ b/Lib9c/Action/RankingBattle4.cs
@@ -18,7 +18,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("ranking_battle4")]
     public class RankingBattle4 : GameAction, IRankingBattleV2
     {

--- a/Lib9c/Action/RankingBattle5.cs
+++ b/Lib9c/Action/RankingBattle5.cs
@@ -19,7 +19,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("ranking_battle5")]
     public class RankingBattle5 : GameAction, IRankingBattleV2
     {

--- a/Lib9c/Action/RankingBattle6.cs
+++ b/Lib9c/Action/RankingBattle6.cs
@@ -19,7 +19,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("ranking_battle6")]
     public class RankingBattle6 : GameAction, IRankingBattleV2
     {

--- a/Lib9c/Action/RankingBattle7.cs
+++ b/Lib9c/Action/RankingBattle7.cs
@@ -19,7 +19,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100086ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("ranking_battle7")]
     public class RankingBattle7 : GameAction, IRankingBattleV2
     {

--- a/Lib9c/Action/RankingBattle8.cs
+++ b/Lib9c/Action/RankingBattle8.cs
@@ -19,7 +19,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100089ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("ranking_battle8")]
     public class RankingBattle8 : GameAction, IRankingBattleV2
     {

--- a/Lib9c/Action/RankingBattle9.cs
+++ b/Lib9c/Action/RankingBattle9.cs
@@ -20,7 +20,7 @@ namespace Nekoyume.Action
 {
     [Serializable]
     [ActionType("ranking_battle9")]
-    [ActionObsolete(ActionObsoleteConfig.V100093ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     public class RankingBattle9 : GameAction, IRankingBattleV2
     {
         public const int StageId = 999999;

--- a/Lib9c/Action/RapidCombination0.cs
+++ b/Lib9c/Action/RapidCombination0.cs
@@ -16,7 +16,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("rapid_combination")]
     public class RapidCombination0 : GameAction, IRapidCombinationV1
     {

--- a/Lib9c/Action/RapidCombination2.cs
+++ b/Lib9c/Action/RapidCombination2.cs
@@ -15,7 +15,7 @@ using Nekoyume.TableData;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("rapid_combination2")]
     public class RapidCombination2 : GameAction, IRapidCombinationV1
     {

--- a/Lib9c/Action/RapidCombination3.cs
+++ b/Lib9c/Action/RapidCombination3.cs
@@ -15,7 +15,7 @@ using Nekoyume.TableData;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("rapid_combination3")]
     public class RapidCombination3 : GameAction, IRapidCombinationV1
     {

--- a/Lib9c/Action/RapidCombination4.cs
+++ b/Lib9c/Action/RapidCombination4.cs
@@ -16,7 +16,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("rapid_combination4")]
     public class RapidCombination4 : GameAction, IRapidCombinationV1
     {

--- a/Lib9c/Action/RapidCombination5.cs
+++ b/Lib9c/Action/RapidCombination5.cs
@@ -16,7 +16,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100083ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("rapid_combination5")]
     public class RapidCombination5 : GameAction, IRapidCombinationV1
     {

--- a/Lib9c/Action/RapidCombination6.cs
+++ b/Lib9c/Action/RapidCombination6.cs
@@ -22,7 +22,7 @@ namespace Nekoyume.Action
     /// Updated at https://github.com/planetarium/lib9c/pull/1194
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100310ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("rapid_combination6")]
     public class RapidCombination6 : GameAction, IRapidCombinationV1
     {

--- a/Lib9c/Action/RapidCombination7.cs
+++ b/Lib9c/Action/RapidCombination7.cs
@@ -20,7 +20,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1194
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100310ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("rapid_combination7")]
     public class RapidCombination7 : GameAction, IRapidCombinationV1
     {

--- a/Lib9c/Action/RedeemCode0.cs
+++ b/Lib9c/Action/RedeemCode0.cs
@@ -16,7 +16,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("redeem_code")]
     public class RedeemCode0 : GameAction, IRedeemCodeV1
     {

--- a/Lib9c/Action/RedeemCode2.cs
+++ b/Lib9c/Action/RedeemCode2.cs
@@ -16,7 +16,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("redeem_code2")]
     public class RedeemCode2 : GameAction, IRedeemCodeV1
     {

--- a/Lib9c/Action/RuneEnhancement0.cs
+++ b/Lib9c/Action/RuneEnhancement0.cs
@@ -17,7 +17,7 @@ using Nekoyume.TableData;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100360ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("runeEnhancement")]
     public class RuneEnhancement0 : GameAction, IRuneEnhancementV1
     {

--- a/Lib9c/Action/Sell0.cs
+++ b/Lib9c/Action/Sell0.cs
@@ -16,7 +16,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("sell")]
     public class Sell0 : GameAction, ISellV1
     {

--- a/Lib9c/Action/Sell10.cs
+++ b/Lib9c/Action/Sell10.cs
@@ -22,7 +22,7 @@ namespace Nekoyume.Action
     /// Updated at https://github.com/planetarium/lib9c/pull/957
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100300ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("sell10")]
     public class Sell10 : GameAction, ISellV2
     {

--- a/Lib9c/Action/Sell11.cs
+++ b/Lib9c/Action/Sell11.cs
@@ -22,7 +22,7 @@ namespace Nekoyume.Action
     /// </summary>
     [Serializable]
     [ActionType("sell11")]
-    [ActionObsolete(ActionObsoleteConfig.V100351ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     public class Sell11 : GameAction, ISellV2
     {
         public Address sellerAvatarAddress;

--- a/Lib9c/Action/Sell2.cs
+++ b/Lib9c/Action/Sell2.cs
@@ -16,7 +16,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("sell2")]
     public class Sell2 : GameAction, ISellV1
     {

--- a/Lib9c/Action/Sell3.cs
+++ b/Lib9c/Action/Sell3.cs
@@ -16,7 +16,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("sell3")]
     public class Sell3 : GameAction, ISellV1
     {

--- a/Lib9c/Action/Sell4.cs
+++ b/Lib9c/Action/Sell4.cs
@@ -18,7 +18,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("sell4")]
     public class Sell4 : GameAction, ISellV1
     {

--- a/Lib9c/Action/Sell5.cs
+++ b/Lib9c/Action/Sell5.cs
@@ -21,7 +21,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("sell5")]
     public class Sell5 : GameAction, ISellV2
     {

--- a/Lib9c/Action/Sell6.cs
+++ b/Lib9c/Action/Sell6.cs
@@ -20,7 +20,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("sell6")]
     public class Sell6 : GameAction, ISellV2
     {

--- a/Lib9c/Action/Sell7.cs
+++ b/Lib9c/Action/Sell7.cs
@@ -19,7 +19,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("sell7")]
     public class Sell7 : GameAction, ISellV2
     {

--- a/Lib9c/Action/Sell8.cs
+++ b/Lib9c/Action/Sell8.cs
@@ -19,7 +19,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("sell8")]
     public class Sell8 : GameAction, ISellV2
     {

--- a/Lib9c/Action/Sell9.cs
+++ b/Lib9c/Action/Sell9.cs
@@ -18,7 +18,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("sell9")]
     public class Sell9 : GameAction, ISellV2
     {

--- a/Lib9c/Action/SellCancellation0.cs
+++ b/Lib9c/Action/SellCancellation0.cs
@@ -15,7 +15,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("sell_cancellation")]
     public class SellCancellation0 : GameAction, ISellCancellationV1
     {

--- a/Lib9c/Action/SellCancellation2.cs
+++ b/Lib9c/Action/SellCancellation2.cs
@@ -15,7 +15,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("sell_cancellation2")]
     public class SellCancellation2 : GameAction, ISellCancellationV1
     {

--- a/Lib9c/Action/SellCancellation3.cs
+++ b/Lib9c/Action/SellCancellation3.cs
@@ -15,7 +15,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("sell_cancellation3")]
     public class SellCancellation3 : GameAction, ISellCancellationV1
     {

--- a/Lib9c/Action/SellCancellation4.cs
+++ b/Lib9c/Action/SellCancellation4.cs
@@ -15,7 +15,7 @@ using Serilog;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("sell_cancellation4")]
     public class SellCancellation4 : GameAction, ISellCancellationV1
     {

--- a/Lib9c/Action/SellCancellation5.cs
+++ b/Lib9c/Action/SellCancellation5.cs
@@ -17,7 +17,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("sell_cancellation5")]
     public class SellCancellation5 : GameAction, ISellCancellationV2
     {

--- a/Lib9c/Action/SellCancellation6.cs
+++ b/Lib9c/Action/SellCancellation6.cs
@@ -19,7 +19,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("sell_cancellation6")]
     public class SellCancellation6 : GameAction, ISellCancellationV2
     {

--- a/Lib9c/Action/SellCancellation7.cs
+++ b/Lib9c/Action/SellCancellation7.cs
@@ -20,7 +20,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("sell_cancellation7")]
     public class SellCancellation7 : GameAction, ISellCancellationV3
     {

--- a/Lib9c/Action/SellCancellation8.cs
+++ b/Lib9c/Action/SellCancellation8.cs
@@ -20,7 +20,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("sell_cancellation8")]
     public class SellCancellation8 : GameAction, ISellCancellationV3
     {

--- a/Lib9c/Action/Stake0.cs
+++ b/Lib9c/Action/Stake0.cs
@@ -12,7 +12,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [ActionType("stake")]
-    [ActionObsolete(ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     public class Stake0 : ActionBase, IStakeV1
     {
         public const long ObsoleteIndex = ActionObsoleteConfig.V200030ObsoleteIndex;

--- a/Lib9c/Action/TransferAsset0.cs
+++ b/Lib9c/Action/TransferAsset0.cs
@@ -14,7 +14,7 @@ using Lib9c.Abstractions;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("transfer_asset")]
     public class TransferAsset0 : ActionBase, ISerializable, ITransferAsset, ITransferAssetV1
     {

--- a/Lib9c/Action/TransferAsset2.cs
+++ b/Lib9c/Action/TransferAsset2.cs
@@ -20,7 +20,7 @@ namespace Nekoyume.Action
     /// Updated at https://github.com/planetarium/lib9c/pull/957
     /// </summary>
     [Serializable]
-    [ActionObsolete(TransferAsset.CrystalTransferringRestrictionStartIndex - 1)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("transfer_asset2")]
     public class TransferAsset2 : ActionBase, ISerializable, ITransferAsset, ITransferAssetV1
     {

--- a/Lib9c/Action/UpdateSell0.cs
+++ b/Lib9c/Action/UpdateSell0.cs
@@ -22,7 +22,7 @@ using BxList = Bencodex.Types.List;
 namespace Nekoyume.Action
 {
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100080ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("update_sell")]
     public class UpdateSell0 : GameAction, IUpdateSellV1
     {

--- a/Lib9c/Action/UpdateSell2.cs
+++ b/Lib9c/Action/UpdateSell2.cs
@@ -26,7 +26,7 @@ namespace Nekoyume.Action
     /// Updated at https://github.com/planetarium/lib9c/pull/1022
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100270ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("update_sell2")]
     public class UpdateSell2 : GameAction, IUpdateSellV1
     {

--- a/Lib9c/Action/UpdateSell3.cs
+++ b/Lib9c/Action/UpdateSell3.cs
@@ -25,7 +25,7 @@ namespace Nekoyume.Action
     /// Updated at https://github.com/planetarium/lib9c/pull/1022
     /// </summary>
     [Serializable]
-    [ActionObsolete(ActionObsoleteConfig.V100320ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     [ActionType("update_sell3")]
     public class UpdateSell3 : GameAction, IUpdateSellV2
     {

--- a/Lib9c/Action/UpdateSell4.cs
+++ b/Lib9c/Action/UpdateSell4.cs
@@ -26,7 +26,7 @@ namespace Nekoyume.Action
     /// </summary>
     [Serializable]
     [ActionType("update_sell4")]
-    [ActionObsolete(ActionObsoleteConfig.V100351ObsoleteIndex)]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
     public class UpdateSell4 : GameAction, IUpdateSellV2
     {
         private const int UpdateCapacity = 100;

--- a/Lib9c/ActionObsoleteConfig.cs
+++ b/Lib9c/ActionObsoleteConfig.cs
@@ -68,5 +68,10 @@ namespace Nekoyume
         // Release plan: About 7_102_350 at 2023-06-29 12:00:00 KST
         // Seconds per block: 10
         public const long V200030ObsoleteIndex = 7_200_000;
+
+        // While v200020, the action obsolete wasn't work well.
+        // So other previous `V*ObsoletedIndex`s lost its meaning and
+        // this block index will replace them.
+        public const long V200020AccidentObsoleteIndex = 7_000_000;
     }
 }


### PR DESCRIPTION
I replaced `ActionObsolete` attributes with `\[ActionObsolete\([^)]*\)\]` => `[ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]` regex replacement