### PR TITLE
✨ Added `MockState` for testing

### DIFF
--- a/.Lib9c.DevExtensions.Tests/Action/FaucetCurrencyTest.cs
+++ b/.Lib9c.DevExtensions.Tests/Action/FaucetCurrencyTest.cs
@@ -32,10 +32,9 @@ namespace Lib9c.DevExtensions.Tests.Action
             _crystal = Currency.Legacy("CRYSTAL", 18, null);
 #pragma warning restore CS0618
 
-            var balance =
-                ImmutableDictionary<(Address Address, Currency Currency), FungibleAssetValue>.Empty
-                    .Add((GoldCurrencyState.Address, _ncg), _ncg * int.MaxValue);
-            _initialState = new Lib9c.Tests.Action.MockStateDelta(balances: balance);
+            _initialState = new MockStateDelta(
+                MockState.Empty
+                    .AddBalance(GoldCurrencyState.Address, _ncg * int.MaxValue));
 
             var goldCurrencyState = new GoldCurrencyState(_ncg);
             _agentAddress = new PrivateKey().ToAddress();

--- a/.Lib9c.Tests/Action/ActivateAccount0Test.cs
+++ b/.Lib9c.Tests/Action/ActivateAccount0Test.cs
@@ -19,9 +19,10 @@ namespace Lib9c.Tests.Action
             var privateKey = new PrivateKey();
             (ActivationKey activationKey, PendingActivationState pendingActivation) =
                 ActivationKey.Create(privateKey, nonce);
-            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
-                .Add(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize())
-                .Add(pendingActivation.address, pendingActivation.Serialize()));
+            var state = new MockStateDelta(
+                MockState.Empty
+                    .SetState(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize())
+                    .SetState(pendingActivation.address, pendingActivation.Serialize()));
 
             ActivateAccount0 action = activationKey.CreateActivateAccount0(nonce);
             IAccountStateDelta nextState = action.Execute(new ActionContext()
@@ -72,10 +73,10 @@ namespace Lib9c.Tests.Action
             var privateKey = new PrivateKey();
             (ActivationKey activationKey, PendingActivationState pendingActivation) =
                 ActivationKey.Create(privateKey, nonce);
-            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
-                .Add(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize())
-                .Add(pendingActivation.address, pendingActivation.Serialize())
-            );
+            var state = new MockStateDelta(
+                MockState.Empty
+                    .SetState(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize())
+                    .SetState(pendingActivation.address, pendingActivation.Serialize()));
 
             // 잘못된 논스를 넣습니다.
             ActivateAccount0 action = activationKey.CreateActivateAccount0(new byte[] { 0x00, });
@@ -99,8 +100,9 @@ namespace Lib9c.Tests.Action
                 ActivationKey.Create(privateKey, nonce);
 
             // state에는 pendingActivation에 해당하는 대기가 없는 상태를 가정합니다.
-            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
-                .Add(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize()));
+            var state = new MockStateDelta(
+                MockState.Empty
+                    .SetState(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize()));
 
             ActivateAccount0 action = activationKey.CreateActivateAccount0(nonce);
             Assert.Throws<PendingActivationDoesNotExistsException>(() =>
@@ -144,9 +146,10 @@ namespace Lib9c.Tests.Action
             var privateKey = new PrivateKey();
             (ActivationKey activationKey, PendingActivationState pendingActivation) =
                 ActivationKey.Create(privateKey, nonce);
-            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
-                .Add(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize())
-                .Add(pendingActivation.address, pendingActivation.Serialize()));
+            var state = new MockStateDelta(
+                MockState.Empty
+                    .SetState(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize())
+                    .SetState(pendingActivation.address, pendingActivation.Serialize()));
 
             ActivateAccount0 action = activationKey.CreateActivateAccount0(nonce);
             IAccountStateDelta nextState = action.Execute(new ActionContext()

--- a/.Lib9c.Tests/Action/AddActivatedAccount0Test.cs
+++ b/.Lib9c.Tests/Action/AddActivatedAccount0Test.cs
@@ -15,10 +15,9 @@ namespace Lib9c.Tests.Action
         {
             var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
             var state = new MockStateDelta(
-                ImmutableDictionary<Address, IValue>.Empty
-                .Add(AdminState.Address, new AdminState(admin, 100).Serialize())
-                .Add(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize())
-            );
+                MockState.Empty
+                    .SetState(AdminState.Address, new AdminState(admin, 100).Serialize())
+                    .SetState(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize()));
             var newComer = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var action = new AddActivatedAccount0(newComer);
 
@@ -45,10 +44,9 @@ namespace Lib9c.Tests.Action
         {
             var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
             var state = new MockStateDelta(
-                ImmutableDictionary<Address, IValue>.Empty
-                .Add(AdminState.Address, new AdminState(admin, 100).Serialize())
-                .Add(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize())
-            );
+                MockState.Empty
+                    .SetState(AdminState.Address, new AdminState(admin, 100).Serialize())
+                    .SetState(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize()));
             var newComer = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var action = new AddActivatedAccount0(newComer);
 
@@ -96,10 +94,9 @@ namespace Lib9c.Tests.Action
         {
             var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
             var state = new MockStateDelta(
-                ImmutableDictionary<Address, IValue>.Empty
-                .Add(AdminState.Address, new AdminState(admin, 100).Serialize())
-                .Add(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize())
-            );
+                MockState.Empty
+                    .SetState(AdminState.Address, new AdminState(admin, 100).Serialize())
+                    .SetState(ActivatedAccountsState.Address, new ActivatedAccountsState().Serialize()));
             var newComer = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var action = new AddActivatedAccount0(newComer);
 

--- a/.Lib9c.Tests/Action/AddActivatedAccountTest.cs
+++ b/.Lib9c.Tests/Action/AddActivatedAccountTest.cs
@@ -21,9 +21,8 @@ namespace Lib9c.Tests.Action
         {
             var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
             var state = new MockStateDelta(
-                ImmutableDictionary<Address, IValue>.Empty
-                .Add(AdminState.Address, new AdminState(admin, 100).Serialize())
-            );
+                MockState.Empty
+                    .SetState(AdminState.Address, new AdminState(admin, 100).Serialize()));
             var newComer = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var activatedAddress = newComer.Derive(ActivationKey.DeriveKey);
             if (alreadyActivated)
@@ -62,9 +61,8 @@ namespace Lib9c.Tests.Action
         {
             var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
             var state = new MockStateDelta(
-                ImmutableDictionary<Address, IValue>.Empty
-                .Add(AdminState.Address, new AdminState(admin, 100).Serialize())
-            );
+                MockState.Empty
+                    .SetState(AdminState.Address, new AdminState(admin, 100).Serialize()));
             var newComer = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var action = new AddActivatedAccount(newComer);
 

--- a/.Lib9c.Tests/Action/AddRedeemCodeTest.cs
+++ b/.Lib9c.Tests/Action/AddRedeemCodeTest.cs
@@ -17,8 +17,8 @@ namespace Lib9c.Tests.Action
         {
             var adminAddress = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var adminState = new AdminState(adminAddress, 100);
-            var initStates = ImmutableDictionary<Address, IValue>.Empty
-                .Add(AdminState.Address, adminState.Serialize());
+            var initStates = MockState.Empty
+                .SetState(AdminState.Address, adminState.Serialize());
             var state = new MockStateDelta(initStates);
             var action = new AddRedeemCode
             {

--- a/.Lib9c.Tests/Action/CreatePendingActivationTest.cs
+++ b/.Lib9c.Tests/Action/CreatePendingActivationTest.cs
@@ -24,9 +24,9 @@ namespace Lib9c.Tests.Action
             var action = new CreatePendingActivation(pendingActivation);
             var adminAddress = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var adminState = new AdminState(adminAddress, 100);
-            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
-                .Add(AdminState.Address, adminState.Serialize())
-            );
+            var state = new MockStateDelta(
+                MockState.Empty
+                    .SetState(AdminState.Address, adminState.Serialize()));
             var actionContext = new ActionContext()
             {
                 BlockIndex = 1,
@@ -52,9 +52,9 @@ namespace Lib9c.Tests.Action
             var action = new CreatePendingActivation(pendingActivation);
             var adminAddress = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var adminState = new AdminState(adminAddress, 100);
-            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
-                .Add(AdminState.Address, adminState.Serialize())
-            );
+            var state = new MockStateDelta(
+                MockState.Empty
+                    .SetState(AdminState.Address, adminState.Serialize()));
 
             Assert.Throws<PolicyExpiredException>(
                 () => action.Execute(new ActionContext()

--- a/.Lib9c.Tests/Action/CreatePendingActivationsTest.cs
+++ b/.Lib9c.Tests/Action/CreatePendingActivationsTest.cs
@@ -28,9 +28,9 @@ namespace Lib9c.Tests.Action
             var action = new CreatePendingActivations(activations);
             var adminAddress = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var adminState = new AdminState(adminAddress, 100);
-            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
-                .Add(AdminState.Address, adminState.Serialize())
-            );
+            var state = new MockStateDelta(
+                MockState.Empty
+                    .SetState(AdminState.Address, adminState.Serialize()));
             var actionContext = new ActionContext()
             {
                 BlockIndex = 1,
@@ -79,9 +79,9 @@ namespace Lib9c.Tests.Action
             var action = new CreatePendingActivations();
             var adminAddress = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var adminState = new AdminState(adminAddress, 100);
-            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
-                .Add(AdminState.Address, adminState.Serialize())
-            );
+            var state = new MockStateDelta(
+                MockState.Empty
+                    .SetState(AdminState.Address, adminState.Serialize()));
 
             Assert.Throws<PolicyExpiredException>(
                 () => action.Execute(new ActionContext()

--- a/.Lib9c.Tests/Action/MigrationActivatedAccountsStateTest.cs
+++ b/.Lib9c.Tests/Action/MigrationActivatedAccountsStateTest.cs
@@ -17,10 +17,10 @@ namespace Lib9c.Tests.Action
         {
             var nonce = new byte[] { 0x00, 0x01, 0x02, 0x03 };
             var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
-            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
-                .Add(AdminState.Address, new AdminState(admin, 100).Serialize())
-                .Add(ActivatedAccountsState.Address, new ActivatedAccountsState().AddAccount(default).Serialize())
-            );
+            var state = new MockStateDelta(
+                MockState.Empty
+                    .SetState(AdminState.Address, new AdminState(admin, 100).Serialize())
+                    .SetState(ActivatedAccountsState.Address, new ActivatedAccountsState().AddAccount(default).Serialize()));
 
             var action = new MigrationActivatedAccountsState();
 

--- a/.Lib9c.Tests/Action/MigrationAvatarStateTest.cs
+++ b/.Lib9c.Tests/Action/MigrationAvatarStateTest.cs
@@ -34,10 +34,10 @@ namespace Lib9c.Tests.Action
             );
             var nonce = new byte[] { 0x00, 0x01, 0x02, 0x03 };
             var admin = new Address("8d9f76aF8Dc5A812aCeA15d8bf56E2F790F47fd7");
-            var state = new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty
-                .Add(AdminState.Address, new AdminState(admin, 100).Serialize())
-                .Add(avatarAddress, avatarState.SerializeV2())
-            );
+            var state = new MockStateDelta(
+                MockState.Empty
+                    .SetState(AdminState.Address, new AdminState(admin, 100).Serialize())
+                    .SetState(avatarAddress, avatarState.SerializeV2()));
 
             var action = new MigrationAvatarState
             {

--- a/.Lib9c.Tests/Action/MockState.cs
+++ b/.Lib9c.Tests/Action/MockState.cs
@@ -1,0 +1,189 @@
+#nullable enable
+
+namespace Lib9c.Tests.Action
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Numerics;
+    using Bencodex.Types;
+    using Libplanet;
+    using Libplanet.Assets;
+    using Libplanet.Consensus;
+    using Libplanet.State;
+
+    /// <summary>
+    /// A mock implementation of <see cref="IAccountState"/> with various overloaded methods for
+    /// improving QoL.
+    /// </summary>
+    /// <remarks>
+    /// All methods are pretty self-explanatory with no side-effects.  There are some caveats:
+    /// <list type="bullet">
+    ///     <item><description>
+    ///         Every balance related operation can accept a negative amount.  Each behave as expected.
+    ///         That is, adding negative amount would decrease the balance.
+    ///     </description></item>
+    ///     <item><description>
+    ///         Negative balance is allowed for all cases.  This includes total supply.
+    ///     </description></item>
+    ///     <item><description>
+    ///         Total supply is not automatically tracked.  That is, changing the balance associated
+    ///         with an <see cref="Address"/> does not change the total supply in any way.
+    ///         Total supply must be explicitly set if needed.
+    ///     </description></item>
+    ///     <item><description>
+    ///         There are only few restrictions that apply for manipulating this object, mostly
+    ///         pertaining to total supplies:
+    ///         <list type="bullet">
+    ///             <item><description>
+    ///                 It is not possible to set a total supply amount for a currency that is
+    ///                 not trackable.
+    ///             </description></item>
+    ///             <item><description>
+    ///                 It is not possible to set a total supply amount that is over the currency's
+    ///                 capped maximum total supply.
+    ///             </description></item>
+    ///         </list>
+    ///     </description></item>
+    /// </list>
+    /// </remarks>
+    public class MockState : IAccountState
+    {
+        private readonly IImmutableDictionary<Address, IValue> _states;
+        private readonly IImmutableDictionary<(Address, Currency), BigInteger> _fungibles;
+        private readonly IImmutableDictionary<Currency, BigInteger> _totalSupplies;
+        private readonly ValidatorSet _validatorSet;
+
+        public MockState()
+            : this(
+                ImmutableDictionary<Address, IValue>.Empty,
+                ImmutableDictionary<(Address Address, Currency Currency), BigInteger>.Empty,
+                ImmutableDictionary<Currency, BigInteger>.Empty,
+                new ValidatorSet())
+        {
+        }
+
+        private MockState(
+            IImmutableDictionary<Address, IValue> state,
+            IImmutableDictionary<(Address Address, Currency Currency), BigInteger> balance,
+            IImmutableDictionary<Currency, BigInteger> totalSupplies,
+            ValidatorSet validatorSet)
+        {
+            _states = state;
+            _fungibles = balance;
+            _totalSupplies = totalSupplies;
+            _validatorSet = validatorSet;
+        }
+
+        public IValue? GetState(Address address) => _states.TryGetValue(address, out IValue? value)
+            ? value
+            : null;
+
+        public IReadOnlyList<IValue?> GetStates(IReadOnlyList<Address> addresses) =>
+            addresses.Select(GetState).ToArray();
+
+        public FungibleAssetValue GetBalance(Address address, Currency currency) =>
+            _fungibles.TryGetValue((address, currency), out BigInteger rawValue)
+                ? FungibleAssetValue.FromRawValue(currency, rawValue)
+                : FungibleAssetValue.FromRawValue(currency, 0);
+
+        public FungibleAssetValue GetTotalSupply(Currency currency)
+        {
+            if (!currency.TotalSupplyTrackable)
+            {
+                var msg =
+                    $"The total supply value of the currency {currency} is not trackable"
+                    + " because it is a legacy untracked currency which might have been"
+                    + " established before the introduction of total supply tracking support.";
+                throw new TotalSupplyNotTrackableException(msg, currency);
+            }
+
+            return _totalSupplies.TryGetValue(currency, out var rawValue)
+                ? FungibleAssetValue.FromRawValue(currency, rawValue)
+                : FungibleAssetValue.FromRawValue(currency, 0);
+        }
+
+        public ValidatorSet GetValidatorSet() => _validatorSet;
+
+        public MockState SetState(Address address, IValue state) =>
+            new MockState(
+                _states.SetItem(address, state),
+                _fungibles,
+                _totalSupplies,
+                _validatorSet);
+
+        public MockState SetBalance(Address address, FungibleAssetValue amount) =>
+            SetBalance((address, amount.Currency), amount.RawValue);
+
+        public MockState SetBalance(Address address, Currency currency, BigInteger rawAmount) =>
+            SetBalance((address, currency), rawAmount);
+
+        public MockState SetBalance((Address Address, Currency Currency) pair, BigInteger rawAmount) =>
+            new MockState(
+                _states,
+                _fungibles.SetItem(pair, rawAmount),
+                _totalSupplies,
+                _validatorSet);
+
+        public MockState AddBalance(Address address, FungibleAssetValue amount) =>
+            AddBalance((address, amount.Currency), amount.RawValue);
+
+        public MockState AddBalance(Address address, Currency currency, BigInteger rawAmount) =>
+            AddBalance((address, currency), rawAmount);
+
+        public MockState AddBalance((Address Address, Currency Currency) pair, BigInteger rawAmount) =>
+            SetBalance(pair, (_fungibles.TryGetValue(pair, out BigInteger amount) ? amount : 0) + rawAmount);
+
+        public MockState SubtractBalance(Address address, FungibleAssetValue amount) =>
+            SubtractBalance((address, amount.Currency), amount.RawValue);
+
+        public MockState SubtractBalance(Address address, Currency currency, BigInteger rawAmount) =>
+            SubtractBalance((address, currency), rawAmount);
+
+        public MockState SubtractBalance((Address Address, Currency Currency) pair, BigInteger rawAmount) =>
+            SetBalance(pair, (_fungibles.TryGetValue(pair, out BigInteger amount) ? amount : 0) - rawAmount);
+
+        public MockState TransferBalance(Address sender, Address recipient, FungibleAssetValue amount) =>
+            TransferBalance(sender, recipient, amount.Currency, amount.RawValue);
+
+        public MockState TransferBalance(Address sender, Address recipient, Currency currency, BigInteger rawAmount) =>
+            SubtractBalance(sender, currency, rawAmount).AddBalance(recipient, currency, rawAmount);
+
+        public MockState SetTotalSupply(FungibleAssetValue amount) =>
+            SetTotalSupply(amount.Currency, amount.RawValue);
+
+        public MockState SetTotalSupply(Currency currency, BigInteger rawAmount) =>
+            currency.TotalSupplyTrackable
+                ? !(currency.MaximumSupply is { } maximumSupply) || rawAmount <= maximumSupply.RawValue
+                    ? new MockState(
+                        _states,
+                        _fungibles,
+                        _totalSupplies.SetItem(currency, rawAmount),
+                        _validatorSet)
+                    : throw new ArgumentException(
+                        $"Given {currency}'s total supply is capped at {maximumSupply.RawValue} and " +
+                        $"cannot be set to {rawAmount}.")
+                : throw new ArgumentException(
+                    $"Given {currency} is not trackable.");
+
+        public MockState AddTotalSupply(FungibleAssetValue amount) =>
+            AddTotalSupply(amount.Currency, amount.RawValue);
+
+        public MockState AddTotalSupply(Currency currency, BigInteger rawAmount) =>
+            SetTotalSupply(currency, (_totalSupplies.TryGetValue(currency, out BigInteger amount) ? amount : 0) + rawAmount);
+
+        public MockState SubtractTotalSupply(FungibleAssetValue amount) =>
+            SubtractTotalSupply(amount.Currency, amount.RawValue);
+
+        public MockState SubtractTotalSupply(Currency currency, BigInteger rawAmount) =>
+            SetTotalSupply(currency, (_totalSupplies.TryGetValue(currency, out BigInteger amount) ? amount : 0) - rawAmount);
+
+        public MockState SetValidator(Validator validator) =>
+            new MockState(
+                _states,
+                _fungibles,
+                _totalSupplies,
+                _validatorSet.Update(validator));
+    }
+}

--- a/.Lib9c.Tests/Action/MockState.cs
+++ b/.Lib9c.Tests/Action/MockState.cs
@@ -185,5 +185,13 @@ namespace Lib9c.Tests.Action
                 _fungibles,
                 _totalSupplies,
                 _validatorSet.Update(validator));
+
+        public IImmutableDictionary<Address, IValue> States => _states;
+
+        public IImmutableDictionary<(Address, Currency), BigInteger> Fungibles => _fungibles;
+
+        public IImmutableDictionary<Currency, BigInteger> TotalSupplies => _totalSupplies;
+
+        public ValidatorSet ValidatorSet => _validatorSet;
     }
 }

--- a/.Lib9c.Tests/Action/MockState.cs
+++ b/.Lib9c.Tests/Action/MockState.cs
@@ -50,12 +50,13 @@ namespace Lib9c.Tests.Action
     /// </remarks>
     public class MockState : IAccountState
     {
+        private static readonly MockState _empty = new MockState();
         private readonly IImmutableDictionary<Address, IValue> _states;
         private readonly IImmutableDictionary<(Address, Currency), BigInteger> _fungibles;
         private readonly IImmutableDictionary<Currency, BigInteger> _totalSupplies;
         private readonly ValidatorSet _validatorSet;
 
-        public MockState()
+        private MockState()
             : this(
                 ImmutableDictionary<Address, IValue>.Empty,
                 ImmutableDictionary<(Address Address, Currency Currency), BigInteger>.Empty,
@@ -75,6 +76,16 @@ namespace Lib9c.Tests.Action
             _totalSupplies = totalSupplies;
             _validatorSet = validatorSet;
         }
+
+        public static MockState Empty => _empty;
+
+        public IImmutableDictionary<Address, IValue> States => _states;
+
+        public IImmutableDictionary<(Address, Currency), BigInteger> Fungibles => _fungibles;
+
+        public IImmutableDictionary<Currency, BigInteger> TotalSupplies => _totalSupplies;
+
+        public ValidatorSet ValidatorSet => _validatorSet;
 
         public IValue? GetState(Address address) => _states.TryGetValue(address, out IValue? value)
             ? value
@@ -185,13 +196,5 @@ namespace Lib9c.Tests.Action
                 _fungibles,
                 _totalSupplies,
                 _validatorSet.Update(validator));
-
-        public IImmutableDictionary<Address, IValue> States => _states;
-
-        public IImmutableDictionary<(Address, Currency), BigInteger> Fungibles => _fungibles;
-
-        public IImmutableDictionary<Currency, BigInteger> TotalSupplies => _totalSupplies;
-
-        public ValidatorSet ValidatorSet => _validatorSet;
     }
 }

--- a/.Lib9c.Tests/Action/MockStateDelta.cs
+++ b/.Lib9c.Tests/Action/MockStateDelta.cs
@@ -21,11 +21,16 @@ namespace Lib9c.Tests.Action
         private readonly IAccountDelta _delta;
 
         public MockStateDelta()
+            : this(MockState.Empty)
+        {
+        }
+
+        public MockStateDelta(MockState mockState)
             : this(
-                ImmutableDictionary<Address, IValue>.Empty,
-                ImmutableDictionary<(Address Address, Currency Currency), BigInteger>.Empty,
-                ImmutableDictionary<Currency, BigInteger>.Empty,
-                new ValidatorSet())
+                mockState.States,
+                mockState.Fungibles,
+                mockState.TotalSupplies,
+                mockState.ValidatorSet)
         {
         }
 

--- a/.Lib9c.Tests/Action/PatchTableSheetTest.cs
+++ b/.Lib9c.Tests/Action/PatchTableSheetTest.cs
@@ -86,9 +86,9 @@ namespace Lib9c.Tests.Action
             var adminAddress = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var adminState = new AdminState(adminAddress, 100);
             const string tableName = "TestTable";
-            var initStates = ImmutableDictionary<Address, IValue>.Empty
-                .Add(AdminState.Address, adminState.Serialize())
-                .Add(Addresses.TableSheet.Derive(tableName), Dictionary.Empty.Add(tableName, "Initial"));
+            var initStates = MockState.Empty
+                .SetState(AdminState.Address, adminState.Serialize())
+                .SetState(Addresses.TableSheet.Derive(tableName), Dictionary.Empty.Add(tableName, "Initial"));
             var state = new MockStateDelta(initStates);
             var action = new PatchTableSheet()
             {
@@ -129,9 +129,9 @@ namespace Lib9c.Tests.Action
             var adminAddress = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var adminState = new AdminState(adminAddress, 100);
             const string tableName = "TestTable";
-            var initStates = ImmutableDictionary<Address, IValue>.Empty
-                .Add(AdminState.Address, adminState.Serialize())
-                .Add(Addresses.TableSheet.Derive(tableName), Dictionary.Empty.Add(tableName, "Initial"));
+            var initStates = MockState.Empty
+                .SetState(AdminState.Address, adminState.Serialize())
+                .SetState(Addresses.TableSheet.Derive(tableName), Dictionary.Empty.Add(tableName, "Initial"));
             var state = new MockStateDelta(initStates);
             var action = new PatchTableSheet()
             {

--- a/.Lib9c.Tests/Action/RenewAdminStateTest.cs
+++ b/.Lib9c.Tests/Action/RenewAdminStateTest.cs
@@ -23,10 +23,9 @@ namespace Lib9c.Tests.Action
             _adminPrivateKey = new PrivateKey();
             _validUntil = 1_500_000L;
             _adminState = new AdminState(_adminPrivateKey.ToAddress(), _validUntil);
-            _stateDelta =
-                new MockStateDelta(ImmutableDictionary<Address, IValue>.Empty.Add(
-                    Addresses.Admin,
-                    _adminState.Serialize()));
+            _stateDelta = new MockStateDelta(
+                MockState.Empty
+                    .SetState(Addresses.Admin, _adminState.Serialize()));
         }
 
         [Fact]

--- a/.Lib9c.Tests/Action/SecureMiningRewardTest.cs
+++ b/.Lib9c.Tests/Action/SecureMiningRewardTest.cs
@@ -35,15 +35,13 @@ namespace Lib9c.Tests.Action
         }.ToImmutableList();
 
         private static readonly MockStateDelta _previousState = new MockStateDelta(
-            states: ImmutableDictionary<Address, IValue>.Empty
-                .Add(AdminState.Address, new AdminState(_admin, 100).Serialize())
-                .Add(GoldCurrencyState.Address, new GoldCurrencyState(NCG).Serialize()),
-            balances: ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_authMiners[0], NCG), NCG * 1000)
-                .Add((_authMiners[1], NCG), NCG * 2000)
-                .Add((_authMiners[2], NCG), NCG * 3000)
-                .Add((_authMiners[3], NCG), NCG * 4000)
-        );
+            MockState.Empty
+                .SetState(AdminState.Address, new AdminState(_admin, 100).Serialize())
+                .SetState(GoldCurrencyState.Address, new GoldCurrencyState(NCG).Serialize())
+                .SetBalance(_authMiners[0], NCG * 1000)
+                .SetBalance(_authMiners[1], NCG * 2000)
+                .SetBalance(_authMiners[2], NCG * 3000)
+                .SetBalance(_authMiners[3], NCG * 4000));
 
         [Fact]
         public void Execute()

--- a/.Lib9c.Tests/Action/TransferAsset2Test.cs
+++ b/.Lib9c.Tests/Action/TransferAsset2Test.cs
@@ -48,15 +48,11 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Execute()
         {
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000)
-                .Add((_recipient, _currency), _currency * 10);
-            var state = ImmutableDictionary<Address, IValue>.Empty
-                .Add(_recipient.Derive(ActivationKey.DeriveKey), true.Serialize());
             var prevState = new MockStateDelta(
-                states: state,
-                balances: balance
-            );
+                MockState.Empty
+                    .SetState(_recipient.Derive(ActivationKey.DeriveKey), true.Serialize())
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_recipient, _currency * 10));
             var action = new TransferAsset2(
                 sender: _sender,
                 recipient: _recipient,
@@ -77,12 +73,10 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void ExecuteWithInvalidSigner()
         {
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000)
-                .Add((_recipient, _currency), _currency * 10);
             var prevState = new MockStateDelta(
-                balances: balance
-            );
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_recipient, _currency * 10));
             var action = new TransferAsset2(
                 sender: _sender,
                 recipient: _recipient,
@@ -109,11 +103,9 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void ExecuteWithInvalidRecipient()
         {
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000);
             var prevState = new MockStateDelta(
-                balances: balance
-            );
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000));
             // Should not allow TransferAsset2 with same sender and recipient.
             var action = new TransferAsset2(
                 sender: _sender,
@@ -148,12 +140,10 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void ExecuteWithInsufficientBalance()
         {
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000)
-                .Add((_recipient, _currency), _currency * 10);
             var prevState = new MockStateDelta(
-                balances: balance
-            );
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_recipient, _currency * 10));
             var action = new TransferAsset2(
                 sender: _sender,
                 recipient: _recipient,
@@ -179,12 +169,10 @@ namespace Lib9c.Tests.Action
             // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
             var currencyBySender = Currency.Legacy("NCG", 2, _sender);
 #pragma warning restore CS0618
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, currencyBySender), _currency * 1000)
-                .Add((_recipient, currencyBySender), _currency * 10);
             var prevState = new MockStateDelta(
-                balances: balance
-            );
+                MockState.Empty
+                    .SetBalance(_sender, currencyBySender * 1000)
+                    .SetBalance(_recipient, currencyBySender * 10));
             var action = new TransferAsset2(
                 sender: _sender,
                 recipient: _recipient,
@@ -213,12 +201,10 @@ namespace Lib9c.Tests.Action
             // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
             var currencyByRecipient = Currency.Legacy("NCG", 2, _sender);
 #pragma warning restore CS0618
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, currencyByRecipient), _currency * 1000)
-                .Add((_recipient, currencyByRecipient), _currency * 10);
             var prevState = new MockStateDelta(
-                balances: balance
-            );
+                MockState.Empty
+                    .SetBalance(_sender, currencyByRecipient * 1000)
+                    .SetBalance(_sender, currencyByRecipient * 10));
             var action = new TransferAsset2(
                 sender: _sender,
                 recipient: _recipient,
@@ -244,16 +230,12 @@ namespace Lib9c.Tests.Action
         public void ExecuteWithUnactivatedRecipient()
         {
             var activatedAddress = new ActivatedAccountsState().AddAccount(new PrivateKey().ToAddress());
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000)
-                .Add((_recipient, _currency), _currency * 10);
-            var state = ImmutableDictionary<Address, IValue>.Empty
-                .Add(_sender.Derive(ActivationKey.DeriveKey), true.Serialize())
-                .Add(Addresses.ActivatedAccount, activatedAddress.Serialize());
             var prevState = new MockStateDelta(
-                states: state,
-                balances: balance
-            );
+                MockState.Empty
+                    .SetState(_sender.Derive(ActivationKey.DeriveKey), true.Serialize())
+                    .SetState(Addresses.ActivatedAccount, activatedAddress.Serialize())
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_recipient, _currency * 10));
             var action = new TransferAsset2(
                 sender: _sender,
                 recipient: _recipient,

--- a/.Lib9c.Tests/Action/TransferAsset3Test.cs
+++ b/.Lib9c.Tests/Action/TransferAsset3Test.cs
@@ -57,31 +57,28 @@ namespace Lib9c.Tests.Action
         [InlineData(false, false, true)]
         public void Execute(bool activate, bool legacyActivate, bool stateExist)
         {
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000)
-                .Add((_recipient, _currency), _currency * 10);
-            var state = ImmutableDictionary<Address, IValue>.Empty;
+            var mockState = MockState.Empty
+                .SetBalance(_sender, _currency * 1000)
+                .SetBalance(_recipient, _currency * 10);
+
             if (activate)
             {
-                state = state.Add(_recipient.Derive(ActivationKey.DeriveKey), true.Serialize());
+                mockState = mockState.SetState(_recipient.Derive(ActivationKey.DeriveKey), true.Serialize());
             }
 
             if (legacyActivate)
             {
                 var activatedAccountState = new ActivatedAccountsState();
                 activatedAccountState = activatedAccountState.AddAccount(_recipient);
-                state = state.Add(activatedAccountState.address, activatedAccountState.Serialize());
+                mockState = mockState.SetState(activatedAccountState.address, activatedAccountState.Serialize());
             }
 
             if (stateExist)
             {
-                state = state.Add(_recipient, new AgentState(_recipient).Serialize());
+                mockState = mockState.SetState(_recipient, new AgentState(_recipient).Serialize());
             }
 
-            var prevState = new MockStateDelta(
-                states: state,
-                balances: balance
-            );
+            var prevState = new MockStateDelta(mockState);
             var action = new TransferAsset3(
                 sender: _sender,
                 recipient: _recipient,
@@ -102,12 +99,10 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void ExecuteWithInvalidSigner()
         {
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000)
-                .Add((_recipient, _currency), _currency * 10);
             var prevState = new MockStateDelta(
-                balances: balance
-            );
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_recipient, _currency * 10));
             var action = new TransferAsset3(
                 sender: _sender,
                 recipient: _recipient,
@@ -137,8 +132,9 @@ namespace Lib9c.Tests.Action
             var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
                 .Add((_sender, _currency), _currency * 1000);
             var prevState = new MockStateDelta(
-                balances: balance
-            );
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000));
+
             // Should not allow TransferAsset with same sender and recipient.
             var action = new TransferAsset3(
                 sender: _sender,
@@ -164,12 +160,11 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void ExecuteWithInsufficientBalance()
         {
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000)
-                .Add((_recipient, _currency), _currency * 10);
             var prevState = new MockStateDelta(
-                balances: balance
-            ).SetState(_recipient, new AgentState(_recipient).Serialize());
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_recipient, _currency * 10))
+                    .SetState(_recipient, new AgentState(_recipient).Serialize());
             var action = new TransferAsset3(
                 sender: _sender,
                 recipient: _recipient,
@@ -195,12 +190,11 @@ namespace Lib9c.Tests.Action
             // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
             var currencyBySender = Currency.Legacy("NCG", 2, _sender);
 #pragma warning restore CS0618
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, currencyBySender), _currency * 1000)
-                .Add((_recipient, currencyBySender), _currency * 10);
             var prevState = new MockStateDelta(
-                balances: balance
-            ).SetState(_recipient, new AgentState(_recipient).Serialize());
+                MockState.Empty
+                    .SetState(_recipient, new AgentState(_recipient).Serialize())
+                    .SetBalance(_sender, currencyBySender * 1000)
+                    .SetBalance(_recipient, currencyBySender * 10));
             var action = new TransferAsset3(
                 sender: _sender,
                 recipient: _recipient,
@@ -229,12 +223,11 @@ namespace Lib9c.Tests.Action
             // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
             var currencyByRecipient = Currency.Legacy("NCG", 2, _sender);
 #pragma warning restore CS0618
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, currencyByRecipient), _currency * 1000)
-                .Add((_recipient, currencyByRecipient), _currency * 10);
             var prevState = new MockStateDelta(
-                balances: balance
-            ).SetState(_recipient, new AgentState(_recipient).Serialize());
+                MockState.Empty
+                    .SetBalance(_sender, currencyByRecipient * 1000)
+                    .SetBalance(_recipient, currencyByRecipient * 10)
+                    .SetState(_recipient, new AgentState(_recipient).Serialize()));
             var action = new TransferAsset3(
                 sender: _sender,
                 recipient: _recipient,
@@ -260,16 +253,12 @@ namespace Lib9c.Tests.Action
         public void ExecuteWithUnactivatedRecipient()
         {
             var activatedAddress = new ActivatedAccountsState().AddAccount(new PrivateKey().ToAddress());
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000)
-                .Add((_recipient, _currency), _currency * 10);
-            var state = ImmutableDictionary<Address, IValue>.Empty
-                .Add(_sender.Derive(ActivationKey.DeriveKey), true.Serialize())
-                .Add(Addresses.ActivatedAccount, activatedAddress.Serialize());
             var prevState = new MockStateDelta(
-                states: state,
-                balances: balance
-            );
+                MockState.Empty
+                    .SetState(_sender.Derive(ActivationKey.DeriveKey), true.Serialize())
+                    .SetState(Addresses.ActivatedAccount, activatedAddress.Serialize())
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_recipient, _currency * 10));
             var action = new TransferAsset3(
                 sender: _sender,
                 recipient: _recipient,
@@ -369,15 +358,10 @@ namespace Lib9c.Tests.Action
         public void Execute_Throw_InvalidTransferCurrencyException()
         {
             var crystal = CrystalCalculator.CRYSTAL;
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, crystal), crystal * 1000);
-            var state = ImmutableDictionary<Address, IValue>.Empty
-                .Add(_recipient.Derive(ActivationKey.DeriveKey), true.Serialize());
-
             var prevState = new MockStateDelta(
-                states: state,
-                balances: balance
-            );
+                MockState.Empty
+                    .SetState(_recipient.Derive(ActivationKey.DeriveKey), true.Serialize())
+                    .SetBalance(_sender, crystal * 1000));
             var action = new TransferAsset3(
                 sender: _sender,
                 recipient: _recipient,

--- a/.Lib9c.Tests/Action/TransferAssetTest.cs
+++ b/.Lib9c.Tests/Action/TransferAssetTest.cs
@@ -51,15 +51,10 @@ namespace Lib9c.Tests.Action
         {
             var contractAddress = _sender.Derive(nameof(RequestPledge));
             var patronAddress = new PrivateKey().ToAddress();
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000)
-                .Add((_recipient, _currency), _currency * 10);
-            var state = ImmutableDictionary<Address, IValue>.Empty;
-
             var prevState = new MockStateDelta(
-                states: state,
-                balances: balance
-            );
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_recipient, _currency * 10));
             var action = new TransferAsset(
                 sender: _sender,
                 recipient: _recipient,
@@ -80,13 +75,11 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Execute_Throw_InvalidTransferSignerException()
         {
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000)
-                .Add((_recipient, _currency), _currency * 10)
-                .Add((_sender, Currencies.Mead), Currencies.Mead * 1);
             var prevState = new MockStateDelta(
-                balances: balance
-            );
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_recipient, _currency * 10)
+                    .SetBalance(_sender, Currencies.Mead * 1));
             var action = new TransferAsset(
                 sender: _sender,
                 recipient: _recipient,
@@ -113,12 +106,10 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Execute_Throw_InvalidTransferRecipientException()
         {
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000)
-                .Add((_sender, Currencies.Mead), Currencies.Mead * 1);
             var prevState = new MockStateDelta(
-                balances: balance
-            );
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_sender, Currencies.Mead * 1));
             // Should not allow TransferAsset with same sender and recipient.
             var action = new TransferAsset(
                 sender: _sender,
@@ -144,13 +135,11 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Execute_Throw_InsufficientBalanceException()
         {
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000)
-                .Add((_recipient, _currency), _currency * 10);
-
             var prevState = new MockStateDelta(
-                balances: balance
-            ).SetState(_recipient, new AgentState(_recipient).Serialize());
+                MockState.Empty
+                    .SetState(_recipient, new AgentState(_recipient).Serialize())
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_recipient, _currency * 10));
             var action = new TransferAsset(
                 sender: _sender,
                 recipient: _recipient,
@@ -182,13 +171,12 @@ namespace Lib9c.Tests.Action
             // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
             var currencyBySender = Currency.Legacy("NCG", 2, minter);
 #pragma warning restore CS0618
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, currencyBySender), _currency * 1000)
-                .Add((_recipient, currencyBySender), _currency * 10)
-                .Add((_sender, Currencies.Mead), Currencies.Mead * 1);
             var prevState = new MockStateDelta(
-                balances: balance
-            ).SetState(_recipient, new AgentState(_recipient).Serialize());
+                MockState.Empty
+                    .SetState(_recipient, new AgentState(_recipient).Serialize())
+                    .SetBalance(_sender, currencyBySender * 1000)
+                    .SetBalance(_recipient, currencyBySender * 10)
+                    .SetBalance(_sender, Currencies.Mead * 1));
             var action = new TransferAsset(
                 sender: _sender,
                 recipient: _recipient,
@@ -291,16 +279,11 @@ namespace Lib9c.Tests.Action
         public void Execute_Throw_InvalidTransferCurrencyException()
         {
             var crystal = CrystalCalculator.CRYSTAL;
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, crystal), crystal * 1000)
-                .Add((_sender, Currencies.Mead), Currencies.Mead * 1);
-            var state = ImmutableDictionary<Address, IValue>.Empty
-                .Add(_recipient.Derive(ActivationKey.DeriveKey), true.Serialize());
-
             var prevState = new MockStateDelta(
-                states: state,
-                balances: balance
-            );
+                MockState.Empty
+                    .SetState(_recipient.Derive(ActivationKey.DeriveKey), true.Serialize())
+                    .SetBalance(_sender, crystal * 1000)
+                    .SetBalance(_sender, Currencies.Mead * 1));
             var action = new TransferAsset(
                 sender: _sender,
                 recipient: _recipient,

--- a/.Lib9c.Tests/Action/TransferAssetTest0.cs
+++ b/.Lib9c.Tests/Action/TransferAssetTest0.cs
@@ -46,12 +46,10 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Execute()
         {
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000)
-                .Add((_recipient, _currency), _currency * 10);
             var prevState = new MockStateDelta(
-                balances: balance
-            );
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_recipient, _currency * 10));
             var action = new TransferAsset0(
                 sender: _sender,
                 recipient: _recipient,
@@ -72,12 +70,10 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void ExecuteWithInvalidSigner()
         {
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000)
-                .Add((_recipient, _currency), _currency * 10);
             var prevState = new MockStateDelta(
-                balances: balance
-            );
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_recipient, _currency * 10));
             var action = new TransferAsset0(
                 sender: _sender,
                 recipient: _recipient,
@@ -104,11 +100,9 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void ExecuteWithInvalidRecipient()
         {
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000);
             var prevState = new MockStateDelta(
-                balances: balance
-            );
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000));
             // Should not allow TransferAsset with same sender and recipient.
             var action = new TransferAsset0(
                 sender: _sender,
@@ -143,12 +137,10 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void ExecuteWithInsufficientBalance()
         {
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000)
-                .Add((_recipient, _currency), _currency * 10);
             var prevState = new MockStateDelta(
-                balances: balance
-            );
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_recipient, _currency * 10));
             var action = new TransferAsset0(
                 sender: _sender,
                 recipient: _recipient,
@@ -174,12 +166,10 @@ namespace Lib9c.Tests.Action
             // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
             var currencyBySender = Currency.Legacy("NCG", 2, _sender);
 #pragma warning restore CS0618
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, currencyBySender), _currency * 1000)
-                .Add((_recipient, currencyBySender), _currency * 10);
             var prevState = new MockStateDelta(
-                balances: balance
-            );
+                MockState.Empty
+                    .SetBalance(_sender, currencyBySender * 1000)
+                    .SetBalance(_recipient, currencyBySender * 10));
             var action = new TransferAsset0(
                 sender: _sender,
                 recipient: _recipient,
@@ -208,12 +198,10 @@ namespace Lib9c.Tests.Action
             // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
             var currencyByRecipient = Currency.Legacy("NCG", 2, _sender);
 #pragma warning restore CS0618
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, currencyByRecipient), _currency * 1000)
-                .Add((_recipient, currencyByRecipient), _currency * 10);
             var prevState = new MockStateDelta(
-                balances: balance
-            );
+                MockState.Empty
+                    .SetBalance(_sender, currencyByRecipient * 1000)
+                    .SetBalance(_recipient, currencyByRecipient * 10));
             var action = new TransferAsset0(
                 sender: _sender,
                 recipient: _recipient,

--- a/.Lib9c.Tests/Action/TransferAssetsTest.cs
+++ b/.Lib9c.Tests/Action/TransferAssetsTest.cs
@@ -67,15 +67,10 @@ namespace Lib9c.Tests.Action
         {
             var contractAddress = _sender.Derive(nameof(RequestPledge));
             var patronAddress = new PrivateKey().ToAddress();
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000)
-                .Add((_recipient, _currency), _currency * 10);
-            var state = ImmutableDictionary<Address, IValue>.Empty;
-
             var prevState = new MockStateDelta(
-                states: state,
-                balances: balance
-            );
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_recipient, _currency * 10));
             var action = new TransferAssets(
                 sender: _sender,
                 new List<(Address, FungibleAssetValue)>
@@ -102,12 +97,10 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Execute_Throw_InvalidTransferSignerException()
         {
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000)
-                .Add((_recipient, _currency), _currency * 10);
             var prevState = new MockStateDelta(
-                balances: balance
-            );
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_recipient, _currency * 10));
             var action = new TransferAssets(
                 sender: _sender,
                 new List<(Address, FungibleAssetValue)>
@@ -136,11 +129,9 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Execute_Throw_InvalidTransferRecipientException()
         {
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000);
             var prevState = new MockStateDelta(
-                balances: balance
-            );
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000));
             // Should not allow TransferAsset with same sender and recipient.
             var action = new TransferAssets(
                 sender: _sender,
@@ -168,13 +159,11 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Execute_Throw_InsufficientBalanceException()
         {
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, _currency), _currency * 1000)
-                .Add((_recipient, _currency), _currency * 10);
-
             var prevState = new MockStateDelta(
-                balances: balance
-            ).SetState(_recipient, new AgentState(_recipient).Serialize());
+                MockState.Empty
+                    .SetState(_recipient, new AgentState(_recipient).Serialize())
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_recipient, _currency * 10));
             var action = new TransferAssets(
                 sender: _sender,
                 new List<(Address, FungibleAssetValue)>
@@ -205,12 +194,11 @@ namespace Lib9c.Tests.Action
             // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
             var currencyBySender = Currency.Legacy("NCG", 2, _sender);
 #pragma warning restore CS0618
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, currencyBySender), _currency * 1000)
-                .Add((_recipient, currencyBySender), _currency * 10);
             var prevState = new MockStateDelta(
-                balances: balance
-            ).SetState(_recipient, new AgentState(_recipient).Serialize());
+                MockState.Empty
+                    .SetState(_recipient, new AgentState(_recipient).Serialize())
+                    .SetBalance(_sender, currencyBySender * 1000)
+                    .SetBalance(_recipient, currencyBySender * 10));
             var action = new TransferAssets(
                 sender: _sender,
                 new List<(Address, FungibleAssetValue)>
@@ -391,15 +379,10 @@ namespace Lib9c.Tests.Action
         public void Execute_Throw_InvalidTransferCurrencyException()
         {
             var crystal = CrystalCalculator.CRYSTAL;
-            var balance = ImmutableDictionary<(Address, Currency), FungibleAssetValue>.Empty
-                .Add((_sender, crystal), crystal * 1000);
-            var state = ImmutableDictionary<Address, IValue>.Empty
-                .Add(_recipient.Derive(ActivationKey.DeriveKey), true.Serialize());
-
             var prevState = new MockStateDelta(
-                states: state,
-                balances: balance
-            );
+                MockState.Empty
+                    .SetState(_recipient.Derive(ActivationKey.DeriveKey), true.Serialize())
+                    .SetBalance(_sender, crystal * 1000));
             var action = new TransferAssets(
                 sender: _sender,
                 recipients: new List<(Address, FungibleAssetValue)>

--- a/.Lib9c.Tests/Action/ValidatorSetOperateTest.cs
+++ b/.Lib9c.Tests/Action/ValidatorSetOperateTest.cs
@@ -44,12 +44,9 @@ namespace Lib9c.Tests.Action
         {
             var adminAddress = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var adminState = new AdminState(adminAddress, 100);
-            var initStates =
-                ImmutableDictionary<Address, IValue>.Empty
-                    .Add(AdminState.Address, adminState.Serialize());
-            var state = new MockStateDelta(
-                initStates,
-                validatorSet: new ValidatorSet());
+            var initStates = MockState.Empty
+                .SetState(AdminState.Address, adminState.Serialize());
+            var state = new MockStateDelta(initStates);
             var action = ValidatorSetOperate.Append(_validator);
             var nextState = action.Execute(
                 new ActionContext()
@@ -68,12 +65,9 @@ namespace Lib9c.Tests.Action
         {
             var adminAddress = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var adminState = new AdminState(adminAddress, 100);
-            var initStates =
-                ImmutableDictionary<Address, IValue>.Empty
-                    .Add(AdminState.Address, adminState.Serialize());
-            var state = new MockStateDelta(
-                initStates,
-                validatorSet: new ValidatorSet());
+            var initStates = MockState.Empty
+                .SetState(AdminState.Address, adminState.Serialize());
+            var state = new MockStateDelta(initStates);
             var action = ValidatorSetOperate.Append(_validator);
 
             PermissionDeniedException exc1 = Assert.Throws<PermissionDeniedException>(() =>


### PR DESCRIPTION
- ~~`IAction.Execute()` should now run with clean `IAccountStateDelta`s~~
- It was allowed to add FAVs that didn't make sense. This is no longer the case.
  - For example, it was possible to "add" `(addressA, currencyB, favC)` where `favC.Currency` was not `currencyB`.
 
----

Addemdum: The first point isn't true yet. I'll bring `MockStateDelta` up to date with a separate PR.