### PR TITLE
♻️ Refactor test classes

### DIFF
--- a/.Lib9c.DevExtensions.Tests/Action/CreateOrReplaceAvatarTest.cs
+++ b/.Lib9c.DevExtensions.Tests/Action/CreateOrReplaceAvatarTest.cs
@@ -28,7 +28,7 @@ namespace Lib9c.DevExtensions.Tests.Action
 
         public CreateOrReplaceAvatarTest()
         {
-            _initialStates = new Lib9c.Tests.Action.State();
+            _initialStates = new Lib9c.Tests.Action.MockStateDelta();
 
 #pragma warning disable CS0618
             var ncgCurrency = Currency.Legacy("NCG", 2, null);

--- a/.Lib9c.DevExtensions.Tests/Action/FaucetCurrencyTest.cs
+++ b/.Lib9c.DevExtensions.Tests/Action/FaucetCurrencyTest.cs
@@ -35,7 +35,7 @@ namespace Lib9c.DevExtensions.Tests.Action
             var balance =
                 ImmutableDictionary<(Address Address, Currency Currency), FungibleAssetValue>.Empty
                     .Add((GoldCurrencyState.Address, _ncg), _ncg * int.MaxValue);
-            _initialState = new Lib9c.Tests.Action.State(balance: balance);
+            _initialState = new Lib9c.Tests.Action.MockStateDelta(balances: balance);
 
             var goldCurrencyState = new GoldCurrencyState(_ncg);
             _agentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.DevExtensions.Tests/Action/FaucetRuneTest.cs
+++ b/.Lib9c.DevExtensions.Tests/Action/FaucetRuneTest.cs
@@ -33,7 +33,7 @@ namespace Lib9c.DevExtensions.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new Lib9c.Tests.Action.State();
+            _initialState = new Lib9c.Tests.Action.MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {

--- a/.Lib9c.Tests/Action/AccountStateDeltaExtensionsTest.cs
+++ b/.Lib9c.Tests/Action/AccountStateDeltaExtensionsTest.cs
@@ -46,7 +46,7 @@ namespace Lib9c.Tests.Action
         public void SetWorldBossKillReward(int level, int expectedRune, int expectedCrystal, Type exc)
         {
             var context = new ActionContext();
-            IAccountStateDelta states = new State();
+            IAccountStateDelta states = new MockStateDelta();
             var rewardInfoAddress = new PrivateKey().ToAddress();
             var rewardRecord = new WorldBossKillRewardRecord();
             for (int i = 0; i < level; i++)
@@ -106,7 +106,7 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void SetCouponWallet()
         {
-            IAccountStateDelta states = new State();
+            IAccountStateDelta states = new MockStateDelta();
             var guid1 = new Guid("6856AE42-A820-4041-92B0-5D7BAA52F2AA");
             var guid2 = new Guid("701BA698-CCB9-4FC7-B88F-7CB8C707D135");
             var guid3 = new Guid("910296E7-34E4-45D7-9B4E-778ED61F278B");
@@ -169,7 +169,7 @@ namespace Lib9c.Tests.Action
             var mead = Currencies.Mead;
             var price = RequestPledge.DefaultRefillMead * mead;
             ActionContext context = new ActionContext();
-            IAccountStateDelta states = new State()
+            IAccountStateDelta states = new MockStateDelta()
                 .SetState(
                     agentContractAddress,
                     List.Empty.Add(patron.Serialize()).Add(true.Serialize()))

--- a/.Lib9c.Tests/Action/AccountStateViewExtensionsTest.cs
+++ b/.Lib9c.Tests/Action/AccountStateViewExtensionsTest.cs
@@ -49,8 +49,8 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void TryGetAvatarState()
         {
-            var states = new State();
-            states = (State)states.SetState(_avatarAddress, _avatarState.Serialize());
+            var states = new MockStateDelta();
+            states = (MockStateDelta)states.SetState(_avatarAddress, _avatarState.Serialize());
 
             Assert.True(states.TryGetAvatarState(_agentAddress, _avatarAddress, out var avatarState2));
             Assert.Equal(_avatarAddress, avatarState2.address);
@@ -60,7 +60,7 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void TryGetAvatarStateEmptyAddress()
         {
-            var states = new State();
+            var states = new MockStateDelta();
 
             Assert.False(states.TryGetAvatarState(default, default, out _));
         }
@@ -68,7 +68,7 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void TryGetAvatarStateAddressKeyNotFoundException()
         {
-            var states = new State().SetState(default, Dictionary.Empty);
+            var states = new MockStateDelta().SetState(default, Dictionary.Empty);
 
             Assert.False(states.TryGetAvatarState(default, default, out _));
         }
@@ -76,7 +76,7 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void TryGetAvatarStateKeyNotFoundException()
         {
-            var states = new State()
+            var states = new MockStateDelta()
                 .SetState(
                 default,
                 Dictionary.Empty
@@ -89,7 +89,7 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void TryGetAvatarStateInvalidCastException()
         {
-            var states = new State().SetState(default, default(Text));
+            var states = new MockStateDelta().SetState(default, default(Text));
 
             Assert.False(states.TryGetAvatarState(default, default, out _));
         }
@@ -97,7 +97,7 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void TryGetAvatarStateInvalidAddress()
         {
-            var states = new State().SetState(default, _avatarState.Serialize());
+            var states = new MockStateDelta().SetState(default, _avatarState.Serialize());
 
             Assert.False(states.TryGetAvatarState(Addresses.GameConfig, _avatarAddress, out _));
         }
@@ -105,8 +105,8 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void GetAvatarStateV2()
         {
-            var states = new State();
-            states = (State)states
+            var states = new MockStateDelta();
+            states = (MockStateDelta)states
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
                 .SetState(_avatarAddress.Derive(LegacyInventoryKey), _avatarState.inventory.Serialize())
                 .SetState(_avatarAddress.Derive(LegacyWorldInformationKey), _avatarState.worldInformation.Serialize())
@@ -124,13 +124,13 @@ namespace Lib9c.Tests.Action
         [InlineData(LegacyQuestListKey)]
         public void GetAvatarStateV2_Throw_FailedLoadStateException(string key)
         {
-            var states = new State();
-            states = (State)states
+            var states = new MockStateDelta();
+            states = (MockStateDelta)states
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
                 .SetState(_avatarAddress.Derive(LegacyInventoryKey), _avatarState.inventory.Serialize())
                 .SetState(_avatarAddress.Derive(LegacyWorldInformationKey), _avatarState.worldInformation.Serialize())
                 .SetState(_avatarAddress.Derive(LegacyQuestListKey), _avatarState.questList.Serialize());
-            states = (State)states.SetState(_avatarAddress.Derive(key), null);
+            states = (MockStateDelta)states.SetState(_avatarAddress.Derive(key), null);
             var exc = Assert.Throws<FailedLoadStateException>(() => states.GetAvatarStateV2(_avatarAddress));
             Assert.Contains(key, exc.Message);
         }
@@ -140,15 +140,15 @@ namespace Lib9c.Tests.Action
         [InlineData(false)]
         public void TryGetAvatarStateV2(bool backward)
         {
-            var states = new State();
+            var states = new MockStateDelta();
             if (backward)
             {
-                states = (State)states
+                states = (MockStateDelta)states
                     .SetState(_avatarAddress, _avatarState.Serialize());
             }
             else
             {
-                states = (State)states
+                states = (MockStateDelta)states
                     .SetState(_avatarAddress, _avatarState.SerializeV2())
                     .SetState(_avatarAddress.Derive(LegacyInventoryKey), _avatarState.inventory.Serialize())
                     .SetState(_avatarAddress.Derive(LegacyWorldInformationKey), _avatarState.worldInformation.Serialize())
@@ -164,16 +164,16 @@ namespace Lib9c.Tests.Action
         [InlineData(false)]
         public void TryGetAgentAvatarStatesV2(bool backward)
         {
-            var states = new State().SetState(_agentAddress, _agentState.Serialize());
+            var states = new MockStateDelta().SetState(_agentAddress, _agentState.Serialize());
 
             if (backward)
             {
-                states = (State)states
+                states = (MockStateDelta)states
                     .SetState(_avatarAddress, _avatarState.Serialize());
             }
             else
             {
-                states = (State)states
+                states = (MockStateDelta)states
                     .SetState(_avatarAddress, _avatarState.SerializeV2())
                     .SetState(_avatarAddress.Derive(LegacyInventoryKey), _avatarState.inventory.Serialize())
                     .SetState(_avatarAddress.Derive(LegacyWorldInformationKey), _avatarState.worldInformation.Serialize())
@@ -187,7 +187,7 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void GetStatesAsDict()
         {
-            IAccountStateDelta states = new State();
+            IAccountStateDelta states = new MockStateDelta();
             var dict = new Dictionary<Address, IValue>
             {
                 { new PrivateKey().ToAddress(), Null.Value },
@@ -214,7 +214,7 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void GetSheets()
         {
-            IAccountStateDelta states = new State();
+            IAccountStateDelta states = new MockStateDelta();
             SheetsExtensionsTest.InitSheets(
                 states,
                 out _,
@@ -241,7 +241,7 @@ namespace Lib9c.Tests.Action
         [InlineData(true)]
         public void GetCrystalCostState(bool exist)
         {
-            IAccountStateDelta state = new State();
+            IAccountStateDelta state = new MockStateDelta();
             int expectedCount = exist ? 1 : 0;
             FungibleAssetValue expectedCrystal = exist
                 ? 100 * CrystalCalculator.CRYSTAL
@@ -274,7 +274,7 @@ namespace Lib9c.Tests.Action
             Address previousCostAddress = Addresses.GetWeeklyCrystalCostAddress(weeklyIndex - 1);
             Address beforePreviousCostAddress = Addresses.GetWeeklyCrystalCostAddress(weeklyIndex - 2);
             var crystalCostState = new CrystalCostState(default, 100 * CrystalCalculator.CRYSTAL);
-            IAccountStateDelta state = new State()
+            IAccountStateDelta state = new MockStateDelta()
                 .SetState(dailyCostAddress, crystalCostState.Serialize())
                 .SetState(weeklyCostAddress, crystalCostState.Serialize())
                 .SetState(previousCostAddress, crystalCostState.Serialize())
@@ -304,7 +304,7 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void GetCouponWallet()
         {
-            IAccountStateDelta states = new State();
+            IAccountStateDelta states = new MockStateDelta();
             var guid1 = new Guid("6856AE42-A820-4041-92B0-5D7BAA52F2AA");
             var guid2 = new Guid("701BA698-CCB9-4FC7-B88F-7CB8C707D135");
             var guid3 = new Guid("910296E7-34E4-45D7-9B4E-778ED61F278B");

--- a/.Lib9c.Tests/Action/ActionContextExtensionsTest.cs
+++ b/.Lib9c.Tests/Action/ActionContextExtensionsTest.cs
@@ -142,7 +142,7 @@ namespace Lib9c.Tests.Action
         [MemberData(nameof(IsMainNetTestcases))]
         public void IsMainNet(GoldCurrencyState goldCurrencyState, bool expected)
         {
-            var state = new State().SetState(Addresses.GoldCurrency, goldCurrencyState.Serialize());
+            var state = new MockStateDelta().SetState(Addresses.GoldCurrency, goldCurrencyState.Serialize());
             IActionContext context = new ActionContext
             {
                 PreviousState = state,

--- a/.Lib9c.Tests/Action/ActionEvaluationTest.cs
+++ b/.Lib9c.Tests/Action/ActionEvaluationTest.cs
@@ -33,7 +33,7 @@ namespace Lib9c.Tests.Action
 #pragma warning restore CS0618
             _signer = new PrivateKey().ToAddress();
             _sender = new PrivateKey().ToAddress();
-            _states = new State()
+            _states = new MockStateDelta()
                 .SetState(_signer, (Text)"ANYTHING")
                 .SetState(default, Dictionary.Empty.Add("key", "value"))
                 .MintAsset(context, _signer, _currency * 10000);

--- a/.Lib9c.Tests/Action/ActivateAccount0Test.cs
+++ b/.Lib9c.Tests/Action/ActivateAccount0Test.cs
@@ -50,7 +50,7 @@ namespace Lib9c.Tests.Action
             ActivateAccount0 action = activationKey.CreateActivateAccount0(nonce);
             IAccountStateDelta nextState = action.Execute(new ActionContext()
             {
-                PreviousState = new State(ImmutableDictionary<Address, IValue>.Empty),
+                PreviousState = new State(),
                 Signer = default,
                 Rehearsal = true,
                 BlockIndex = 1,
@@ -123,7 +123,7 @@ namespace Lib9c.Tests.Action
                 ActivationKey.Create(privateKey, nonce);
 
             // state가 올바르게 초기화되지 않은 상태를 가정합니다.
-            var state = new State(ImmutableDictionary<Address, IValue>.Empty);
+            var state = new State();
 
             ActivateAccount0 action = activationKey.CreateActivateAccount0(nonce);
             Assert.Throws<ActivatedAccountsDoesNotExistsException>(() =>

--- a/.Lib9c.Tests/Action/ActivateAccount0Test.cs
+++ b/.Lib9c.Tests/Action/ActivateAccount0Test.cs
@@ -19,7 +19,7 @@ namespace Lib9c.Tests.Action
             var privateKey = new PrivateKey();
             (ActivationKey activationKey, PendingActivationState pendingActivation) =
                 ActivationKey.Create(privateKey, nonce);
-            var state = new State(ImmutableDictionary<Address, IValue>.Empty
+            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
                 .Add(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize())
                 .Add(pendingActivation.address, pendingActivation.Serialize()));
 
@@ -50,7 +50,7 @@ namespace Lib9c.Tests.Action
             ActivateAccount0 action = activationKey.CreateActivateAccount0(nonce);
             IAccountStateDelta nextState = action.Execute(new ActionContext()
             {
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = default,
                 Rehearsal = true,
                 BlockIndex = 1,
@@ -72,7 +72,7 @@ namespace Lib9c.Tests.Action
             var privateKey = new PrivateKey();
             (ActivationKey activationKey, PendingActivationState pendingActivation) =
                 ActivationKey.Create(privateKey, nonce);
-            var state = new State(ImmutableDictionary<Address, IValue>.Empty
+            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
                 .Add(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize())
                 .Add(pendingActivation.address, pendingActivation.Serialize())
             );
@@ -99,7 +99,7 @@ namespace Lib9c.Tests.Action
                 ActivationKey.Create(privateKey, nonce);
 
             // state에는 pendingActivation에 해당하는 대기가 없는 상태를 가정합니다.
-            var state = new State(ImmutableDictionary<Address, IValue>.Empty
+            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
                 .Add(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize()));
 
             ActivateAccount0 action = activationKey.CreateActivateAccount0(nonce);
@@ -123,7 +123,7 @@ namespace Lib9c.Tests.Action
                 ActivationKey.Create(privateKey, nonce);
 
             // state가 올바르게 초기화되지 않은 상태를 가정합니다.
-            var state = new State();
+            var state = new MockStateDelta();
 
             ActivateAccount0 action = activationKey.CreateActivateAccount0(nonce);
             Assert.Throws<ActivatedAccountsDoesNotExistsException>(() =>
@@ -144,7 +144,7 @@ namespace Lib9c.Tests.Action
             var privateKey = new PrivateKey();
             (ActivationKey activationKey, PendingActivationState pendingActivation) =
                 ActivationKey.Create(privateKey, nonce);
-            var state = new State(ImmutableDictionary<Address, IValue>.Empty
+            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
                 .Add(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize())
                 .Add(pendingActivation.address, pendingActivation.Serialize()));
 

--- a/.Lib9c.Tests/Action/ActivateAccountTest.cs
+++ b/.Lib9c.Tests/Action/ActivateAccountTest.cs
@@ -26,16 +26,16 @@ namespace Lib9c.Tests.Action
                 ActivationKey.Create(privateKey, nonce);
 
             Address activatedAddress = default(Address).Derive(ActivationKey.DeriveKey);
-            var state = new State();
+            var state = new MockStateDelta();
 
             if (pendingExist)
             {
-                state = (State)state.SetState(pendingActivation.address, pendingActivation.Serialize());
+                state = (MockStateDelta)state.SetState(pendingActivation.address, pendingActivation.Serialize());
             }
 
             if (alreadyActivated)
             {
-                state = (State)state.SetState(activatedAddress, true.Serialize());
+                state = (MockStateDelta)state.SetState(activatedAddress, true.Serialize());
             }
 
             ActivateAccount action = activationKey.CreateActivateAccount(invalid ? new byte[] { 0x00 } : nonce);
@@ -75,7 +75,7 @@ namespace Lib9c.Tests.Action
             Address activatedAddress = default(Address).Derive(ActivationKey.DeriveKey);
             IAccountStateDelta nextState = action.Execute(new ActionContext()
             {
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = default,
                 Rehearsal = true,
                 BlockIndex = 1,

--- a/.Lib9c.Tests/Action/ActivateAccountTest.cs
+++ b/.Lib9c.Tests/Action/ActivateAccountTest.cs
@@ -75,7 +75,7 @@ namespace Lib9c.Tests.Action
             Address activatedAddress = default(Address).Derive(ActivationKey.DeriveKey);
             IAccountStateDelta nextState = action.Execute(new ActionContext()
             {
-                PreviousState = new State(ImmutableDictionary<Address, IValue>.Empty),
+                PreviousState = new State(),
                 Signer = default,
                 Rehearsal = true,
                 BlockIndex = 1,

--- a/.Lib9c.Tests/Action/AddActivatedAccount0Test.cs
+++ b/.Lib9c.Tests/Action/AddActivatedAccount0Test.cs
@@ -75,7 +75,7 @@ namespace Lib9c.Tests.Action
         public void ExecuteWithNonExistsAccounts()
         {
             var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
-            var state = new State(ImmutableDictionary<Address, IValue>.Empty);
+            var state = new State();
             var newComer = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var action = new AddActivatedAccount0(newComer);
 

--- a/.Lib9c.Tests/Action/AddActivatedAccount0Test.cs
+++ b/.Lib9c.Tests/Action/AddActivatedAccount0Test.cs
@@ -14,7 +14,7 @@ namespace Lib9c.Tests.Action
         public void Execute()
         {
             var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
-            var state = new State(
+            var state = new MockStateDelta(
                 ImmutableDictionary<Address, IValue>.Empty
                 .Add(AdminState.Address, new AdminState(admin, 100).Serialize())
                 .Add(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize())
@@ -44,7 +44,7 @@ namespace Lib9c.Tests.Action
         public void Rehearsal()
         {
             var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
-            var state = new State(
+            var state = new MockStateDelta(
                 ImmutableDictionary<Address, IValue>.Empty
                 .Add(AdminState.Address, new AdminState(admin, 100).Serialize())
                 .Add(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize())
@@ -75,7 +75,7 @@ namespace Lib9c.Tests.Action
         public void ExecuteWithNonExistsAccounts()
         {
             var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
-            var state = new State();
+            var state = new MockStateDelta();
             var newComer = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var action = new AddActivatedAccount0(newComer);
 
@@ -95,7 +95,7 @@ namespace Lib9c.Tests.Action
         public void CheckPermission()
         {
             var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
-            var state = new State(
+            var state = new MockStateDelta(
                 ImmutableDictionary<Address, IValue>.Empty
                 .Add(AdminState.Address, new AdminState(admin, 100).Serialize())
                 .Add(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize())

--- a/.Lib9c.Tests/Action/AddActivatedAccountTest.cs
+++ b/.Lib9c.Tests/Action/AddActivatedAccountTest.cs
@@ -20,7 +20,7 @@ namespace Lib9c.Tests.Action
         public void Execute(bool isAdmin, long blockIndex, bool alreadyActivated, Type exc)
         {
             var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
-            var state = new State(
+            var state = new MockStateDelta(
                 ImmutableDictionary<Address, IValue>.Empty
                 .Add(AdminState.Address, new AdminState(admin, 100).Serialize())
             );
@@ -28,7 +28,7 @@ namespace Lib9c.Tests.Action
             var activatedAddress = newComer.Derive(ActivationKey.DeriveKey);
             if (alreadyActivated)
             {
-                state = (State)state.SetState(activatedAddress, true.Serialize());
+                state = (MockStateDelta)state.SetState(activatedAddress, true.Serialize());
             }
 
             var action = new AddActivatedAccount(newComer);
@@ -61,7 +61,7 @@ namespace Lib9c.Tests.Action
         public void Rehearsal()
         {
             var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
-            var state = new State(
+            var state = new MockStateDelta(
                 ImmutableDictionary<Address, IValue>.Empty
                 .Add(AdminState.Address, new AdminState(admin, 100).Serialize())
             );

--- a/.Lib9c.Tests/Action/AddRedeemCodeTest.cs
+++ b/.Lib9c.Tests/Action/AddRedeemCodeTest.cs
@@ -19,7 +19,7 @@ namespace Lib9c.Tests.Action
             var adminState = new AdminState(adminAddress, 100);
             var initStates = ImmutableDictionary<Address, IValue>.Empty
                 .Add(AdminState.Address, adminState.Serialize());
-            var state = new State(initStates);
+            var state = new MockStateDelta(initStates);
             var action = new AddRedeemCode
             {
                 redeemCsv = "New Value",
@@ -69,7 +69,7 @@ namespace Lib9c.Tests.Action
             {
                 Signer = adminAddress,
                 BlockIndex = 0,
-                PreviousState = new State()
+                PreviousState = new MockStateDelta()
                     .SetState(Addresses.Admin, adminState.Serialize())
                     .SetState(Addresses.RedeemCode, new RedeemCodeState(new RedeemCodeListSheet()).Serialize()),
             });
@@ -91,7 +91,7 @@ namespace Lib9c.Tests.Action
             var sheet = new RedeemCodeListSheet();
             sheet.Set(csv);
 
-            var state = new State()
+            var state = new MockStateDelta()
                     .SetState(Addresses.RedeemCode, new RedeemCodeState(sheet).Serialize());
 
             var action = new AddRedeemCode
@@ -118,7 +118,7 @@ namespace Lib9c.Tests.Action
             var nextState = action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Rehearsal = true,
             });
 

--- a/.Lib9c.Tests/Action/AddRedeemCodeTest.cs
+++ b/.Lib9c.Tests/Action/AddRedeemCodeTest.cs
@@ -19,7 +19,7 @@ namespace Lib9c.Tests.Action
             var adminState = new AdminState(adminAddress, 100);
             var initStates = ImmutableDictionary<Address, IValue>.Empty
                 .Add(AdminState.Address, adminState.Serialize());
-            var state = new State(initStates, ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty);
+            var state = new State(initStates);
             var action = new AddRedeemCode
             {
                 redeemCsv = "New Value",

--- a/.Lib9c.Tests/Action/ApprovePledgeTest.cs
+++ b/.Lib9c.Tests/Action/ApprovePledgeTest.cs
@@ -21,7 +21,7 @@ namespace Lib9c.Tests.Action
             var address = new PrivateKey().ToAddress();
             var patron = new PrivateKey().ToAddress();
             var contractAddress = address.Derive(nameof(RequestPledge));
-            IAccountStateDelta states = new State()
+            IAccountStateDelta states = new MockStateDelta()
                 .SetState(
                     contractAddress,
                     List.Empty.Add(patron.Serialize()).Add(false.Serialize()).Add(mead.Serialize())
@@ -63,7 +63,7 @@ namespace Lib9c.Tests.Action
                 contract = List.Empty.Add(patron.Serialize()).Add(true.Serialize());
             }
 
-            IAccountStateDelta states = new State().SetState(contractAddress, contract);
+            IAccountStateDelta states = new MockStateDelta().SetState(contractAddress, contract);
 
             var action = new ApprovePledge
             {

--- a/.Lib9c.Tests/Action/ArenahelperTest.cs
+++ b/.Lib9c.Tests/Action/ArenahelperTest.cs
@@ -35,7 +35,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _state = new State();
+            _state = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             var tableSheets = new TableSheets(sheets);

--- a/.Lib9c.Tests/Action/BattleArena10Test.cs
+++ b/.Lib9c.Tests/Action/BattleArena10Test.cs
@@ -47,7 +47,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialStates = new State();
+            _initialStates = new MockStateDelta();
 
             _sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in _sheets)

--- a/.Lib9c.Tests/Action/BattleArena11Test.cs
+++ b/.Lib9c.Tests/Action/BattleArena11Test.cs
@@ -47,7 +47,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialStates = new State();
+            _initialStates = new MockStateDelta();
 
             _sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in _sheets)

--- a/.Lib9c.Tests/Action/BattleArena12Test.cs
+++ b/.Lib9c.Tests/Action/BattleArena12Test.cs
@@ -47,7 +47,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialStates = new State();
+            _initialStates = new MockStateDelta();
 
             _sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in _sheets)

--- a/.Lib9c.Tests/Action/BattleArena1Test.cs
+++ b/.Lib9c.Tests/Action/BattleArena1Test.cs
@@ -48,7 +48,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _state = new State();
+            _state = new MockStateDelta();
 
             _sheets = TableSheetsImporter.ImportSheets();
             var tableSheets = new TableSheets(_sheets);

--- a/.Lib9c.Tests/Action/BattleArena2Test.cs
+++ b/.Lib9c.Tests/Action/BattleArena2Test.cs
@@ -50,7 +50,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _state = new State();
+            _state = new MockStateDelta();
 
             _sheets = TableSheetsImporter.ImportSheets();
             var tableSheets = new TableSheets(_sheets);

--- a/.Lib9c.Tests/Action/BattleArena3Test.cs
+++ b/.Lib9c.Tests/Action/BattleArena3Test.cs
@@ -50,7 +50,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _state = new State();
+            _state = new MockStateDelta();
 
             _sheets = TableSheetsImporter.ImportSheets();
             var tableSheets = new TableSheets(_sheets);

--- a/.Lib9c.Tests/Action/BattleArena4Test.cs
+++ b/.Lib9c.Tests/Action/BattleArena4Test.cs
@@ -50,7 +50,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _state = new State();
+            _state = new MockStateDelta();
 
             _sheets = TableSheetsImporter.ImportSheets();
             var tableSheets = new TableSheets(_sheets);

--- a/.Lib9c.Tests/Action/BattleArena5Test.cs
+++ b/.Lib9c.Tests/Action/BattleArena5Test.cs
@@ -45,7 +45,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialStates = new State();
+            _initialStates = new MockStateDelta();
 
             _sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in _sheets)

--- a/.Lib9c.Tests/Action/BattleArena6Test.cs
+++ b/.Lib9c.Tests/Action/BattleArena6Test.cs
@@ -46,7 +46,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialStates = new State();
+            _initialStates = new MockStateDelta();
 
             _sheets = TableSheetsImporter.ImportSheets();
             _sheets.Remove(nameof(RuneOptionSheet));

--- a/.Lib9c.Tests/Action/BattleArena7Test.cs
+++ b/.Lib9c.Tests/Action/BattleArena7Test.cs
@@ -46,7 +46,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialStates = new State();
+            _initialStates = new MockStateDelta();
 
             _sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in _sheets)

--- a/.Lib9c.Tests/Action/BattleArena8Test.cs
+++ b/.Lib9c.Tests/Action/BattleArena8Test.cs
@@ -47,7 +47,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialStates = new State();
+            _initialStates = new MockStateDelta();
 
             _sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in _sheets)

--- a/.Lib9c.Tests/Action/BattleArena9Test.cs
+++ b/.Lib9c.Tests/Action/BattleArena9Test.cs
@@ -47,7 +47,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialStates = new State();
+            _initialStates = new MockStateDelta();
 
             _sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in _sheets)

--- a/.Lib9c.Tests/Action/BattleGrandFinale1Test.cs
+++ b/.Lib9c.Tests/Action/BattleGrandFinale1Test.cs
@@ -46,7 +46,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialStates = new State();
+            _initialStates = new MockStateDelta();
 
             _sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in _sheets)

--- a/.Lib9c.Tests/Action/BattleGrandFinale2Test.cs
+++ b/.Lib9c.Tests/Action/BattleGrandFinale2Test.cs
@@ -46,7 +46,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialStates = new State();
+            _initialStates = new MockStateDelta();
 
             _sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in _sheets)

--- a/.Lib9c.Tests/Action/BattleGrandFinale3Test.cs
+++ b/.Lib9c.Tests/Action/BattleGrandFinale3Test.cs
@@ -46,7 +46,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialStates = new State();
+            _initialStates = new MockStateDelta();
 
             _sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in _sheets)

--- a/.Lib9c.Tests/Action/Buy10Test.cs
+++ b/.Lib9c.Tests/Action/Buy10Test.cs
@@ -45,7 +45,7 @@ namespace Lib9c.Tests.Action
                 .CreateLogger();
 
             var context = new ActionContext();
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -805,7 +805,7 @@ namespace Lib9c.Tests.Action
                 OrderReceipt.DeriveAddress(_orderId),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/Buy11Test.cs
+++ b/.Lib9c.Tests/Action/Buy11Test.cs
@@ -47,7 +47,7 @@ namespace Lib9c.Tests.Action
                 .CreateLogger();
 
             var context = new ActionContext();
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -811,7 +811,7 @@ namespace Lib9c.Tests.Action
                 OrderReceipt.DeriveAddress(_orderId),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/Buy2Test.cs
+++ b/.Lib9c.Tests/Action/Buy2Test.cs
@@ -36,7 +36,7 @@ namespace Lib9c.Tests.Action
                 .CreateLogger();
 
             var context = new ActionContext();
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {

--- a/.Lib9c.Tests/Action/Buy3Test.cs
+++ b/.Lib9c.Tests/Action/Buy3Test.cs
@@ -36,7 +36,7 @@
                 .CreateLogger();
 
             var context = new ActionContext();
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -208,7 +208,7 @@
             Assert.Throws<InvalidAddressException>(() => action.Execute(new ActionContext()
                 {
                     BlockIndex = 0,
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Random = new TestRandom(),
                     Signer = _buyerAgentAddress,
                 })
@@ -229,7 +229,7 @@
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
                 {
                     BlockIndex = 0,
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Random = new TestRandom(),
                     Signer = _buyerAgentAddress,
                 })

--- a/.Lib9c.Tests/Action/Buy4Test.cs
+++ b/.Lib9c.Tests/Action/Buy4Test.cs
@@ -38,7 +38,7 @@
                 .CreateLogger();
 
             var context = new ActionContext();
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -232,7 +232,7 @@
             Assert.Throws<InvalidAddressException>(() => action.Execute(new ActionContext()
                 {
                     BlockIndex = 0,
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Random = new TestRandom(),
                     Signer = _buyerAgentAddress,
                 })
@@ -253,7 +253,7 @@
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
                 {
                     BlockIndex = 0,
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Random = new TestRandom(),
                     Signer = _buyerAgentAddress,
                 })

--- a/.Lib9c.Tests/Action/Buy5Test.cs
+++ b/.Lib9c.Tests/Action/Buy5Test.cs
@@ -39,7 +39,7 @@ namespace Lib9c.Tests.Action
                 .CreateLogger();
 
             var context = new ActionContext();
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -366,7 +366,7 @@ namespace Lib9c.Tests.Action
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
                 {
                     BlockIndex = 0,
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Random = new TestRandom(),
                     Signer = _buyerAgentAddress,
                 })

--- a/.Lib9c.Tests/Action/Buy6Test.cs
+++ b/.Lib9c.Tests/Action/Buy6Test.cs
@@ -40,7 +40,7 @@ namespace Lib9c.Tests.Action
                 .CreateLogger();
 
             var context = new ActionContext();
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -444,7 +444,7 @@ namespace Lib9c.Tests.Action
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
                 {
                     BlockIndex = 0,
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Random = new TestRandom(),
                     Signer = _buyerAgentAddress,
                 })

--- a/.Lib9c.Tests/Action/Buy7Test.cs
+++ b/.Lib9c.Tests/Action/Buy7Test.cs
@@ -40,7 +40,7 @@ namespace Lib9c.Tests.Action
                 .CreateLogger();
 
             var context = new ActionContext();
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -445,7 +445,7 @@ namespace Lib9c.Tests.Action
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
                 {
                     BlockIndex = 0,
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Random = new TestRandom(),
                     Signer = _buyerAgentAddress,
                 })

--- a/.Lib9c.Tests/Action/Buy8Test.cs
+++ b/.Lib9c.Tests/Action/Buy8Test.cs
@@ -42,7 +42,7 @@
                 .CreateLogger();
 
             var context = new ActionContext();
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -587,7 +587,7 @@
                 OrderReceipt.DeriveAddress(_orderId),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/Buy9Test.cs
+++ b/.Lib9c.Tests/Action/Buy9Test.cs
@@ -42,7 +42,7 @@
                 .CreateLogger();
 
             var context = new ActionContext();
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -686,7 +686,7 @@
                 OrderReceipt.DeriveAddress(_orderId),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/BuyMultipleTest.cs
+++ b/.Lib9c.Tests/Action/BuyMultipleTest.cs
@@ -37,7 +37,7 @@
                 .CreateLogger();
 
             var context = new ActionContext();
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -410,7 +410,7 @@
             Assert.Throws<InvalidAddressException>(() => action.Execute(new ActionContext()
                 {
                     BlockIndex = 0,
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Random = new TestRandom(),
                     Signer = _buyerAgentAddress,
                 })
@@ -429,7 +429,7 @@
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
                 {
                     BlockIndex = 0,
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Random = new TestRandom(),
                     Signer = _buyerAgentAddress,
                 })

--- a/.Lib9c.Tests/Action/BuyProduct0Test.cs
+++ b/.Lib9c.Tests/Action/BuyProduct0Test.cs
@@ -46,7 +46,7 @@ namespace Lib9c.Tests.Action
                 .CreateLogger();
 
             var context = new ActionContext();
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {

--- a/.Lib9c.Tests/Action/BuyProductTest.cs
+++ b/.Lib9c.Tests/Action/BuyProductTest.cs
@@ -46,7 +46,7 @@ namespace Lib9c.Tests.Action
                 .CreateLogger();
 
             var context = new ActionContext();
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {

--- a/.Lib9c.Tests/Action/BuyTest.cs
+++ b/.Lib9c.Tests/Action/BuyTest.cs
@@ -45,7 +45,7 @@ namespace Lib9c.Tests.Action
                 .CreateLogger();
 
             var context = new ActionContext();
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {

--- a/.Lib9c.Tests/Action/CancelMonsterCollectTest.cs
+++ b/.Lib9c.Tests/Action/CancelMonsterCollectTest.cs
@@ -22,7 +22,7 @@ namespace Lib9c.Tests.Action
         public CancelMonsterCollectTest()
         {
             _signer = default;
-            _state = new State();
+            _state = new MockStateDelta();
             Dictionary<string, string> sheets = TableSheetsImporter.ImportSheets();
             _tableSheets = new TableSheets(sheets);
             var agentState = new AgentState(_signer);

--- a/.Lib9c.Tests/Action/CancelProductRegistrationTest.cs
+++ b/.Lib9c.Tests/Action/CancelProductRegistrationTest.cs
@@ -34,7 +34,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {

--- a/.Lib9c.Tests/Action/ChargeActionPoint0Test.cs
+++ b/.Lib9c.Tests/Action/ChargeActionPoint0Test.cs
@@ -54,7 +54,7 @@ namespace Lib9c.Tests.Action
 
             Assert.Equal(0, avatarState.actionPoint);
 
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(Addresses.GameConfig, gameConfigState.Serialize())
                 .SetState(agentAddress, agent.Serialize())
                 .SetState(avatarAddress, avatarState.Serialize());

--- a/.Lib9c.Tests/Action/ChargeActionPoint2Test.cs
+++ b/.Lib9c.Tests/Action/ChargeActionPoint2Test.cs
@@ -44,7 +44,7 @@ namespace Lib9c.Tests.Action
             };
             agent.avatarAddresses.Add(0, _avatarAddress);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(Addresses.GameConfig, gameConfigState.Serialize())
                 .SetState(_agentAddress, agent.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize());
@@ -111,7 +111,7 @@ namespace Lib9c.Tests.Action
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
                 {
                     BlockIndex = 0,
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Random = new TestRandom(),
                     Signer = default,
                 })

--- a/.Lib9c.Tests/Action/ChargeActionPointTest.cs
+++ b/.Lib9c.Tests/Action/ChargeActionPointTest.cs
@@ -47,7 +47,7 @@ namespace Lib9c.Tests.Action
             };
             agent.avatarAddresses.Add(0, _avatarAddress);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(Addresses.GameConfig, gameConfigState.Serialize())
                 .SetState(_agentAddress, agent.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize());
@@ -186,7 +186,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/ClaimMonsterCollectionReward0Test.cs
+++ b/.Lib9c.Tests/Action/ClaimMonsterCollectionReward0Test.cs
@@ -25,7 +25,7 @@ namespace Lib9c.Tests.Action
         {
             _signer = default;
             _avatarAddress = _signer.Derive("avatar");
-            _state = new State();
+            _state = new MockStateDelta();
             Dictionary<string, string> sheets = TableSheetsImporter.ImportSheets();
             _tableSheets = new TableSheets(sheets);
             var rankingMapAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/ClaimMonsterCollectionReward2Test.cs
+++ b/.Lib9c.Tests/Action/ClaimMonsterCollectionReward2Test.cs
@@ -36,7 +36,7 @@
 
             _signer = default;
             _avatarAddress = _signer.Derive("avatar");
-            _state = new State();
+            _state = new MockStateDelta();
             Dictionary<string, string> sheets = TableSheetsImporter.ImportSheets();
             _tableSheets = new TableSheets(sheets);
             var rankingMapAddress = new PrivateKey().ToAddress();
@@ -211,7 +211,7 @@
 
             IAccountStateDelta nextState = action.Execute(new ActionContext
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _signer,
                     BlockIndex = 0,
                     Rehearsal = true,

--- a/.Lib9c.Tests/Action/ClaimMonsterCollectionRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimMonsterCollectionRewardTest.cs
@@ -36,7 +36,7 @@ namespace Lib9c.Tests.Action
 
             _signer = default;
             _avatarAddress = _signer.Derive("avatar");
-            _state = new State();
+            _state = new MockStateDelta();
             Dictionary<string, string> sheets = TableSheetsImporter.ImportSheets();
             var tableSheets = new TableSheets(sheets);
             var rankingMapAddress = new PrivateKey().ToAddress();
@@ -188,7 +188,7 @@ namespace Lib9c.Tests.Action
         {
             IAccountStateDelta nextState = _action.Execute(new ActionContext
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _signer,
                     BlockIndex = 0,
                     Rehearsal = true,

--- a/.Lib9c.Tests/Action/ClaimRaidRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimRaidRewardTest.cs
@@ -20,7 +20,7 @@ namespace Lib9c.Tests.Action
         {
             var tableCsv = TableSheetsImporter.ImportSheets();
             _tableSheets = new TableSheets(tableCsv);
-            _state = new State();
+            _state = new MockStateDelta();
             foreach (var kv in tableCsv)
             {
                 _state = _state.SetState(Addresses.GetSheetAddress(kv.Key), kv.Value.Serialize());

--- a/.Lib9c.Tests/Action/ClaimStakeReward1Test.cs
+++ b/.Lib9c.Tests/Action/ClaimStakeReward1Test.cs
@@ -31,7 +31,7 @@ namespace Lib9c.Tests.Action
                 .CreateLogger();
 
             var context = new ActionContext();
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)

--- a/.Lib9c.Tests/Action/ClaimStakeReward2Test.cs
+++ b/.Lib9c.Tests/Action/ClaimStakeReward2Test.cs
@@ -32,7 +32,7 @@ namespace Lib9c.Tests.Action
                 .CreateLogger();
 
             var context = new ActionContext();
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)

--- a/.Lib9c.Tests/Action/ClaimWorldBossKillRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimWorldBossKillRewardTest.cs
@@ -27,7 +27,7 @@ namespace Lib9c.Tests.Action
             var tableSheets = new TableSheets(sheets);
             Address agentAddress = new PrivateKey().ToAddress();
             Address avatarAddress = new PrivateKey().ToAddress();
-            IAccountStateDelta state = new State();
+            IAccountStateDelta state = new MockStateDelta();
 
             var runeWeightSheet = new RuneWeightSheet();
             runeWeightSheet.Set(@"id,boss_id,rank,rune_id,weight

--- a/.Lib9c.Tests/Action/CombinationConsumable0Test.cs
+++ b/.Lib9c.Tests/Action/CombinationConsumable0Test.cs
@@ -52,7 +52,7 @@ namespace Lib9c.Tests.Action
                 default
             );
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize());
 
@@ -119,7 +119,7 @@ namespace Lib9c.Tests.Action
 
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                     BlockIndex = 1,
                     Random = _random,

--- a/.Lib9c.Tests/Action/CombinationConsumable2Test.cs
+++ b/.Lib9c.Tests/Action/CombinationConsumable2Test.cs
@@ -52,7 +52,7 @@ namespace Lib9c.Tests.Action
                 default
             );
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize());
 

--- a/.Lib9c.Tests/Action/CombinationConsumable3Test.cs
+++ b/.Lib9c.Tests/Action/CombinationConsumable3Test.cs
@@ -52,7 +52,7 @@ namespace Lib9c.Tests.Action
                 default
             );
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize());
 

--- a/.Lib9c.Tests/Action/CombinationConsumable4Test.cs
+++ b/.Lib9c.Tests/Action/CombinationConsumable4Test.cs
@@ -52,7 +52,7 @@ namespace Lib9c.Tests.Action
                 default
             );
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize());
 

--- a/.Lib9c.Tests/Action/CombinationConsumable5Test.cs
+++ b/.Lib9c.Tests/Action/CombinationConsumable5Test.cs
@@ -52,7 +52,7 @@ namespace Lib9c.Tests.Action
                 default
             );
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize());
 

--- a/.Lib9c.Tests/Action/CombinationConsumable6Test.cs
+++ b/.Lib9c.Tests/Action/CombinationConsumable6Test.cs
@@ -53,7 +53,7 @@
                 default
             );
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize());
 

--- a/.Lib9c.Tests/Action/CombinationConsumable7Test.cs
+++ b/.Lib9c.Tests/Action/CombinationConsumable7Test.cs
@@ -52,7 +52,7 @@ namespace Lib9c.Tests.Action
                 default
             );
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize());
 

--- a/.Lib9c.Tests/Action/CombinationConsumableTest.cs
+++ b/.Lib9c.Tests/Action/CombinationConsumableTest.cs
@@ -58,7 +58,7 @@ namespace Lib9c.Tests.Action
             var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
 #pragma warning restore CS0618
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
                 .SetState(

--- a/.Lib9c.Tests/Action/CombinationEquipment0Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment0Test.cs
@@ -57,7 +57,7 @@ namespace Lib9c.Tests.Action
 #pragma warning restore CS0618
 
             var context = new ActionContext();
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
                 .SetState(
@@ -185,7 +185,7 @@ namespace Lib9c.Tests.Action
 
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
             {
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
                 Random = new TestRandom(),
             }));

--- a/.Lib9c.Tests/Action/CombinationEquipment10Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment10Test.cs
@@ -69,7 +69,7 @@ namespace Lib9c.Tests.Action
             var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
 #pragma warning restore CS0618
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
                 .SetState(
@@ -141,7 +141,7 @@ namespace Lib9c.Tests.Action
                 Addresses.Blacksmith,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext
             {

--- a/.Lib9c.Tests/Action/CombinationEquipment11Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment11Test.cs
@@ -72,7 +72,7 @@ namespace Lib9c.Tests.Action
             var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
 #pragma warning restore CS0618
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
                 .SetState(
@@ -148,7 +148,7 @@ namespace Lib9c.Tests.Action
                 ItemEnhancement10.GetFeeStoreAddress(),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext
             {

--- a/.Lib9c.Tests/Action/CombinationEquipment12Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment12Test.cs
@@ -82,7 +82,7 @@ namespace Lib9c.Tests.Action
                 _slotAddress,
                 GameConfig.RequireClearedStageLevel.CombinationEquipmentAction);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_slotAddress, combinationSlotState.Serialize())
                 .SetState(GoldCurrencyState.Address, gold.Serialize());
 

--- a/.Lib9c.Tests/Action/CombinationEquipment13Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment13Test.cs
@@ -77,7 +77,7 @@
                 _slotAddress,
                 GameConfig.RequireClearedStageLevel.CombinationEquipmentAction);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_slotAddress, combinationSlotState.Serialize())
                 .SetState(GoldCurrencyState.Address, gold.Serialize());
 

--- a/.Lib9c.Tests/Action/CombinationEquipment14Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment14Test.cs
@@ -78,7 +78,7 @@
                 _slotAddress,
                 GameConfig.RequireClearedStageLevel.CombinationEquipmentAction);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_slotAddress, combinationSlotState.Serialize())
                 .SetState(GoldCurrencyState.Address, gold.Serialize());
 

--- a/.Lib9c.Tests/Action/CombinationEquipment15Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment15Test.cs
@@ -78,7 +78,7 @@ namespace Lib9c.Tests.Action
                 _slotAddress,
                 GameConfig.RequireClearedStageLevel.CombinationEquipmentAction);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_slotAddress, combinationSlotState.Serialize())
                 .SetState(GoldCurrencyState.Address, gold.Serialize());
 

--- a/.Lib9c.Tests/Action/CombinationEquipment2Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment2Test.cs
@@ -57,7 +57,7 @@ namespace Lib9c.Tests.Action
 #pragma warning restore CS0618
 
             var context = new ActionContext();
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
                 .SetState(

--- a/.Lib9c.Tests/Action/CombinationEquipment3Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment3Test.cs
@@ -62,7 +62,7 @@ namespace Lib9c.Tests.Action
 #pragma warning restore CS0618
 
             var context = new ActionContext();
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
                 .SetState(

--- a/.Lib9c.Tests/Action/CombinationEquipment4Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment4Test.cs
@@ -62,7 +62,7 @@ namespace Lib9c.Tests.Action
 #pragma warning restore CS0618
 
             var context = new ActionContext();
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
                 .SetState(

--- a/.Lib9c.Tests/Action/CombinationEquipment5Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment5Test.cs
@@ -62,7 +62,7 @@ namespace Lib9c.Tests.Action
 #pragma warning restore CS0618
 
             var context = new ActionContext();
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
                 .SetState(

--- a/.Lib9c.Tests/Action/CombinationEquipment6Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment6Test.cs
@@ -64,7 +64,7 @@ namespace Lib9c.Tests.Action
 #pragma warning restore CS0618
 
             var context = new ActionContext();
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
                 .SetState(
@@ -254,7 +254,7 @@ namespace Lib9c.Tests.Action
                 Addresses.Blacksmith,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext
             {

--- a/.Lib9c.Tests/Action/CombinationEquipment7Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment7Test.cs
@@ -64,7 +64,7 @@ namespace Lib9c.Tests.Action
 #pragma warning restore CS0618
 
             var context = new ActionContext();
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
                 .SetState(
@@ -253,7 +253,7 @@ namespace Lib9c.Tests.Action
                 Addresses.Blacksmith,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext
             {

--- a/.Lib9c.Tests/Action/CombinationEquipment8Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment8Test.cs
@@ -68,7 +68,7 @@ namespace Lib9c.Tests.Action
             var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
 #pragma warning restore CS0618
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
                 .SetState(
@@ -140,7 +140,7 @@ namespace Lib9c.Tests.Action
                 Addresses.Blacksmith,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext
             {

--- a/.Lib9c.Tests/Action/CombinationEquipment9Test.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipment9Test.cs
@@ -68,7 +68,7 @@ namespace Lib9c.Tests.Action
             var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
 #pragma warning restore CS0618
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
                 .SetState(
@@ -140,7 +140,7 @@ namespace Lib9c.Tests.Action
                 Addresses.Blacksmith,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext
             {

--- a/.Lib9c.Tests/Action/CombinationEquipmentTest.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipmentTest.cs
@@ -78,7 +78,7 @@ namespace Lib9c.Tests.Action
                 _slotAddress,
                 GameConfig.RequireClearedStageLevel.CombinationEquipmentAction);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_slotAddress, combinationSlotState.Serialize())
                 .SetState(GoldCurrencyState.Address, gold.Serialize());
 

--- a/.Lib9c.Tests/Action/Coupons/IssueCouponsTest.cs
+++ b/.Lib9c.Tests/Action/Coupons/IssueCouponsTest.cs
@@ -18,7 +18,7 @@ namespace Lib9c.Tests.Action.Coupons
         [Fact]
         public void Execute()
         {
-            IAccountStateDelta state = new Lib9c.Tests.Action.State()
+            IAccountStateDelta state = new Lib9c.Tests.Action.MockStateDelta()
                 .SetState(
                     AdminState.Address,
                     new AdminState(CouponsFixture.AgentAddress1, 1)

--- a/.Lib9c.Tests/Action/Coupons/RedeemCouponTest.cs
+++ b/.Lib9c.Tests/Action/Coupons/RedeemCouponTest.cs
@@ -20,7 +20,7 @@ namespace Lib9c.Tests.Action.Coupons
         {
             IRandom random = new TestRandom();
             var sheets = TableSheetsImporter.ImportSheets();
-            IAccountStateDelta state = new Lib9c.Tests.Action.State()
+            IAccountStateDelta state = new Lib9c.Tests.Action.MockStateDelta()
                 .SetState(
                     Addresses.GameConfig,
                     new GameConfigState(sheets[nameof(GameConfigSheet)]).Serialize()

--- a/.Lib9c.Tests/Action/Coupons/TransferCouponsTest.cs
+++ b/.Lib9c.Tests/Action/Coupons/TransferCouponsTest.cs
@@ -17,7 +17,7 @@ namespace Lib9c.Tests.Action.Coupons
         [Fact]
         public void Execute()
         {
-            IAccountStateDelta state = new Lib9c.Tests.Action.State();
+            IAccountStateDelta state = new Lib9c.Tests.Action.MockStateDelta();
             IRandom random = new TestRandom();
 
             var coupon1 = new Coupon(CouponsFixture.Guid1, CouponsFixture.RewardSet1);

--- a/.Lib9c.Tests/Action/CreateAvatar0Test.cs
+++ b/.Lib9c.Tests/Action/CreateAvatar0Test.cs
@@ -53,7 +53,7 @@ namespace Lib9c.Tests.Action
 
             var sheets = TableSheetsImporter.ImportSheets();
             var context = new ActionContext();
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(GoldCurrencyState.Address, gold.Serialize())
                 .SetState(
                     Addresses.GoldDistribution,
@@ -112,7 +112,7 @@ namespace Lib9c.Tests.Action
                 name = nickName,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             Assert.Throws<InvalidNamePatternException>(() => action.Execute(new ActionContext()
                 {
@@ -146,7 +146,7 @@ namespace Lib9c.Tests.Action
                 name = "test",
             };
 
-            var state = new State().SetState(_avatarAddress, avatarState.Serialize());
+            var state = new MockStateDelta().SetState(_avatarAddress, avatarState.Serialize());
 
             Assert.Throws<InvalidAddressException>(() => action.Execute(new ActionContext()
                 {
@@ -163,7 +163,7 @@ namespace Lib9c.Tests.Action
         public void ExecuteThrowAvatarIndexOutOfRangeException(int index)
         {
             var agentState = new AgentState(_agentAddress);
-            var state = new State().SetState(_agentAddress, agentState.Serialize());
+            var state = new MockStateDelta().SetState(_agentAddress, agentState.Serialize());
             var action = new CreateAvatar0()
             {
                 avatarAddress = _avatarAddress,
@@ -192,7 +192,7 @@ namespace Lib9c.Tests.Action
         {
             var agentState = new AgentState(_agentAddress);
             agentState.avatarAddresses[index] = _avatarAddress;
-            var state = new State().SetState(_agentAddress, agentState.Serialize());
+            var state = new MockStateDelta().SetState(_agentAddress, agentState.Serialize());
 
             var action = new CreateAvatar0()
             {
@@ -254,7 +254,7 @@ namespace Lib9c.Tests.Action
                 updatedAddresses.Add(slotAddress);
             }
 
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(Addresses.Ranking, new RankingState0().Serialize())
                 .SetState(GoldCurrencyState.Address, gold.Serialize());
 

--- a/.Lib9c.Tests/Action/CreateAvatar2Test.cs
+++ b/.Lib9c.Tests/Action/CreateAvatar2Test.cs
@@ -50,7 +50,7 @@ namespace Lib9c.Tests.Action
 
             var sheets = TableSheetsImporter.ImportSheets();
             var context = new ActionContext();
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(GoldCurrencyState.Address, gold.Serialize())
                 .SetState(
                     Addresses.GoldDistribution,
@@ -115,7 +115,7 @@ namespace Lib9c.Tests.Action
                 name = nickName,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             Assert.Throws<InvalidNamePatternException>(() => action.Execute(new ActionContext()
                 {
@@ -156,7 +156,7 @@ namespace Lib9c.Tests.Action
                 name = "test",
             };
 
-            var state = new State().SetState(avatarAddress, avatarState.Serialize());
+            var state = new MockStateDelta().SetState(avatarAddress, avatarState.Serialize());
 
             Assert.Throws<InvalidAddressException>(() => action.Execute(new ActionContext()
                 {
@@ -173,7 +173,7 @@ namespace Lib9c.Tests.Action
         public void ExecuteThrowAvatarIndexOutOfRangeException(int index)
         {
             var agentState = new AgentState(_agentAddress);
-            var state = new State().SetState(_agentAddress, agentState.Serialize());
+            var state = new MockStateDelta().SetState(_agentAddress, agentState.Serialize());
             var action = new CreateAvatar2()
             {
                 index = index,
@@ -208,7 +208,7 @@ namespace Lib9c.Tests.Action
                 )
             );
             agentState.avatarAddresses[index] = avatarAddress;
-            var state = new State().SetState(_agentAddress, agentState.Serialize());
+            var state = new MockStateDelta().SetState(_agentAddress, agentState.Serialize());
 
             var action = new CreateAvatar2()
             {
@@ -277,7 +277,7 @@ namespace Lib9c.Tests.Action
                 updatedAddresses.Add(slotAddress);
             }
 
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(Addresses.Ranking, new RankingState0().Serialize())
                 .SetState(GoldCurrencyState.Address, gold.Serialize());
 

--- a/.Lib9c.Tests/Action/CreateAvatar3Test.cs
+++ b/.Lib9c.Tests/Action/CreateAvatar3Test.cs
@@ -51,7 +51,7 @@
 
             var sheets = TableSheetsImporter.ImportSheets();
             var context = new ActionContext();
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(GoldCurrencyState.Address, gold.Serialize())
                 .SetState(
                     Addresses.GoldDistribution,
@@ -117,7 +117,7 @@
                 name = nickName,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             Assert.Throws<InvalidNamePatternException>(() => action.Execute(new ActionContext()
                 {
@@ -158,7 +158,7 @@
                 name = "test",
             };
 
-            var state = new State().SetState(avatarAddress, avatarState.Serialize());
+            var state = new MockStateDelta().SetState(avatarAddress, avatarState.Serialize());
 
             Assert.Throws<InvalidAddressException>(() => action.Execute(new ActionContext()
                 {
@@ -175,7 +175,7 @@
         public void ExecuteThrowAvatarIndexOutOfRangeException(int index)
         {
             var agentState = new AgentState(_agentAddress);
-            var state = new State().SetState(_agentAddress, agentState.Serialize());
+            var state = new MockStateDelta().SetState(_agentAddress, agentState.Serialize());
             var action = new CreateAvatar3()
             {
                 index = index,
@@ -210,7 +210,7 @@
                 )
             );
             agentState.avatarAddresses[index] = avatarAddress;
-            var state = new State().SetState(_agentAddress, agentState.Serialize());
+            var state = new MockStateDelta().SetState(_agentAddress, agentState.Serialize());
 
             var action = new CreateAvatar3()
             {
@@ -282,7 +282,7 @@
                 updatedAddresses.Add(slotAddress);
             }
 
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(Addresses.Ranking, new RankingState0().Serialize())
                 .SetState(GoldCurrencyState.Address, gold.Serialize());
 

--- a/.Lib9c.Tests/Action/CreateAvatar6Test.cs
+++ b/.Lib9c.Tests/Action/CreateAvatar6Test.cs
@@ -51,7 +51,7 @@ namespace Lib9c.Tests.Action
 
             var sheets = TableSheetsImporter.ImportSheets();
             var context = new ActionContext();
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(GoldCurrencyState.Address, gold.Serialize())
                 .SetState(
                     Addresses.GoldDistribution,
@@ -117,7 +117,7 @@ namespace Lib9c.Tests.Action
                 name = nickName,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             Assert.Throws<InvalidNamePatternException>(() => action.Execute(new ActionContext()
                 {
@@ -158,7 +158,7 @@ namespace Lib9c.Tests.Action
                 name = "test",
             };
 
-            var state = new State().SetState(avatarAddress, avatarState.Serialize());
+            var state = new MockStateDelta().SetState(avatarAddress, avatarState.Serialize());
 
             Assert.Throws<InvalidAddressException>(() => action.Execute(new ActionContext()
                 {
@@ -175,7 +175,7 @@ namespace Lib9c.Tests.Action
         public void ExecuteThrowAvatarIndexOutOfRangeException(int index)
         {
             var agentState = new AgentState(_agentAddress);
-            var state = new State().SetState(_agentAddress, agentState.Serialize());
+            var state = new MockStateDelta().SetState(_agentAddress, agentState.Serialize());
             var action = new CreateAvatar6()
             {
                 index = index,
@@ -210,7 +210,7 @@ namespace Lib9c.Tests.Action
                 )
             );
             agentState.avatarAddresses[index] = avatarAddress;
-            var state = new State().SetState(_agentAddress, agentState.Serialize());
+            var state = new MockStateDelta().SetState(_agentAddress, agentState.Serialize());
 
             var action = new CreateAvatar6()
             {
@@ -282,7 +282,7 @@ namespace Lib9c.Tests.Action
                 updatedAddresses.Add(slotAddress);
             }
 
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(Addresses.Ranking, new RankingState0().Serialize())
                 .SetState(GoldCurrencyState.Address, gold.Serialize());
 

--- a/.Lib9c.Tests/Action/CreateAvatar7Test.cs
+++ b/.Lib9c.Tests/Action/CreateAvatar7Test.cs
@@ -45,7 +45,7 @@ namespace Lib9c.Tests.Action
 #pragma warning restore CS0618
 
             var sheets = TableSheetsImporter.ImportSheets();
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(
                     Addresses.GameConfig,
                     new GameConfigState(sheets[nameof(GameConfigSheet)]).Serialize()
@@ -98,7 +98,7 @@ namespace Lib9c.Tests.Action
                 name = nickName,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             Assert.Throws<InvalidNamePatternException>(() => action.Execute(new ActionContext()
                 {
@@ -139,7 +139,7 @@ namespace Lib9c.Tests.Action
                 name = "test",
             };
 
-            var state = new State().SetState(avatarAddress, avatarState.Serialize());
+            var state = new MockStateDelta().SetState(avatarAddress, avatarState.Serialize());
 
             Assert.Throws<InvalidAddressException>(() => action.Execute(new ActionContext()
                 {
@@ -156,7 +156,7 @@ namespace Lib9c.Tests.Action
         public void ExecuteThrowAvatarIndexOutOfRangeException(int index)
         {
             var agentState = new AgentState(_agentAddress);
-            var state = new State().SetState(_agentAddress, agentState.Serialize());
+            var state = new MockStateDelta().SetState(_agentAddress, agentState.Serialize());
             var action = new CreateAvatar7()
             {
                 index = index,
@@ -191,7 +191,7 @@ namespace Lib9c.Tests.Action
                 )
             );
             agentState.avatarAddresses[index] = avatarAddress;
-            var state = new State().SetState(_agentAddress, agentState.Serialize());
+            var state = new MockStateDelta().SetState(_agentAddress, agentState.Serialize());
 
             var action = new CreateAvatar7()
             {
@@ -261,7 +261,7 @@ namespace Lib9c.Tests.Action
                 updatedAddresses.Add(slotAddress);
             }
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/CreateAvatarTest.cs
+++ b/.Lib9c.Tests/Action/CreateAvatarTest.cs
@@ -41,7 +41,7 @@ namespace Lib9c.Tests.Action
             };
 
             var sheets = TableSheetsImporter.ImportSheets();
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(
                     Addresses.GameConfig,
                     new GameConfigState(sheets[nameof(GameConfigSheet)]).Serialize()
@@ -97,7 +97,7 @@ namespace Lib9c.Tests.Action
                 name = nickName,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             Assert.Throws<InvalidNamePatternException>(() => action.Execute(new ActionContext()
                 {
@@ -138,7 +138,7 @@ namespace Lib9c.Tests.Action
                 name = "test",
             };
 
-            var state = new State().SetState(avatarAddress, avatarState.Serialize());
+            var state = new MockStateDelta().SetState(avatarAddress, avatarState.Serialize());
 
             Assert.Throws<InvalidAddressException>(() => action.Execute(new ActionContext()
                 {
@@ -155,7 +155,7 @@ namespace Lib9c.Tests.Action
         public void ExecuteThrowAvatarIndexOutOfRangeException(int index)
         {
             var agentState = new AgentState(_agentAddress);
-            var state = new State().SetState(_agentAddress, agentState.Serialize());
+            var state = new MockStateDelta().SetState(_agentAddress, agentState.Serialize());
             var action = new CreateAvatar()
             {
                 index = index,
@@ -190,7 +190,7 @@ namespace Lib9c.Tests.Action
                 )
             );
             agentState.avatarAddresses[index] = avatarAddress;
-            var state = new State().SetState(_agentAddress, agentState.Serialize());
+            var state = new MockStateDelta().SetState(_agentAddress, agentState.Serialize());
 
             var action = new CreateAvatar()
             {
@@ -260,7 +260,7 @@ namespace Lib9c.Tests.Action
                 updatedAddresses.Add(slotAddress);
             }
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/CreatePendingActivationTest.cs
+++ b/.Lib9c.Tests/Action/CreatePendingActivationTest.cs
@@ -90,7 +90,7 @@ namespace Lib9c.Tests.Action
                     BlockIndex = 101,
                     Signer = default,
                     Rehearsal = true,
-                    PreviousState = new State(ImmutableDictionary<Address, IValue>.Empty),
+                    PreviousState = new State(),
                 }
             );
             Assert.Equal(

--- a/.Lib9c.Tests/Action/CreatePendingActivationTest.cs
+++ b/.Lib9c.Tests/Action/CreatePendingActivationTest.cs
@@ -24,7 +24,7 @@ namespace Lib9c.Tests.Action
             var action = new CreatePendingActivation(pendingActivation);
             var adminAddress = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var adminState = new AdminState(adminAddress, 100);
-            var state = new State(ImmutableDictionary<Address, IValue>.Empty
+            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
                 .Add(AdminState.Address, adminState.Serialize())
             );
             var actionContext = new ActionContext()
@@ -52,7 +52,7 @@ namespace Lib9c.Tests.Action
             var action = new CreatePendingActivation(pendingActivation);
             var adminAddress = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var adminState = new AdminState(adminAddress, 100);
-            var state = new State(ImmutableDictionary<Address, IValue>.Empty
+            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
                 .Add(AdminState.Address, adminState.Serialize())
             );
 
@@ -90,7 +90,7 @@ namespace Lib9c.Tests.Action
                     BlockIndex = 101,
                     Signer = default,
                     Rehearsal = true,
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                 }
             );
             Assert.Equal(

--- a/.Lib9c.Tests/Action/CreatePendingActivationsTest.cs
+++ b/.Lib9c.Tests/Action/CreatePendingActivationsTest.cs
@@ -28,7 +28,7 @@ namespace Lib9c.Tests.Action
             var action = new CreatePendingActivations(activations);
             var adminAddress = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var adminState = new AdminState(adminAddress, 100);
-            var state = new State(ImmutableDictionary<Address, IValue>.Empty
+            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
                 .Add(AdminState.Address, adminState.Serialize())
             );
             var actionContext = new ActionContext()
@@ -79,7 +79,7 @@ namespace Lib9c.Tests.Action
             var action = new CreatePendingActivations();
             var adminAddress = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var adminState = new AdminState(adminAddress, 100);
-            var state = new State(ImmutableDictionary<Address, IValue>.Empty
+            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
                 .Add(AdminState.Address, adminState.Serialize())
             );
 

--- a/.Lib9c.Tests/Action/CreatePledgeTest.cs
+++ b/.Lib9c.Tests/Action/CreatePledgeTest.cs
@@ -35,7 +35,7 @@ namespace Lib9c.Tests.Action
             var agentAddress = new PrivateKey().ToAddress();
             var pledgeAddress = agentAddress.GetPledgeAddress();
             var context = new ActionContext();
-            IAccountStateDelta states = new State()
+            IAccountStateDelta states = new MockStateDelta()
                 .SetState(Addresses.Admin, adminState.Serialize())
                 .MintAsset(context, patronAddress, 4 * 500 * mead);
 

--- a/.Lib9c.Tests/Action/DailyReward0Test.cs
+++ b/.Lib9c.Tests/Action/DailyReward0Test.cs
@@ -23,7 +23,7 @@
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -85,7 +85,7 @@
 
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                     BlockIndex = 0,
                 })

--- a/.Lib9c.Tests/Action/DailyReward2Test.cs
+++ b/.Lib9c.Tests/Action/DailyReward2Test.cs
@@ -25,7 +25,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -98,7 +98,7 @@ namespace Lib9c.Tests.Action
 
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                     BlockIndex = 0,
                 })

--- a/.Lib9c.Tests/Action/DailyReward3Test.cs
+++ b/.Lib9c.Tests/Action/DailyReward3Test.cs
@@ -25,7 +25,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -98,7 +98,7 @@ namespace Lib9c.Tests.Action
 
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                     BlockIndex = 0,
                 })

--- a/.Lib9c.Tests/Action/DailyReward4Test.cs
+++ b/.Lib9c.Tests/Action/DailyReward4Test.cs
@@ -28,7 +28,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -113,7 +113,7 @@ namespace Lib9c.Tests.Action
 
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                     BlockIndex = 0,
                 })
@@ -131,7 +131,7 @@ namespace Lib9c.Tests.Action
             var nextState = action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Random = new TestRandom(),
                 Rehearsal = true,
                 Signer = _agentAddress,

--- a/.Lib9c.Tests/Action/DailyReward5Test.cs
+++ b/.Lib9c.Tests/Action/DailyReward5Test.cs
@@ -26,7 +26,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -70,7 +70,7 @@ namespace Lib9c.Tests.Action
             var nextState = action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Random = new TestRandom(),
                 Rehearsal = true,
                 Signer = _agentAddress,
@@ -119,7 +119,7 @@ namespace Lib9c.Tests.Action
 
         [Fact]
         public void Execute_Throw_FailedLoadStateException() =>
-            Assert.Throws<FailedLoadStateException>(() => ExecuteInternal(new State()));
+            Assert.Throws<FailedLoadStateException>(() => ExecuteInternal(new MockStateDelta()));
 
         [Theory]
         [InlineData(0, 0, true)]

--- a/.Lib9c.Tests/Action/DailyReward6Test.cs
+++ b/.Lib9c.Tests/Action/DailyReward6Test.cs
@@ -28,7 +28,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -72,7 +72,7 @@ namespace Lib9c.Tests.Action
             var nextState = action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Random = new TestRandom(),
                 Rehearsal = true,
                 Signer = _agentAddress,
@@ -122,7 +122,7 @@ namespace Lib9c.Tests.Action
 
         [Fact]
         public void Execute_Throw_FailedLoadStateException() =>
-            Assert.Throws<FailedLoadStateException>(() => ExecuteInternal(new State()));
+            Assert.Throws<FailedLoadStateException>(() => ExecuteInternal(new MockStateDelta()));
 
         [Theory]
         [InlineData(0, 0, true)]

--- a/.Lib9c.Tests/Action/DailyRewardTest.cs
+++ b/.Lib9c.Tests/Action/DailyRewardTest.cs
@@ -26,7 +26,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -70,7 +70,7 @@ namespace Lib9c.Tests.Action
             var nextState = action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Random = new TestRandom(),
                 Rehearsal = true,
                 Signer = _agentAddress,
@@ -114,7 +114,7 @@ namespace Lib9c.Tests.Action
 
         [Fact]
         public void Execute_Throw_FailedLoadStateException() =>
-            Assert.Throws<FailedLoadStateException>(() => ExecuteInternal(new State()));
+            Assert.Throws<FailedLoadStateException>(() => ExecuteInternal(new MockStateDelta()));
 
         [Theory]
         [InlineData(0, 0, true)]

--- a/.Lib9c.Tests/Action/EndPledgeTest.cs
+++ b/.Lib9c.Tests/Action/EndPledgeTest.cs
@@ -20,7 +20,7 @@ namespace Lib9c.Tests.Action
             var patron = new PrivateKey().ToAddress();
             var agent = new PrivateKey().ToAddress();
             var context = new ActionContext();
-            IAccountStateDelta states = new State()
+            IAccountStateDelta states = new MockStateDelta()
                 .SetState(agent.GetPledgeAddress(), List.Empty.Add(patron.Serialize()).Add(true.Serialize()));
             var mead = Currencies.Mead;
             if (balance > 0)
@@ -53,7 +53,7 @@ namespace Lib9c.Tests.Action
             Address patron = new PrivateKey().ToAddress();
             Address agent = new PrivateKey().ToAddress();
             List contract = List.Empty.Add(patron.Serialize()).Add(true.Serialize());
-            IAccountStateDelta states = new State().SetState(agent.GetPledgeAddress(), contract);
+            IAccountStateDelta states = new MockStateDelta().SetState(agent.GetPledgeAddress(), contract);
 
             var action = new EndPledge
             {

--- a/.Lib9c.Tests/Action/EventConsumableItemCraftsTest.cs
+++ b/.Lib9c.Tests/Action/EventConsumableItemCraftsTest.cs
@@ -25,7 +25,7 @@ namespace Lib9c.Tests.Action
 
         public EventConsumableItemCraftsTest()
         {
-            _initialStates = new State();
+            _initialStates = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {

--- a/.Lib9c.Tests/Action/EventDungeonBattleV1Test.cs
+++ b/.Lib9c.Tests/Action/EventDungeonBattleV1Test.cs
@@ -30,7 +30,7 @@ namespace Lib9c.Tests.Action
 
         public EventDungeonBattleV1Test()
         {
-            _initialStates = new State();
+            _initialStates = new MockStateDelta();
 
 #pragma warning disable CS0618
             // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319

--- a/.Lib9c.Tests/Action/EventDungeonBattleV2Test.cs
+++ b/.Lib9c.Tests/Action/EventDungeonBattleV2Test.cs
@@ -30,7 +30,7 @@ namespace Lib9c.Tests.Action
 
         public EventDungeonBattleV2Test()
         {
-            _initialStates = new State();
+            _initialStates = new MockStateDelta();
 
 #pragma warning disable CS0618
             // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319

--- a/.Lib9c.Tests/Action/EventDungeonBattleV3Test.cs
+++ b/.Lib9c.Tests/Action/EventDungeonBattleV3Test.cs
@@ -30,7 +30,7 @@ namespace Lib9c.Tests.Action
 
         public EventDungeonBattleV3Test()
         {
-            _initialStates = new State();
+            _initialStates = new MockStateDelta();
 
 #pragma warning disable CS0618
             // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319

--- a/.Lib9c.Tests/Action/EventDungeonBattleV4Test.cs
+++ b/.Lib9c.Tests/Action/EventDungeonBattleV4Test.cs
@@ -31,7 +31,7 @@ namespace Lib9c.Tests.Action
 
         public EventDungeonBattleV4Test()
         {
-            _initialStates = new State();
+            _initialStates = new MockStateDelta();
 
 #pragma warning disable CS0618
             // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319

--- a/.Lib9c.Tests/Action/EventDungeonBattleV5Test.cs
+++ b/.Lib9c.Tests/Action/EventDungeonBattleV5Test.cs
@@ -32,7 +32,7 @@ namespace Lib9c.Tests.Action
 
         public EventDungeonBattleV5Test()
         {
-            _initialStates = new State();
+            _initialStates = new MockStateDelta();
 
 #pragma warning disable CS0618
             // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319

--- a/.Lib9c.Tests/Action/EventMaterialItemCraftsTest.cs
+++ b/.Lib9c.Tests/Action/EventMaterialItemCraftsTest.cs
@@ -27,7 +27,7 @@ namespace Lib9c.Tests.Action
 
         public EventMaterialItemCraftsTest()
         {
-            _initialStates = new State();
+            _initialStates = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {

--- a/.Lib9c.Tests/Action/GrindingTest.cs
+++ b/.Lib9c.Tests/Action/GrindingTest.cs
@@ -61,7 +61,7 @@ namespace Lib9c.Tests.Action
 #pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(_ncgCurrency);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(
                     Addresses.GetSheetAddress<CrystalMonsterCollectionMultiplierSheet>(),
                     _tableSheets.CrystalMonsterCollectionMultiplierSheet.Serialize())

--- a/.Lib9c.Tests/Action/HackAndSlash0Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash0Test.cs
@@ -59,7 +59,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
@@ -189,7 +189,7 @@ namespace Lib9c.Tests.Action
 
             var exec = Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
             {
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
                 Random = new TestRandom(),
             }));
@@ -591,7 +591,7 @@ namespace Lib9c.Tests.Action
                 _rankingMapAddress,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/HackAndSlash10Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash10Test.cs
@@ -72,7 +72,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -487,7 +487,7 @@ namespace Lib9c.Tests.Action
                 avatarAddress = _avatarAddress,
             };
 
-            IAccountStateDelta state = backward ? new State() : _initialState;
+            IAccountStateDelta state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState
@@ -1128,7 +1128,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/HackAndSlash11Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash11Test.cs
@@ -72,7 +72,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -445,7 +445,7 @@ namespace Lib9c.Tests.Action
                 avatarAddress = _avatarAddress,
             };
 
-            IAccountStateDelta state = backward ? new State() : _initialState;
+            IAccountStateDelta state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState
@@ -1072,7 +1072,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/HackAndSlash12Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash12Test.cs
@@ -72,7 +72,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -429,7 +429,7 @@ namespace Lib9c.Tests.Action
                 avatarAddress = _avatarAddress,
             };
 
-            IAccountStateDelta state = backward ? new State() : _initialState;
+            IAccountStateDelta state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState
@@ -1068,7 +1068,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext
             {

--- a/.Lib9c.Tests/Action/HackAndSlash13Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash13Test.cs
@@ -72,7 +72,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -435,7 +435,7 @@ namespace Lib9c.Tests.Action
                 avatarAddress = _avatarAddress,
             };
 
-            IAccountStateDelta state = backward ? new State() : _initialState;
+            IAccountStateDelta state = backward ? new MockStateDelta() : _initialState;
 
             if (!backward)
             {
@@ -1106,7 +1106,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext
             {

--- a/.Lib9c.Tests/Action/HackAndSlash15Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash15Test.cs
@@ -71,7 +71,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -431,7 +431,7 @@ namespace Lib9c.Tests.Action
                 avatarAddress = _avatarAddress,
             };
 
-            IAccountStateDelta state = backward ? new State() : _initialState;
+            IAccountStateDelta state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState

--- a/.Lib9c.Tests/Action/HackAndSlash16Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash16Test.cs
@@ -72,7 +72,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -432,7 +432,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatarAddress,
             };
 
-            IAccountStateDelta state = backward ? new State() : _initialState;
+            IAccountStateDelta state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState

--- a/.Lib9c.Tests/Action/HackAndSlash17Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash17Test.cs
@@ -72,7 +72,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -432,7 +432,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatarAddress,
             };
 
-            IAccountStateDelta state = backward ? new State() : _initialState;
+            IAccountStateDelta state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState

--- a/.Lib9c.Tests/Action/HackAndSlash18Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash18Test.cs
@@ -78,7 +78,7 @@ namespace Lib9c.Tests.Action
             var currency = Currency.Legacy("NCG", 2, null);
 #pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(Addresses.GoldCurrency, goldCurrencyState.Serialize())
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
@@ -430,7 +430,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatarAddress,
             };
 
-            IAccountStateDelta state = backward ? new State() : _initialState;
+            IAccountStateDelta state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState

--- a/.Lib9c.Tests/Action/HackAndSlash19Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash19Test.cs
@@ -77,7 +77,7 @@ namespace Lib9c.Tests.Action
             var currency = Currency.Legacy("NCG", 2, null);
 #pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(Addresses.GoldCurrency, goldCurrencyState.Serialize())
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
@@ -434,7 +434,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatarAddress,
             };
 
-            IAccountStateDelta state = backward ? new State() : _initialState;
+            IAccountStateDelta state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState

--- a/.Lib9c.Tests/Action/HackAndSlash20Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash20Test.cs
@@ -78,7 +78,7 @@ namespace Lib9c.Tests.Action
             var currency = Currency.Legacy("NCG", 2, null);
 #pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(Addresses.GoldCurrency, goldCurrencyState.Serialize())
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
@@ -435,7 +435,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatarAddress,
             };
 
-            IAccountStateDelta state = backward ? new State() : _initialState;
+            IAccountStateDelta state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState

--- a/.Lib9c.Tests/Action/HackAndSlash21Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash21Test.cs
@@ -79,7 +79,7 @@ namespace Lib9c.Tests.Action
             var currency = Currency.Legacy("NCG", 2, null);
 #pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(Addresses.GoldCurrency, goldCurrencyState.Serialize())
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
@@ -436,7 +436,7 @@ namespace Lib9c.Tests.Action
                 AvatarAddress = _avatarAddress,
             };
 
-            IAccountStateDelta state = backward ? new State() : _initialState;
+            IAccountStateDelta state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState

--- a/.Lib9c.Tests/Action/HackAndSlash2Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash2Test.cs
@@ -61,7 +61,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
@@ -198,7 +198,7 @@ namespace Lib9c.Tests.Action
 
             var exec = Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
             {
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
                 Random = new TestRandom(),
             }));
@@ -600,7 +600,7 @@ namespace Lib9c.Tests.Action
                 _rankingMapAddress,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/HackAndSlash3Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash3Test.cs
@@ -58,7 +58,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())

--- a/.Lib9c.Tests/Action/HackAndSlash4Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash4Test.cs
@@ -61,7 +61,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
@@ -379,7 +379,7 @@ namespace Lib9c.Tests.Action
 
             var exec = Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
             {
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
                 Random = new TestRandom(),
             }));

--- a/.Lib9c.Tests/Action/HackAndSlash5Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash5Test.cs
@@ -61,7 +61,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
@@ -380,7 +380,7 @@ namespace Lib9c.Tests.Action
 
             var exec = Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
             {
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
                 Random = new TestRandom(),
             }));

--- a/.Lib9c.Tests/Action/HackAndSlash6Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash6Test.cs
@@ -63,7 +63,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
@@ -396,7 +396,7 @@ namespace Lib9c.Tests.Action
 
             Assert.Null(action.Result);
 
-            IAccountStateDelta state = backward ? new State() : _initialState;
+            IAccountStateDelta state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState
@@ -813,7 +813,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/HackAndSlash7Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash7Test.cs
@@ -72,7 +72,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -497,7 +497,7 @@ namespace Lib9c.Tests.Action
                 WeeklyArenaAddress = _weeklyArenaState.address,
             };
 
-            IAccountStateDelta state = backward ? new State() : _initialState;
+            IAccountStateDelta state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState
@@ -876,7 +876,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/HackAndSlash8Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash8Test.cs
@@ -72,7 +72,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -490,7 +490,7 @@ namespace Lib9c.Tests.Action
                 avatarAddress = _avatarAddress,
             };
 
-            IAccountStateDelta state = backward ? new State() : _initialState;
+            IAccountStateDelta state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState
@@ -857,7 +857,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/HackAndSlash9Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlash9Test.cs
@@ -72,7 +72,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -510,7 +510,7 @@ namespace Lib9c.Tests.Action
                 avatarAddress = _avatarAddress,
             };
 
-            IAccountStateDelta state = backward ? new State() : _initialState;
+            IAccountStateDelta state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState
@@ -1151,7 +1151,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/HackAndSlashRandomBuffTest.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashRandomBuffTest.cs
@@ -72,7 +72,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())

--- a/.Lib9c.Tests/Action/HackAndSlashSweep1Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweep1Test.cs
@@ -67,7 +67,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -197,7 +197,7 @@ namespace Lib9c.Tests.Action
                 stageId = 1,
             };
 
-            var state = backward ? new State() : _initialState;
+            var state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState

--- a/.Lib9c.Tests/Action/HackAndSlashSweep2Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweep2Test.cs
@@ -67,7 +67,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -197,7 +197,7 @@ namespace Lib9c.Tests.Action
                 stageId = 1,
             };
 
-            var state = backward ? new State() : _initialState;
+            var state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState

--- a/.Lib9c.Tests/Action/HackAndSlashSweep3Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweep3Test.cs
@@ -68,7 +68,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -227,7 +227,7 @@ namespace Lib9c.Tests.Action
                 stageId = 1,
             };
 
-            var state = backward ? new State() : _initialState;
+            var state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState

--- a/.Lib9c.Tests/Action/HackAndSlashSweep4Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweep4Test.cs
@@ -68,7 +68,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -247,7 +247,7 @@ namespace Lib9c.Tests.Action
                 stageId = 1,
             };
 
-            var state = backward ? new State() : _initialState;
+            var state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState

--- a/.Lib9c.Tests/Action/HackAndSlashSweep5Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweep5Test.cs
@@ -69,7 +69,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -250,7 +250,7 @@ namespace Lib9c.Tests.Action
                 stageId = 1,
             };
 
-            var state = backward ? new State() : _initialState;
+            var state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState

--- a/.Lib9c.Tests/Action/HackAndSlashSweep6Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweep6Test.cs
@@ -75,7 +75,7 @@ namespace Lib9c.Tests.Action
 #pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
             _weeklyArenaState = new WeeklyArenaState(0);
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -257,7 +257,7 @@ namespace Lib9c.Tests.Action
                 stageId = 1,
             };
 
-            var state = backward ? new State() : _initialState;
+            var state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState

--- a/.Lib9c.Tests/Action/HackAndSlashSweep7Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweep7Test.cs
@@ -75,7 +75,7 @@ namespace Lib9c.Tests.Action
 #pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
             _weeklyArenaState = new WeeklyArenaState(0);
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -260,7 +260,7 @@ namespace Lib9c.Tests.Action
                 stageId = 1,
             };
 
-            var state = backward ? new State() : _initialState;
+            var state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState

--- a/.Lib9c.Tests/Action/HackAndSlashSweep8Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweep8Test.cs
@@ -75,7 +75,7 @@ namespace Lib9c.Tests.Action
 #pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
             _weeklyArenaState = new WeeklyArenaState(0);
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -262,7 +262,7 @@ namespace Lib9c.Tests.Action
                 stageId = 1,
             };
 
-            var state = backward ? new State() : _initialState;
+            var state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState

--- a/.Lib9c.Tests/Action/HackAndSlashSweep9Test.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweep9Test.cs
@@ -76,7 +76,7 @@ namespace Lib9c.Tests.Action
 #pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
             _weeklyArenaState = new WeeklyArenaState(0);
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -263,7 +263,7 @@ namespace Lib9c.Tests.Action
                 stageId = 1,
             };
 
-            var state = backward ? new State() : _initialState;
+            var state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState

--- a/.Lib9c.Tests/Action/HackAndSlashTest14.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashTest14.cs
@@ -71,7 +71,7 @@ namespace Lib9c.Tests.Action
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.SerializeV2())
                 .SetState(_avatarAddress, _avatarState.SerializeV2())
@@ -422,7 +422,7 @@ namespace Lib9c.Tests.Action
                 avatarAddress = _avatarAddress,
             };
 
-            IAccountStateDelta state = backward ? new State() : _initialState;
+            IAccountStateDelta state = backward ? new MockStateDelta() : _initialState;
             if (!backward)
             {
                 state = _initialState

--- a/.Lib9c.Tests/Action/InitializeStatesTest.cs
+++ b/.Lib9c.Tests/Action/InitializeStatesTest.cs
@@ -61,7 +61,7 @@ namespace Lib9c.Tests.Action
             {
                 BlockIndex = 0,
                 Miner = default,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
             });
 
             var addresses = new List<Address>()
@@ -127,7 +127,7 @@ namespace Lib9c.Tests.Action
             {
                 BlockIndex = 0,
                 Miner = default,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
             });
 
             var fetchedState = new AuthorizedMinersState(
@@ -175,7 +175,7 @@ namespace Lib9c.Tests.Action
             {
                 BlockIndex = 0,
                 Miner = default,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
             });
 
             var fetchedState = new ActivatedAccountsState(
@@ -226,7 +226,7 @@ namespace Lib9c.Tests.Action
             {
                 BlockIndex = 0,
                 Miner = default,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
             });
 
             var fetchedState = new CreditsState(
@@ -271,7 +271,7 @@ namespace Lib9c.Tests.Action
             {
                 BlockIndex = 0,
                 Miner = default,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
             });
 
             var fetchedState = new ActivatedAccountsState(

--- a/.Lib9c.Tests/Action/ItemEnhancement0Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement0Test.cs
@@ -58,7 +58,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));
 
             var context = new ActionContext();
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
                 .SetState(_slotAddress, new CombinationSlotState(_slotAddress, 0).Serialize())
@@ -137,7 +137,7 @@ namespace Lib9c.Tests.Action
 
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                     BlockIndex = 0,
                 })
@@ -505,7 +505,7 @@ namespace Lib9c.Tests.Action
                 Addresses.Blacksmith,
             };
 
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(GoldCurrencyState.Address, gold.Serialize());
 
             var nextState = action.Execute(new ActionContext()

--- a/.Lib9c.Tests/Action/ItemEnhancement10Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement10Test.cs
@@ -63,7 +63,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));
 
             var context = new ActionContext();
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
                 .SetState(_slotAddress, new CombinationSlotState(_slotAddress, 0).Serialize())
@@ -227,7 +227,7 @@ namespace Lib9c.Tests.Action
                 ItemEnhancement10.GetFeeStoreAddress(),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/ItemEnhancement2Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement2Test.cs
@@ -57,7 +57,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));
 
             var context = new ActionContext();
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
                 .SetState(_slotAddress, new CombinationSlotState(_slotAddress, 0).Serialize())
@@ -136,7 +136,7 @@ namespace Lib9c.Tests.Action
 
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext()
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                     BlockIndex = 0,
                 })
@@ -470,7 +470,7 @@ namespace Lib9c.Tests.Action
                 Addresses.Blacksmith,
             };
 
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(GoldCurrencyState.Address, gold.Serialize());
 
             var nextState = action.Execute(new ActionContext()

--- a/.Lib9c.Tests/Action/ItemEnhancement3Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement3Test.cs
@@ -57,7 +57,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));
 
             var context = new ActionContext();
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
                 .SetState(_slotAddress, new CombinationSlotState(_slotAddress, 0).Serialize())

--- a/.Lib9c.Tests/Action/ItemEnhancement4Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement4Test.cs
@@ -58,7 +58,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));
 
             var context = new ActionContext();
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
                 .SetState(_slotAddress, new CombinationSlotState(_slotAddress, 0).Serialize())

--- a/.Lib9c.Tests/Action/ItemEnhancement5Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement5Test.cs
@@ -58,7 +58,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));
 
             var context = new ActionContext();
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
                 .SetState(_slotAddress, new CombinationSlotState(_slotAddress, 0).Serialize())

--- a/.Lib9c.Tests/Action/ItemEnhancement6Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement6Test.cs
@@ -58,7 +58,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));
 
             var context = new ActionContext();
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
                 .SetState(_slotAddress, new CombinationSlotState(_slotAddress, 0).Serialize())

--- a/.Lib9c.Tests/Action/ItemEnhancement7Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement7Test.cs
@@ -60,7 +60,7 @@
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));
 
             var context = new ActionContext();
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
                 .SetState(_slotAddress, new CombinationSlotState(_slotAddress, 0).Serialize())
@@ -196,7 +196,7 @@
                 Addresses.Blacksmith,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/ItemEnhancement8Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement8Test.cs
@@ -60,7 +60,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));
 
             var context = new ActionContext();
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
                 .SetState(_slotAddress, new CombinationSlotState(_slotAddress, 0).Serialize())
@@ -196,7 +196,7 @@ namespace Lib9c.Tests.Action
                 Addresses.Blacksmith,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/ItemEnhancement9Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement9Test.cs
@@ -61,7 +61,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));
 
             var context = new ActionContext();
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
                 .SetState(_slotAddress, new CombinationSlotState(_slotAddress, 0).Serialize())
@@ -221,7 +221,7 @@ namespace Lib9c.Tests.Action
                 Addresses.Blacksmith,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/ItemEnhancementTest.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancementTest.cs
@@ -57,7 +57,7 @@ namespace Lib9c.Tests.Action
             var slotAddress = _avatarAddress.Derive(string.Format(CultureInfo.InvariantCulture, CombinationSlotState.DeriveFormat, 0));
 
             var context = new ActionContext();
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, _avatarState.Serialize())
                 .SetState(slotAddress, new CombinationSlotState(slotAddress, 0).Serialize())

--- a/.Lib9c.Tests/Action/JoinArena1Test.cs
+++ b/.Lib9c.Tests/Action/JoinArena1Test.cs
@@ -46,7 +46,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _state = new State();
+            _state = new MockStateDelta();
 
             _signer = new PrivateKey().ToAddress();
             _avatarAddress = _signer.Derive("avatar");

--- a/.Lib9c.Tests/Action/JoinArena2Test.cs
+++ b/.Lib9c.Tests/Action/JoinArena2Test.cs
@@ -46,7 +46,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _state = new State();
+            _state = new MockStateDelta();
 
             _signer = new PrivateKey().ToAddress();
             _avatarAddress = _signer.Derive("avatar");

--- a/.Lib9c.Tests/Action/JoinArena3Test.cs
+++ b/.Lib9c.Tests/Action/JoinArena3Test.cs
@@ -47,7 +47,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _state = new State();
+            _state = new MockStateDelta();
 
             _signer = new PrivateKey().ToAddress();
             _avatarAddress = _signer.Derive("avatar");

--- a/.Lib9c.Tests/Action/MarketValidationTest.cs
+++ b/.Lib9c.Tests/Action/MarketValidationTest.cs
@@ -24,7 +24,7 @@ namespace Lib9c.Tests.Action
 
         public MarketValidationTest()
         {
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(GoldCurrencyState.Address, new GoldCurrencyState(Gold).Serialize());
         }
 

--- a/.Lib9c.Tests/Action/MigrateMonsterCollectionTest.cs
+++ b/.Lib9c.Tests/Action/MigrateMonsterCollectionTest.cs
@@ -32,7 +32,7 @@ namespace Lib9c.Tests.Action
 
             _signer = default;
             _avatarAddress = _signer.Derive("avatar");
-            _state = new State();
+            _state = new MockStateDelta();
             Dictionary<string, string> sheets = TableSheetsImporter.ImportSheets();
             var tableSheets = new TableSheets(sheets);
             var rankingMapAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/MigrationActivatedAccountsStateTest.cs
+++ b/.Lib9c.Tests/Action/MigrationActivatedAccountsStateTest.cs
@@ -17,7 +17,7 @@ namespace Lib9c.Tests.Action
         {
             var nonce = new byte[] { 0x00, 0x01, 0x02, 0x03 };
             var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
-            var state = new State(ImmutableDictionary<Address, IValue>.Empty
+            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
                 .Add(AdminState.Address, new AdminState(admin, 100).Serialize())
                 .Add(ActivatedAccountsState.Address, new ActivatedAccountsState().AddAccount(default).Serialize())
             );

--- a/.Lib9c.Tests/Action/MigrationAvatarStateTest.cs
+++ b/.Lib9c.Tests/Action/MigrationAvatarStateTest.cs
@@ -34,7 +34,7 @@ namespace Lib9c.Tests.Action
             );
             var nonce = new byte[] { 0x00, 0x01, 0x02, 0x03 };
             var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
-            var state = new State(ImmutableDictionary<Address, IValue>.Empty
+            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
                 .Add(AdminState.Address, new AdminState(admin, 100).Serialize())
                 .Add(avatarAddress, avatarState.SerializeV2())
             );

--- a/.Lib9c.Tests/Action/MigrationLegacyShopTest.cs
+++ b/.Lib9c.Tests/Action/MigrationLegacyShopTest.cs
@@ -28,7 +28,7 @@ namespace Lib9c.Tests.Action
         {
             var adminAddress = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var adminState = new AdminState(adminAddress, 100);
-            var states = new State().SetState(Addresses.Admin, adminState.Serialize());
+            var states = new MockStateDelta().SetState(Addresses.Admin, adminState.Serialize());
             var signer = isAdmin ? adminAddress : default;
             var blockIndex = expire ? 200 : 100;
 

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle0Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle0Test.cs
@@ -57,7 +57,7 @@
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
@@ -284,7 +284,7 @@
             {
                 action.Execute(new ActionContext()
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                 });
             });

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle10Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle10Test.cs
@@ -55,7 +55,7 @@ namespace Lib9c.Tests.Action
             };
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
                 .SetState(_avatarAddress.Derive(LegacyInventoryKey), avatarState.inventory.Serialize())
@@ -257,7 +257,7 @@ namespace Lib9c.Tests.Action
             {
                 action.Execute(new ActionContext
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                 });
             });

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle11Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle11Test.cs
@@ -53,7 +53,7 @@ namespace Lib9c.Tests.Action
             };
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
                 .SetState(_avatarAddress.Derive(LegacyInventoryKey), avatarState.inventory.Serialize())
@@ -258,7 +258,7 @@ namespace Lib9c.Tests.Action
             {
                 action.Execute(new ActionContext
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                 });
             });

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle12Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle12Test.cs
@@ -59,7 +59,7 @@ namespace Lib9c.Tests.Action
             var currency = Currency.Legacy("NCG", 2, null);
 #pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(Addresses.GoldCurrency, goldCurrencyState.Serialize())
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
@@ -265,7 +265,7 @@ namespace Lib9c.Tests.Action
             {
                 action.Execute(new ActionContext
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                 });
             });

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle13Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle13Test.cs
@@ -60,7 +60,7 @@ namespace Lib9c.Tests.Action
             var currency = Currency.Legacy("NCG", 2, null);
 #pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(Addresses.GoldCurrency, goldCurrencyState.Serialize())
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
@@ -266,7 +266,7 @@ namespace Lib9c.Tests.Action
             {
                 action.Execute(new ActionContext
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                 });
             });

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle2Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle2Test.cs
@@ -57,7 +57,7 @@
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
@@ -284,7 +284,7 @@
             {
                 action.Execute(new ActionContext()
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                 });
             });

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle3Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle3Test.cs
@@ -57,7 +57,7 @@
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
@@ -285,7 +285,7 @@
             {
                 action.Execute(new ActionContext()
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                 });
             });

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle4Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle4Test.cs
@@ -58,7 +58,7 @@
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
@@ -294,7 +294,7 @@
             {
                 action.Execute(new ActionContext()
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                 });
             });
@@ -612,7 +612,7 @@
                 _avatarAddress.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle5Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle5Test.cs
@@ -55,7 +55,7 @@
             };
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
                 .SetState(_rankingMapAddress, new RankingMapState(_rankingMapAddress).Serialize());
@@ -286,7 +286,7 @@
             {
                 action.Execute(new ActionContext()
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                 });
             });
@@ -596,7 +596,7 @@
                 _avatarAddress.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle6Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle6Test.cs
@@ -56,7 +56,7 @@
             };
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
                 .SetState(_avatarAddress.Derive(LegacyInventoryKey), avatarState.inventory.Serialize())
@@ -298,7 +298,7 @@
             {
                 action.Execute(new ActionContext()
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                 });
             });
@@ -755,7 +755,7 @@
                 _avatarAddress.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle7Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle7Test.cs
@@ -56,7 +56,7 @@ namespace Lib9c.Tests.Action
             };
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
                 .SetState(_avatarAddress.Derive(LegacyInventoryKey), avatarState.inventory.Serialize())
@@ -298,7 +298,7 @@ namespace Lib9c.Tests.Action
             {
                 action.Execute(new ActionContext()
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                 });
             });
@@ -755,7 +755,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle8Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle8Test.cs
@@ -53,7 +53,7 @@ namespace Lib9c.Tests.Action
             };
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
                 .SetState(_avatarAddress.Derive(LegacyInventoryKey), avatarState.inventory.Serialize())
@@ -281,7 +281,7 @@ namespace Lib9c.Tests.Action
             {
                 action.Execute(new ActionContext()
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                 });
             });
@@ -704,7 +704,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/MimisbrunnrBattle9Test.cs
+++ b/.Lib9c.Tests/Action/MimisbrunnrBattle9Test.cs
@@ -54,7 +54,7 @@ namespace Lib9c.Tests.Action
             };
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
                 .SetState(_avatarAddress.Derive(LegacyInventoryKey), avatarState.inventory.Serialize())
@@ -256,7 +256,7 @@ namespace Lib9c.Tests.Action
             {
                 action.Execute(new ActionContext
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _agentAddress,
                 });
             });
@@ -755,7 +755,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext
             {

--- a/.Lib9c.Tests/Action/MockDelta.cs
+++ b/.Lib9c.Tests/Action/MockDelta.cs
@@ -1,0 +1,72 @@
+#nullable enable
+
+namespace Lib9c.Tests.Action
+{
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Numerics;
+    using Bencodex.Types;
+    using Libplanet;
+    using Libplanet.Assets;
+    using Libplanet.Consensus;
+    using Libplanet.State;
+
+    /// <summary>
+    /// Almost a replica of https://github.com/planetarium/libplanet/blob/main/Libplanet/State/AccountDelta.cs
+    /// except this has its constructors exposed as public for testing.
+    /// </summary>
+    public class MockDelta : IAccountDelta
+    {
+        public MockDelta()
+        {
+            States = ImmutableDictionary<Address, IValue>.Empty;
+            Fungibles = ImmutableDictionary<(Address, Currency), BigInteger>.Empty;
+            TotalSupplies = ImmutableDictionary<Currency, BigInteger>.Empty;
+            ValidatorSet = null;
+        }
+
+        public MockDelta(
+            IImmutableDictionary<Address, IValue> statesDelta,
+            IImmutableDictionary<(Address, Currency), BigInteger> fungiblesDelta,
+            IImmutableDictionary<Currency, BigInteger> totalSuppliesDelta,
+            ValidatorSet? validatorSetDelta)
+        {
+            States = statesDelta;
+            Fungibles = fungiblesDelta;
+            TotalSupplies = totalSuppliesDelta;
+            ValidatorSet = validatorSetDelta;
+        }
+
+        /// <inheritdoc cref="IAccountDelta.UpdatedAddresses"/>
+        public IImmutableSet<Address> UpdatedAddresses =>
+            StateUpdatedAddresses.Union(FungibleUpdatedAddresses);
+
+        /// <inheritdoc cref="IAccountDelta.StateUpdatedAddresses"/>
+        public IImmutableSet<Address> StateUpdatedAddresses =>
+            States.Keys.ToImmutableHashSet();
+
+        /// <inheritdoc cref="IAccountDelta.States"/>
+        public IImmutableDictionary<Address, IValue> States { get; }
+
+        /// <inheritdoc cref="IAccountDelta.FungibleUpdatedAddresses"/>
+        public IImmutableSet<Address> FungibleUpdatedAddresses =>
+            Fungibles.Keys.Select(pair => pair.Item1).ToImmutableHashSet();
+
+        /// <inheritdoc cref="IAccountDelta.UpdatedFungibleAssets"/>
+        public IImmutableSet<(Address, Currency)> UpdatedFungibleAssets =>
+            Fungibles.Keys.ToImmutableHashSet();
+
+        /// <inheritdoc cref="IAccountDelta.Fungibles"/>
+        public IImmutableDictionary<(Address, Currency), BigInteger> Fungibles { get; }
+
+        /// <inheritdoc cref="IAccountDelta.UpdatedTotalSupplyCurrencies"/>
+        public IImmutableSet<Currency> UpdatedTotalSupplyCurrencies =>
+            TotalSupplies.Keys.ToImmutableHashSet();
+
+        /// <inheritdoc cref="IAccountDelta.TotalSupplies"/>
+        public IImmutableDictionary<Currency, BigInteger> TotalSupplies { get; }
+
+        /// <inheritdoc cref="IAccountDelta.ValidatorSet"/>
+        public ValidatorSet? ValidatorSet { get; }
+    }
+}

--- a/.Lib9c.Tests/Action/MockStateDelta.cs
+++ b/.Lib9c.Tests/Action/MockStateDelta.cs
@@ -12,15 +12,15 @@ namespace Lib9c.Tests.Action
     using Libplanet.Consensus;
     using Libplanet.State;
 
-    public class State : IAccountStateDelta
+    public class MockStateDelta : IAccountStateDelta
     {
-        private readonly IImmutableDictionary<Address, IValue> _state;
-        private readonly IImmutableDictionary<(Address, Currency), BigInteger> _balance;
+        private readonly IImmutableDictionary<Address, IValue> _states;
+        private readonly IImmutableDictionary<(Address, Currency), BigInteger> _fungibles;
         private readonly IImmutableDictionary<Currency, BigInteger> _totalSupplies;
         private readonly ValidatorSet _validatorSet;
         private readonly IAccountDelta _delta;
 
-        public State()
+        public MockStateDelta()
             : this(
                 ImmutableDictionary<Address, IValue>.Empty,
                 ImmutableDictionary<(Address Address, Currency Currency), BigInteger>.Empty,
@@ -32,14 +32,14 @@ namespace Lib9c.Tests.Action
         // Pretends all given arguments are part of the delta, i.e., have been modified
         // using appropriate methods such as Transfer/Mint/Burn to set the values.
         // Also convert to internal data types.
-        public State(
-            IImmutableDictionary<Address, IValue> state = null,
-            IImmutableDictionary<(Address Address, Currency Currency), FungibleAssetValue> balance = null,
+        public MockStateDelta(
+            IImmutableDictionary<Address, IValue> states = null,
+            IImmutableDictionary<(Address Address, Currency Currency), FungibleAssetValue> balances = null,
             IImmutableDictionary<Currency, FungibleAssetValue> totalSupplies = null,
             ValidatorSet validatorSet = null)
         {
-            _state = state ?? ImmutableDictionary<Address, IValue>.Empty;
-            _balance = balance is { } b
+            _states = states ?? ImmutableDictionary<Address, IValue>.Empty;
+            _fungibles = balances is { } b
                 ? b.ToImmutableDictionary(kv => kv.Key, kv => kv.Value.RawValue)
                 : ImmutableDictionary<(Address, Currency), BigInteger>.Empty;
             _totalSupplies = totalSupplies is { } t
@@ -48,22 +48,22 @@ namespace Lib9c.Tests.Action
             _validatorSet =
                 validatorSet ?? new ValidatorSet();
 
-            _delta = new Delta(_state, _balance, _totalSupplies, _validatorSet);
+            _delta = new MockDelta(_states, _fungibles, _totalSupplies, _validatorSet);
         }
 
         // For Transfer/Mint/Burn
-        private State(
+        private MockStateDelta(
             IImmutableDictionary<Address, IValue> state,
             IImmutableDictionary<(Address Address, Currency Currency), BigInteger> balance,
             IImmutableDictionary<Currency, BigInteger> totalSupplies,
             ValidatorSet validatorSet)
         {
-            _state = state;
-            _balance = balance;
+            _states = state;
+            _fungibles = balance;
             _totalSupplies = totalSupplies;
             _validatorSet = validatorSet;
 
-            _delta = new Delta(_state, _balance, _totalSupplies, _validatorSet);
+            _delta = new MockDelta(_states, _fungibles, _totalSupplies, _validatorSet);
         }
 
         public IAccountDelta Delta => _delta;
@@ -86,9 +86,9 @@ namespace Lib9c.Tests.Action
             addresses.Select(GetState).ToArray();
 
         public IAccountStateDelta SetState(Address address, IValue state) =>
-            new State(
-                _state.SetItem(address, state),
-                _balance,
+            new MockStateDelta(
+                _states.SetItem(address, state),
+                _fungibles,
                 _totalSupplies,
                 _validatorSet);
 
@@ -122,9 +122,9 @@ namespace Lib9c.Tests.Action
                         value.Currency,
                         (GetTotalSupply(value.Currency) + value).RawValue)
                     : _totalSupplies;
-            return new State(
-                _state,
-                _balance.SetItem(
+            return new MockStateDelta(
+                _states,
+                _fungibles.SetItem(
                     (recipient, value.Currency),
                     (GetBalance(recipient, value.Currency) + value).RawValue),
                 totalSupplies,
@@ -140,9 +140,9 @@ namespace Lib9c.Tests.Action
                         value.Currency,
                         (GetTotalSupply(value.Currency) - value).RawValue)
                     : _totalSupplies;
-            return new State(
-                _state,
-                _balance.SetItem(
+            return new MockStateDelta(
+                _states,
+                _fungibles.SetItem(
                     (owner, value.Currency),
                     (GetBalance(owner, value.Currency) - value).RawValue),
                 totalSupplies,
@@ -177,72 +177,17 @@ namespace Lib9c.Tests.Action
                 throw new InsufficientBalanceException(msg, sender, senderBalance);
             }
 
-            IImmutableDictionary<(Address, Currency), BigInteger> newBalance = _balance
+            IImmutableDictionary<(Address, Currency), BigInteger> newBalance = _fungibles
                 .SetItem((sender, currency), (senderBalance - value).RawValue)
                 .SetItem((recipient, currency), (recipientBalance + value).RawValue);
-            return new State(_state, newBalance, _totalSupplies, _validatorSet);
+            return new MockStateDelta(_states, newBalance, _totalSupplies, _validatorSet);
         }
 
         public IAccountStateDelta SetValidator(Validator validator)
         {
-            return new State(_state, _balance, _totalSupplies, GetValidatorSet().Update(validator));
+            return new MockStateDelta(_states, _fungibles, _totalSupplies, GetValidatorSet().Update(validator));
         }
 
         public ValidatorSet GetValidatorSet() => _validatorSet;
     }
-
-#pragma warning disable SA1402
-    public class Delta : IAccountDelta
-    {
-        private readonly IImmutableDictionary<Address, IValue> _state;
-        private readonly IImmutableDictionary<(Address, Currency), BigInteger> _balance;
-        private readonly IImmutableDictionary<Currency, BigInteger> _totalSupplies;
-        private readonly ValidatorSet _validatorSet;
-
-        public Delta()
-            : this(
-                ImmutableDictionary<Address, IValue>.Empty,
-                ImmutableDictionary<(Address, Currency), BigInteger>.Empty,
-                ImmutableDictionary<Currency, BigInteger>.Empty,
-                null)
-        {
-        }
-
-        public Delta(
-            IImmutableDictionary<Address, IValue> state,
-            IImmutableDictionary<(Address Address, Currency Currency), BigInteger> balance,
-            IImmutableDictionary<Currency, BigInteger> totalSupplies,
-            ValidatorSet validatorSet)
-        {
-            _state = state;
-            _balance = balance;
-            _totalSupplies = totalSupplies;
-            _validatorSet = validatorSet;
-        }
-
-        public IImmutableSet<Address> UpdatedAddresses =>
-            StateUpdatedAddresses.Union(FungibleUpdatedAddresses);
-
-        public IImmutableSet<Address> StateUpdatedAddresses => _state.Keys.ToImmutableHashSet();
-
-        public IImmutableDictionary<Address, IValue> States => _state;
-
-        public IImmutableSet<Address> FungibleUpdatedAddresses =>
-            UpdatedFungibleAssets.Select(pair => pair.Item1).ToImmutableHashSet();
-
-        public IImmutableSet<(Address, Currency)> UpdatedFungibleAssets =>
-            Fungibles.Keys.ToImmutableHashSet();
-
-        public IImmutableDictionary<(Address, Currency), BigInteger> Fungibles =>
-            _balance;
-
-        public IImmutableSet<Currency> UpdatedTotalSupplyCurrencies =>
-            TotalSupplies.Keys.ToImmutableHashSet();
-
-        public IImmutableDictionary<Currency, BigInteger> TotalSupplies =>
-            _totalSupplies;
-
-        public ValidatorSet ValidatorSet => _validatorSet;
-    }
-#pragma warning restore SA1402
 }

--- a/.Lib9c.Tests/Action/MonsterCollect0Test.cs
+++ b/.Lib9c.Tests/Action/MonsterCollect0Test.cs
@@ -28,7 +28,7 @@ namespace Lib9c.Tests.Action
             var currency = Currency.Legacy("NCG", 2, null);
 #pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(Addresses.GoldCurrency, goldCurrencyState.Serialize());
             foreach ((string key, string value) in sheets)
             {
@@ -111,7 +111,7 @@ namespace Lib9c.Tests.Action
 
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext
             {
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _signer,
                 BlockIndex = 1,
             }));
@@ -238,7 +238,7 @@ namespace Lib9c.Tests.Action
             };
             IAccountStateDelta nextState = action.Execute(new ActionContext
             {
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _signer,
                 Rehearsal = true,
             });

--- a/.Lib9c.Tests/Action/MonsterCollect2Test.cs
+++ b/.Lib9c.Tests/Action/MonsterCollect2Test.cs
@@ -29,7 +29,7 @@ namespace Lib9c.Tests.Action
             var currency = Currency.Legacy("NCG", 2, null);
 #pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(Addresses.GoldCurrency, goldCurrencyState.Serialize());
             foreach ((string key, string value) in sheets)
             {
@@ -133,7 +133,7 @@ namespace Lib9c.Tests.Action
 
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext
             {
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _signer,
                 BlockIndex = 1,
             }));
@@ -164,7 +164,7 @@ namespace Lib9c.Tests.Action
             };
             IAccountStateDelta nextState = action.Execute(new ActionContext
             {
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _signer,
                 Rehearsal = true,
             });

--- a/.Lib9c.Tests/Action/MonsterCollectTest.cs
+++ b/.Lib9c.Tests/Action/MonsterCollectTest.cs
@@ -29,7 +29,7 @@ namespace Lib9c.Tests.Action
             var currency = Currency.Legacy("NCG", 2, null);
 #pragma warning restore CS0618
             var goldCurrencyState = new GoldCurrencyState(currency);
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(Addresses.GoldCurrency, goldCurrencyState.Serialize());
             foreach ((string key, string value) in sheets)
             {
@@ -134,7 +134,7 @@ namespace Lib9c.Tests.Action
 
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext
             {
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _signer,
                 BlockIndex = 1,
             }));
@@ -185,7 +185,7 @@ namespace Lib9c.Tests.Action
             };
             IAccountStateDelta nextState = action.Execute(new ActionContext
             {
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _signer,
                 Rehearsal = true,
             });

--- a/.Lib9c.Tests/Action/PatchTableSheetTest.cs
+++ b/.Lib9c.Tests/Action/PatchTableSheetTest.cs
@@ -89,7 +89,7 @@ namespace Lib9c.Tests.Action
             var initStates = ImmutableDictionary<Address, IValue>.Empty
                 .Add(AdminState.Address, adminState.Serialize())
                 .Add(Addresses.TableSheet.Derive(tableName), Dictionary.Empty.Add(tableName, "Initial"));
-            var state = new State(initStates, ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty);
+            var state = new State(initStates);
             var action = new PatchTableSheet()
             {
                 TableName = tableName,
@@ -132,7 +132,7 @@ namespace Lib9c.Tests.Action
             var initStates = ImmutableDictionary<Address, IValue>.Empty
                 .Add(AdminState.Address, adminState.Serialize())
                 .Add(Addresses.TableSheet.Derive(tableName), Dictionary.Empty.Add(tableName, "Initial"));
-            var state = new State(initStates, ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty);
+            var state = new State(initStates);
             var action = new PatchTableSheet()
             {
                 TableName = nameof(CostumeStatSheet),

--- a/.Lib9c.Tests/Action/PatchTableSheetTest.cs
+++ b/.Lib9c.Tests/Action/PatchTableSheetTest.cs
@@ -25,7 +25,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -89,7 +89,7 @@ namespace Lib9c.Tests.Action
             var initStates = ImmutableDictionary<Address, IValue>.Empty
                 .Add(AdminState.Address, adminState.Serialize())
                 .Add(Addresses.TableSheet.Derive(tableName), Dictionary.Empty.Add(tableName, "Initial"));
-            var state = new State(initStates);
+            var state = new MockStateDelta(initStates);
             var action = new PatchTableSheet()
             {
                 TableName = tableName,
@@ -132,7 +132,7 @@ namespace Lib9c.Tests.Action
             var initStates = ImmutableDictionary<Address, IValue>.Empty
                 .Add(AdminState.Address, adminState.Serialize())
                 .Add(Addresses.TableSheet.Derive(tableName), Dictionary.Empty.Add(tableName, "Initial"));
-            var state = new State(initStates);
+            var state = new MockStateDelta(initStates);
             var action = new PatchTableSheet()
             {
                 TableName = nameof(CostumeStatSheet),

--- a/.Lib9c.Tests/Action/PrepareRewardAssetsTest.cs
+++ b/.Lib9c.Tests/Action/PrepareRewardAssetsTest.cs
@@ -37,7 +37,7 @@ namespace Lib9c.Tests.Action
 #pragma warning restore CS0618
             }
 
-            IAccountStateDelta state = new State()
+            IAccountStateDelta state = new MockStateDelta()
                 .SetState(Addresses.Admin, adminState.Serialize());
 
             var action = new PrepareRewardAssets(poolAddress, assets);

--- a/.Lib9c.Tests/Action/Raid1Test.cs
+++ b/.Lib9c.Tests/Action/Raid1Test.cs
@@ -114,7 +114,7 @@ namespace Lib9c.Tests.Action
             var fee = _tableSheets.WorldBossListSheet[raidId].EntranceFee;
 
             var context = new ActionContext();
-            IAccountStateDelta state = new State()
+            IAccountStateDelta state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(_agentAddress, new AgentState(_agentAddress).Serialize());
 
@@ -376,7 +376,7 @@ namespace Lib9c.Tests.Action
             Address bossAddress = Addresses.GetWorldBossAddress(raidId);
             Address worldBossKillRewardRecordAddress = Addresses.GetWorldBossKillRewardRecordAddress(_avatarAddress, raidId);
 
-            IAccountStateDelta state = new State()
+            IAccountStateDelta state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(_agentAddress, new AgentState(_agentAddress).Serialize());
 
@@ -528,7 +528,7 @@ namespace Lib9c.Tests.Action
             Address bossAddress = Addresses.GetWorldBossAddress(raidId);
             Address worldBossKillRewardRecordAddress = Addresses.GetWorldBossKillRewardRecordAddress(_avatarAddress, raidId);
 
-            IAccountStateDelta state = new State()
+            IAccountStateDelta state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(_agentAddress, new AgentState(_agentAddress).Serialize());
 

--- a/.Lib9c.Tests/Action/Raid2Test.cs
+++ b/.Lib9c.Tests/Action/Raid2Test.cs
@@ -117,7 +117,7 @@ namespace Lib9c.Tests.Action
             var fee = _tableSheets.WorldBossListSheet[raidId].EntranceFee;
 
             var context = new ActionContext();
-            IAccountStateDelta state = new State()
+            IAccountStateDelta state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(_agentAddress, new AgentState(_agentAddress).Serialize());
 
@@ -394,7 +394,7 @@ namespace Lib9c.Tests.Action
             Address bossAddress = Addresses.GetWorldBossAddress(raidId);
             Address worldBossKillRewardRecordAddress = Addresses.GetWorldBossKillRewardRecordAddress(_avatarAddress, raidId);
 
-            IAccountStateDelta state = new State()
+            IAccountStateDelta state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(_agentAddress, new AgentState(_agentAddress).Serialize());
 

--- a/.Lib9c.Tests/Action/Raid3Test.cs
+++ b/.Lib9c.Tests/Action/Raid3Test.cs
@@ -118,7 +118,7 @@ namespace Lib9c.Tests.Action
             var fee = _tableSheets.WorldBossListSheet[raidId].EntranceFee;
 
             var context = new ActionContext();
-            IAccountStateDelta state = new State()
+            IAccountStateDelta state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(_agentAddress, new AgentState(_agentAddress).Serialize());
 
@@ -396,7 +396,7 @@ namespace Lib9c.Tests.Action
             Address bossAddress = Addresses.GetWorldBossAddress(raidId);
             Address worldBossKillRewardRecordAddress = Addresses.GetWorldBossKillRewardRecordAddress(_avatarAddress, raidId);
 
-            IAccountStateDelta state = new State()
+            IAccountStateDelta state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(_agentAddress, new AgentState(_agentAddress).Serialize());
 

--- a/.Lib9c.Tests/Action/Raid4Test.cs
+++ b/.Lib9c.Tests/Action/Raid4Test.cs
@@ -137,7 +137,7 @@ namespace Lib9c.Tests.Action
             var fee = _tableSheets.WorldBossListSheet[raidId].EntranceFee;
 
             var context = new ActionContext();
-            IAccountStateDelta state = new State()
+            IAccountStateDelta state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(_agentAddress, new AgentState(_agentAddress).Serialize());
 
@@ -437,7 +437,7 @@ namespace Lib9c.Tests.Action
             Address bossAddress = Addresses.GetWorldBossAddress(raidId);
             Address worldBossKillRewardRecordAddress = Addresses.GetWorldBossKillRewardRecordAddress(_avatarAddress, raidId);
 
-            IAccountStateDelta state = new State()
+            IAccountStateDelta state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(_agentAddress, new AgentState(_agentAddress).Serialize());
 
@@ -589,7 +589,7 @@ namespace Lib9c.Tests.Action
                 "1,900002,0,100,0,1,1,40";
 
             var goldCurrencyState = new GoldCurrencyState(_goldCurrency);
-            IAccountStateDelta state = new State()
+            IAccountStateDelta state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(_agentAddress, new AgentState(_agentAddress).Serialize());
 

--- a/.Lib9c.Tests/Action/Raid5Test.cs
+++ b/.Lib9c.Tests/Action/Raid5Test.cs
@@ -137,7 +137,7 @@ namespace Lib9c.Tests.Action
             var fee = _tableSheets.WorldBossListSheet[raidId].EntranceFee;
 
             var context = new ActionContext();
-            IAccountStateDelta state = new State()
+            IAccountStateDelta state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(_agentAddress, new AgentState(_agentAddress).Serialize());
 
@@ -437,7 +437,7 @@ namespace Lib9c.Tests.Action
             Address bossAddress = Addresses.GetWorldBossAddress(raidId);
             Address worldBossKillRewardRecordAddress = Addresses.GetWorldBossKillRewardRecordAddress(_avatarAddress, raidId);
 
-            IAccountStateDelta state = new State()
+            IAccountStateDelta state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(_agentAddress, new AgentState(_agentAddress).Serialize());
 
@@ -591,7 +591,7 @@ namespace Lib9c.Tests.Action
                 "1,900002,0,100,0,1,1,40";
 
             var goldCurrencyState = new GoldCurrencyState(_goldCurrency);
-            IAccountStateDelta state = new State()
+            IAccountStateDelta state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(_agentAddress, new AgentState(_agentAddress).Serialize());
 

--- a/.Lib9c.Tests/Action/Raid6Test.cs
+++ b/.Lib9c.Tests/Action/Raid6Test.cs
@@ -137,7 +137,7 @@ namespace Lib9c.Tests.Action
             var fee = _tableSheets.WorldBossListSheet[raidId].EntranceFee;
 
             var context = new ActionContext();
-            IAccountStateDelta state = new State()
+            IAccountStateDelta state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(_agentAddress, new AgentState(_agentAddress).Serialize());
 
@@ -437,7 +437,7 @@ namespace Lib9c.Tests.Action
             Address bossAddress = Addresses.GetWorldBossAddress(raidId);
             Address worldBossKillRewardRecordAddress = Addresses.GetWorldBossKillRewardRecordAddress(_avatarAddress, raidId);
 
-            IAccountStateDelta state = new State()
+            IAccountStateDelta state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(_agentAddress, new AgentState(_agentAddress).Serialize());
 
@@ -591,7 +591,7 @@ namespace Lib9c.Tests.Action
                 "1,900002,0,100,0,1,1,40";
 
             var goldCurrencyState = new GoldCurrencyState(_goldCurrency);
-            IAccountStateDelta state = new State()
+            IAccountStateDelta state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(_agentAddress, new AgentState(_agentAddress).Serialize());
 

--- a/.Lib9c.Tests/Action/RankingBattle0Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle0Test.cs
@@ -30,7 +30,7 @@ namespace Lib9c.Tests.Action
 
         public RankingBattle0Test()
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)

--- a/.Lib9c.Tests/Action/RankingBattle10Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle10Test.cs
@@ -32,7 +32,7 @@ namespace Lib9c.Tests.Action
 
         public RankingBattle10Test(ITestOutputHelper outputHelper)
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var keys = new List<string>
             {
@@ -478,7 +478,7 @@ namespace Lib9c.Tests.Action
                 _avatar1Address.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext
             {

--- a/.Lib9c.Tests/Action/RankingBattle11Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle11Test.cs
@@ -35,7 +35,7 @@ namespace Lib9c.Tests.Action
 
         public RankingBattle11Test(ITestOutputHelper outputHelper)
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var keys = new List<string>
             {
@@ -680,7 +680,7 @@ namespace Lib9c.Tests.Action
                 _avatar1Address.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext
             {

--- a/.Lib9c.Tests/Action/RankingBattle2Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle2Test.cs
@@ -30,7 +30,7 @@ namespace Lib9c.Tests.Action
 
         public RankingBattle2Test(ITestOutputHelper outputHelper)
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)

--- a/.Lib9c.Tests/Action/RankingBattle3Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle3Test.cs
@@ -30,7 +30,7 @@ namespace Lib9c.Tests.Action
 
         public RankingBattle3Test(ITestOutputHelper outputHelper)
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)

--- a/.Lib9c.Tests/Action/RankingBattle4Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle4Test.cs
@@ -31,7 +31,7 @@ namespace Lib9c.Tests.Action
 
         public RankingBattle4Test(ITestOutputHelper outputHelper)
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)

--- a/.Lib9c.Tests/Action/RankingBattle5Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle5Test.cs
@@ -33,7 +33,7 @@
 
         public RankingBattle5Test(ITestOutputHelper outputHelper)
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
@@ -443,7 +443,7 @@
                 _avatar1Address.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/RankingBattle6Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle6Test.cs
@@ -33,7 +33,7 @@ namespace Lib9c.Tests.Action
 
         public RankingBattle6Test(ITestOutputHelper outputHelper)
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
@@ -443,7 +443,7 @@ namespace Lib9c.Tests.Action
                 _avatar1Address.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/RankingBattle7Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle7Test.cs
@@ -33,7 +33,7 @@
 
         public RankingBattle7Test(ITestOutputHelper outputHelper)
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
@@ -443,7 +443,7 @@
                 _avatar1Address.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/RankingBattle8Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle8Test.cs
@@ -34,7 +34,7 @@
 
         public RankingBattle8Test(ITestOutputHelper outputHelper)
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
@@ -480,7 +480,7 @@
                 _avatar1Address.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/RankingBattle9Test.cs
+++ b/.Lib9c.Tests/Action/RankingBattle9Test.cs
@@ -34,7 +34,7 @@ namespace Lib9c.Tests.Action
 
         public RankingBattle9Test(ITestOutputHelper outputHelper)
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
@@ -480,7 +480,7 @@ namespace Lib9c.Tests.Action
                 _avatar1Address.Derive(LegacyQuestListKey),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/RankingBattleTest.cs
+++ b/.Lib9c.Tests/Action/RankingBattleTest.cs
@@ -30,7 +30,7 @@ namespace Lib9c.Tests.Action
 
         public RankingBattleTest(ITestOutputHelper outputHelper)
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var keys = new List<string>
             {

--- a/.Lib9c.Tests/Action/RapidCombination0Test.cs
+++ b/.Lib9c.Tests/Action/RapidCombination0Test.cs
@@ -28,7 +28,7 @@ namespace Lib9c.Tests.Action
 
         public RapidCombination0Test()
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)

--- a/.Lib9c.Tests/Action/RapidCombination2Test.cs
+++ b/.Lib9c.Tests/Action/RapidCombination2Test.cs
@@ -28,7 +28,7 @@ namespace Lib9c.Tests.Action
 
         public RapidCombination2Test()
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)

--- a/.Lib9c.Tests/Action/RapidCombination3Test.cs
+++ b/.Lib9c.Tests/Action/RapidCombination3Test.cs
@@ -28,7 +28,7 @@ namespace Lib9c.Tests.Action
 
         public RapidCombination3Test()
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)

--- a/.Lib9c.Tests/Action/RapidCombination4Test.cs
+++ b/.Lib9c.Tests/Action/RapidCombination4Test.cs
@@ -30,7 +30,7 @@
 
         public RapidCombination4Test()
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
@@ -383,7 +383,7 @@
                 slotAddress,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var action = new RapidCombination4
             {

--- a/.Lib9c.Tests/Action/RapidCombination5Test.cs
+++ b/.Lib9c.Tests/Action/RapidCombination5Test.cs
@@ -30,7 +30,7 @@ namespace Lib9c.Tests.Action
 
         public RapidCombination5Test()
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
@@ -383,7 +383,7 @@ namespace Lib9c.Tests.Action
                 slotAddress,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var action = new RapidCombination5
             {

--- a/.Lib9c.Tests/Action/RapidCombination6Test.cs
+++ b/.Lib9c.Tests/Action/RapidCombination6Test.cs
@@ -32,7 +32,7 @@ namespace Lib9c.Tests.Action
 
         public RapidCombination6Test()
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
@@ -385,7 +385,7 @@ namespace Lib9c.Tests.Action
                 slotAddress,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var action = new RapidCombination6
             {

--- a/.Lib9c.Tests/Action/RapidCombination8Test.cs
+++ b/.Lib9c.Tests/Action/RapidCombination8Test.cs
@@ -32,7 +32,7 @@ namespace Lib9c.Tests.Action
 
         public RapidCombination8Test()
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
@@ -385,7 +385,7 @@ namespace Lib9c.Tests.Action
                 slotAddress,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var action = new RapidCombination8
             {

--- a/.Lib9c.Tests/Action/RapidCombinationTest.cs
+++ b/.Lib9c.Tests/Action/RapidCombinationTest.cs
@@ -32,7 +32,7 @@ namespace Lib9c.Tests.Action
 
         public RapidCombinationTest()
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
@@ -385,7 +385,7 @@ namespace Lib9c.Tests.Action
                 slotAddress,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var action = new RapidCombination
             {

--- a/.Lib9c.Tests/Action/RapidCombinationTest7.cs
+++ b/.Lib9c.Tests/Action/RapidCombinationTest7.cs
@@ -32,7 +32,7 @@ namespace Lib9c.Tests.Action
 
         public RapidCombinationTest7()
         {
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
@@ -385,7 +385,7 @@ namespace Lib9c.Tests.Action
                 slotAddress,
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var action = new RapidCombination7
             {

--- a/.Lib9c.Tests/Action/ReRegisterProduct0Test.cs
+++ b/.Lib9c.Tests/Action/ReRegisterProduct0Test.cs
@@ -40,7 +40,7 @@
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {

--- a/.Lib9c.Tests/Action/ReRegisterProductTest.cs
+++ b/.Lib9c.Tests/Action/ReRegisterProductTest.cs
@@ -40,7 +40,7 @@
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {

--- a/.Lib9c.Tests/Action/RedeemCode0Test.cs
+++ b/.Lib9c.Tests/Action/RedeemCode0Test.cs
@@ -68,7 +68,7 @@ namespace Lib9c.Tests.Action
 #pragma warning restore CS0618
 
             var context = new ActionContext();
-            var initialState = new State()
+            var initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())
                 .SetState(RedeemCodeState.Address, prevRedeemCodesState.Serialize())
@@ -125,7 +125,7 @@ namespace Lib9c.Tests.Action
             {
                 BlockIndex = 1,
                 Miner = default,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Rehearsal = true,
                 Signer = _agentAddress,
             });

--- a/.Lib9c.Tests/Action/RedeemCodeTest.cs
+++ b/.Lib9c.Tests/Action/RedeemCodeTest.cs
@@ -71,7 +71,7 @@ namespace Lib9c.Tests.Action
 #pragma warning restore CS0618
 
             var context = new ActionContext();
-            var initialState = new State()
+            var initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(RedeemCodeState.Address, prevRedeemCodesState.Serialize())
                 .SetState(GoldCurrencyState.Address, goldState.Serialize())
@@ -140,7 +140,7 @@ namespace Lib9c.Tests.Action
             {
                 BlockIndex = 1,
                 Miner = default,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Rehearsal = true,
                 Signer = _agentAddress,
             });

--- a/.Lib9c.Tests/Action/RegisterProduct0Test.cs
+++ b/.Lib9c.Tests/Action/RegisterProduct0Test.cs
@@ -55,7 +55,7 @@ namespace Lib9c.Tests.Action
             };
             agentState.avatarAddresses[0] = AvatarAddress;
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(GoldCurrencyState.Address, new GoldCurrencyState(Gold).Serialize())
                 .SetState(Addresses.GetSheetAddress<MaterialItemSheet>(), _tableSheets.MaterialItemSheet.Serialize())
                 .SetState(Addresses.GameConfig, _gameConfigState.Serialize())

--- a/.Lib9c.Tests/Action/RegisterProductTest.cs
+++ b/.Lib9c.Tests/Action/RegisterProductTest.cs
@@ -55,7 +55,7 @@ namespace Lib9c.Tests.Action
             };
             agentState.avatarAddresses[0] = AvatarAddress;
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(GoldCurrencyState.Address, new GoldCurrencyState(Gold).Serialize())
                 .SetState(Addresses.GetSheetAddress<MaterialItemSheet>(), _tableSheets.MaterialItemSheet.Serialize())
                 .SetState(Addresses.GameConfig, _gameConfigState.Serialize())

--- a/.Lib9c.Tests/Action/RenewAdminStateTest.cs
+++ b/.Lib9c.Tests/Action/RenewAdminStateTest.cs
@@ -24,7 +24,7 @@ namespace Lib9c.Tests.Action
             _validUntil = 1_500_000L;
             _adminState = new AdminState(_adminPrivateKey.ToAddress(), _validUntil);
             _stateDelta =
-                new State(ImmutableDictionary<Address, IValue>.Empty.Add(
+                new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty.Add(
                     Addresses.Admin,
                     _adminState.Serialize()));
         }

--- a/.Lib9c.Tests/Action/RequestPledgeTest.cs
+++ b/.Lib9c.Tests/Action/RequestPledgeTest.cs
@@ -21,7 +21,7 @@ namespace Lib9c.Tests.Action
             Currency mead = Currencies.Mead;
             Address patron = new PrivateKey().ToAddress();
             var context = new ActionContext();
-            IAccountStateDelta states = new State().MintAsset(context, patron, 2 * mead);
+            IAccountStateDelta states = new MockStateDelta().MintAsset(context, patron, 2 * mead);
             var address = new PrivateKey().ToAddress();
             var action = new RequestPledge
             {
@@ -52,7 +52,7 @@ namespace Lib9c.Tests.Action
             Address patron = new PrivateKey().ToAddress();
             var address = new PrivateKey().ToAddress();
             Address contractAddress = address.GetPledgeAddress();
-            IAccountStateDelta states = new State().SetState(contractAddress, List.Empty);
+            IAccountStateDelta states = new MockStateDelta().SetState(contractAddress, List.Empty);
             var action = new RequestPledge
             {
                 AgentAddress = address,

--- a/.Lib9c.Tests/Action/RewardGoldTest.cs
+++ b/.Lib9c.Tests/Action/RewardGoldTest.cs
@@ -37,7 +37,7 @@ namespace Lib9c.Tests.Action
     {
         private readonly AvatarState _avatarState;
         private readonly AvatarState _avatarState2;
-        private readonly State _baseState;
+        private readonly MockStateDelta _baseState;
         private readonly TableSheets _tableSheets;
 
         public RewardGoldTest()
@@ -77,7 +77,7 @@ namespace Lib9c.Tests.Action
             var gold = new GoldCurrencyState(Currency.Legacy("NCG", 2, null));
 #pragma warning restore CS0618
             IActionContext context = new ActionContext();
-            _baseState = (State)new State()
+            _baseState = (MockStateDelta)new MockStateDelta()
                 .SetState(GoldCurrencyState.Address, gold.Serialize())
                 .SetState(Addresses.GoldDistribution, GoldDistributionTest.Fixture.Select(v => v.Serialize()).Serialize())
                 .MintAsset(context, GoldCurrencyState.Address, gold.Currency * 100000000000);
@@ -573,7 +573,7 @@ namespace Lib9c.Tests.Action
             var patronAddress = new PrivateKey().ToAddress();
             var contractAddress = agentAddress.GetPledgeAddress();
             IActionContext context = new ActionContext();
-            IAccountStateDelta states = new State()
+            IAccountStateDelta states = new MockStateDelta()
                 .MintAsset(context, patronAddress, patronMead * Currencies.Mead)
                 .TransferAsset(context, patronAddress, agentAddress, 1 * Currencies.Mead)
                 .SetState(contractAddress, List.Empty.Add(patronAddress.Serialize()).Add(true.Serialize()).Add(balance.Serialize()))

--- a/.Lib9c.Tests/Action/RuneEnhancement0Test.cs
+++ b/.Lib9c.Tests/Action/RuneEnhancement0Test.cs
@@ -40,7 +40,7 @@ namespace Lib9c.Tests.Action
 
             var goldCurrencyState = new GoldCurrencyState(_goldCurrency);
             var context = new ActionContext();
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(agentAddress, new AgentState(agentAddress).Serialize());
 
@@ -170,7 +170,7 @@ namespace Lib9c.Tests.Action
                 .StartedBlockIndex;
 
             var goldCurrencyState = new GoldCurrencyState(_goldCurrency);
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(agentAddress, new AgentState(agentAddress).Serialize());
 
@@ -223,7 +223,7 @@ namespace Lib9c.Tests.Action
                 .StartedBlockIndex;
 
             var goldCurrencyState = new GoldCurrencyState(_goldCurrency);
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(agentAddress, new AgentState(agentAddress).Serialize());
 
@@ -292,7 +292,7 @@ namespace Lib9c.Tests.Action
 
             var goldCurrencyState = new GoldCurrencyState(_goldCurrency);
             var context = new ActionContext();
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(agentAddress, new AgentState(agentAddress).Serialize());
 
@@ -405,7 +405,7 @@ namespace Lib9c.Tests.Action
                 .StartedBlockIndex;
 
             var goldCurrencyState = new GoldCurrencyState(_goldCurrency);
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(agentAddress, new AgentState(agentAddress).Serialize());
 

--- a/.Lib9c.Tests/Action/RuneEnhancementTest.cs
+++ b/.Lib9c.Tests/Action/RuneEnhancementTest.cs
@@ -55,7 +55,7 @@ namespace Lib9c.Tests.Action
             );
             agentState.avatarAddresses.Add(0, avatarAddress);
             var context = new ActionContext();
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(agentAddress, agentState.SerializeV2())
                 .SetState(avatarAddress, avatarState.SerializeV2())
@@ -194,7 +194,7 @@ namespace Lib9c.Tests.Action
                 rankingMapAddress
             );
             agentState.avatarAddresses.Add(0, avatarAddress);
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(agentAddress, agentState.SerializeV2())
                 .SetState(avatarAddress, avatarState.SerializeV2())
@@ -256,7 +256,7 @@ namespace Lib9c.Tests.Action
                 rankingMapAddress
             );
             agentState.avatarAddresses.Add(0, avatarAddress);
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(agentAddress, agentState.SerializeV2())
                 .SetState(avatarAddress, avatarState.SerializeV2())
@@ -334,7 +334,7 @@ namespace Lib9c.Tests.Action
             );
             agentState.avatarAddresses.Add(0, avatarAddress);
             var context = new ActionContext();
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(agentAddress, agentState.SerializeV2())
                 .SetState(avatarAddress, avatarState.SerializeV2())
@@ -456,7 +456,7 @@ namespace Lib9c.Tests.Action
                 rankingMapAddress
             );
             agentState.avatarAddresses.Add(0, avatarAddress);
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(agentAddress, agentState.SerializeV2())
                 .SetState(avatarAddress, avatarState.SerializeV2())
@@ -505,7 +505,7 @@ namespace Lib9c.Tests.Action
                 .StartedBlockIndex;
 
             var goldCurrencyState = new GoldCurrencyState(_goldCurrency);
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(agentAddress, new AgentState(agentAddress).Serialize());
 

--- a/.Lib9c.Tests/Action/Scenario/ArenaScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/ArenaScenarioTest.cs
@@ -38,7 +38,7 @@ namespace Lib9c.Tests.Action.Scenario
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _state = new Tests.Action.State();
+            _state = new Tests.Action.MockStateDelta();
 
             _sheets = TableSheetsImporter.ImportSheets();
             var tableSheets = new TableSheets(_sheets);

--- a/.Lib9c.Tests/Action/Scenario/CombinationAndRapidCombinationTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/CombinationAndRapidCombinationTest.cs
@@ -80,7 +80,7 @@
             _worldInformationAddress = _avatarAddress.Derive(LegacyWorldInformationKey);
             _questListAddress = _avatarAddress.Derive(LegacyQuestListKey);
 
-            _initialState = new Tests.Action.State()
+            _initialState = new Tests.Action.MockStateDelta()
                 .SetState(GoldCurrencyState.Address, gold.Serialize())
                 .SetState(gameConfigState.address, gameConfigState.Serialize())
                 .SetState(_agentAddress, agentState.Serialize())

--- a/.Lib9c.Tests/Action/Scenario/MarketScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/MarketScenarioTest.cs
@@ -103,7 +103,7 @@ namespace Lib9c.Tests.Action.Scenario
             agentState3.avatarAddresses[0] = _buyerAvatarAddress;
 
             _currency = Currency.Legacy("NCG", 2, minters: null);
-            _initialState = new Tests.Action.State()
+            _initialState = new Tests.Action.MockStateDelta()
                 .SetState(GoldCurrencyState.Address, new GoldCurrencyState(_currency).Serialize())
                 .SetState(Addresses.GameConfig, _gameConfigState.Serialize())
                 .SetState(Addresses.GetSheetAddress<MaterialItemSheet>(), _tableSheets.MaterialItemSheet.Serialize())

--- a/.Lib9c.Tests/Action/Scenario/MeadScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/MeadScenarioTest.cs
@@ -21,7 +21,7 @@ namespace Lib9c.Tests.Action.Scenario
             Currency mead = Currencies.Mead;
             var patron = new PrivateKey().ToAddress();
             IActionContext context = new ActionContext();
-            IAccountStateDelta states = new State().MintAsset(context, patron, 10 * mead);
+            IAccountStateDelta states = new MockStateDelta().MintAsset(context, patron, 10 * mead);
 
             var agentAddress = new PrivateKey().ToAddress();
             var requestPledge = new RequestPledge
@@ -86,7 +86,7 @@ namespace Lib9c.Tests.Action.Scenario
                 var action = (IAction)Activator.CreateInstance(typeId)!;
                 var actionContext = new ActionContext
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                 };
                 try
                 {

--- a/.Lib9c.Tests/Action/Scenario/RuneScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/RuneScenarioTest.cs
@@ -40,7 +40,7 @@ namespace Lib9c.Tests.Action.Scenario
             );
 
             var context = new ActionContext();
-            IAccountStateDelta initialState = new Tests.Action.State()
+            IAccountStateDelta initialState = new Tests.Action.MockStateDelta()
                 .SetState(agentAddress, agentState.Serialize())
                 .SetState(avatarAddress, avatarState.SerializeV2())
                 .SetState(

--- a/.Lib9c.Tests/Action/Scenario/SellAndCancellationAndSellTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/SellAndCancellationAndSellTest.cs
@@ -60,7 +60,7 @@ namespace Lib9c.Tests.Action.Scenario
                     GameConfig.RequireClearedStageLevel.ActionsInShop),
             };
 
-            _initialState = new Tests.Action.State()
+            _initialState = new Tests.Action.MockStateDelta()
                 .SetState(GoldCurrencyState.Address, gold.Serialize())
                 .SetState(gameConfigState.address, gameConfigState.Serialize())
                 .SetState(_agentAddress, agentState.Serialize())

--- a/.Lib9c.Tests/Action/Scenario/StakeAndClaimStakeReward2ScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/StakeAndClaimStakeReward2ScenarioTest.cs
@@ -15,7 +15,7 @@ namespace Lib9c.Tests.Action.Scenario
     using Xunit;
     using Xunit.Abstractions;
     using static Lib9c.SerializeKeys;
-    using State = Lib9c.Tests.Action.State;
+    using State = Lib9c.Tests.Action.MockStateDelta;
 
     public class StakeAndClaimStakeReward2ScenarioTest
     {

--- a/.Lib9c.Tests/Action/Scenario/WorldUnlockScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/WorldUnlockScenarioTest.cs
@@ -50,7 +50,7 @@ namespace Lib9c.Tests.Action.Scenario
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-            _initialState = new Lib9c.Tests.Action.State()
+            _initialState = new Lib9c.Tests.Action.MockStateDelta()
                 .SetState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(_avatarAddress, avatarState.Serialize())

--- a/.Lib9c.Tests/Action/SecureMiningRewardTest.cs
+++ b/.Lib9c.Tests/Action/SecureMiningRewardTest.cs
@@ -34,11 +34,11 @@ namespace Lib9c.Tests.Action
             new Address("636d187B4d434244A92B65B06B5e7da14b3810A9"),
         }.ToImmutableList();
 
-        private static readonly State _previousState = new State(
-            state: ImmutableDictionary<Address, IValue>.Empty
+        private static readonly MockStateDelta _previousState = new MockStateDelta(
+            states: ImmutableDictionary<Address, IValue>.Empty
                 .Add(AdminState.Address, new AdminState(_admin, 100).Serialize())
                 .Add(GoldCurrencyState.Address, new GoldCurrencyState(NCG).Serialize()),
-            balance: ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
+            balances: ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_authMiners[0], NCG), NCG * 1000)
                 .Add((_authMiners[1], NCG), NCG * 2000)
                 .Add((_authMiners[2], NCG), NCG * 3000)

--- a/.Lib9c.Tests/Action/Sell0Test.cs
+++ b/.Lib9c.Tests/Action/Sell0Test.cs
@@ -31,7 +31,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -155,7 +155,7 @@ namespace Lib9c.Tests.Action
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }

--- a/.Lib9c.Tests/Action/Sell10Test.cs
+++ b/.Lib9c.Tests/Action/Sell10Test.cs
@@ -39,7 +39,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -256,7 +256,7 @@ namespace Lib9c.Tests.Action
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }
@@ -443,7 +443,7 @@ namespace Lib9c.Tests.Action
                 OrderDigestListState.DeriveAddress(_avatarAddress),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/Sell11Test.cs
+++ b/.Lib9c.Tests/Action/Sell11Test.cs
@@ -39,7 +39,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -304,7 +304,7 @@ namespace Lib9c.Tests.Action
             Assert.Throws<InvalidOperationException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }
@@ -491,7 +491,7 @@ namespace Lib9c.Tests.Action
                 OrderDigestListState.DeriveAddress(_avatarAddress),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/Sell2Test.cs
+++ b/.Lib9c.Tests/Action/Sell2Test.cs
@@ -31,7 +31,7 @@
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -192,7 +192,7 @@
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }

--- a/.Lib9c.Tests/Action/Sell3Test.cs
+++ b/.Lib9c.Tests/Action/Sell3Test.cs
@@ -33,7 +33,7 @@
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -193,7 +193,7 @@
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }

--- a/.Lib9c.Tests/Action/Sell4Test.cs
+++ b/.Lib9c.Tests/Action/Sell4Test.cs
@@ -36,7 +36,7 @@
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -224,7 +224,7 @@
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }

--- a/.Lib9c.Tests/Action/Sell5Test.cs
+++ b/.Lib9c.Tests/Action/Sell5Test.cs
@@ -35,7 +35,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -300,7 +300,7 @@ namespace Lib9c.Tests.Action
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }

--- a/.Lib9c.Tests/Action/Sell6Test.cs
+++ b/.Lib9c.Tests/Action/Sell6Test.cs
@@ -35,7 +35,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -603,7 +603,7 @@ namespace Lib9c.Tests.Action
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }

--- a/.Lib9c.Tests/Action/Sell7Test.cs
+++ b/.Lib9c.Tests/Action/Sell7Test.cs
@@ -39,7 +39,7 @@
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -297,7 +297,7 @@
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }
@@ -466,7 +466,7 @@
                 OrderDigestListState.DeriveAddress(_avatarAddress),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/Sell8Test.cs
+++ b/.Lib9c.Tests/Action/Sell8Test.cs
@@ -39,7 +39,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -290,7 +290,7 @@ namespace Lib9c.Tests.Action
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }
@@ -459,7 +459,7 @@ namespace Lib9c.Tests.Action
                 OrderDigestListState.DeriveAddress(_avatarAddress),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/Sell9Test.cs
+++ b/.Lib9c.Tests/Action/Sell9Test.cs
@@ -39,7 +39,7 @@
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -256,7 +256,7 @@
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }
@@ -443,7 +443,7 @@
                 OrderDigestListState.DeriveAddress(_avatarAddress),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/SellCancellation0Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation0Test.cs
@@ -28,7 +28,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {

--- a/.Lib9c.Tests/Action/SellCancellation2Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation2Test.cs
@@ -30,7 +30,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {

--- a/.Lib9c.Tests/Action/SellCancellation3Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation3Test.cs
@@ -28,7 +28,7 @@
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {

--- a/.Lib9c.Tests/Action/SellCancellation4Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation4Test.cs
@@ -28,7 +28,7 @@
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {

--- a/.Lib9c.Tests/Action/SellCancellation5Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation5Test.cs
@@ -32,7 +32,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {

--- a/.Lib9c.Tests/Action/SellCancellation6Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation6Test.cs
@@ -34,7 +34,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {

--- a/.Lib9c.Tests/Action/SellCancellation7Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation7Test.cs
@@ -37,7 +37,7 @@
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -475,7 +475,7 @@
                 Addresses.GetItemAddress(default),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/SellCancellation8Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation8Test.cs
@@ -37,7 +37,7 @@
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -496,7 +496,7 @@
                 Addresses.GetItemAddress(default),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/SellCancellationTest.cs
+++ b/.Lib9c.Tests/Action/SellCancellationTest.cs
@@ -39,7 +39,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -531,7 +531,7 @@ namespace Lib9c.Tests.Action
                 Addresses.GetItemAddress(default),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/SellTest.cs
+++ b/.Lib9c.Tests/Action/SellTest.cs
@@ -38,7 +38,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -303,7 +303,7 @@ namespace Lib9c.Tests.Action
             Assert.Throws<InvalidOperationException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }
@@ -490,7 +490,7 @@ namespace Lib9c.Tests.Action
                 OrderDigestListState.DeriveAddress(_avatarAddress),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/Snapshot/TransferAsset0SnapshotTest.cs
+++ b/.Lib9c.Tests/Action/Snapshot/TransferAsset0SnapshotTest.cs
@@ -49,7 +49,7 @@ namespace Lib9c.Tests.Action.Snapshot
             var recipientAddress = recipientPrivateKey.ToAddress();
             var crystal = CrystalCalculator.CRYSTAL;
             var context = new ActionContext();
-            IAccountStateDelta state = new State().MintAsset(context, senderAddress, crystal * 100);
+            IAccountStateDelta state = new MockStateDelta().MintAsset(context, senderAddress, crystal * 100);
             var actionContext = new ActionContext
             {
                 Signer = senderAddress,
@@ -88,7 +88,7 @@ namespace Lib9c.Tests.Action.Snapshot
             var recipientAddress = recipientPrivateKey.ToAddress();
             var crystal = CrystalCalculator.CRYSTAL;
             var context = new ActionContext();
-            var state = new State().MintAsset(context, senderAddress, crystal * 100);
+            var state = new MockStateDelta().MintAsset(context, senderAddress, crystal * 100);
             var actionContext = new ActionContext
             {
                 Signer = senderAddress,

--- a/.Lib9c.Tests/Action/Stake0Test.cs
+++ b/.Lib9c.Tests/Action/Stake0Test.cs
@@ -29,7 +29,7 @@ namespace Lib9c.Tests.Action
                 .CreateLogger();
 
             var context = new ActionContext();
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)

--- a/.Lib9c.Tests/Action/StakeTest.cs
+++ b/.Lib9c.Tests/Action/StakeTest.cs
@@ -28,7 +28,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
 
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)

--- a/.Lib9c.Tests/Action/State.cs
+++ b/.Lib9c.Tests/Action/State.cs
@@ -20,6 +20,15 @@ namespace Lib9c.Tests.Action
         private readonly ValidatorSet _validatorSet;
         private readonly IAccountDelta _delta;
 
+        public State()
+            : this(
+                ImmutableDictionary<Address, IValue>.Empty,
+                ImmutableDictionary<(Address Address, Currency Currency), BigInteger>.Empty,
+                ImmutableDictionary<Currency, BigInteger>.Empty,
+                new ValidatorSet())
+        {
+        }
+
         // Pretends all given arguments are part of the delta, i.e., have been modified
         // using appropriate methods such as Transfer/Mint/Burn to set the values.
         // Also convert to internal data types.

--- a/.Lib9c.Tests/Action/TransferAsset2Test.cs
+++ b/.Lib9c.Tests/Action/TransferAsset2Test.cs
@@ -284,7 +284,7 @@ namespace Lib9c.Tests.Action
 
             IAccountStateDelta nextState = action.Execute(new ActionContext()
             {
-                PreviousState = new State(ImmutableDictionary<Address, IValue>.Empty),
+                PreviousState = new State(),
                 Signer = default,
                 Rehearsal = true,
                 BlockIndex = 1,

--- a/.Lib9c.Tests/Action/TransferAsset2Test.cs
+++ b/.Lib9c.Tests/Action/TransferAsset2Test.cs
@@ -53,9 +53,9 @@ namespace Lib9c.Tests.Action
                 .Add((_recipient, _currency), _currency * 10);
             var state = ImmutableDictionary<Address, IValue>.Empty
                 .Add(_recipient.Derive(ActivationKey.DeriveKey), true.Serialize());
-            var prevState = new State(
-                state: state,
-                balance: balance
+            var prevState = new MockStateDelta(
+                states: state,
+                balances: balance
             );
             var action = new TransferAsset2(
                 sender: _sender,
@@ -80,8 +80,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, _currency), _currency * 1000)
                 .Add((_recipient, _currency), _currency * 10);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             );
             var action = new TransferAsset2(
                 sender: _sender,
@@ -111,8 +111,8 @@ namespace Lib9c.Tests.Action
         {
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, _currency), _currency * 1000);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             );
             // Should not allow TransferAsset2 with same sender and recipient.
             var action = new TransferAsset2(
@@ -151,8 +151,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, _currency), _currency * 1000)
                 .Add((_recipient, _currency), _currency * 10);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             );
             var action = new TransferAsset2(
                 sender: _sender,
@@ -182,8 +182,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, currencyBySender), _currency * 1000)
                 .Add((_recipient, currencyBySender), _currency * 10);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             );
             var action = new TransferAsset2(
                 sender: _sender,
@@ -216,8 +216,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, currencyByRecipient), _currency * 1000)
                 .Add((_recipient, currencyByRecipient), _currency * 10);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             );
             var action = new TransferAsset2(
                 sender: _sender,
@@ -250,9 +250,9 @@ namespace Lib9c.Tests.Action
             var state = ImmutableDictionary<Address, IValue>.Empty
                 .Add(_sender.Derive(ActivationKey.DeriveKey), true.Serialize())
                 .Add(Addresses.ActivatedAccount, activatedAddress.Serialize());
-            var prevState = new State(
-                state: state,
-                balance: balance
+            var prevState = new MockStateDelta(
+                states: state,
+                balances: balance
             );
             var action = new TransferAsset2(
                 sender: _sender,
@@ -284,7 +284,7 @@ namespace Lib9c.Tests.Action
 
             IAccountStateDelta nextState = action.Execute(new ActionContext()
             {
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = default,
                 Rehearsal = true,
                 BlockIndex = 1,
@@ -394,7 +394,7 @@ namespace Lib9c.Tests.Action
             {
                 action.Execute(new ActionContext()
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _sender,
                     Rehearsal = false,
                     BlockIndex = TransferAsset3.CrystalTransferringRestrictionStartIndex,

--- a/.Lib9c.Tests/Action/TransferAsset3Test.cs
+++ b/.Lib9c.Tests/Action/TransferAsset3Test.cs
@@ -300,7 +300,7 @@ namespace Lib9c.Tests.Action
 
             IAccountStateDelta nextState = action.Execute(new ActionContext()
             {
-                PreviousState = new State(ImmutableDictionary<Address, IValue>.Empty),
+                PreviousState = new State(),
                 Signer = default,
                 Rehearsal = true,
                 BlockIndex = 1,

--- a/.Lib9c.Tests/Action/TransferAsset3Test.cs
+++ b/.Lib9c.Tests/Action/TransferAsset3Test.cs
@@ -78,9 +78,9 @@ namespace Lib9c.Tests.Action
                 state = state.Add(_recipient, new AgentState(_recipient).Serialize());
             }
 
-            var prevState = new State(
-                state: state,
-                balance: balance
+            var prevState = new MockStateDelta(
+                states: state,
+                balances: balance
             );
             var action = new TransferAsset3(
                 sender: _sender,
@@ -105,8 +105,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, _currency), _currency * 1000)
                 .Add((_recipient, _currency), _currency * 10);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             );
             var action = new TransferAsset3(
                 sender: _sender,
@@ -136,8 +136,8 @@ namespace Lib9c.Tests.Action
         {
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, _currency), _currency * 1000);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             );
             // Should not allow TransferAsset with same sender and recipient.
             var action = new TransferAsset3(
@@ -167,8 +167,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, _currency), _currency * 1000)
                 .Add((_recipient, _currency), _currency * 10);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             ).SetState(_recipient, new AgentState(_recipient).Serialize());
             var action = new TransferAsset3(
                 sender: _sender,
@@ -198,8 +198,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, currencyBySender), _currency * 1000)
                 .Add((_recipient, currencyBySender), _currency * 10);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             ).SetState(_recipient, new AgentState(_recipient).Serialize());
             var action = new TransferAsset3(
                 sender: _sender,
@@ -232,8 +232,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, currencyByRecipient), _currency * 1000)
                 .Add((_recipient, currencyByRecipient), _currency * 10);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             ).SetState(_recipient, new AgentState(_recipient).Serialize());
             var action = new TransferAsset3(
                 sender: _sender,
@@ -266,9 +266,9 @@ namespace Lib9c.Tests.Action
             var state = ImmutableDictionary<Address, IValue>.Empty
                 .Add(_sender.Derive(ActivationKey.DeriveKey), true.Serialize())
                 .Add(Addresses.ActivatedAccount, activatedAddress.Serialize());
-            var prevState = new State(
-                state: state,
-                balance: balance
+            var prevState = new MockStateDelta(
+                states: state,
+                balances: balance
             );
             var action = new TransferAsset3(
                 sender: _sender,
@@ -300,7 +300,7 @@ namespace Lib9c.Tests.Action
 
             IAccountStateDelta nextState = action.Execute(new ActionContext()
             {
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = default,
                 Rehearsal = true,
                 BlockIndex = 1,
@@ -374,9 +374,9 @@ namespace Lib9c.Tests.Action
             var state = ImmutableDictionary<Address, IValue>.Empty
                 .Add(_recipient.Derive(ActivationKey.DeriveKey), true.Serialize());
 
-            var prevState = new State(
-                state: state,
-                balance: balance
+            var prevState = new MockStateDelta(
+                states: state,
+                balances: balance
             );
             var action = new TransferAsset3(
                 sender: _sender,

--- a/.Lib9c.Tests/Action/TransferAssetTest.cs
+++ b/.Lib9c.Tests/Action/TransferAssetTest.cs
@@ -56,9 +56,9 @@ namespace Lib9c.Tests.Action
                 .Add((_recipient, _currency), _currency * 10);
             var state = ImmutableDictionary<Address, IValue>.Empty;
 
-            var prevState = new State(
-                state: state,
-                balance: balance
+            var prevState = new MockStateDelta(
+                states: state,
+                balances: balance
             );
             var action = new TransferAsset(
                 sender: _sender,
@@ -84,8 +84,8 @@ namespace Lib9c.Tests.Action
                 .Add((_sender, _currency), _currency * 1000)
                 .Add((_recipient, _currency), _currency * 10)
                 .Add((_sender, Currencies.Mead), Currencies.Mead * 1);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             );
             var action = new TransferAsset(
                 sender: _sender,
@@ -116,8 +116,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, _currency), _currency * 1000)
                 .Add((_sender, Currencies.Mead), Currencies.Mead * 1);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             );
             // Should not allow TransferAsset with same sender and recipient.
             var action = new TransferAsset(
@@ -148,8 +148,8 @@ namespace Lib9c.Tests.Action
                 .Add((_sender, _currency), _currency * 1000)
                 .Add((_recipient, _currency), _currency * 10);
 
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             ).SetState(_recipient, new AgentState(_recipient).Serialize());
             var action = new TransferAsset(
                 sender: _sender,
@@ -186,8 +186,8 @@ namespace Lib9c.Tests.Action
                 .Add((_sender, currencyBySender), _currency * 1000)
                 .Add((_recipient, currencyBySender), _currency * 10)
                 .Add((_sender, Currencies.Mead), Currencies.Mead * 1);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             ).SetState(_recipient, new AgentState(_recipient).Serialize());
             var action = new TransferAsset(
                 sender: _sender,
@@ -222,7 +222,7 @@ namespace Lib9c.Tests.Action
             var context = new ActionContext();
             IAccountStateDelta nextState = action.Execute(new ActionContext()
             {
-                PreviousState = new State().MintAsset(context, _sender, Currencies.Mead * 1),
+                PreviousState = new MockStateDelta().MintAsset(context, _sender, Currencies.Mead * 1),
                 Signer = default,
                 Rehearsal = true,
                 BlockIndex = 1,
@@ -297,9 +297,9 @@ namespace Lib9c.Tests.Action
             var state = ImmutableDictionary<Address, IValue>.Empty
                 .Add(_recipient.Derive(ActivationKey.DeriveKey), true.Serialize());
 
-            var prevState = new State(
-                state: state,
-                balance: balance
+            var prevState = new MockStateDelta(
+                states: state,
+                balances: balance
             );
             var action = new TransferAsset(
                 sender: _sender,

--- a/.Lib9c.Tests/Action/TransferAssetTest0.cs
+++ b/.Lib9c.Tests/Action/TransferAssetTest0.cs
@@ -49,8 +49,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, _currency), _currency * 1000)
                 .Add((_recipient, _currency), _currency * 10);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             );
             var action = new TransferAsset0(
                 sender: _sender,
@@ -75,8 +75,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, _currency), _currency * 1000)
                 .Add((_recipient, _currency), _currency * 10);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             );
             var action = new TransferAsset0(
                 sender: _sender,
@@ -106,8 +106,8 @@ namespace Lib9c.Tests.Action
         {
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, _currency), _currency * 1000);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             );
             // Should not allow TransferAsset with same sender and recipient.
             var action = new TransferAsset0(
@@ -146,8 +146,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, _currency), _currency * 1000)
                 .Add((_recipient, _currency), _currency * 10);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             );
             var action = new TransferAsset0(
                 sender: _sender,
@@ -177,8 +177,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, currencyBySender), _currency * 1000)
                 .Add((_recipient, currencyBySender), _currency * 10);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             );
             var action = new TransferAsset0(
                 sender: _sender,
@@ -211,8 +211,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, currencyByRecipient), _currency * 1000)
                 .Add((_recipient, currencyByRecipient), _currency * 10);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             );
             var action = new TransferAsset0(
                 sender: _sender,
@@ -246,7 +246,7 @@ namespace Lib9c.Tests.Action
 
             IAccountStateDelta nextState = action.Execute(new ActionContext()
             {
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = default,
                 Rehearsal = true,
                 BlockIndex = 1,

--- a/.Lib9c.Tests/Action/TransferAssetTest0.cs
+++ b/.Lib9c.Tests/Action/TransferAssetTest0.cs
@@ -246,7 +246,7 @@ namespace Lib9c.Tests.Action
 
             IAccountStateDelta nextState = action.Execute(new ActionContext()
             {
-                PreviousState = new State(ImmutableDictionary<Address, IValue>.Empty),
+                PreviousState = new State(),
                 Signer = default,
                 Rehearsal = true,
                 BlockIndex = 1,

--- a/.Lib9c.Tests/Action/TransferAssets0Test.cs
+++ b/.Lib9c.Tests/Action/TransferAssets0Test.cs
@@ -100,9 +100,9 @@ namespace Lib9c.Tests.Action
                     .Add(_recipient2, new AgentState(_recipient2).Serialize());
             }
 
-            var prevState = new State(
-                state: state,
-                balance: balance
+            var prevState = new MockStateDelta(
+                states: state,
+                balances: balance
             );
             var action = new TransferAssets0(
                 sender: _sender,
@@ -131,8 +131,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, _currency), _currency * 1000)
                 .Add((_recipient, _currency), _currency * 10);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             );
             var action = new TransferAssets0(
                 sender: _sender,
@@ -164,8 +164,8 @@ namespace Lib9c.Tests.Action
         {
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, _currency), _currency * 1000);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             );
             // Should not allow TransferAsset with same sender and recipient.
             var action = new TransferAssets0(
@@ -197,8 +197,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, _currency), _currency * 1000)
                 .Add((_recipient, _currency), _currency * 10);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             ).SetState(_recipient, new AgentState(_recipient).Serialize());
             var action = new TransferAssets0(
                 sender: _sender,
@@ -230,8 +230,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, currencyBySender), _currency * 1000)
                 .Add((_recipient, currencyBySender), _currency * 10);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             ).SetState(_recipient, new AgentState(_recipient).Serialize());
             var action = new TransferAssets0(
                 sender: _sender,
@@ -266,8 +266,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, currencyByRecipient), _currency * 1000)
                 .Add((_recipient, currencyByRecipient), _currency * 10);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             ).SetState(_recipient, new AgentState(_recipient).Serialize());
             var action = new TransferAssets0(
                 sender: _sender,
@@ -302,9 +302,9 @@ namespace Lib9c.Tests.Action
             var state = ImmutableDictionary<Address, IValue>.Empty
                 .Add(_sender.Derive(ActivationKey.DeriveKey), true.Serialize())
                 .Add(Addresses.ActivatedAccount, activatedAddress.Serialize());
-            var prevState = new State(
-                state: state,
-                balance: balance
+            var prevState = new MockStateDelta(
+                states: state,
+                balances: balance
             );
             var action = new TransferAssets0(
                 sender: _sender,
@@ -340,7 +340,7 @@ namespace Lib9c.Tests.Action
 
             IAccountStateDelta nextState = action.Execute(new ActionContext()
             {
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = default,
                 Rehearsal = true,
                 BlockIndex = 1,
@@ -472,7 +472,7 @@ namespace Lib9c.Tests.Action
             {
                 action.Execute(new ActionContext()
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _sender,
                     Rehearsal = false,
                     BlockIndex = 1,
@@ -489,9 +489,9 @@ namespace Lib9c.Tests.Action
             var state = ImmutableDictionary<Address, IValue>.Empty
                 .Add(_recipient.Derive(ActivationKey.DeriveKey), true.Serialize());
 
-            var prevState = new State(
-                state: state,
-                balance: balance
+            var prevState = new MockStateDelta(
+                states: state,
+                balances: balance
             );
             var action = new TransferAssets0(
                 sender: _sender,

--- a/.Lib9c.Tests/Action/TransferAssets0Test.cs
+++ b/.Lib9c.Tests/Action/TransferAssets0Test.cs
@@ -340,7 +340,7 @@ namespace Lib9c.Tests.Action
 
             IAccountStateDelta nextState = action.Execute(new ActionContext()
             {
-                PreviousState = new State(ImmutableDictionary<Address, IValue>.Empty),
+                PreviousState = new State(),
                 Signer = default,
                 Rehearsal = true,
                 BlockIndex = 1,

--- a/.Lib9c.Tests/Action/TransferAssetsTest.cs
+++ b/.Lib9c.Tests/Action/TransferAssetsTest.cs
@@ -247,7 +247,7 @@ namespace Lib9c.Tests.Action
 
             IAccountStateDelta nextState = action.Execute(new ActionContext()
             {
-                PreviousState = new State(ImmutableDictionary<Address, IValue>.Empty),
+                PreviousState = new State(),
                 Signer = default,
                 Rehearsal = true,
                 BlockIndex = 1,

--- a/.Lib9c.Tests/Action/TransferAssetsTest.cs
+++ b/.Lib9c.Tests/Action/TransferAssetsTest.cs
@@ -72,9 +72,9 @@ namespace Lib9c.Tests.Action
                 .Add((_recipient, _currency), _currency * 10);
             var state = ImmutableDictionary<Address, IValue>.Empty;
 
-            var prevState = new State(
-                state: state,
-                balance: balance
+            var prevState = new MockStateDelta(
+                states: state,
+                balances: balance
             );
             var action = new TransferAssets(
                 sender: _sender,
@@ -105,8 +105,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, _currency), _currency * 1000)
                 .Add((_recipient, _currency), _currency * 10);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             );
             var action = new TransferAssets(
                 sender: _sender,
@@ -138,8 +138,8 @@ namespace Lib9c.Tests.Action
         {
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, _currency), _currency * 1000);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             );
             // Should not allow TransferAsset with same sender and recipient.
             var action = new TransferAssets(
@@ -172,8 +172,8 @@ namespace Lib9c.Tests.Action
                 .Add((_sender, _currency), _currency * 1000)
                 .Add((_recipient, _currency), _currency * 10);
 
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             ).SetState(_recipient, new AgentState(_recipient).Serialize());
             var action = new TransferAssets(
                 sender: _sender,
@@ -208,8 +208,8 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, currencyBySender), _currency * 1000)
                 .Add((_recipient, currencyBySender), _currency * 10);
-            var prevState = new State(
-                balance: balance
+            var prevState = new MockStateDelta(
+                balances: balance
             ).SetState(_recipient, new AgentState(_recipient).Serialize());
             var action = new TransferAssets(
                 sender: _sender,
@@ -247,7 +247,7 @@ namespace Lib9c.Tests.Action
 
             IAccountStateDelta nextState = action.Execute(new ActionContext()
             {
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = default,
                 Rehearsal = true,
                 BlockIndex = 1,
@@ -379,7 +379,7 @@ namespace Lib9c.Tests.Action
             {
                 action.Execute(new ActionContext()
                 {
-                    PreviousState = new State(),
+                    PreviousState = new MockStateDelta(),
                     Signer = _sender,
                     Rehearsal = false,
                     BlockIndex = 1,
@@ -396,9 +396,9 @@ namespace Lib9c.Tests.Action
             var state = ImmutableDictionary<Address, IValue>.Empty
                 .Add(_recipient.Derive(ActivationKey.DeriveKey), true.Serialize());
 
-            var prevState = new State(
-                state: state,
-                balance: balance
+            var prevState = new MockStateDelta(
+                states: state,
+                balances: balance
             );
             var action = new TransferAssets(
                 sender: _sender,

--- a/.Lib9c.Tests/Action/UnlockEquipmentRecipe1Test.cs
+++ b/.Lib9c.Tests/Action/UnlockEquipmentRecipe1Test.cs
@@ -52,7 +52,7 @@ namespace Lib9c.Tests.Action
 
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(Addresses.GetSheetAddress<EquipmentItemSheet>(), _tableSheets.EquipmentItemSheet.Serialize())
                 .SetState(Addresses.GetSheetAddress<EquipmentItemRecipeSheet>(), _tableSheets.EquipmentItemRecipeSheet.Serialize())

--- a/.Lib9c.Tests/Action/UnlockEquipmentRecipeTest.cs
+++ b/.Lib9c.Tests/Action/UnlockEquipmentRecipeTest.cs
@@ -52,7 +52,7 @@ namespace Lib9c.Tests.Action
 
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(Addresses.GetSheetAddress<EquipmentItemSheet>(), _tableSheets.EquipmentItemSheet.Serialize())
                 .SetState(Addresses.GetSheetAddress<EquipmentItemRecipeSheet>(), _tableSheets.EquipmentItemRecipeSheet.Serialize())

--- a/.Lib9c.Tests/Action/UnlockRuneSlotTest.cs
+++ b/.Lib9c.Tests/Action/UnlockRuneSlotTest.cs
@@ -35,7 +35,7 @@ namespace Lib9c.Tests.Action
                 .StartedBlockIndex;
 
             var goldCurrencyState = new GoldCurrencyState(_goldCurrency);
-            var state = new State()
+            var state = new MockStateDelta()
                 .SetState(goldCurrencyState.address, goldCurrencyState.Serialize())
                 .SetState(agentAddress, new AgentState(agentAddress).Serialize());
 

--- a/.Lib9c.Tests/Action/UnlockWorld1Test.cs
+++ b/.Lib9c.Tests/Action/UnlockWorld1Test.cs
@@ -50,7 +50,7 @@
 
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(Addresses.GetSheetAddress<WorldUnlockSheet>(), _tableSheets.WorldUnlockSheet.Serialize())
                 .SetState(Addresses.GameConfig, gameConfigState.Serialize());
         }

--- a/.Lib9c.Tests/Action/UnlockWorldTest.cs
+++ b/.Lib9c.Tests/Action/UnlockWorldTest.cs
@@ -50,7 +50,7 @@ namespace Lib9c.Tests.Action
 
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
-            _initialState = new State()
+            _initialState = new MockStateDelta()
                 .SetState(Addresses.GetSheetAddress<WorldUnlockSheet>(), _tableSheets.WorldUnlockSheet.Serialize())
                 .SetState(Addresses.GameConfig, gameConfigState.Serialize());
         }

--- a/.Lib9c.Tests/Action/UpdateSell0Test.cs
+++ b/.Lib9c.Tests/Action/UpdateSell0Test.cs
@@ -38,7 +38,7 @@
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -276,7 +276,7 @@
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }
@@ -367,7 +367,7 @@
                 OrderDigestListState.DeriveAddress(_avatarAddress),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/UpdateSell2Test.cs
+++ b/.Lib9c.Tests/Action/UpdateSell2Test.cs
@@ -38,7 +38,7 @@
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -257,7 +257,7 @@
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }
@@ -348,7 +348,7 @@
                 OrderDigestListState.DeriveAddress(_avatarAddress),
             };
 
-            var state = new State();
+            var state = new MockStateDelta();
 
             var nextState = action.Execute(new ActionContext()
             {

--- a/.Lib9c.Tests/Action/UpdateSell3Test.cs
+++ b/.Lib9c.Tests/Action/UpdateSell3Test.cs
@@ -38,7 +38,7 @@
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -258,7 +258,7 @@
             Assert.Throws<ListEmptyException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }
@@ -283,7 +283,7 @@
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }

--- a/.Lib9c.Tests/Action/UpdateSell4Test.cs
+++ b/.Lib9c.Tests/Action/UpdateSell4Test.cs
@@ -38,7 +38,7 @@
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -258,7 +258,7 @@
             Assert.Throws<ListEmptyException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }
@@ -283,7 +283,7 @@
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }

--- a/.Lib9c.Tests/Action/UpdateSellTest.cs
+++ b/.Lib9c.Tests/Action/UpdateSellTest.cs
@@ -38,7 +38,7 @@
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             var sheets = TableSheetsImporter.ImportSheets();
             foreach (var (key, value) in sheets)
             {
@@ -258,7 +258,7 @@
             Assert.Throws<ListEmptyException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }
@@ -283,7 +283,7 @@
             Assert.Throws<FailedLoadStateException>(() => action.Execute(new ActionContext
             {
                 BlockIndex = 0,
-                PreviousState = new State(),
+                PreviousState = new MockStateDelta(),
                 Signer = _agentAddress,
             }));
         }

--- a/.Lib9c.Tests/Action/ValidatorSetOperateTest.cs
+++ b/.Lib9c.Tests/Action/ValidatorSetOperateTest.cs
@@ -27,7 +27,7 @@ namespace Lib9c.Tests.Action
                 .WriteTo.TestOutput(outputHelper)
                 .CreateLogger();
 
-            _initialState = new State();
+            _initialState = new MockStateDelta();
             _validator = new Validator(new PrivateKey().PublicKey, BigInteger.One);
 
             var sheets = TableSheetsImporter.ImportSheets();
@@ -47,7 +47,7 @@ namespace Lib9c.Tests.Action
             var initStates =
                 ImmutableDictionary<Address, IValue>.Empty
                     .Add(AdminState.Address, adminState.Serialize());
-            var state = new State(
+            var state = new MockStateDelta(
                 initStates,
                 validatorSet: new ValidatorSet());
             var action = ValidatorSetOperate.Append(_validator);
@@ -71,7 +71,7 @@ namespace Lib9c.Tests.Action
             var initStates =
                 ImmutableDictionary<Address, IValue>.Empty
                     .Add(AdminState.Address, adminState.Serialize());
-            var state = new State(
+            var state = new MockStateDelta(
                 initStates,
                 validatorSet: new ValidatorSet());
             var action = ValidatorSetOperate.Append(_validator);
@@ -107,7 +107,7 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Update_Throws_WhenDoNotExistValidator()
         {
-            var state = new State();
+            var state = new MockStateDelta();
             var action = ValidatorSetOperate.Update(_validator);
             InvalidOperationException exc = Assert.Throws<InvalidOperationException>(() =>
                 action.Execute(new ActionContext
@@ -122,7 +122,7 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Remove_Throws_WhenDoNotExistValidator()
         {
-            var state = new State();
+            var state = new MockStateDelta();
             var action = ValidatorSetOperate.Remove(_validator);
             InvalidOperationException exc = Assert.Throws<InvalidOperationException>(() =>
                 action.Execute(new ActionContext

--- a/.Lib9c.Tests/Extensions/SheetsExtensionsTest.cs
+++ b/.Lib9c.Tests/Extensions/SheetsExtensionsTest.cs
@@ -24,7 +24,7 @@
 
         public SheetsExtensionsTest()
         {
-            _states = new Tests.Action.State();
+            _states = new Tests.Action.MockStateDelta();
             InitSheets(
                 _states,
                 out _sheetNameAndFiles,

--- a/.Lib9c.Tests/TestHelper/BlockChainHelper.cs
+++ b/.Lib9c.Tests/TestHelper/BlockChainHelper.cs
@@ -99,7 +99,7 @@
             var sheets = TableSheetsImporter.ImportSheets();
             var weeklyArenaAddress = WeeklyArenaState.DeriveAddress(0);
             var context = new ActionContext();
-            var initialState = new Tests.Action.State()
+            var initialState = new Tests.Action.MockStateDelta()
                 .SetState(GoldCurrencyState.Address, goldCurrencyState.Serialize())
                 .SetState(
                     Addresses.GoldDistribution,

--- a/.Lib9c.Tests/Util/InitializeUtil.cs
+++ b/.Lib9c.Tests/Util/InitializeUtil.cs
@@ -11,7 +11,7 @@ namespace Lib9c.Tests.Util
     using Nekoyume.Action;
     using Nekoyume.Model.State;
     using Nekoyume.TableData;
-    using State = Lib9c.Tests.Action.State;
+    using State = Lib9c.Tests.Action.MockStateDelta;
     using StateExtensions = Nekoyume.Model.State.StateExtensions;
 
     public static class InitializeUtil


### PR DESCRIPTION
As there are `IAccountStateDelta`, `IAccountState`, and `IAccountDelta` as separate interfaces, the name of `State` class has been changed to `StateDelta` to avoid future confusion. This is mainly a preparatory work to smooth over introducing a different and new `State` class in a follow-up PR.

----

Addendum: On second thought, to be safe, I'll be naming things `MockStateDelta`, `MockDelta`, and `MockState` to avoid mistakes.