### PR TITLE
Update submodule updater

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,5 +122,5 @@ jobs:
         committer: >
           Submodule Updater <engineering+submodule-updater@planetariumhq.com>
         targets: |
-          ${{ github.repository_owner }}/NineChronicles:refs/heads/release/*
+          planetarium/NineChronicles:refs/heads/release/*
           ${{ github.repository_owner }}/NineChronicles.Headless:refs/heads/release/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,3 +124,4 @@ jobs:
         targets: |
           planetarium/NineChronicles:refs/heads/release/*
           ${{ github.repository_owner }}/NineChronicles.Headless:refs/heads/release/*
+          ${{ github.repository_owner }}/market-service:refs/heads/release/*


### PR DESCRIPTION
- Send `9c` bump PR to upstream (resolve license issue during CI build)
- Also send bump PR to `market-service`