### PR TITLE
Upgrade ClaimStakeReward action from 3 to 4

### DIFF
--- a/.Lib9c.Tests/Action/ClaimStakeReward3Test.cs
+++ b/.Lib9c.Tests/Action/ClaimStakeReward3Test.cs
@@ -70,10 +70,7 @@ namespace Lib9c.Tests.Action
             ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval,
             40,
             4,
-            0,
-            null,
-            null,
-            0L
+            0
         )]
         [InlineData(
             ClaimStakeReward2.ObsoletedIndex,
@@ -82,10 +79,7 @@ namespace Lib9c.Tests.Action
             ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval,
             4800,
             36,
-            4,
-            null,
-            null,
-            0L
+            4
         )]
         // Calculate rune start from hard fork index
         [InlineData(
@@ -95,10 +89,7 @@ namespace Lib9c.Tests.Action
             ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval,
             136800,
             1026,
-            4,
-            null,
-            null,
-            0L
+            4
         )]
         // Stake reward v2
         // Stake before v2, prev. receive v1, receive v1 & v2
@@ -109,10 +100,7 @@ namespace Lib9c.Tests.Action
             StakeState.StakeRewardSheetV2Index + 1,
             5,
             1,
-            0,
-            null,
-            null,
-            0L
+            0
         )]
         // Stake before v2, prev. receive v2, receive v2
         [InlineData(
@@ -122,10 +110,7 @@ namespace Lib9c.Tests.Action
             StakeState.StakeRewardSheetV2Index + StakeState.RewardInterval,
             5,
             1,
-            0,
-            null,
-            null,
-            0L
+            0
         )]
         // Stake after v2, no prev. receive, receive v2
         [InlineData(
@@ -135,10 +120,7 @@ namespace Lib9c.Tests.Action
             StakeState.StakeRewardSheetV2Index + StakeState.RewardInterval,
             1200,
             9,
-            1,
-            null,
-            null,
-            0L
+            1
         )]
         // stake after v2, prev. receive v2, receive v2
         [InlineData(
@@ -148,10 +130,7 @@ namespace Lib9c.Tests.Action
             StakeState.StakeRewardSheetV2Index + StakeState.RewardInterval * 2,
             5,
             1,
-            0,
-            null,
-            null,
-            0L
+            0
         )]
         // stake before currency as reward, non prev.
         [InlineData(
@@ -161,10 +140,7 @@ namespace Lib9c.Tests.Action
             StakeState.CurrencyAsRewardStartIndex + StakeState.RewardInterval,
             3_000_000,
             37_506,
-            4_998,
-            AgentAddressHex,
-            "GARAGE",
-            100_000L
+            4_998
         )]
         // stake before currency as reward, prev.
         [InlineData(
@@ -174,10 +150,7 @@ namespace Lib9c.Tests.Action
             StakeState.CurrencyAsRewardStartIndex + StakeState.RewardInterval,
             2_000_000,
             25_004,
-            3_332,
-            AgentAddressHex,
-            "GARAGE",
-            100_000L
+            3_332
         )]
         public void Execute_Success(
             long startedBlockIndex,
@@ -186,10 +159,7 @@ namespace Lib9c.Tests.Action
             long blockIndex,
             int expectedHourglass,
             int expectedApStone,
-            int expectedRune,
-            string expectedCurrencyAddrHex,
-            string expectedCurrencyTicker,
-            long expectedCurrencyAmount)
+            int expectedRune)
         {
             Execute(
                 _initialStatesWithAvatarStateV1,
@@ -201,10 +171,7 @@ namespace Lib9c.Tests.Action
                 blockIndex,
                 expectedHourglass,
                 expectedApStone,
-                expectedRune,
-                expectedCurrencyAddrHex,
-                expectedCurrencyTicker,
-                expectedCurrencyAmount);
+                expectedRune);
 
             Execute(
                 _initialStatesWithAvatarStateV2,
@@ -216,10 +183,7 @@ namespace Lib9c.Tests.Action
                 blockIndex,
                 expectedHourglass,
                 expectedApStone,
-                expectedRune,
-                expectedCurrencyAddrHex,
-                expectedCurrencyTicker,
-                expectedCurrencyAmount);
+                expectedRune);
         }
 
         private void Execute(
@@ -232,10 +196,7 @@ namespace Lib9c.Tests.Action
             long blockIndex,
             int expectedHourglass,
             int expectedApStone,
-            int expectedRune,
-            string expectedCurrencyAddrHex,
-            string expectedCurrencyTicker,
-            long expectedCurrencyAmount)
+            int expectedRune)
         {
             var stakeStateAddr = StakeState.DeriveAddress(agentAddr);
             var initialStakeState = new StakeState(stakeStateAddr, startedBlockIndex);
@@ -267,14 +228,6 @@ namespace Lib9c.Tests.Action
             Assert.Equal(
                 expectedRune * RuneHelper.StakeRune,
                 states.GetBalance(avatarAddr, RuneHelper.StakeRune));
-            if (!string.IsNullOrEmpty(expectedCurrencyAddrHex))
-            {
-                var addr = new Address(expectedCurrencyAddrHex);
-                var currency = Currencies.GetMinterlessCurrency(expectedCurrencyTicker);
-                Assert.Equal(
-                    expectedCurrencyAmount * currency,
-                    states.GetBalance(addr, currency));
-            }
 
             Assert.True(states.TryGetStakeState(agentAddr, out StakeState stakeState));
             Assert.Equal(blockIndex, stakeState.ReceivedBlockIndex);

--- a/.Lib9c.Tests/Action/ClaimStakeReward3Test.cs
+++ b/.Lib9c.Tests/Action/ClaimStakeReward3Test.cs
@@ -42,8 +42,8 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Serialization()
         {
-            var action = new ClaimStakeReward(_avatarAddr);
-            var deserialized = new ClaimStakeReward();
+            var action = new ClaimStakeReward3(_avatarAddr);
+            var deserialized = new ClaimStakeReward3();
             deserialized.LoadPlainValue(action.PlainValue);
             Assert.Equal(action.AvatarAddress, deserialized.AvatarAddress);
         }
@@ -53,7 +53,7 @@ namespace Lib9c.Tests.Action
         [InlineData(ClaimStakeReward2.ObsoletedIndex - 1)]
         public void Execute_Throw_ActionUnAvailableException(long blockIndex)
         {
-            var action = new ClaimStakeReward(_avatarAddr);
+            var action = new ClaimStakeReward3(_avatarAddr);
             Assert.Throws<ActionUnavailableException>(() => action.Execute(new ActionContext
             {
                 PreviousStates = _initialStatesWithAvatarStateV2,
@@ -248,7 +248,7 @@ namespace Lib9c.Tests.Action
                 .SetState(stakeStateAddr, initialStakeState.Serialize())
                 .MintAsset(stakeStateAddr, _ncg * stakeAmount);
 
-            var action = new ClaimStakeReward(avatarAddr);
+            var action = new ClaimStakeReward3(avatarAddr);
             var states = action.Execute(new ActionContext
             {
                 PreviousStates = prevState,

--- a/.Lib9c.Tests/Action/ClaimStakeRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimStakeRewardTest.cs
@@ -1,0 +1,269 @@
+#nullable enable
+
+namespace Lib9c.Tests.Action
+{
+    using System.Linq;
+    using Lib9c.Tests.Util;
+    using Libplanet;
+    using Libplanet.Assets;
+    using Libplanet.State;
+    using Nekoyume.Action;
+    using Nekoyume.Helper;
+    using Nekoyume.Model.State;
+    using Serilog;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class ClaimStakeRewardTest
+    {
+        private const string AgentAddressHex = "0x0000000001000000000100000000010000000001";
+        private readonly Address _agentAddr = new Address(AgentAddressHex);
+        private readonly Address _avatarAddr;
+        private readonly IAccountStateDelta _initialStatesWithAvatarStateV1;
+        private readonly IAccountStateDelta _initialStatesWithAvatarStateV2;
+        private readonly Currency _ncg;
+
+        public ClaimStakeRewardTest(ITestOutputHelper outputHelper)
+        {
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.TestOutput(outputHelper)
+                .CreateLogger();
+            (
+                _,
+                _,
+                _avatarAddr,
+                _initialStatesWithAvatarStateV1,
+                _initialStatesWithAvatarStateV2) = InitializeUtil.InitializeStates(
+                agentAddr: _agentAddr);
+            _ncg = _initialStatesWithAvatarStateV1.GetGoldCurrency();
+        }
+
+        [Fact]
+        public void Serialization()
+        {
+            var action = new ClaimStakeReward(_avatarAddr);
+            var deserialized = new ClaimStakeReward();
+            deserialized.LoadPlainValue(action.PlainValue);
+            Assert.Equal(action.AvatarAddress, deserialized.AvatarAddress);
+        }
+
+        [Theory]
+        [InlineData(
+            ClaimStakeReward2.ObsoletedIndex,
+            100L,
+            null,
+            ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval,
+            40,
+            4,
+            0,
+            null,
+            null,
+            0L
+        )]
+        [InlineData(
+            ClaimStakeReward2.ObsoletedIndex,
+            6000L,
+            null,
+            ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval,
+            4800,
+            36,
+            4,
+            null,
+            null,
+            0L
+        )]
+        // Calculate rune start from hard fork index
+        [InlineData(
+            0L,
+            6000L,
+            0L,
+            ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval,
+            136800,
+            1026,
+            4,
+            null,
+            null,
+            0L
+        )]
+        // Stake reward v2
+        // Stake before v2, prev. receive v1, receive v1 & v2
+        [InlineData(
+            StakeState.StakeRewardSheetV2Index - StakeState.RewardInterval * 2,
+            50L,
+            StakeState.StakeRewardSheetV2Index - StakeState.RewardInterval,
+            StakeState.StakeRewardSheetV2Index + 1,
+            5,
+            1,
+            0,
+            null,
+            null,
+            0L
+        )]
+        // Stake before v2, prev. receive v2, receive v2
+        [InlineData(
+            StakeState.StakeRewardSheetV2Index - StakeState.RewardInterval,
+            50L,
+            StakeState.StakeRewardSheetV2Index,
+            StakeState.StakeRewardSheetV2Index + StakeState.RewardInterval,
+            5,
+            1,
+            0,
+            null,
+            null,
+            0L
+        )]
+        // Stake after v2, no prev. receive, receive v2
+        [InlineData(
+            StakeState.StakeRewardSheetV2Index,
+            6000L,
+            null,
+            StakeState.StakeRewardSheetV2Index + StakeState.RewardInterval,
+            1200,
+            9,
+            1,
+            null,
+            null,
+            0L
+        )]
+        // stake after v2, prev. receive v2, receive v2
+        [InlineData(
+            StakeState.StakeRewardSheetV2Index,
+            50L,
+            StakeState.StakeRewardSheetV2Index + StakeState.RewardInterval,
+            StakeState.StakeRewardSheetV2Index + StakeState.RewardInterval * 2,
+            5,
+            1,
+            0,
+            null,
+            null,
+            0L
+        )]
+        // stake before currency as reward, non prev.
+        [InlineData(
+            StakeState.CurrencyAsRewardStartIndex - StakeState.RewardInterval * 2,
+            10_000_000L,
+            null,
+            StakeState.CurrencyAsRewardStartIndex + StakeState.RewardInterval,
+            3_000_000,
+            37_506,
+            4_998,
+            AgentAddressHex,
+            "GARAGE",
+            100_000L
+        )]
+        // stake before currency as reward, prev.
+        [InlineData(
+            StakeState.CurrencyAsRewardStartIndex - StakeState.RewardInterval * 2,
+            10_000_000L,
+            StakeState.CurrencyAsRewardStartIndex - StakeState.RewardInterval,
+            StakeState.CurrencyAsRewardStartIndex + StakeState.RewardInterval,
+            2_000_000,
+            25_004,
+            3_332,
+            AgentAddressHex,
+            "GARAGE",
+            100_000L
+        )]
+        public void Execute_Success(
+            long startedBlockIndex,
+            long stakeAmount,
+            long? previousRewardReceiveIndex,
+            long blockIndex,
+            int expectedHourglass,
+            int expectedApStone,
+            int expectedRune,
+            string expectedCurrencyAddrHex,
+            string expectedCurrencyTicker,
+            long expectedCurrencyAmount)
+        {
+            Execute(
+                _initialStatesWithAvatarStateV1,
+                _agentAddr,
+                _avatarAddr,
+                startedBlockIndex,
+                stakeAmount,
+                previousRewardReceiveIndex,
+                blockIndex,
+                expectedHourglass,
+                expectedApStone,
+                expectedRune,
+                expectedCurrencyAddrHex,
+                expectedCurrencyTicker,
+                expectedCurrencyAmount);
+
+            Execute(
+                _initialStatesWithAvatarStateV2,
+                _agentAddr,
+                _avatarAddr,
+                startedBlockIndex,
+                stakeAmount,
+                previousRewardReceiveIndex,
+                blockIndex,
+                expectedHourglass,
+                expectedApStone,
+                expectedRune,
+                expectedCurrencyAddrHex,
+                expectedCurrencyTicker,
+                expectedCurrencyAmount);
+        }
+
+        private void Execute(
+            IAccountStateDelta prevState,
+            Address agentAddr,
+            Address avatarAddr,
+            long startedBlockIndex,
+            long stakeAmount,
+            long? previousRewardReceiveIndex,
+            long blockIndex,
+            int expectedHourglass,
+            int expectedApStone,
+            int expectedRune,
+            string expectedCurrencyAddrHex,
+            string expectedCurrencyTicker,
+            long expectedCurrencyAmount)
+        {
+            var stakeStateAddr = StakeState.DeriveAddress(agentAddr);
+            var initialStakeState = new StakeState(stakeStateAddr, startedBlockIndex);
+            if (!(previousRewardReceiveIndex is null))
+            {
+                initialStakeState.Claim((long)previousRewardReceiveIndex);
+            }
+
+            prevState = prevState
+                .SetState(stakeStateAddr, initialStakeState.Serialize())
+                .MintAsset(stakeStateAddr, _ncg * stakeAmount);
+
+            var action = new ClaimStakeReward(avatarAddr);
+            var states = action.Execute(new ActionContext
+            {
+                PreviousStates = prevState,
+                Signer = agentAddr,
+                BlockIndex = blockIndex,
+            });
+
+            AvatarState avatarState = states.GetAvatarStateV2(avatarAddr);
+            Assert.Equal(
+                expectedHourglass,
+                avatarState.inventory.Items.First(x => x.item.Id == 400000).count);
+            // It must be never added into the inventory if the amount is 0.
+            Assert.Equal(
+                expectedApStone,
+                avatarState.inventory.Items.First(x => x.item.Id == 500000).count);
+            Assert.Equal(
+                expectedRune * RuneHelper.StakeRune,
+                states.GetBalance(avatarAddr, RuneHelper.StakeRune));
+            if (!string.IsNullOrEmpty(expectedCurrencyAddrHex))
+            {
+                var addr = new Address(expectedCurrencyAddrHex);
+                var currency = Currencies.GetMinterlessCurrency(expectedCurrencyTicker);
+                Assert.Equal(
+                    expectedCurrencyAmount * currency,
+                    states.GetBalance(addr, currency));
+            }
+
+            Assert.True(states.TryGetStakeState(agentAddr, out StakeState stakeState));
+            Assert.Equal(blockIndex, stakeState.ReceivedBlockIndex);
+        }
+    }
+}

--- a/.Lib9c.Tests/Action/Factory/ClaimStakeRewardFactoryTest.cs
+++ b/.Lib9c.Tests/Action/Factory/ClaimStakeRewardFactoryTest.cs
@@ -12,7 +12,7 @@ namespace Lib9c.Tests.Action.Factory
         [Theory]
         [InlineData(ClaimStakeReward2.ObsoletedIndex - 1, typeof(ClaimStakeReward2))]
         [InlineData(ClaimStakeReward2.ObsoletedIndex, typeof(ClaimStakeReward2))]
-        [InlineData(ClaimStakeReward2.ObsoletedIndex + 1, typeof(ClaimStakeReward))]
+        [InlineData(ClaimStakeReward2.ObsoletedIndex + 1, typeof(ClaimStakeReward3))]
         public void Create_ByBlockIndex_Success(
             long blockIndex,
             Type type)
@@ -25,7 +25,7 @@ namespace Lib9c.Tests.Action.Factory
         [Theory]
         [InlineData(1, typeof(ClaimStakeReward1))]
         [InlineData(2, typeof(ClaimStakeReward2))]
-        [InlineData(3, typeof(ClaimStakeReward))]
+        [InlineData(3, typeof(ClaimStakeReward3))]
         public void Create_ByVersion_Success(
             int version,
             Type type)

--- a/.Lib9c.Tests/Action/Scenario/StakeAndClaimStakeReward3ScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/StakeAndClaimStakeReward3ScenarioTest.cs
@@ -615,7 +615,7 @@ namespace Lib9c.Tests.Action.Scenario
             Assert.NotNull(stakeState);
             Assert.Equal(0 * RuneHelper.StakeRune, _initialStatesWithAvatarStateV2.GetBalance(_avatarAddr, RuneHelper.StakeRune));
 
-            action = new ClaimStakeReward(_avatarAddr);
+            action = new ClaimStakeReward3(_avatarAddr);
             states = action.Execute(new ActionContext
             {
                 PreviousStates = states,
@@ -672,7 +672,7 @@ namespace Lib9c.Tests.Action.Scenario
                 _ncg * stakeAmount,
                 states.GetBalance(stakeState.address, _ncg));
 
-            action = new ClaimStakeReward(_avatarAddr);
+            action = new ClaimStakeReward3(_avatarAddr);
             states = action.Execute(new ActionContext
             {
                 PreviousStates = states,
@@ -745,7 +745,7 @@ namespace Lib9c.Tests.Action.Scenario
                 _ncg * stakeAmount,
                 states.GetBalance(stakeState.address, _ncg));
 
-            action = new ClaimStakeReward(_avatarAddr);
+            action = new ClaimStakeReward3(_avatarAddr);
             states = action.Execute(new ActionContext
             {
                 PreviousStates = states,
@@ -801,7 +801,7 @@ namespace Lib9c.Tests.Action.Scenario
             // 201,600 블록 도달 이후 → 지정된 캐릭터 앞으로 이하 보상의 수령이 가능해야 한다.
             foreach ((long claimBlockIndex, (int itemId, int amount)[] expectedItems) in claimEvents)
             {
-                action = new ClaimStakeReward(_avatarAddr);
+                action = new ClaimStakeReward3(_avatarAddr);
                 states = action.Execute(new ActionContext
                 {
                     PreviousStates = states,
@@ -853,7 +853,7 @@ namespace Lib9c.Tests.Action.Scenario
                 Assert.Throws<RequiredBlockIndexException>(() =>
                 {
                     // 현재 스테이킹된 NCG를 인출할 수 없다
-                    action = new ClaimStakeReward(_avatarAddr);
+                    action = new ClaimStakeReward3(_avatarAddr);
                     states = action.Execute(new ActionContext
                     {
                         PreviousStates = states,
@@ -888,7 +888,7 @@ namespace Lib9c.Tests.Action.Scenario
                 BlockIndex = ClaimStakeReward2.ObsoletedIndex,
             });
 
-            action = new ClaimStakeReward(_avatarAddr);
+            action = new ClaimStakeReward3(_avatarAddr);
             Assert.Throws<RequiredBlockIndexException>(() => states = action.Execute(new ActionContext
             {
                 PreviousStates = states,

--- a/.Lib9c.Tests/Action/Scenario/StakeAndClaimStakeRewardScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/StakeAndClaimStakeRewardScenarioTest.cs
@@ -1,0 +1,1010 @@
+namespace Lib9c.Tests.Action.Scenario
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Lib9c.Tests.Util;
+    using Libplanet;
+    using Libplanet.Action;
+    using Libplanet.Assets;
+    using Libplanet.State;
+    using Nekoyume.Action;
+    using Nekoyume.Helper;
+    using Nekoyume.Model.State;
+    using Serilog;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class StakeAndClaimStakeRewardScenarioTest
+    {
+        private const string AgentAddressHex = "0x0000000001000000000100000000010000000001";
+        private readonly Address _agentAddr = new Address(AgentAddressHex);
+        private readonly Address _avatarAddr;
+        private readonly IAccountStateDelta _initialStatesWithAvatarStateV2;
+        private readonly Currency _ncg;
+
+        public StakeAndClaimStakeRewardScenarioTest(ITestOutputHelper outputHelper)
+        {
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.TestOutput(outputHelper)
+                .CreateLogger();
+
+            (
+                _,
+                _,
+                _avatarAddr,
+                _,
+                _initialStatesWithAvatarStateV2) = InitializeUtil.InitializeStates(
+                agentAddr: _agentAddr);
+            _ncg = _initialStatesWithAvatarStateV2.GetGoldCurrency();
+        }
+
+        public static IEnumerable<object[]> StakeAndClaimStakeRewardTestCases()
+        {
+            // 일반적인 보상수령 확인
+            // 1단계 수준(50~499NCG)의 deposit save 완료
+            //      → 최초 보상 시점 (50,400블록 이후) 도달
+            //      → 지정된 캐릭터 앞으로 이하 보상의 수령이 가능해야 한다.
+            // (보상내용: 1 hourglass / 10 NCG, 1 ap portion / 800 NCG 소수점 버림, 기존 deposit 유지 확인)
+            yield return new object[]
+            {
+                50L,
+                new[]
+                {
+                    (400_000, 5),
+                    (500_000, 1),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 50_400L,
+                0,
+                null,
+                null,
+                0L,
+            };
+            yield return new object[]
+            {
+                499L,
+                new[]
+                {
+                    (400_000, 49),
+                    (500_000, 1),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 50_400L,
+                0,
+                null,
+                null,
+                0L,
+            };
+
+            // 2단계 수준(500~4,999NCG)의 deposit save 완료
+            //      → 최초 보상 시점 (50,400블록 이후) 도달
+            //      → 지정된 캐릭터 앞으로 이하 보상의 수령이 가능해야 한다.
+            // (보상내용: 1 hourglass / 8 NCG, 1 ap portion / 800 NCG 소수점 버림, 기존 deposit 유지 확인)
+            yield return new object[]
+            {
+                500L,
+                new[]
+                {
+                    (400_000, 62),
+                    (500_000, 2),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 50_400L,
+                0,
+                null,
+                null,
+                0L,
+            };
+            yield return new object[]
+            {
+                799L,
+                new[]
+                {
+                    (400_000, 99),
+                    (500_000, 2),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 50_400L,
+                0,
+                null,
+                null,
+                0L,
+            };
+            yield return new object[]
+            {
+                4_999L,
+                new[]
+                {
+                    (400_000, 624),
+                    (500_000, 8),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 50_400L,
+                0,
+                null,
+                null,
+                0L,
+            };
+
+            // 3단계 수준(5,000~49,999NCG)의 deposit save 완료
+            //      → 최초 보상 시점 (50,400블록 이후) 도달
+            //      → 지정된 캐릭터 앞으로 이하 보상의 수령이 가능해야 한다.
+            // (보상내용: 1 hourglass / 5 NCG, 1 ap portion / 800 NCG 소수점 버림, 기존 deposit 유지 확인)
+            yield return new object[]
+            {
+                5_000L,
+                new[]
+                {
+                    (400_000, 1000),
+                    (500_000, 8),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 50_400L,
+                0,
+                null,
+                null,
+                0L,
+            };
+            yield return new object[]
+            {
+                49_999L,
+                new[]
+                {
+                    (400_000, 9_999),
+                    (500_000, 64),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 50_400L,
+                8,
+                null,
+                null,
+                0L,
+            };
+
+            // 4단계 수준(50,000~499,999NCG)의 deposit save 완료
+            //      → 최초 보상 시점 (50,400블록 이후) 도달
+            //      → 지정된 캐릭터 앞으로 이하 보상의 수령이 가능해야 한다.
+            // (보상내용: 1 hourglass / 5 NCG, 1 ap portion / 800 NCG 소수점 버림, 기존 deposit 유지 확인)
+            yield return new object[]
+            {
+                50_000L,
+                new[]
+                {
+                    (400_000, 10_000),
+                    (500_000, 64),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 50_400L,
+                8,
+                null,
+                null,
+                0L,
+            };
+            yield return new object[]
+            {
+                499_999L,
+                new[]
+                {
+                    (400_000, 99_999),
+                    (500_000, 626),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 50_400L,
+                83,
+                null,
+                null,
+                0L,
+            };
+
+            // 5단계 수준(500,000~100,000,000NCG)의 deposit save 완료
+            //      → 최초 보상 시점 (50,400블록 이후) 도달
+            //      → 지정된 캐릭터 앞으로 이하 보상의 수령이 가능해야 한다.
+            // (보상내용: 1 hourglass / 5 NCG, 1 ap portion / 800 NCG 소수점 버림, 기존 deposit 유지 확인)
+            yield return new object[]
+            {
+                500_000L,
+                new[]
+                {
+                    (400_000, 100_000),
+                    (500_000, 627),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 50_400L,
+                83,
+                null,
+                null,
+                0L,
+            };
+            yield return new object[]
+            {
+                99_999_999L,
+                new[]
+                {
+                    (400_000, 19_999_999),
+                    (500_000, 125_001),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 50_400L,
+                16_666,
+                null,
+                null,
+                0L,
+            };
+
+            // 지연된 보상수령 확인
+            // 1단계 수준(50~499NCG)의 deposit save 완료
+            //      → 최초 보상 시점 (50,400블록 이후) 도달
+            //      → 보상을 수령하지 않음
+            //      → 2번째 보상 시점 (100,800블록 이후) 도달
+            //      → 이하 보상의 수령이 가능해야 한다.
+            // (보상내용: 2 hourglass / 50 NCG, 소수점 버림, 기존 deposit 유지 확인)
+            yield return new object[]
+            {
+                50L,
+                new[]
+                {
+                    (400_000, 45),
+                    (500_000, 9),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 500_800L,
+                0,
+                null,
+                null,
+                0L,
+            };
+            yield return new object[]
+            {
+                499L,
+                new[]
+                {
+                    (400_000, 441),
+                    (500_000, 9),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 500_800L,
+                0,
+                null,
+                null,
+                0L,
+            };
+
+            // 2단계 수준(500~4,999NCG)의 deposit save 완료
+            //      → 최초 보상 시점 (50,400블록 이후) 도달
+            //      → 보상을 수령하지 않음
+            //      → 2번째 보상 시점 (100,800블록 이후) 도달
+            //      → 이하 보상의 수령이 가능해야 한다.
+            // (보상내용: 2 hourglass / 8 NCG, 2 ap portion / 800 NCG 소수점 버림, 기존 deposit 유지 확인)
+            yield return new object[]
+            {
+                500L,
+                new[]
+                {
+                    (400_000, 558),
+                    (500_000, 18),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 500_800L,
+                0,
+                null,
+                null,
+                0L,
+            };
+            yield return new object[]
+            {
+                799L,
+                new[]
+                {
+                    (400_000, 891),
+                    (500_000, 18),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 500_800L,
+                0,
+                null,
+                null,
+                0L,
+            };
+            yield return new object[]
+            {
+                4_999L,
+                new[]
+                {
+                    (400_000, 5_616),
+                    (500_000, 72),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 500_800L,
+                0,
+                null,
+                null,
+                0L,
+            };
+
+            // 3단계 수준(5,000~49,999NCG)의 deposit save 완료
+            //      → 최초 보상 시점 (50,400블록 이후) 도달
+            //      → 보상을 수령하지 않음
+            //      → 2번째 보상 시점 (100,800블록 이후) 도달
+            //      → 이하 보상의 수령이 가능해야 한다.
+            // (보상내용: 2 hourglass / 5 NCG, 2 ap portion / 180 NCG 소수점 버림, 기존 deposit 유지 확인)
+            yield return new object[]
+            {
+                5_000L,
+                new[]
+                {
+                    (400_000, 9_000),
+                    (500_000, 72),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 500_800L,
+                0,
+                null,
+                null,
+                0L,
+            };
+            yield return new object[]
+            {
+                49_999L,
+                new[]
+                {
+                    (400_000, 89_991),
+                    (500_000, 576),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 500_800L,
+                72,
+                null,
+                null,
+                0L,
+            };
+
+            // 4단계 수준(50,000~499,999NCG)의 deposit save 완료
+            //      → 최초 보상 시점 (50,400블록 이후) 도달
+            //      → 보상을 수령하지 않음
+            //      → 2번째 보상 시점 (100,800블록 이후) 도달
+            //      → 이하 보상의 수령이 가능해야 한다.
+            // (보상내용: 2 hourglass / 5 NCG, 2 ap portion / 180 NCG 소수점 버림, 기존 deposit 유지 확인)
+            yield return new object[]
+            {
+                50_000L,
+                new[]
+                {
+                    (400_000, 90_000),
+                    (500_000, 576),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 500_800L,
+                72,
+                null,
+                null,
+                0L,
+            };
+            yield return new object[]
+            {
+                499_999L,
+                new[]
+                {
+                    (400_000, 899_991),
+                    (500_000, 5_634),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 500_800L,
+                747,
+                null,
+                null,
+                0L,
+            };
+
+            // 5단계 수준(500,000~4,999,999NCG)의 deposit save 완료
+            //      → 최초 보상 시점 (50,400블록 이후) 도달
+            //      → 지정된 캐릭터 앞으로 이하 보상의 수령이 가능해야 한다.
+            // (보상내용: 1 hourglass / 5 NCG, 1 ap portion / 160 NCG 소수점 버림, 기존 deposit 유지 확인)
+            // 5단계 수준(500,000~500,000,000NCG)의 deposit save 완료
+            //      → 최초 보상 시점 (50,400블록 이후) 도달
+            //      → 보상을 수령하지 않음
+            //      → 2번째 보상 시점 (100,800블록 이후) 도달
+            //      → 이하 보상의 수령이 가능해야 한다.
+            // (보상내용: 2 hourglass / 5 NCG, 2 ap portion / 160 NCG 소수점 버림, 기존 deposit 유지 확인)
+            yield return new object[]
+            {
+                500_000L,
+                new[]
+                {
+                    (400_000, 900_000),
+                    (500_000, 5_643),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 500_800L,
+                747,
+                null,
+                null,
+                0L,
+            };
+            yield return new object[]
+            {
+                4_999_999L,
+                new[]
+                {
+                    (400_000, 8_999_991),
+                    (500_000, 56_259),
+                },
+                ClaimStakeReward2.ObsoletedIndex + 500_800L,
+                7_497,
+                null,
+                null,
+                0L,
+            };
+        }
+
+        public static IEnumerable<object[]> StakeLessAfterLockupTestcases()
+        {
+            (long ClaimBlockIndex, (int ItemId, int Amount)[])[] BuildEvents(
+                int hourglassRate,
+                int apPotionRate,
+                int apPotionBonus,
+                long stakeAmount)
+            {
+                const int hourglassItemId = 400_000, apPotionItemId = 500_000;
+                return new[]
+                {
+                    (
+                        ClaimStakeReward2.ObsoletedIndex + StakeState.RewardInterval,
+                        new[]
+                        {
+                            (hourglassItemId, (int)(stakeAmount / hourglassRate)),
+                            (apPotionItemId, (int)(stakeAmount / apPotionRate + apPotionBonus)),
+                        }
+                    ),
+                    (
+                        ClaimStakeReward2.ObsoletedIndex + StakeState.RewardInterval * 2,
+                        new[]
+                        {
+                            (hourglassItemId, (int)(stakeAmount / hourglassRate)),
+                            (apPotionItemId, (int)(stakeAmount / apPotionRate + apPotionBonus)),
+                        }
+                    ),
+                    (
+                        ClaimStakeReward2.ObsoletedIndex + StakeState.RewardInterval * 3,
+                        new[]
+                        {
+                            (hourglassItemId, (int)(stakeAmount / hourglassRate)),
+                            (apPotionItemId, (int)(stakeAmount / apPotionRate + apPotionBonus)),
+                        }
+                    ),
+                    (
+                        ClaimStakeReward2.ObsoletedIndex + StakeState.RewardInterval * 4,
+                        new[]
+                        {
+                            (hourglassItemId, (int)(stakeAmount / hourglassRate)),
+                            (apPotionItemId, (int)(stakeAmount / apPotionRate + apPotionBonus)),
+                        }
+                    ),
+                };
+            }
+
+            // 1단계 수준(50~499NCG)의 deposit save 완료
+            //      → 1~3회까지 모든 보상을 수령함
+            //      → 201,600 블록 도달 이후
+            //      → 지정된 캐릭터 앞으로 이하 보상의 수령이 가능해야 한다.
+            //        (보상내용: 1 hourglass / 50 NCG, 1 ap portion / 800 NCG 소수점 버림, 기존 deposit 유지 확인)
+            //      → 기존 deposit보다 낮은 금액으로 edit save 한다.
+            //      → 보상 타이머 리셋 확인
+            //      → (기존 deposit - 현재 deposit 만큼의 ncg 인출 상태 확인)
+            //      → 현재 스테이킹된 NCG를 인출할 수 없다 (스테이킹 추가는 가능)
+            //      → (현재 deposit 묶인 상태 확인)
+            yield return new object[]
+            {
+                51L,
+                51L,
+                50L,
+                BuildEvents(10, 800, 1, 50),
+            };
+            yield return new object[]
+            {
+                499L,
+                499L,
+                50L,
+                BuildEvents(10, 800, 1, 499),
+            };
+
+            // 현재의 스테이킹된 NCG의 전액 인출을 시도한다(deposit NCG 인출 상태 확인)
+            //      → 스테이킹 완전 소멸 확인
+            yield return new object[]
+            {
+                50L,
+                50L,
+                0L,
+                BuildEvents(10, 800, 1, 50),
+            };
+            yield return new object[]
+            {
+                499L,
+                499L,
+                0L,
+                BuildEvents(10, 800, 1, 499),
+            };
+
+            // 2단계 수준(500~4,999NCG)의 deposit save 완료
+            //      → 1~3회까지 모든 보상을 수령함
+            //      → 201,600 블록 도달 이후
+            //      → 지정된 캐릭터 앞으로 이하 보상의 수령이 가능해야 한다.
+            //        (보상내용: 1 hourglass / 8 NCG, 1 ap portion / 800 NCG 소수점 버림, 기존 deposit 유지 확인)
+            //      → 기존 deposit보다 낮은 금액으로 edit save 한다.
+            //      → 보상 타이머 리셋 확인
+            //      → (기존 deposit - 현재 deposit 만큼의 ncg 인출 상태 확인)
+            //      → 현재 스테이킹된 NCG를 인출할 수 없다 (스테이킹 추가는 가능)
+            //      → (현재 deposit 묶인 상태 확인)
+            yield return new object[]
+            {
+                500L,
+                500L,
+                499L,
+                BuildEvents(8, 800, 2, 500),
+            };
+            yield return new object[]
+            {
+                4_999L,
+                4_999L,
+                500L,
+                BuildEvents(8, 800, 2, 4_999),
+            };
+
+            // 현재의 스테이킹된 NCG의 전액 인출을 시도한다(deposit NCG 인출 상태 확인)
+            //      → 스테이킹 완전 소멸 확인
+            yield return new object[]
+            {
+                500L,
+                500L,
+                0L,
+                BuildEvents(8, 800, 2, 500),
+            };
+            yield return new object[]
+            {
+                4_999L,
+                4_999L,
+                0L,
+                BuildEvents(8, 800, 2, 4_999),
+            };
+
+            // 3단계 수준(5,000~49,999NCG)의 deposit save 완료
+            //      → 1~3회까지 모든 보상을 수령함
+            //      → 201,600 블록 도달 이후
+            //      → 지정된 캐릭터 앞으로 이하 보상의 수령이 가능해야 한다.
+            //        (보상내용: 1 hourglass / 5 NCG, 1 ap portion / 800 NCG 소수점 버림, 기존 deposit 유지 확인)
+            //      → 기존 deposit보다 낮은 금액으로 edit save 한다.
+            //      → 보상 타이머 리셋 확인
+            //      → (기존 deposit - 현재 deposit 만큼의 ncg 인출 상태 확인)
+            //      → 현재 스테이킹된 NCG를 인출할 수 없다 (스테이킹 추가는 가능)
+            //      → (현재 deposit 묶인 상태 확인)
+            yield return new object[]
+            {
+                5_000L,
+                5_000L,
+                4_999L,
+                BuildEvents(5, 800, 2, 5_000),
+            };
+            yield return new object[]
+            {
+                49_999L,
+                49_999L,
+                5_000L,
+                BuildEvents(5, 800, 2, 49_999),
+            };
+
+            // 현재의 스테이킹된 NCG의 전액 인출을 시도한다(deposit NCG 인출 상태 확인)
+            //      → 스테이킹 완전 소멸 확인
+            yield return new object[]
+            {
+                5_000L,
+                5_000L,
+                0L,
+                BuildEvents(5, 800, 2, 5_000),
+            };
+            yield return new object[]
+            {
+                49_999L,
+                49_999L,
+                0L,
+                BuildEvents(5, 800, 2, 49_999),
+            };
+
+            // 4단계 수준(50,000~499,999NCG)의 deposit save 완료
+            //      → 1~3회까지 모든 보상을 수령함
+            //      → 201,600 블록 도달 이후
+            //      → 지정된 캐릭터 앞으로 이하 보상의 수령이 가능해야 한다.
+            //        (보상내용: 1 hourglass / 5 NCG, 1 ap portion / 800 NCG 소수점 버림, 기존 deposit 유지 확인)
+            //      → 기존 deposit보다 낮은 금액으로 edit save 한다.
+            //      → 보상 타이머 리셋 확인
+            //      → (기존 deposit - 현재 deposit 만큼의 ncg 인출 상태 확인)
+            //      → 현재 스테이킹된 NCG를 인출할 수 없다 (스테이킹 추가는 가능)
+            //      → (현재 deposit 묶인 상태 확인)
+            yield return new object[]
+            {
+                50_000L,
+                50_000L,
+                49_999L,
+                BuildEvents(5, 800, 2, 50_000),
+            };
+            yield return new object[]
+            {
+                499_999L,
+                499_999L,
+                50_000L,
+                BuildEvents(5, 800, 2, 499_999),
+            };
+
+            // 현재의 스테이킹된 NCG의 전액 인출을 시도한다(deposit NCG 인출 상태 확인)
+            //      → 스테이킹 완전 소멸 확인
+            yield return new object[]
+            {
+                50_000L,
+                50_000L,
+                0L,
+                BuildEvents(5, 800, 2, 50_000),
+            };
+            yield return new object[]
+            {
+                499_999L,
+                499_999L,
+                0L,
+                BuildEvents(5, 800, 2, 499_999),
+            };
+
+            // 5단계 수준(500,000~100,000,000NCG)의 deposit save 완료
+            //      → 1~3회까지 모든 보상을 수령함
+            //      → 201,600 블록 도달 이후
+            //      → 지정된 캐릭터 앞으로 이하 보상의 수령이 가능해야 한다.
+            //        (보상내용: 1 hourglass / 5 NCG, 1 ap portion / 800 NCG 소수점 버림, 기존 deposit 유지 확인)
+            //      → 기존 deposit보다 낮은 금액으로 edit save 한다.
+            //      → 보상 타이머 리셋 확인
+            //      → (기존 deposit - 현재 deposit 만큼의 ncg 인출 상태 확인)
+            //      → 현재 스테이킹된 NCG를 인출할 수 없다 (스테이킹 추가는 가능)
+            //      → (현재 deposit 묶인 상태 확인)
+            yield return new object[]
+            {
+                500_000L,
+                500_000L,
+                499_999L,
+                BuildEvents(5, 800, 2, 500_000),
+            };
+            yield return new object[]
+            {
+                500_000_000L,
+                500_000_000L,
+                500_000L,
+                BuildEvents(5, 800, 2, 500_000_000),
+            };
+
+            // 현재의 스테이킹된 NCG의 전액 인출을 시도한다(deposit NCG 인출 상태 확인)
+            //      → 스테이킹 완전 소멸 확인
+            yield return new object[]
+            {
+                500_000L,
+                500_000L,
+                0L,
+                BuildEvents(5, 800, 2, 500_000),
+            };
+            yield return new object[]
+            {
+                500_000_000L,
+                500_000_000L,
+                0L,
+                BuildEvents(5, 800, 2, 500_000_000),
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(StakeAndClaimStakeRewardTestCases))]
+        public void StakeAndClaimStakeReward(
+            long stakeAmount,
+            (int ItemId, int Amount)[] expectedItems,
+            long receiveBlockIndex,
+            int expectedRune,
+            string expectedCurrencyAddrHex,
+            string expectedCurrencyTicker,
+            long expectedCurrencyAmount)
+        {
+            var states = _initialStatesWithAvatarStateV2.MintAsset(_agentAddr, _ncg * stakeAmount);
+
+            IAction action = new Stake(stakeAmount);
+            states = action.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _agentAddr,
+                BlockIndex = ClaimStakeReward2.ObsoletedIndex,
+            });
+
+            Assert.True(states.TryGetStakeState(_agentAddr, out var stakeState));
+            Assert.NotNull(stakeState);
+            Assert.Equal(
+                0 * RuneHelper.StakeRune,
+                _initialStatesWithAvatarStateV2.GetBalance(_avatarAddr, RuneHelper.StakeRune));
+
+            action = new ClaimStakeReward(_avatarAddr);
+            states = action.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _agentAddr,
+                BlockIndex = receiveBlockIndex,
+            });
+
+            // 지정된 캐릭터 앞으로 이하 보상의 수령이 가능해야 한다.
+            var avatarState = states.GetAvatarStateV2(_avatarAddr);
+            foreach (var (itemId, amount) in expectedItems)
+            {
+                Assert.True(avatarState.inventory.HasItem(itemId, amount));
+            }
+
+            // 기존 deposit 유지 확인
+            Assert.Equal(
+                _ncg * stakeAmount,
+                states.GetBalance(stakeState.address, _ncg));
+            Assert.Equal(
+                expectedRune * RuneHelper.StakeRune,
+                states.GetBalance(_avatarAddr, RuneHelper.StakeRune));
+
+            if (!string.IsNullOrEmpty(expectedCurrencyAddrHex))
+            {
+                var addr = new Address(expectedCurrencyAddrHex);
+                var currency = Currencies.GetMinterlessCurrency(expectedCurrencyTicker);
+                Assert.Equal(
+                    expectedCurrencyAmount * currency,
+                    states.GetBalance(addr, currency));
+            }
+        }
+
+        [Theory]
+        [InlineData(500L, 50L, 499L)]
+        [InlineData(500L, 499L, 500L)]
+        [InlineData(5_000L, 500L, 4_999L)]
+        [InlineData(5_000L, 4_999L, 5_000L)]
+        [InlineData(50_000L, 5_000L, 49_999L)]
+        [InlineData(50_000L, 49_999L, 50_000L)]
+        [InlineData(500_000L, 50_000L, 499_999L)]
+        [InlineData(500_000L, 499_999L, 500_000L)]
+        [InlineData(500_000_000L, 500_000L, 500_000_000L)]
+        public void StakeAndStakeMore(long initialBalance, long stakeAmount, long newStakeAmount)
+        {
+            var newStakeBlockIndex =
+                ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval - 1;
+            // Validate testcases
+            Assert.True(stakeAmount < newStakeAmount);
+
+            var states =
+                _initialStatesWithAvatarStateV2.MintAsset(_agentAddr, _ncg * initialBalance);
+
+            IAction action = new Stake(stakeAmount);
+            states = action.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _agentAddr,
+                BlockIndex = ClaimStakeReward2.ObsoletedIndex,
+            });
+
+            Assert.True(states.TryGetStakeState(_agentAddr, out var stakeState));
+            Assert.NotNull(stakeState);
+            Assert.Equal(
+                _ncg * (initialBalance - stakeAmount),
+                states.GetBalance(_agentAddr, _ncg));
+            Assert.Equal(
+                _ncg * stakeAmount,
+                states.GetBalance(stakeState.address, _ncg));
+
+            action = new ClaimStakeReward(_avatarAddr);
+            states = action.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _agentAddr,
+                BlockIndex = newStakeBlockIndex,
+            });
+
+            action = new Stake(newStakeAmount);
+            // 스테이킹 추가는 가능
+            // 락업기간 이전에 deposit을 추가해서 save 할 수 있는지
+            states = action.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _agentAddr,
+                BlockIndex = newStakeBlockIndex,
+            });
+
+            Assert.True(states.TryGetStakeState(_agentAddr, out stakeState));
+            Assert.NotNull(stakeState);
+            // 쌓여있던 보상 타이머가 정상적으로 리셋되는지
+            Assert.Equal(newStakeBlockIndex, stakeState.StartedBlockIndex);
+            // 락업기간이 새롭게 201,600으로 갱신되는지 확인
+            Assert.Equal(
+                newStakeBlockIndex + StakeState.LockupInterval,
+                stakeState.CancellableBlockIndex);
+            Assert.Equal(
+                _ncg * (initialBalance - newStakeAmount),
+                states.GetBalance(_agentAddr, _ncg));
+            // 기존보다 초과해서 설정한 deposit 으로 묶인 상태 갱신된 것 확인
+            Assert.Equal(
+                _ncg * newStakeAmount,
+                states.GetBalance(stakeState.address, _ncg));
+        }
+
+        [Theory]
+        [InlineData(500L, 51L, 50L)]
+        [InlineData(500L, 499L, 50L)]
+        [InlineData(5_000L, 500L, 499L)]
+        [InlineData(5_000L, 500L, 50L)]
+        [InlineData(5_000L, 4_999L, 500L)]
+        [InlineData(50_000L, 5_000L, 4_999L)]
+        [InlineData(50_000L, 49_999L, 5_000L)]
+        [InlineData(500_000L, 50_000L, 49_999L)]
+        [InlineData(500_000L, 499_999L, 50_000L)]
+        [InlineData(500_000_000L, 500_000L, 99_999L)]
+        [InlineData(500_000_000L, 500_000_000L, 0L)]
+        [InlineData(500_000_000L, 500_000_000L, 99_999_999L)]
+        public void StakeAndStakeLess(long initialBalance, long stakeAmount, long newStakeAmount)
+        {
+            // Validate testcases
+            Assert.True(initialBalance >= stakeAmount);
+            Assert.True(newStakeAmount < stakeAmount);
+
+            var states =
+                _initialStatesWithAvatarStateV2.MintAsset(_agentAddr, _ncg * initialBalance);
+
+            IAction action = new Stake(stakeAmount);
+            states = action.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _agentAddr,
+                BlockIndex = ClaimStakeReward2.ObsoletedIndex,
+            });
+
+            Assert.True(states.TryGetStakeState(_agentAddr, out var stakeState));
+            Assert.NotNull(stakeState);
+            Assert.Equal(
+                _ncg * (initialBalance - stakeAmount),
+                states.GetBalance(_agentAddr, _ncg));
+            Assert.Equal(
+                _ncg * stakeAmount,
+                states.GetBalance(stakeState.address, _ncg));
+
+            action = new ClaimStakeReward(_avatarAddr);
+            states = action.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _agentAddr,
+                BlockIndex = ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval - 1,
+            });
+
+            action = new Stake(newStakeAmount);
+            // 락업기간 이전에 deposit을 감소해서 save할때 락업되어 거부되는가
+            Assert.Throws<RequiredBlockIndexException>(() => states = action.Execute(
+                new ActionContext
+                {
+                    PreviousStates = states,
+                    Signer = _agentAddr,
+                    BlockIndex = ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval - 1,
+                }));
+
+            Assert.True(states.TryGetStakeState(_agentAddr, out stakeState));
+            Assert.NotNull(stakeState);
+            Assert.Equal(
+                _ncg * (initialBalance - stakeAmount),
+                states.GetBalance(_agentAddr, _ncg));
+            Assert.Equal(
+                _ncg * stakeAmount,
+                states.GetBalance(stakeState.address, _ncg));
+        }
+
+        [Theory]
+        [MemberData(nameof(StakeLessAfterLockupTestcases))]
+        // 락업기간 종료 이후 deposit을 현재보다 낮게 설정했을때, 설정이 잘되서 새롭게 락업되는지 확인
+        // 락업기간 종료 이후 보상 수령하고 락업해제되는지 확인
+        public void StakeLessAfterLockup(
+            long initialBalance,
+            long stakeAmount,
+            long newStakeAmount,
+            (long ClaimBlockIndex, (int ItemId, int Amount)[] ExpectedItems)[] claimEvents)
+        {
+            StakeState stakeState;
+
+            // Validate testcases
+            Assert.True(stakeAmount > newStakeAmount);
+
+            var states =
+                _initialStatesWithAvatarStateV2.MintAsset(_agentAddr, _ncg * initialBalance);
+
+            IAction action = new Stake(stakeAmount);
+            states = action.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _agentAddr,
+                BlockIndex = ClaimStakeReward2.ObsoletedIndex,
+            });
+
+            // 1~3회까지 모든 보상을 수령함
+            // 201,600 블록 도달 이후 → 지정된 캐릭터 앞으로 이하 보상의 수령이 가능해야 한다.
+            foreach ((var claimBlockIndex, (int itemId, int amount)[] expectedItems) in claimEvents)
+            {
+                action = new ClaimStakeReward(_avatarAddr);
+                states = action.Execute(new ActionContext
+                {
+                    PreviousStates = states,
+                    Signer = _agentAddr,
+                    BlockIndex = claimBlockIndex,
+                });
+
+                var avatarState = states.GetAvatarStateV2(_avatarAddr);
+                foreach (var (itemId, amount) in expectedItems)
+                {
+                    Assert.True(avatarState.inventory.HasItem(itemId, amount));
+                }
+
+                Assert.True(states.TryGetStakeState(_agentAddr, out stakeState));
+                Assert.NotNull(stakeState);
+                // deposit 유지 확인
+                Assert.Equal(
+                    _ncg * stakeAmount,
+                    states.GetBalance(stakeState.address, _ncg));
+            }
+
+            action = new Stake(newStakeAmount);
+            states = action.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _agentAddr,
+                BlockIndex = ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval,
+            });
+
+            // Setup staking again.
+            if (newStakeAmount > 0)
+            {
+                Assert.True(states.TryGetStakeState(_agentAddr, out stakeState));
+                Assert.NotNull(stakeState);
+                // 쌓여있던 보상 타이머가 정상적으로 리셋되는지
+                Assert.Equal(
+                    ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval,
+                    stakeState.StartedBlockIndex);
+                // 락업기간이 새롭게 201,600으로 갱신되는지 확인
+                Assert.Equal(
+                    ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval +
+                    StakeState.LockupInterval,
+                    stakeState.CancellableBlockIndex);
+                // 기존 deposit - 현재 deposit 만큼의 ncg 인출 상태 확인
+                Assert.Equal(
+                    _ncg * (initialBalance - newStakeAmount),
+                    states.GetBalance(_agentAddr, _ncg));
+                Assert.Equal(
+                    _ncg * newStakeAmount,
+                    states.GetBalance(stakeState.address, _ncg));
+
+                Assert.Throws<RequiredBlockIndexException>(() =>
+                {
+                    // 현재 스테이킹된 NCG를 인출할 수 없다
+                    action = new ClaimStakeReward(_avatarAddr);
+                    states = action.Execute(new ActionContext
+                    {
+                        PreviousStates = states,
+                        Signer = _agentAddr,
+                        BlockIndex = ClaimStakeReward2.ObsoletedIndex + StakeState.LockupInterval +
+                                     1,
+                    });
+                });
+                // 현재 deposit 묶인 상태 확인
+                Assert.Equal(
+                    _ncg * newStakeAmount,
+                    states.GetBalance(stakeState.address, _ncg));
+            }
+            else
+            {
+                Assert.Equal(
+                    _ncg * initialBalance,
+                    states.GetBalance(_agentAddr, _ncg));
+                Assert.False(states.TryGetStakeState(_agentAddr, out stakeState));
+                Assert.Null(stakeState);
+            }
+        }
+
+        [Fact]
+        public void StakeAndClaimStakeRewardBeforeRewardInterval()
+        {
+            var states = _initialStatesWithAvatarStateV2.MintAsset(_agentAddr, _ncg * 500);
+            IAction action = new Stake(500);
+            states = action.Execute(new ActionContext
+            {
+                PreviousStates = states,
+                Signer = _agentAddr,
+                BlockIndex = ClaimStakeReward2.ObsoletedIndex,
+            });
+
+            action = new ClaimStakeReward(_avatarAddr);
+            Assert.Throws<RequiredBlockIndexException>(() => states = action.Execute(
+                new ActionContext
+                {
+                    PreviousStates = states,
+                    Signer = _agentAddr,
+                    BlockIndex = ClaimStakeReward2.ObsoletedIndex + StakeState.RewardInterval - 1,
+                }));
+
+            var avatarState = states.GetAvatarStateV2(_avatarAddr);
+            Assert.Empty(avatarState.inventory.Items.Where(x => x.item.Id == 400000));
+            Assert.Empty(avatarState.inventory.Items.Where(x => x.item.Id == 500000));
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/State/StakeStateTest.cs
+++ b/.Lib9c.Tests/Model/State/StakeStateTest.cs
@@ -70,8 +70,9 @@ namespace Lib9c.Tests.Model.State
         }
 
         [Theory]
-        [InlineData(1L, 1L, -110)]
+        [InlineData(1L, ClaimStakeReward2.ObsoletedIndex - 1L, 0)]
         [InlineData(1L, ClaimStakeReward2.ObsoletedIndex, 0)]
+        [InlineData(1L, ClaimStakeReward2.ObsoletedIndex + RewardInterval - 1L, 0)]
         [InlineData(1L, ClaimStakeReward2.ObsoletedIndex + RewardInterval, 1)]
         public void CalculateAccumulateRuneRewards(
             long startedBlockIndex,
@@ -93,23 +94,26 @@ namespace Lib9c.Tests.Model.State
         [InlineData(RewardInterval, 0L, RewardInterval * 9, null, 8)]
         [InlineData(RewardInterval + 1L, 0L, RewardInterval * 9, null, 7)]
         // control received block index.
-        [InlineData(0L, 1L, RewardInterval * 9, null, 9)]
-        [InlineData(0L, RewardInterval - 1L, RewardInterval * 9, null, 9)]
+        [InlineData(0L, 1L, RewardInterval * 9, null, 8)]
         [InlineData(0L, RewardInterval, RewardInterval * 9, null, 8)]
-        [InlineData(0L, RewardInterval + 1L, RewardInterval * 9, null, 8)]
+        [InlineData(0L, RewardInterval + 1L, RewardInterval * 9, null, 7)]
         // control reward start block index.
         [InlineData(0L, 0L, RewardInterval * 9, 0L, 9)]
         [InlineData(0L, 0L, RewardInterval * 9, 1L, 8)]
         [InlineData(0L, 0L, RewardInterval * 9, RewardInterval, 8)]
         [InlineData(0L, 0L, RewardInterval * 9, RewardInterval + 1L, 7)]
         // control complex. reward start block index is inside of reward range.
-        [InlineData(1L, 0L, RewardInterval * 9, RewardInterval, 7)]
-        [InlineData(1L, 0L, RewardInterval * 9 + 1L, RewardInterval, 8)]
+        [InlineData(1L, 0L, RewardInterval * 9, 1L, 8)]
+        [InlineData(1L, 0L, RewardInterval * 9, RewardInterval + 1L, 7)]
         [InlineData(RewardInterval, 0L, RewardInterval * 9, RewardInterval, 8)]
+        [InlineData(RewardInterval, 0L, RewardInterval * 9, RewardInterval + 1L, 7)]
+        [InlineData(RewardInterval, RewardInterval * 2, RewardInterval * 9, RewardInterval, 7)]
+        [InlineData(RewardInterval, RewardInterval * 2 + 1L, RewardInterval * 9, RewardInterval, 6)]
         // reward start block index is greater than reward range.
         [InlineData(0L, 0L, RewardInterval * 9, RewardInterval * 9 + 1L, 0)]
         // reward start block index is less than reward range.
         [InlineData(1L, 0L, RewardInterval * 9 + 1L, 0L, 9)]
+        [InlineData(RewardInterval, RewardInterval * 2, RewardInterval * 9, 0L, 7)]
         public void GetRewardStep(
             long startedBlockIndex,
             long receivedBlockIndex,

--- a/Lib9c/Action/ClaimStakeReward.cs
+++ b/Lib9c/Action/ClaimStakeReward.cs
@@ -1,0 +1,330 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Bencodex.Types;
+using Lib9c;
+using Lib9c.Abstractions;
+using Libplanet;
+using Libplanet.Action;
+using Libplanet.Assets;
+using Libplanet.State;
+using Nekoyume.Extensions;
+using Nekoyume.Helper;
+using Nekoyume.Model.Item;
+using Nekoyume.Model.State;
+using Nekoyume.TableData;
+using static Lib9c.SerializeKeys;
+
+namespace Nekoyume.Action
+{
+    /// <summary>
+    /// Hard forked at https://github.com/planetarium/lib9c/pull/1458
+    /// </summary>
+    [ActionType(ActionTypeText)]
+    public class ClaimStakeReward : GameAction, IClaimStakeReward, IClaimStakeRewardV1
+    {
+        private const string ActionTypeText = "claim_stake_reward4";
+
+        /// <summary>
+        /// This is the version 1 of the stake reward sheet.
+        /// The version 1 is used for calculating the reward for the stake
+        /// that is accumulated before the table patch.
+        /// </summary>
+        public static class V1
+        {
+            public const int MaxLevel = 5;
+
+            public const string StakeRegularRewardSheetCsv =
+                @"level,required_gold,item_id,rate,type
+1,50,400000,10,Item
+1,50,500000,800,Item
+1,50,20001,6000,Rune
+2,500,400000,8,Item
+2,500,500000,800,Item
+2,500,20001,6000,Rune
+3,5000,400000,5,Item
+3,5000,500000,800,Item
+3,5000,20001,6000,Rune
+4,50000,400000,5,Item
+4,50000,500000,800,Item
+4,50000,20001,6000,Rune
+5,500000,400000,5,Item
+5,500000,500000,800,Item
+5,500000,20001,6000,Rune";
+
+            public const string StakeRegularFixedRewardSheetCsv =
+                @"level,required_gold,item_id,count
+1,50,500000,1
+2,500,500000,2
+3,5000,500000,2
+4,50000,500000,2
+5,500000,500000,2";
+
+            private static StakeRegularRewardSheet _stakeRegularRewardSheet;
+            private static StakeRegularFixedRewardSheet _stakeRegularFixedRewardSheet;
+
+            public static StakeRegularRewardSheet StakeRegularRewardSheet
+            {
+                get
+                {
+                    if (_stakeRegularRewardSheet is null)
+                    {
+                        _stakeRegularRewardSheet = new StakeRegularRewardSheet();
+                        _stakeRegularRewardSheet.Set(StakeRegularRewardSheetCsv);
+                    }
+
+                    return _stakeRegularRewardSheet;
+                }
+            }
+
+            public static StakeRegularFixedRewardSheet StakeRegularFixedRewardSheet
+            {
+                get
+                {
+                    if (_stakeRegularFixedRewardSheet is null)
+                    {
+                        _stakeRegularFixedRewardSheet = new StakeRegularFixedRewardSheet();
+                        _stakeRegularFixedRewardSheet.Set(StakeRegularFixedRewardSheetCsv);
+                    }
+
+                    return _stakeRegularFixedRewardSheet;
+                }
+            }
+        }
+
+        // NOTE: Use this when the <see cref="StakeRegularFixedRewardSheet"/> or
+        // <see cref="StakeRegularRewardSheet"/> is patched.
+        // public static class V2
+        // {
+        // }
+
+        internal Address AvatarAddress { get; private set; }
+
+        Address IClaimStakeRewardV1.AvatarAddress => AvatarAddress;
+
+        public ClaimStakeReward(Address avatarAddress) : this()
+        {
+            AvatarAddress = avatarAddress;
+        }
+
+        public ClaimStakeReward()
+        {
+        }
+
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            ImmutableDictionary<string, IValue>.Empty
+                .Add(AvatarAddressKey, AvatarAddress.Serialize());
+
+        protected override void LoadPlainValueInternal(
+            IImmutableDictionary<string, IValue> plainValue)
+        {
+            AvatarAddress = plainValue[AvatarAddressKey].ToAddress();
+        }
+
+        public override IAccountStateDelta Execute(IActionContext context)
+        {
+            context.UseGas(1);
+            if (context.Rehearsal)
+            {
+                return context.PreviousStates;
+            }
+
+            var states = context.PreviousStates;
+            var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
+            if (!states.TryGetStakeState(context.Signer, out var stakeState))
+            {
+                throw new FailedLoadStateException(
+                    ActionTypeText,
+                    addressesHex,
+                    typeof(StakeState),
+                    StakeState.DeriveAddress(context.Signer));
+            }
+
+            if (!stakeState.IsClaimable(context.BlockIndex, out _, out _))
+            {
+                throw new RequiredBlockIndexException(
+                    ActionTypeText,
+                    addressesHex,
+                    context.BlockIndex);
+            }
+
+            if (!states.TryGetAvatarStateV2(
+                    context.Signer,
+                    AvatarAddress,
+                    out var avatarState,
+                    out var migrationRequired))
+            {
+                throw new FailedLoadStateException(
+                    ActionTypeText,
+                    addressesHex,
+                    typeof(AvatarState),
+                    AvatarAddress);
+            }
+
+            var sheets = states.GetSheets(sheetTypes: new[]
+            {
+                typeof(StakeRegularRewardSheet),
+                typeof(ConsumableItemSheet),
+                typeof(CostumeItemSheet),
+                typeof(EquipmentItemSheet),
+                typeof(MaterialItemSheet),
+            });
+
+            var currency = states.GetGoldCurrency();
+            var stakedAmount = states.GetBalance(stakeState.address, currency);
+            var stakeRegularRewardSheet = sheets.GetSheet<StakeRegularRewardSheet>();
+            var level =
+                stakeRegularRewardSheet.FindLevelByStakedAmount(context.Signer, stakedAmount);
+            var itemSheet = sheets.GetItemSheet();
+            stakeState.CalculateAccumulatedItemRewards(
+                context.BlockIndex,
+                out var itemV1Step,
+                out var itemV2Step);
+            stakeState.CalculateAccumulatedRuneRewards(
+                context.BlockIndex,
+                out var runeV1Step,
+                out var runeV2Step);
+            stakeState.CalculateAccumulatedCurrencyRewards(
+                context.BlockIndex,
+                out var currencyV1Step,
+                out var currencyV2Step);
+            if (itemV1Step > 0)
+            {
+                var v1Level = Math.Min(level, V1.MaxLevel);
+                var fixedRewardV1 = V1.StakeRegularFixedRewardSheet[v1Level].Rewards;
+                var regularRewardV1 = V1.StakeRegularRewardSheet[v1Level].Rewards;
+                states = ProcessReward(
+                    context,
+                    states,
+                    ref avatarState,
+                    itemSheet,
+                    stakedAmount,
+                    itemV1Step,
+                    runeV1Step,
+                    currencyV1Step,
+                    fixedRewardV1,
+                    regularRewardV1);
+            }
+
+            if (itemV2Step > 0)
+            {
+                var regularFixedReward =
+                    states.TryGetSheet<StakeRegularFixedRewardSheet>(out var fixedRewardSheet)
+                        ? fixedRewardSheet[level].Rewards
+                        : new List<StakeRegularFixedRewardSheet.RewardInfo>();
+                var regularReward = sheets.GetSheet<StakeRegularRewardSheet>()[level].Rewards;
+                states = ProcessReward(
+                    context,
+                    states,
+                    ref avatarState,
+                    itemSheet,
+                    stakedAmount,
+                    itemV2Step,
+                    runeV2Step,
+                    currencyV2Step,
+                    regularFixedReward,
+                    regularReward);
+            }
+
+            stakeState.Claim(context.BlockIndex);
+
+            if (migrationRequired)
+            {
+                states = states
+                    .SetState(avatarState.address, avatarState.SerializeV2())
+                    .SetState(
+                        avatarState.address.Derive(LegacyWorldInformationKey),
+                        avatarState.worldInformation.Serialize())
+                    .SetState(
+                        avatarState.address.Derive(LegacyQuestListKey),
+                        avatarState.questList.Serialize());
+            }
+
+            return states
+                .SetState(stakeState.address, stakeState.Serialize())
+                .SetState(
+                    avatarState.address.Derive(LegacyInventoryKey),
+                    avatarState.inventory.Serialize());
+        }
+
+        private IAccountStateDelta ProcessReward(
+            IActionContext context,
+            IAccountStateDelta states,
+            ref AvatarState avatarState,
+            ItemSheet itemSheet,
+            FungibleAssetValue stakedAmount,
+            int itemRewardStep,
+            int runeRewardStep,
+            int currencyRewardStep,
+            List<StakeRegularFixedRewardSheet.RewardInfo> fixedReward,
+            List<StakeRegularRewardSheet.RewardInfo> regularReward)
+        {
+            var stakedCurrency = stakedAmount.Currency;
+
+            // Regular Reward
+            foreach (var reward in regularReward)
+            {
+                switch (reward.Type)
+                {
+                    case StakeRegularRewardSheet.StakeRewardType.Item:
+                        var (quantity, _) = stakedAmount.DivRem(stakedCurrency * reward.Rate);
+                        if (quantity < 1)
+                        {
+                            // If the quantity is zero, it doesn't add the item into inventory.
+                            continue;
+                        }
+
+                        ItemSheet.Row row = itemSheet[reward.ItemId];
+                        ItemBase item = row is MaterialItemSheet.Row materialRow
+                            ? ItemFactory.CreateTradableMaterial(materialRow)
+                            : ItemFactory.CreateItem(row, context.Random);
+                        avatarState.inventory.AddItem(item, (int)quantity * itemRewardStep);
+                        break;
+                    case StakeRegularRewardSheet.StakeRewardType.Rune:
+                        var runeReward = runeRewardStep *
+                                         RuneHelper.CalculateStakeReward(stakedAmount, reward.Rate);
+                        if (runeReward < 1 * RuneHelper.StakeRune)
+                        {
+                            continue;
+                        }
+
+                        states = states.MintAsset(AvatarAddress, runeReward);
+                        break;
+                    case StakeRegularRewardSheet.StakeRewardType.Currency:
+                        if (string.IsNullOrEmpty(reward.CurrencyTicker))
+                        {
+                            throw new NullReferenceException("currency ticker is null or empty");
+                        }
+
+                        var rewardCurrency =
+                            Currencies.GetMinterlessCurrency(reward.CurrencyTicker);
+                        var rewardCurrencyQuantity =
+                            stakedAmount.DivRem(reward.Rate * stakedAmount.Currency).Quotient;
+                        if (rewardCurrencyQuantity <= 0)
+                        {
+                            continue;
+                        }
+
+                        states = states.MintAsset(
+                            context.Signer,
+                            rewardCurrencyQuantity * currencyRewardStep * rewardCurrency);
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            // Fixed Reward
+            foreach (var reward in fixedReward)
+            {
+                ItemSheet.Row row = itemSheet[reward.ItemId];
+                ItemBase item = row is MaterialItemSheet.Row materialRow
+                    ? ItemFactory.CreateTradableMaterial(materialRow)
+                    : ItemFactory.CreateItem(row, context.Random);
+                avatarState.inventory.AddItem(item, reward.Count * itemRewardStep);
+            }
+
+            return states;
+        }
+    }
+}

--- a/Lib9c/Action/ClaimStakeReward1.cs
+++ b/Lib9c/Action/ClaimStakeReward1.cs
@@ -64,7 +64,7 @@ namespace Nekoyume.Action
             int level = stakeRegularRewardSheet.FindLevelByStakedAmount(context.Signer, stakedAmount);
             var rewards = stakeRegularRewardSheet[level].Rewards;
             ItemSheet itemSheet = sheets.GetItemSheet();
-            var accumulatedRewards = stakeState.CalculateAccumulatedItemRewards(context.BlockIndex);
+            var accumulatedRewards = stakeState.CalculateAccumulatedItemRewardsV1(context.BlockIndex);
             foreach (var reward in rewards)
             {
                 var (quantity, _) = stakedAmount.DivRem(currency * reward.Rate);

--- a/Lib9c/Action/ClaimStakeReward2.cs
+++ b/Lib9c/Action/ClaimStakeReward2.cs
@@ -91,7 +91,7 @@ namespace Nekoyume.Action
                 stakeRegularRewardSheet.FindLevelByStakedAmount(context.Signer, stakedAmount);
             var rewards = stakeRegularRewardSheet[level].Rewards;
             ItemSheet itemSheet = sheets.GetItemSheet();
-            var accumulatedRewards = stakeState.CalculateAccumulatedItemRewards(context.BlockIndex);
+            var accumulatedRewards = stakeState.CalculateAccumulatedItemRewardsV1(context.BlockIndex);
             foreach (var reward in rewards)
             {
                 var (quantity, _) = stakedAmount.DivRem(currency * reward.Rate);

--- a/Lib9c/Action/ClaimStakeReward3.cs
+++ b/Lib9c/Action/ClaimStakeReward3.cs
@@ -114,7 +114,6 @@ namespace Nekoyume.Action
             FungibleAssetValue stakedAmount,
             int itemRewardStep,
             int runeRewardStep,
-            int currencyRewardStep,
             List<StakeRegularFixedRewardSheet.RewardInfo> fixedReward,
             List<StakeRegularRewardSheet.RewardInfo> regularReward)
         {
@@ -148,25 +147,6 @@ namespace Nekoyume.Action
                         }
 
                         states = states.MintAsset(AvatarAddress, runeReward);
-                        break;
-                    case StakeRegularRewardSheet.StakeRewardType.Currency:
-                        if (string.IsNullOrEmpty(reward.CurrencyTicker))
-                        {
-                            throw new NullReferenceException("currency ticker is null or empty");
-                        }
-
-                        var rewardCurrency =
-                            Currencies.GetMinterlessCurrency(reward.CurrencyTicker);
-                        var rewardCurrencyQuantity =
-                            stakedAmount.DivRem(reward.Rate * stakedAmount.Currency).Quotient;
-                        if (rewardCurrencyQuantity <= 0)
-                        {
-                            continue;
-                        }
-
-                        states = states.MintAsset(
-                            context.Signer,
-                            rewardCurrencyQuantity * currencyRewardStep * rewardCurrency);
                         break;
                     default:
                         break;
@@ -252,9 +232,6 @@ namespace Nekoyume.Action
                 context.BlockIndex,
                 out var runeV1Step,
                 out var runeV2Step);
-            stakeState.CalculateAccumulatedCurrencyRewards(
-                context.BlockIndex,
-                out var currencyV2Step);
             if (itemV1Step > 0)
             {
                 var v1Level = Math.Min(level, V1.MaxLevel);
@@ -272,7 +249,6 @@ namespace Nekoyume.Action
                     stakedAmount,
                     itemV1Step,
                     runeV1Step,
-                    0,
                     fixedRewardV1,
                     regularRewardV1);
             }
@@ -292,7 +268,6 @@ namespace Nekoyume.Action
                     stakedAmount,
                     itemV2Step,
                     runeV2Step,
-                    currencyV2Step,
                     regularFixedReward,
                     regularReward);
             }

--- a/Lib9c/Action/ClaimStakeReward3.cs
+++ b/Lib9c/Action/ClaimStakeReward3.cs
@@ -21,7 +21,7 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1458
     /// </summary>
     [ActionType(ActionTypeText)]
-    public class ClaimStakeReward : GameAction, IClaimStakeReward, IClaimStakeRewardV1
+    public class ClaimStakeReward3 : GameAction, IClaimStakeReward, IClaimStakeRewardV1
     {
         private const string ActionTypeText = "claim_stake_reward3";
 
@@ -74,12 +74,12 @@ namespace Nekoyume.Action
 
         Address IClaimStakeRewardV1.AvatarAddress => AvatarAddress;
 
-        public ClaimStakeReward(Address avatarAddress) : this()
+        public ClaimStakeReward3(Address avatarAddress) : this()
         {
             AvatarAddress = avatarAddress;
         }
 
-        public ClaimStakeReward()
+        public ClaimStakeReward3()
         {
             var regularRewardSheetV1 = new StakeRegularRewardSheet();
             regularRewardSheetV1.Set(V1.StakeRegularRewardSheetCsv);

--- a/Lib9c/Action/ClaimStakeReward3.cs
+++ b/Lib9c/Action/ClaimStakeReward3.cs
@@ -21,9 +21,11 @@ namespace Nekoyume.Action
     /// Hard forked at https://github.com/planetarium/lib9c/pull/1458
     /// </summary>
     [ActionType(ActionTypeText)]
+    [ActionObsolete(ObsoleteBlockIndex)]
     public class ClaimStakeReward3 : GameAction, IClaimStakeReward, IClaimStakeRewardV1
     {
         private const string ActionTypeText = "claim_stake_reward3";
+        public const long ObsoleteBlockIndex = ActionObsoleteConfig.V200030ObsoleteIndex;
 
         /// <summary>
         /// This is the version 1 of the stake reward sheet.
@@ -192,10 +194,10 @@ namespace Nekoyume.Action
                 return context.PreviousStates;
             }
 
-            var states = context.PreviousStates;
             CheckActionAvailable(ClaimStakeReward2.ObsoletedIndex, context);
-            // TODO: Uncomment this when new version of action is created
-            // CheckObsolete(ObsoletedIndex, context);
+            CheckObsolete(ObsoleteBlockIndex, context);
+
+            var states = context.PreviousStates;
             var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
             if (!states.TryGetStakeState(context.Signer, out StakeState stakeState))
             {

--- a/Lib9c/Action/ClaimStakeReward3.cs
+++ b/Lib9c/Action/ClaimStakeReward3.cs
@@ -224,11 +224,11 @@ namespace Nekoyume.Action
             var level =
                 stakeRegularRewardSheet.FindLevelByStakedAmount(context.Signer, stakedAmount);
             var itemSheet = sheets.GetItemSheet();
-            stakeState.CalculateAccumulatedItemRewards(
+            stakeState.CalculateAccumulatedItemRewardsV1(
                 context.BlockIndex,
                 out var itemV1Step,
                 out var itemV2Step);
-            stakeState.CalculateAccumulatedRuneRewards(
+            stakeState.CalculateAccumulatedRuneRewardsV1(
                 context.BlockIndex,
                 out var runeV1Step,
                 out var runeV2Step);

--- a/Lib9c/Action/Factory/ClaimStakeRewardFactory.cs
+++ b/Lib9c/Action/Factory/ClaimStakeRewardFactory.cs
@@ -13,7 +13,7 @@ namespace Nekoyume.Action.Factory
         {
             if (blockIndex > ClaimStakeReward2.ObsoletedIndex)
             {
-                return new ClaimStakeReward(avatarAddress);
+                return new ClaimStakeReward3(avatarAddress);
             }
 
             // FIXME: This method should consider the starting block index of
@@ -29,7 +29,7 @@ namespace Nekoyume.Action.Factory
         {
             1 => new ClaimStakeReward1(avatarAddress),
             2 => new ClaimStakeReward2(avatarAddress),
-            3 => new ClaimStakeReward(avatarAddress),
+            3 => new ClaimStakeReward3(avatarAddress),
             _ => throw new ArgumentOutOfRangeException(
                 $"Invalid version: {version}"),
         };


### PR DESCRIPTION
- Make `claim_stake_reward3` action obsolete at `ActionObsoleteConfig.V200030ObsoleteIndex`.
- Introduce `claim_stake_reward4` action as `ClaimStakeReward`.
