### PR TITLE
⬆️ Bump libplanet to 2.1.0

### DIFF
--- a/Lib9c.Policy/Policy/BlockPolicySource.Utils.cs
+++ b/Lib9c.Policy/Policy/BlockPolicySource.Utils.cs
@@ -74,16 +74,9 @@ namespace Nekoyume.Blockchain.Policy
 
         internal static AdminState GetAdminState(BlockChain blockChain)
         {
-            try
-            {
-                return blockChain.GetState(AdminState.Address) is Dictionary rawAdmin
-                    ? new AdminState(rawAdmin)
-                    : null;
-            }
-            catch (IncompleteBlockStatesException)
-            {
-                return null;
-            }
+            return blockChain.GetState(AdminState.Address) is Dictionary rawAdmin
+                ? new AdminState(rawAdmin)
+                : null;
         }
 
         private static InvalidBlockBytesLengthException ValidateTransactionsBytesRaw(

--- a/Lib9c.Policy/Policy/BlockPolicySource.cs
+++ b/Lib9c.Policy/Policy/BlockPolicySource.cs
@@ -276,14 +276,6 @@ namespace Nekoyume.Blockchain.Policy
                     $"Transaction {transaction.Id} has invalid signautre.",
                     transaction.Id);
             }
-            catch (IncompleteBlockStatesException)
-            {
-                // It can be caused during `Swarm<T>.PreloadAsync()` because it doesn't fill its
-                // state right away...
-                // FIXME: It should be removed after fix that Libplanet fills its state on IBD.
-                // See also: https://github.com/planetarium/lib9c/pull/151#discussion_r506039478
-                return null;
-            }
 
             return null;
         }


### PR DESCRIPTION
⬆️ 
`IncompleteBlockStatesException` has been removed from libplanet. I'm not sure the old patchwork made in https://github.com/planetarium/lib9c/pull/151#discussion_r506039478 is still relevant. 🤨