### PR TITLE
Repair incorrectly modified indexes

### DIFF
--- a/Lib9c/Action/ClaimStakeReward1.cs
+++ b/Lib9c/Action/ClaimStakeReward1.cs
@@ -13,7 +13,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [ActionType("claim_stake_reward")]
-    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
+    [ActionObsolete(ObsoleteIndex)]
     public class ClaimStakeReward1 : GameAction, IClaimStakeReward, IClaimStakeRewardV1
     {
         public const long ObsoleteIndex = ActionObsoleteConfig.V200030ObsoleteIndex;

--- a/Lib9c/Action/Stake0.cs
+++ b/Lib9c/Action/Stake0.cs
@@ -12,7 +12,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Action
 {
     [ActionType("stake")]
-    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
+    [ActionObsolete(ObsoleteIndex)]
     public class Stake0 : ActionBase, IStakeV1
     {
         public const long ObsoleteIndex = ActionObsoleteConfig.V200030ObsoleteIndex;


### PR DESCRIPTION
This pull request is from #1963. The #1963 's purpose was to shift all obsolete indexes became meaningless to the new index. But some actions were obsoleted too, though they weren't obsoleted in the v200020 version, by my mistake. This pull request recovers them.