### PR TITLE
Optimize HackAndSlash.Execute #1

### DIFF
--- a/.Lib9c.Tests/Action/HitHelperTest.cs
+++ b/.Lib9c.Tests/Action/HitHelperTest.cs
@@ -1,0 +1,34 @@
+namespace Lib9c.Tests.Action
+{
+    using System;
+    using Nekoyume.Battle;
+    using Xunit;
+
+    public class HitHelperTest
+    {
+        [Fact]
+        public void GetHitStep2()
+        {
+            // copy from previous logic
+            int GetHitStep2Legacy(int attackerHit, int defenderHit)
+            {
+                attackerHit = Math.Max(1, attackerHit);
+                defenderHit = Math.Max(1, defenderHit);
+                var additionalCorrection = (int)((attackerHit - defenderHit / 3m) / defenderHit * 100);
+                return Math.Min(
+                    Math.Max(additionalCorrection, HitHelper.GetHitStep2AdditionalCorrectionMin),
+                    HitHelper.GetHitStep2AdditionalCorrectionMax);
+            }
+
+            for (int i = 0; i < 9; i++)
+            {
+                for (int j = 0; j < 9; j++)
+                {
+                    var legacy = GetHitStep2Legacy(i, j);
+                    var current = HitHelper.GetHitStep2(i, j);
+                    Assert.True(legacy == current, $"{i}, {j}, {legacy}, {current}");
+                }
+            }
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/Skill/CombatTest.cs
+++ b/.Lib9c.Tests/Model/Skill/CombatTest.cs
@@ -75,7 +75,7 @@ namespace Lib9c.Tests.Model.Skill
             var normalAttack = new NormalAttack(skillRow, 0, 100, default, StatType.NONE);
 
             var prevHP = _player.CurrentHP;
-            normalAttack.Use(_enemy, 1, new List<StatBuff>());
+            normalAttack.Use(_enemy, 1, new List<StatBuff>(), false);
             var currentHP = _player.CurrentHP;
             var damage = prevHP - currentHP;
 
@@ -100,11 +100,41 @@ namespace Lib9c.Tests.Model.Skill
             var normalAttack = new NormalAttack(skillRow, 0, 100, default, StatType.NONE);
 
             var prevHP = _player.CurrentHP;
-            normalAttack.Use(_enemy, 1, new List<StatBuff>());
+            normalAttack.Use(_enemy, 1, new List<StatBuff>(), false);
             var currentHP = _player.CurrentHP;
             var damage = prevHP - currentHP;
 
             Assert.Equal(expectedDamage, damage);
+        }
+
+        [Fact]
+        public void Thorn()
+        {
+            var prevHP = _enemy.CurrentHP;
+            var skill = _enemy.GiveThornDamage(1);
+            var currentHP = _enemy.CurrentHP;
+            // get 1dmg from thorn
+            Assert.Equal(prevHP - 1, currentHP);
+            Assert.Equal(prevHP, skill.Character.CurrentHP);
+            var skillInfo = Assert.Single(skill.SkillInfos);
+            Assert.Equal(currentHP, skillInfo.Target!.CurrentHP);
+        }
+
+        [Fact]
+        public void Bleed()
+        {
+            var actionBuffSheet = _tableSheets.ActionBuffSheet;
+            var row = actionBuffSheet.Values.First();
+            var bleed = Assert.IsType<Bleed>(BuffFactory.GetActionBuff(_enemy.Stats, row));
+            var dmg = bleed.Power;
+            var prevHP = _player.CurrentHP;
+            var skill = bleed.GiveEffect(_player, 1);
+            var currentHP = _player.CurrentHP;
+            // get dmg from bleed
+            Assert.Equal(prevHP - dmg, currentHP);
+            Assert.Equal(prevHP, skill.Character.CurrentHP);
+            var skillInfo = Assert.Single(skill.SkillInfos);
+            Assert.Equal(currentHP, skillInfo.Target!.CurrentHP);
         }
     }
 }

--- a/.Lib9c.Tests/Model/Skill/NormalAttackTest.cs
+++ b/.Lib9c.Tests/Model/Skill/NormalAttackTest.cs
@@ -79,13 +79,14 @@ namespace Lib9c.Tests.Model.Skill
             var battleStatusSkill = normalAttack.Use(
                 player,
                 0,
-                new List<StatBuff>());
+                new List<StatBuff>(),
+                true);
             Assert.NotNull(battleStatusSkill);
             Assert.Single(battleStatusSkill.SkillInfos);
 
             var skillInfo = battleStatusSkill.SkillInfos.FirstOrDefault();
             Assert.NotNull(skillInfo);
-            Assert.Equal(enemy.Id, skillInfo.Target.Id);
+            Assert.Equal(enemy.Id, skillInfo.CharacterId);
         }
     }
 }

--- a/.Lib9c.Tests/Model/Skill/NormalAttackTest.cs
+++ b/.Lib9c.Tests/Model/Skill/NormalAttackTest.cs
@@ -26,8 +26,10 @@ namespace Lib9c.Tests.Model.Skill
                 .CreateLogger();
         }
 
-        [Fact]
-        public void Use()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Use(bool copyCharacter)
         {
             var sheets = TableSheetsImporter.ImportSheets();
             var tableSheets = new TableSheets(sheets);
@@ -65,7 +67,8 @@ namespace Lib9c.Tests.Model.Skill
                 StageSimulator.GetWaveRewards(
                     random,
                     tableSheets.StageSheet[1],
-                    tableSheets.MaterialItemSheet)
+                    tableSheets.MaterialItemSheet),
+                copyCharacter
             );
             var player = new Player(avatarState, simulator);
 
@@ -80,13 +83,12 @@ namespace Lib9c.Tests.Model.Skill
                 player,
                 0,
                 new List<StatBuff>(),
-                true);
+                copyCharacter);
             Assert.NotNull(battleStatusSkill);
-            Assert.Single(battleStatusSkill.SkillInfos);
-
-            var skillInfo = battleStatusSkill.SkillInfos.FirstOrDefault();
-            Assert.NotNull(skillInfo);
+            Assert.Equal(!copyCharacter, battleStatusSkill.Character is null);
+            var skillInfo = Assert.Single(battleStatusSkill.SkillInfos);
             Assert.Equal(enemy.Id, skillInfo.CharacterId);
+            Assert.Equal(!copyCharacter, skillInfo.Target is null);
         }
     }
 }

--- a/Lib9c/Action/HackAndSlash.cs
+++ b/Lib9c/Action/HackAndSlash.cs
@@ -465,7 +465,8 @@ namespace Nekoyume.Action
                     simulatorSheets,
                     enemySkillSheet,
                     costumeStatSheet,
-                    rewards);
+                    rewards,
+                    false);
                 sw.Stop();
                 Log.Verbose("{AddressesHex}HAS Initialize Simulator: {Elapsed}", addressesHex, sw.Elapsed);
 

--- a/Lib9c/Action/HackAndSlash.cs
+++ b/Lib9c/Action/HackAndSlash.cs
@@ -439,8 +439,14 @@ namespace Nekoyume.Action
                 }
             }
 
+            var stageWaveRow =  sheets.GetSheet<StageWaveSheet>()[StageId];
+            var enemySkillSheet = sheets.GetSheet<EnemySkillSheet>();
+            var costumeStatSheet = sheets.GetSheet<CostumeStatSheet>();
+            var stageCleared = !isNotClearedStage;
+            var starCount = 0;
             for (var i = 0; i < TotalPlayCount; i++)
             {
+                var rewards = StageSimulator.GetWaveRewards(random, stageRow, materialItemSheet);
                 sw.Restart();
                 // First simulating will use Foods and Random Skills.
                 // Remainder simulating will not use Foods.
@@ -453,13 +459,13 @@ namespace Nekoyume.Action
                     WorldId,
                     StageId,
                     stageRow,
-                    sheets.GetSheet<StageWaveSheet>()[StageId],
-                    avatarState.worldInformation.IsStageCleared(StageId),
+                    stageWaveRow,
+                    stageCleared,
                     StageRewardExpHelper.GetExp(avatarState.level, StageId),
                     simulatorSheets,
-                    sheets.GetSheet<EnemySkillSheet>(),
-                    sheets.GetSheet<CostumeStatSheet>(),
-                    StageSimulator.GetWaveRewards(random, stageRow, materialItemSheet));
+                    enemySkillSheet,
+                    costumeStatSheet,
+                    rewards);
                 sw.Stop();
                 Log.Verbose("{AddressesHex}HAS Initialize Simulator: {Elapsed}", addressesHex, sw.Elapsed);
 
@@ -471,13 +477,17 @@ namespace Nekoyume.Action
                 sw.Restart();
                 if (simulator.Log.IsClear)
                 {
-                    simulator.Player.worldInformation.ClearStage(
-                        WorldId,
-                        StageId,
-                        blockIndex,
-                        worldSheet,
-                        worldUnlockSheet
-                    );
+                    if (!stageCleared)
+                    {
+                        avatarState.worldInformation.ClearStage(
+                            WorldId,
+                            StageId,
+                            blockIndex,
+                            worldSheet,
+                            worldUnlockSheet
+                        );
+                        stageCleared = true;
+                    }
                     sw.Stop();
                     Log.Verbose("{AddressesHex}HAS ClearStage: {Elapsed}", addressesHex, sw.Elapsed);
                 }
@@ -504,9 +514,8 @@ namespace Nekoyume.Action
                     player.eventMapForBeforeV100310.Clear();
                 }
 
+                starCount += simulator.Log.clearedWaveNumber;
                 avatarState.Update(simulator);
-                // Update CrystalRandomSkillState.Stars by clearedWaveNumber. (add)
-                skillState?.Update(simulator.Log.clearedWaveNumber, crystalStageBuffSheet);
 
                 sw.Stop();
                 Log.Verbose(
@@ -526,6 +535,8 @@ namespace Nekoyume.Action
             Log.Verbose("{AddressesHex}HAS loop Simulate: {Elapsed}, Count: {PlayCount}",
                 addressesHex, sw.Elapsed, TotalPlayCount);
 
+            // Update CrystalRandomSkillState.Stars by clearedWaveNumber. (add)
+            skillState?.Update(starCount, crystalStageBuffSheet);
             sw.Restart();
             avatarState.UpdateQuestRewards(materialItemSheet);
             avatarState.updatedAt = blockIndex;

--- a/Lib9c/Battle/AttackCountHelper.cs
+++ b/Lib9c/Battle/AttackCountHelper.cs
@@ -1,67 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Nekoyume.Battle
 {
     public static class AttackCountHelper
     {
-        public struct Info
-        {
-            public decimal DamageMultiplier;
-            public decimal AdditionalCriticalChance;
-        }
-
         public const int CountMaxLowerLimit = 2;
         public const int CountMaxUpperLimit = 5;
-
-        /// <summary>
-        /// key: attack count max
-        /// value: attack count, info
-        /// </summary>
-        public static readonly IReadOnlyDictionary<int, IReadOnlyDictionary<int, Info>> CachedInfo =
-            new Dictionary<int, IReadOnlyDictionary<int, Info>>
-            {
-                {
-                    1, new Dictionary<int, Info>
-                    {
-                        {1, new Info {DamageMultiplier = 1m, AdditionalCriticalChance = 0m}}
-                    }
-                },
-                {
-                    2, new Dictionary<int, Info>
-                    {
-                        {1, new Info {DamageMultiplier = 1m, AdditionalCriticalChance = 0m}},
-                        {2, new Info {DamageMultiplier = 2m, AdditionalCriticalChance = 25m}}
-                    }
-                },
-                {
-                    3, new Dictionary<int, Info>
-                    {
-                        {1, new Info {DamageMultiplier = 1m, AdditionalCriticalChance = 0m}},
-                        {2, new Info {DamageMultiplier = 2m, AdditionalCriticalChance = 10m}},
-                        {3, new Info {DamageMultiplier = 3m, AdditionalCriticalChance = 35m}}
-                    }
-                },
-                {
-                    4, new Dictionary<int, Info>
-                    {
-                        {1, new Info {DamageMultiplier = 1m, AdditionalCriticalChance = 0m}},
-                        {2, new Info {DamageMultiplier = 2m, AdditionalCriticalChance = 10m}},
-                        {3, new Info {DamageMultiplier = 3m, AdditionalCriticalChance = 20m}},
-                        {4, new Info {DamageMultiplier = 4m, AdditionalCriticalChance = 45m}}
-                    }
-                },
-                {
-                    5, new Dictionary<int, Info>
-                    {
-                        {1, new Info {DamageMultiplier = 1m, AdditionalCriticalChance = 0m}},
-                        {2, new Info {DamageMultiplier = 2m, AdditionalCriticalChance = 10m}},
-                        {3, new Info {DamageMultiplier = 3m, AdditionalCriticalChance = 20m}},
-                        {4, new Info {DamageMultiplier = 4m, AdditionalCriticalChance = 30m}},
-                        {5, new Info {DamageMultiplier = 5m, AdditionalCriticalChance = 55m}}
-                    }
-                }
-            };
 
         public static int GetCountMax(int level)
         {
@@ -76,40 +22,69 @@ namespace Nekoyume.Battle
                 : CountMaxUpperLimit;
         }
 
-        public static decimal GetDamageMultiplier(int attackCount, int attackCountMax)
+        public static int GetDamageMultiplier(int attackCount, int attackCountMax)
         {
             if (attackCount > attackCountMax)
                 throw new ArgumentOutOfRangeException(
                     $"{nameof(attackCount)}: {attackCount} / {nameof(attackCountMax)}: {attackCountMax}");
 
-            var info = GetInfo(attackCount, attackCountMax);
-            return info.DamageMultiplier;
+            if (attackCountMax <= 5)
+            {
+                return Math.Max(1, attackCount);
+            }
+
+            throw new ArgumentOutOfRangeException();
         }
 
-        public static decimal GetAdditionalCriticalChance(int attackCount, int attackCountMax)
+        public static int GetAdditionalCriticalChance(int attackCount, int attackCountMax)
         {
             if (attackCount > attackCountMax)
                 throw new ArgumentOutOfRangeException(
                     $"{nameof(attackCount)}: {attackCount} / {nameof(attackCountMax)}: {attackCountMax}");
+            switch (attackCount)
+            {
+                case 1:
+                    return 0;
+                case 2:
+                    switch (attackCountMax)
+                    {
+                        case 2:
+                            return 25;
+                        case 3:
+                        case 4:
+                        case 5:
+                            return 10;
+                    }
+                    break;
+                case 3:
+                    switch (attackCountMax)
+                    {
+                        case 3:
+                            return 35;
+                        case 4:
+                        case 5:
+                            return 20;
+                    }
+                    break;
+                case 4:
+                    switch (attackCountMax)
+                    {
+                        case 4:
+                            return 45;
+                        case 5:
+                            return 30;
+                    }
+                    break;
+                case 5:
+                    switch (attackCountMax)
+                    {
+                        case 5:
+                            return 55;
+                    }
+                    break;
+            }
 
-            var info = GetInfo(attackCount, attackCountMax);
-            return info.AdditionalCriticalChance;
-        }
-
-        private static Info GetInfo(int attackCount, int attackCountMax)
-        {
-            if (attackCount > attackCountMax)
-                throw new ArgumentOutOfRangeException(
-                    $"{nameof(attackCount)}: {attackCount} / {nameof(attackCountMax)}: {attackCountMax}");
-
-            if (!CachedInfo.ContainsKey(attackCountMax))
-                throw new ArgumentOutOfRangeException($"{nameof(attackCountMax)}: {attackCountMax}");
-
-            if (!CachedInfo[attackCountMax].ContainsKey(attackCount))
-                throw new ArgumentOutOfRangeException(
-                    $"{nameof(attackCountMax)}: {attackCountMax} / {nameof(attackCount)}: {attackCount}");
-
-            return CachedInfo[attackCountMax][attackCount];
+            throw new ArgumentOutOfRangeException();
         }
     }
 }

--- a/Lib9c/Battle/HitHelper.cs
+++ b/Lib9c/Battle/HitHelper.cs
@@ -64,101 +64,52 @@ namespace Nekoyume.Battle
 
         public static int GetHitStep1(int attackerLevel, int defenderLevel)
         {
-            var correction = 0;
             var diff = attackerLevel - defenderLevel;
 
             if (diff <= GetHitStep1LevelDiffMin)
             {
-                correction = GetHitStep1CorrectionMin;
-            }
-            else if (diff >= GetHitStep1LevelDiffMax)
-            {
-                correction = GetHitStep1CorrectionMax;
-            }
-            else
-            {
-                switch (diff)
-                {
-                    case -13:
-                        correction = -4;
-                        break;
-                    case -12:
-                        correction = -3;
-                        break;
-                    case -11:
-                        correction = -2;
-                        break;
-                    case -10:
-                        correction = -1;
-                        break;
-                    case -9:
-                        correction = 0;
-                        break;
-                    case -8:
-                        correction = 1;
-                        break;
-                    case -7:
-                        correction = 2;
-                        break;
-                    case -6:
-                        correction = 4;
-                        break;
-                    case -5:
-                        correction = 6;
-                        break;
-                    case -4:
-                        correction = 8;
-                        break;
-                    case -3:
-                        correction = 13;
-                        break;
-                    case -2:
-                        correction = 20;
-                        break;
-                    case -1:
-                        correction = 28;
-                        break;
-                    case 0:
-                        correction = 40;
-                        break;
-                    case 1:
-                        correction = 41;
-                        break;
-                    case 2:
-                        correction = 42;
-                        break;
-                    case 3:
-                        correction = 43;
-                        break;
-                    case 4:
-                        correction = 44;
-                        break;
-                    case 5:
-                        correction = 45;
-                        break;
-                    case 6:
-                        correction = 46;
-                        break;
-                    case 7:
-                        correction = 47;
-                        break;
-                    case 8:
-                        correction = 48;
-                        break;
-                    case 9:
-                        correction = 49;
-                        break;
-                }
+                return GetHitStep1CorrectionMin;
             }
 
-            return correction;
+            if (diff >= GetHitStep1LevelDiffMax)
+            {
+                return GetHitStep1CorrectionMax;
+            }
+
+            return diff switch
+            {
+                -13 => -4,
+                -12 => -3,
+                -11 => -2,
+                -10 => -1,
+                -9 => 0,
+                -8 => 1,
+                -7 => 2,
+                -6 => 4,
+                -5 => 6,
+                -4 => 8,
+                -3 => 13,
+                -2 => 20,
+                -1 => 28,
+                0 => 40,
+                1 => 41,
+                2 => 42,
+                3 => 43,
+                4 => 44,
+                5 => 45,
+                6 => 46,
+                7 => 47,
+                8 => 48,
+                9 => 49,
+                _ => 0
+            };
         }
 
         public static int GetHitStep2(int attackerHit, int defenderHit)
         {
             attackerHit = Math.Max(1, attackerHit);
             defenderHit = Math.Max(1, defenderHit);
-            var additionalCorrection = (int) ((attackerHit - defenderHit / 3m) / defenderHit * 100);
+            var additionalCorrection = (attackerHit * 100 - defenderHit * 100 / 3) / defenderHit;
             return Math.Min(Math.Max(additionalCorrection, GetHitStep2AdditionalCorrectionMin),
                 GetHitStep2AdditionalCorrectionMax);
         }

--- a/Lib9c/Battle/HitHelper.cs
+++ b/Lib9c/Battle/HitHelper.cs
@@ -109,7 +109,7 @@ namespace Nekoyume.Battle
         {
             attackerHit = Math.Max(1, attackerHit);
             defenderHit = Math.Max(1, defenderHit);
-            var additionalCorrection = (attackerHit * 100 - defenderHit * 100 / 3) / defenderHit;
+            var additionalCorrection = (attackerHit * 10000 - defenderHit * 10000 / 3) / defenderHit / 100;
             return Math.Min(Math.Max(additionalCorrection, GetHitStep2AdditionalCorrectionMin),
                 GetHitStep2AdditionalCorrectionMax);
         }

--- a/Lib9c/Battle/ISimulator.cs
+++ b/Lib9c/Battle/ISimulator.cs
@@ -14,5 +14,6 @@ namespace Nekoyume.Battle
         IEnumerable<ItemBase> Reward { get; }
         int WaveNumber { get; }
         int WaveTurn { get; }
+        bool LogEvent { get; }
     }
 }

--- a/Lib9c/Battle/RaidBoss.cs
+++ b/Lib9c/Battle/RaidBoss.cs
@@ -104,7 +104,8 @@ namespace Nekoyume.Model
                     Simulator.StatBuffSheet,
                     Simulator.SkillActionBuffSheet,
                     Simulator.ActionBuffSheet
-                )
+                ),
+                false
             );
 
             Simulator.Log.Add(usedSkill);
@@ -145,16 +146,17 @@ namespace Nekoyume.Model
                     Simulator.StatBuffSheet,
                     Simulator.SkillActionBuffSheet,
                     Simulator.ActionBuffSheet
-                )
+                ),
+                false
             );
 
             Simulator.Log.Add(usedSkill);
             foreach (var info in usedSkill.SkillInfos)
             {
-                if (!info.Target.IsDead)
+                if (!info.IsDead)
                     continue;
 
-                var target = Targets.FirstOrDefault(i => i.Id == info.Target.Id);
+                var target = Targets.FirstOrDefault(i => i.Id == info.Id);
                 target?.Die();
             }
         }

--- a/Lib9c/Battle/RaidBoss.cs
+++ b/Lib9c/Battle/RaidBoss.cs
@@ -105,7 +105,7 @@ namespace Nekoyume.Model
                     Simulator.SkillActionBuffSheet,
                     Simulator.ActionBuffSheet
                 ),
-                false
+                Simulator.LogEvent
             );
 
             Simulator.Log.Add(usedSkill);
@@ -147,7 +147,7 @@ namespace Nekoyume.Model
                     Simulator.SkillActionBuffSheet,
                     Simulator.ActionBuffSheet
                 ),
-                false
+                Simulator.LogEvent
             );
 
             Simulator.Log.Add(usedSkill);
@@ -156,7 +156,7 @@ namespace Nekoyume.Model
                 if (!info.IsDead)
                     continue;
 
-                var target = Targets.FirstOrDefault(i => i.Id == info.Id);
+                var target = Targets.FirstOrDefault(i => i.Id == info.CharacterId);
                 target?.Die();
             }
         }

--- a/Lib9c/Battle/Simulator.cs
+++ b/Lib9c/Battle/Simulator.cs
@@ -33,14 +33,14 @@ namespace Nekoyume.Battle
         public int WaveNumber { get; protected set; }
         public int WaveTurn { get; set; }
         public abstract IEnumerable<ItemBase> Reward { get; }
+        public bool LogEvent { get; protected set; }
 
-        protected Simulator(
-            IRandom random,
+        protected Simulator(IRandom random,
             AvatarState avatarState,
             List<Guid> foods,
-            SimulatorSheetsV1 simulatorSheets
-        ) : this(random, new Player(avatarState, simulatorSheets), foods, simulatorSheets)
+            SimulatorSheetsV1 simulatorSheets, bool logEvent = true) : this(random, new Player(avatarState, simulatorSheets), foods, simulatorSheets)
         {
+            LogEvent = logEvent;
         }
 
         protected Simulator(

--- a/Lib9c/Battle/StageSimulator.cs
+++ b/Lib9c/Battle/StageSimulator.cs
@@ -128,7 +128,7 @@ namespace Nekoyume.Battle
                         ActionBuffSheet
                     );
 
-                    skill.Use(Player, 0, buffs);
+                    skill.Use(Player, 0, buffs, log);
                 }
 
                 while (true)

--- a/Lib9c/Battle/StageSimulator.cs
+++ b/Lib9c/Battle/StageSimulator.cs
@@ -13,6 +13,7 @@ using Nekoyume.Model.State;
 using Nekoyume.Model.Buff;
 using Nekoyume.TableData;
 using Priority_Queue;
+using Skill = Nekoyume.Model.Skill.Skill;
 
 namespace Nekoyume.Battle
 {
@@ -32,12 +33,11 @@ namespace Nekoyume.Battle
         private int TurnLimit { get; }
         public override IEnumerable<ItemBase> Reward => _waveRewards;
 
-        public StageSimulator(
-            IRandom random,
+        public StageSimulator(IRandom random,
             AvatarState avatarState,
             List<Guid> foods,
             List<RuneState> runeStates,
-            List<Model.Skill.Skill> skillsOnWaveStart,
+            List<Skill> skillsOnWaveStart,
             int worldId,
             int stageId,
             StageSheet.Row stageRow,
@@ -47,12 +47,14 @@ namespace Nekoyume.Battle
             SimulatorSheets simulatorSheets,
             EnemySkillSheet enemySkillSheet,
             CostumeStatSheet costumeStatSheet,
-            List<ItemBase> waveRewards)
+            List<ItemBase> waveRewards,
+            bool logEvent = true)
             : base(
                 random,
                 avatarState,
                 foods,
-                simulatorSheets)
+                simulatorSheets,
+                logEvent)
         {
             Player.SetCostumeStat(costumeStatSheet);
             if (runeStates != null)
@@ -99,7 +101,7 @@ namespace Nekoyume.Battle
             return waveRewards;
         }
 
-        public Player Simulate(bool log = false)
+        public Player Simulate()
         {
             Log.worldId = WorldId;
             Log.stageId = StageId;
@@ -128,7 +130,7 @@ namespace Nekoyume.Battle
                         ActionBuffSheet
                     );
 
-                    skill.Use(Player, 0, buffs, log);
+                    skill.Use(Player, 0, buffs, LogEvent);
                 }
 
                 while (true)
@@ -141,7 +143,7 @@ namespace Nekoyume.Battle
                             Result = BattleLog.Result.Lose;
                             if (Exp > 0)
                             {
-                                Player.GetExp((int)(Exp * 0.3m), log);
+                                Player.GetExp((int)(Exp * 0.3m), LogEvent);
                             }
                         }
                         else
@@ -168,7 +170,7 @@ namespace Nekoyume.Battle
                             Result = BattleLog.Result.Lose;
                             if (Exp > 0)
                             {
-                                Player.GetExp((int)(Exp * 0.3m), log);
+                                Player.GetExp((int)(Exp * 0.3m), LogEvent);
                             }
                         }
                         else
@@ -191,7 +193,7 @@ namespace Nekoyume.Battle
                             {
                                 if (Exp > 0)
                                 {
-                                    Player.GetExp(Exp, log);
+                                    Player.GetExp(Exp, LogEvent);
                                 }
 
                                 break;
@@ -199,7 +201,7 @@ namespace Nekoyume.Battle
                             case 2:
                             {
                                 ItemMap = Player.GetRewards(_waveRewards);
-                                if (log)
+                                if (LogEvent)
                                 {
                                     var dropBox = new DropBox(null, _waveRewards);
                                     Log.Add(dropBox);

--- a/Lib9c/Battle/StageSimulator.cs
+++ b/Lib9c/Battle/StageSimulator.cs
@@ -99,7 +99,7 @@ namespace Nekoyume.Battle
             return waveRewards;
         }
 
-        public Player Simulate()
+        public Player Simulate(bool log = false)
         {
             Log.worldId = WorldId;
             Log.stageId = StageId;
@@ -128,8 +128,7 @@ namespace Nekoyume.Battle
                         ActionBuffSheet
                     );
 
-                    var usedSkill = skill.Use(Player, 0, buffs);
-                    Log.Add(usedSkill);
+                    skill.Use(Player, 0, buffs);
                 }
 
                 while (true)
@@ -142,7 +141,7 @@ namespace Nekoyume.Battle
                             Result = BattleLog.Result.Lose;
                             if (Exp > 0)
                             {
-                                Player.GetExp((int)(Exp * 0.3m), true);
+                                Player.GetExp((int)(Exp * 0.3m), log);
                             }
                         }
                         else
@@ -169,7 +168,7 @@ namespace Nekoyume.Battle
                             Result = BattleLog.Result.Lose;
                             if (Exp > 0)
                             {
-                                Player.GetExp((int)(Exp * 0.3m), true);
+                                Player.GetExp((int)(Exp * 0.3m), log);
                             }
                         }
                         else
@@ -192,7 +191,7 @@ namespace Nekoyume.Battle
                             {
                                 if (Exp > 0)
                                 {
-                                    Player.GetExp(Exp, true);
+                                    Player.GetExp(Exp, log);
                                 }
 
                                 break;
@@ -200,10 +199,13 @@ namespace Nekoyume.Battle
                             case 2:
                             {
                                 ItemMap = Player.GetRewards(_waveRewards);
-                                var dropBox = new DropBox(null, _waveRewards);
-                                Log.Add(dropBox);
-                                var getReward = new GetReward(null, _waveRewards);
-                                Log.Add(getReward);
+                                if (log)
+                                {
+                                    var dropBox = new DropBox(null, _waveRewards);
+                                    Log.Add(dropBox);
+                                    var getReward = new GetReward(null, _waveRewards);
+                                    Log.Add(getReward);
+                                }
                                 break;
                             }
                             default:

--- a/Lib9c/Battle/StageSimulatorV1.cs
+++ b/Lib9c/Battle/StageSimulatorV1.cs
@@ -301,7 +301,7 @@ namespace Nekoyume.Battle
         {
             Player.SetCostumeStat(costumeStatSheet);
         }
-        
+
         public Player Simulate(int playCount)
         {
             Log.worldId = WorldId;
@@ -331,7 +331,7 @@ namespace Nekoyume.Battle
                         ActionBuffSheet
                     );
 
-                    var usedSkill = skill.Use(Player, 0, buffs);
+                    var usedSkill = skill.Use(Player, 0, buffs, false);
                     Log.Add(usedSkill);
                 }
 

--- a/Lib9c/Battle/StageSimulatorV1.cs
+++ b/Lib9c/Battle/StageSimulatorV1.cs
@@ -331,7 +331,7 @@ namespace Nekoyume.Battle
                         ActionBuffSheet
                     );
 
-                    var usedSkill = skill.Use(Player, 0, buffs, false);
+                    var usedSkill = skill.Use(Player, 0, buffs, LogEvent);
                     Log.Add(usedSkill);
                 }
 

--- a/Lib9c/Battle/StageSimulatorV2.cs
+++ b/Lib9c/Battle/StageSimulatorV2.cs
@@ -122,7 +122,7 @@ namespace Nekoyume.Battle
                         ActionBuffSheet
                     );
 
-                    var usedSkill = skill.Use(Player, 0, buffs);
+                    var usedSkill = skill.Use(Player, 0, buffs, false);
                     Log.Add(usedSkill);
                 }
 

--- a/Lib9c/Battle/StageSimulatorV2.cs
+++ b/Lib9c/Battle/StageSimulatorV2.cs
@@ -122,7 +122,7 @@ namespace Nekoyume.Battle
                         ActionBuffSheet
                     );
 
-                    var usedSkill = skill.Use(Player, 0, buffs, false);
+                    var usedSkill = skill.Use(Player, 0, buffs, LogEvent);
                     Log.Add(usedSkill);
                 }
 

--- a/Lib9c/Battle/StageSimulatorV3.cs
+++ b/Lib9c/Battle/StageSimulatorV3.cs
@@ -128,7 +128,7 @@ namespace Nekoyume.Battle
                         ActionBuffSheet
                     );
 
-                    var usedSkill = skill.Use(Player, 0, buffs);
+                    var usedSkill = skill.Use(Player, 0, buffs, false);
                     Log.Add(usedSkill);
                 }
 

--- a/Lib9c/Battle/StageSimulatorV3.cs
+++ b/Lib9c/Battle/StageSimulatorV3.cs
@@ -128,7 +128,7 @@ namespace Nekoyume.Battle
                         ActionBuffSheet
                     );
 
-                    var usedSkill = skill.Use(Player, 0, buffs, false);
+                    var usedSkill = skill.Use(Player, 0, buffs, LogEvent);
                     Log.Add(usedSkill);
                 }
 

--- a/Lib9c/Battle/Wave.cs
+++ b/Lib9c/Battle/Wave.cs
@@ -25,9 +25,12 @@ namespace Nekoyume.Battle
                 enemy.InitAI();
             }
 
-            // var enemies = _enemies.Select(enemy => new Enemy(enemy)).ToList();
-            // var spawnWave = new SpawnWave(null, simulator.WaveNumber, simulator.WaveTurn, enemies, HasBoss);
-            // simulator.Log.Add(spawnWave);
+            if (simulator.LogEvent)
+            {
+                var enemies = _enemies.Select(enemy => new Enemy(enemy)).ToList();
+                var spawnWave = new SpawnWave(null, simulator.WaveNumber, simulator.WaveTurn, enemies, HasBoss);
+                simulator.Log.Add(spawnWave);
+            }
         }
 
         [Obsolete("Use Spawn")]

--- a/Lib9c/Battle/Wave.cs
+++ b/Lib9c/Battle/Wave.cs
@@ -25,9 +25,9 @@ namespace Nekoyume.Battle
                 enemy.InitAI();
             }
 
-            var enemies = _enemies.Select(enemy => new Enemy(enemy)).ToList();
-            var spawnWave = new SpawnWave(null, simulator.WaveNumber, simulator.WaveTurn, enemies, HasBoss);
-            simulator.Log.Add(spawnWave);
+            // var enemies = _enemies.Select(enemy => new Enemy(enemy)).ToList();
+            // var spawnWave = new SpawnWave(null, simulator.WaveNumber, simulator.WaveTurn, enemies, HasBoss);
+            // simulator.Log.Add(spawnWave);
         }
 
         [Obsolete("Use Spawn")]

--- a/Lib9c/Model/BattleStatus/Skill.cs
+++ b/Lib9c/Model/BattleStatus/Skill.cs
@@ -12,22 +12,26 @@ namespace Nekoyume.Model.BattleStatus
         [Serializable]
         public class SkillInfo
         {
-            public readonly CharacterBase Target;
             public readonly int Effect;
             public readonly bool Critical;
             public readonly SkillCategory SkillCategory;
             public readonly ElementalType ElementalType;
             public readonly SkillTargetType SkillTargetType;
             public readonly int WaveTurn;
+            public readonly int Thorn;
+            public readonly bool IsDead;
+            public readonly Guid Id;
 
-            
+
             public readonly Model.Buff.Buff? Buff;
 
-            public SkillInfo(CharacterBase character, int effect, bool critical, SkillCategory skillCategory,
+            public SkillInfo(Guid id, bool isDead, int thorn, int effect, bool critical, SkillCategory skillCategory,
                 int waveTurn, ElementalType elementalType = ElementalType.Normal,
                 SkillTargetType targetType = SkillTargetType.Enemy, Model.Buff.Buff? buff = null)
             {
-                Target = character;
+                Id = id;
+                IsDead = isDead;
+                Thorn = thorn;
                 Effect = effect;
                 Critical = critical;
                 SkillCategory = skillCategory;
@@ -42,7 +46,7 @@ namespace Nekoyume.Model.BattleStatus
 
         public readonly IEnumerable<SkillInfo> SkillInfos;
 
-        
+
         public readonly IEnumerable<SkillInfo>? BuffInfos;
 
         protected Skill(int skillId, CharacterBase character, IEnumerable<SkillInfo> skillInfos,

--- a/Lib9c/Model/BattleStatus/Skill.cs
+++ b/Lib9c/Model/BattleStatus/Skill.cs
@@ -12,6 +12,7 @@ namespace Nekoyume.Model.BattleStatus
         [Serializable]
         public class SkillInfo
         {
+            public readonly CharacterBase? Target;
             public readonly int Effect;
             public readonly bool Critical;
             public readonly SkillCategory SkillCategory;
@@ -20,16 +21,16 @@ namespace Nekoyume.Model.BattleStatus
             public readonly int WaveTurn;
             public readonly int Thorn;
             public readonly bool IsDead;
-            public readonly Guid Id;
+            public readonly Guid CharacterId;
 
 
             public readonly Model.Buff.Buff? Buff;
 
-            public SkillInfo(Guid id, bool isDead, int thorn, int effect, bool critical, SkillCategory skillCategory,
+            public SkillInfo(Guid characterId, bool isDead, int thorn, int effect, bool critical, SkillCategory skillCategory,
                 int waveTurn, ElementalType elementalType = ElementalType.Normal,
-                SkillTargetType targetType = SkillTargetType.Enemy, Model.Buff.Buff? buff = null)
+                SkillTargetType targetType = SkillTargetType.Enemy, Model.Buff.Buff? buff = null, CharacterBase? target = null)
             {
-                Id = id;
+                CharacterId = characterId;
                 IsDead = isDead;
                 Thorn = thorn;
                 Effect = effect;
@@ -39,6 +40,7 @@ namespace Nekoyume.Model.BattleStatus
                 SkillTargetType = targetType;
                 Buff = buff;
                 WaveTurn = waveTurn;
+                Target = target;
             }
         }
 

--- a/Lib9c/Model/Buff/Bleed.cs
+++ b/Lib9c/Model/Buff/Bleed.cs
@@ -41,7 +41,7 @@ namespace Nekoyume.Model.Buff
 
             var damageInfos = new List<BattleStatus.Skill.SkillInfo>
             {
-                new BattleStatus.Skill.SkillInfo((CharacterBase)affectedCharacter.Clone(), damage, false,
+                new BattleStatus.Skill.SkillInfo(affectedCharacter.Id, affectedCharacter.IsDead, affectedCharacter.Thorn, damage, false,
                     SkillCategory.Debuff, simulatorWaveTurn, RowData.ElementalType,
                     RowData.TargetType)
             };

--- a/Lib9c/Model/Buff/Bleed.cs
+++ b/Lib9c/Model/Buff/Bleed.cs
@@ -41,9 +41,10 @@ namespace Nekoyume.Model.Buff
 
             var damageInfos = new List<BattleStatus.Skill.SkillInfo>
             {
+                // Copy new Character with damaged.
                 new BattleStatus.Skill.SkillInfo(affectedCharacter.Id, affectedCharacter.IsDead, affectedCharacter.Thorn, damage, false,
                     SkillCategory.Debuff, simulatorWaveTurn, RowData.ElementalType,
-                    RowData.TargetType)
+                    RowData.TargetType, target: (CharacterBase)affectedCharacter.Clone())
             };
 
             return new Model.BattleStatus.TickDamage(

--- a/Lib9c/Model/Character/ArenaCharacter.cs
+++ b/Lib9c/Model/Character/ArenaCharacter.cs
@@ -819,7 +819,7 @@ namespace Nekoyume.Model
                 return CRI >= chance;
 
             var additionalCriticalChance =
-                (int) AttackCountHelper.GetAdditionalCriticalChance(_attackCount, _attackCountMax);
+                AttackCountHelper.GetAdditionalCriticalChance(_attackCount, _attackCountMax);
             return CRI + additionalCriticalChance >= chance;
         }
 
@@ -850,7 +850,7 @@ namespace Nekoyume.Model
                 _attackCount = 1;
             }
 
-            var damageMultiplier = (int) AttackCountHelper.GetDamageMultiplier(_attackCount, _attackCountMax);
+            var damageMultiplier = AttackCountHelper.GetDamageMultiplier(_attackCount, _attackCountMax);
             damage *= damageMultiplier;
             return damage;
         }

--- a/Lib9c/Model/Character/CharacterBase.cs
+++ b/Lib9c/Model/Character/CharacterBase.cs
@@ -250,7 +250,8 @@ namespace Nekoyume.Model
                     Simulator.StatBuffSheet,
                     Simulator.SkillActionBuffSheet,
                     Simulator.ActionBuffSheet
-                )
+                ),
+                false
             );
 
             if (!Simulator.SkillSheet.TryGetValue(selectedSkill.SkillRow.Id, out var sheetSkill))
@@ -278,7 +279,8 @@ namespace Nekoyume.Model
                     Simulator.StatBuffSheet,
                     Simulator.SkillActionBuffSheet,
                     Simulator.ActionBuffSheet
-                )
+                ),
+                false
             );
 
             Skills.SetCooldown(selectedSkill.SkillRow.Id, selectedSkill.SkillRow.Cooldown);
@@ -301,7 +303,8 @@ namespace Nekoyume.Model
                     Simulator.StatBuffSheet,
                     Simulator.SkillActionBuffSheet,
                     Simulator.ActionBuffSheet
-                )
+                ),
+                false
             );
 
             Skills.SetCooldown(selectedSkill.SkillRow.Id, selectedSkill.SkillRow.Cooldown);
@@ -566,9 +569,9 @@ namespace Nekoyume.Model
                     skillInfo.SkillCategory == SkillCategory.DoubleAttack ||
                     skillInfo.SkillCategory == SkillCategory.AreaAttack ||
                     skillInfo.SkillCategory == SkillCategory.BuffRemovalAttack;
-                if (isAttackSkill && skillInfo.Target.Thorn > 0)
+                if (isAttackSkill && skillInfo.Thorn > 0)
                 {
-                    var effect = GiveThornDamage(skillInfo.Target.Thorn);
+                    GiveThornDamage(skillInfo.Thorn);
                     // Simulator.Log.Add(effect);
                 }
             }
@@ -582,31 +585,23 @@ namespace Nekoyume.Model
             FinishTargetIfKilled(usedSkill);
         }
 
-        private BattleStatus.Skill GiveThornDamage(int targetThorn)
+        private void GiveThornDamage(int targetThorn)
         {
-            var clone = (CharacterBase)Clone();
+            // var clone = (CharacterBase)Clone();
             // minimum 1 damage
             var thornDamage = Math.Max(1, targetThorn - DEF);
             CurrentHP -= thornDamage;
-            var damageInfos = new List<BattleStatus.Skill.SkillInfo>()
-            {
-                new BattleStatus.Skill.SkillInfo(
-                    (CharacterBase)Clone(),
-                    thornDamage,
-                    false,
-                    SkillCategory.TickDamage,
-                    Simulator.WaveTurn,
-                    ElementalType.Normal,
-                    SkillTargetType.Enemy)
-            };
-
-            var tickDamage = new TickDamage(
-                default,
-                clone,
-                damageInfos,
-                null);
-
-            return tickDamage;
+            // var damageInfos = new List<BattleStatus.Skill.SkillInfo>()
+            // {
+            //     new BattleStatus.Skill.SkillInfo(
+            //         (CharacterBase)Clone(),
+            //         thornDamage,
+            //         false,
+            //         SkillCategory.TickDamage,
+            //         Simulator.WaveTurn,
+            //         ElementalType.Normal,
+            //         SkillTargetType.Enemy)
+            // };
         }
 
         private void FinishTargetIfKilledForBeforeV100310(BattleStatus.Skill usedSkill)
@@ -614,7 +609,7 @@ namespace Nekoyume.Model
             var isFirst = true;
             foreach (var info in usedSkill.SkillInfos)
             {
-                if (!info.Target.IsDead)
+                if (!info.IsDead)
                 {
                     continue;
                 }
@@ -626,7 +621,7 @@ namespace Nekoyume.Model
                 }
 
                 var target = Targets.FirstOrDefault(i =>
-                    i.Id == info.Target.Id);
+                    i.Id == info.Id);
                 switch (target)
                 {
                     case Player player:
@@ -655,12 +650,12 @@ namespace Nekoyume.Model
             var killedTargets = new List<CharacterBase>();
             foreach (var info in usedSkill.SkillInfos)
             {
-                if (!info.Target.IsDead)
+                if (!info.IsDead)
                 {
                     continue;
                 }
 
-                var target = Targets.FirstOrDefault(i => i.Id == info.Target.Id);
+                var target = Targets.FirstOrDefault(i => i.Id == info.Id);
                 if (!killedTargets.Contains(target))
                 {
                     killedTargets.Add(target);

--- a/Lib9c/Model/Character/CharacterBase.cs
+++ b/Lib9c/Model/Character/CharacterBase.cs
@@ -413,7 +413,7 @@ namespace Nekoyume.Model
                 return CRI >= chance;
 
             var additionalCriticalChance =
-                (int) AttackCountHelper.GetAdditionalCriticalChance(AttackCount, AttackCountMax);
+                AttackCountHelper.GetAdditionalCriticalChance(AttackCount, AttackCountMax);
             return CRI + additionalCriticalChance >= chance;
         }
 
@@ -446,7 +446,7 @@ namespace Nekoyume.Model
                 AttackCount = 1;
             }
 
-            var damageMultiplier = (int) AttackCountHelper.GetDamageMultiplier(AttackCount, AttackCountMax);
+            var damageMultiplier = AttackCountHelper.GetDamageMultiplier(AttackCount, AttackCountMax);
             damage *= damageMultiplier;
 
 #if TEST_LOG

--- a/Lib9c/Model/Character/CharacterBase.cs
+++ b/Lib9c/Model/Character/CharacterBase.cs
@@ -225,7 +225,7 @@ namespace Nekoyume.Model
                 pair.Value.RemainedDuration--;
             }
         }
-        
+
         protected virtual void ReduceSkillCooldown()
         {
             Skills.ReduceCooldown();
@@ -259,7 +259,7 @@ namespace Nekoyume.Model
             }
 
             Skills.SetCooldown(selectedSkill.SkillRow.Id, sheetSkill.Cooldown);
-            Simulator.Log.Add(usedSkill);
+            // Simulator.Log.Add(usedSkill);
             return usedSkill;
         }
 
@@ -328,7 +328,7 @@ namespace Nekoyume.Model
                 return;
 
             Stats.SetBuffs(StatBuffs);
-            Simulator.Log.Add(new RemoveBuffs((CharacterBase) Clone()));
+            // Simulator.Log.Add(new RemoveBuffs((CharacterBase) Clone()));
         }
 
         protected virtual void EndTurn()
@@ -465,8 +465,8 @@ namespace Nekoyume.Model
 
         protected virtual void OnDead()
         {
-            var dead = new Dead((CharacterBase) Clone());
-            Simulator.Log.Add(dead);
+            // var dead = new Dead((CharacterBase) Clone());
+            // Simulator.Log.Add(dead);
         }
 
         public void Heal(int heal)
@@ -554,7 +554,7 @@ namespace Nekoyume.Model
             foreach (var bleed in bleeds)
             {
                 var effect = bleed.GiveEffect(this, Simulator.WaveTurn);
-                Simulator.Log.Add(effect);
+                // Simulator.Log.Add(effect);
             }
 
             // Apply thorn damage if target has thorn
@@ -569,7 +569,7 @@ namespace Nekoyume.Model
                 if (isAttackSkill && skillInfo.Target.Thorn > 0)
                 {
                     var effect = GiveThornDamage(skillInfo.Target.Thorn);
-                    Simulator.Log.Add(effect);
+                    // Simulator.Log.Add(effect);
                 }
             }
 

--- a/Lib9c/Model/Character/Player.cs
+++ b/Lib9c/Model/Character/Player.cs
@@ -522,7 +522,8 @@ namespace Nekoyume.Model
                     Simulator.StatBuffSheet,
                     Simulator.SkillActionBuffSheet,
                     Simulator.ActionBuffSheet
-                )
+                ),
+                false
             );
 
             var cooldown = RuneSkillCooldownMap[selectedSkill.SkillRow.Id];

--- a/Lib9c/Model/Character/Player.cs
+++ b/Lib9c/Model/Character/Player.cs
@@ -449,8 +449,11 @@ namespace Nekoyume.Model
         public virtual void Spawn()
         {
             InitAI();
-            // var spawn = new SpawnPlayer((CharacterBase)Clone());
-            // Simulator.Log.Add(spawn);
+            if (Simulator.LogEvent)
+            {
+                var spawn = new SpawnPlayer((CharacterBase)Clone());
+                Simulator.Log.Add(spawn);
+            }
         }
 
         [Obsolete("Use Spawn")]
@@ -512,6 +515,8 @@ namespace Nekoyume.Model
                 return base.UseSkill();
             }
 
+            bool log = Simulator.LogEvent;
+
             var usedSkill = selectedSkill.Use(
                 this,
                 Simulator.WaveTurn,
@@ -523,12 +528,15 @@ namespace Nekoyume.Model
                     Simulator.SkillActionBuffSheet,
                     Simulator.ActionBuffSheet
                 ),
-                false
+                log
             );
 
             var cooldown = RuneSkillCooldownMap[selectedSkill.SkillRow.Id];
             RuneSkills.SetCooldown(selectedSkill.SkillRow.Id, cooldown);
-            // Simulator.Log.Add(usedSkill);
+            if (log)
+            {
+                Simulator.Log.Add(usedSkill);
+            }
             return usedSkill;
         }
 
@@ -673,7 +681,10 @@ namespace Nekoyume.Model
 
             Simulator.TurnNumber++;
             Simulator.WaveTurn++;
-            // Simulator.Log.Add(new WaveTurnEnd(this, Simulator.TurnNumber, Simulator.WaveTurn));
+            if (Simulator.LogEvent)
+            {
+                Simulator.Log.Add(new WaveTurnEnd(this, Simulator.TurnNumber, Simulator.WaveTurn));
+            }
         }
     }
 }

--- a/Lib9c/Model/Character/Player.cs
+++ b/Lib9c/Model/Character/Player.cs
@@ -449,8 +449,8 @@ namespace Nekoyume.Model
         public virtual void Spawn()
         {
             InitAI();
-            var spawn = new SpawnPlayer((CharacterBase)Clone());
-            Simulator.Log.Add(spawn);
+            // var spawn = new SpawnPlayer((CharacterBase)Clone());
+            // Simulator.Log.Add(spawn);
         }
 
         [Obsolete("Use Spawn")]
@@ -527,7 +527,7 @@ namespace Nekoyume.Model
 
             var cooldown = RuneSkillCooldownMap[selectedSkill.SkillRow.Id];
             RuneSkills.SetCooldown(selectedSkill.SkillRow.Id, cooldown);
-            Simulator.Log.Add(usedSkill);
+            // Simulator.Log.Add(usedSkill);
             return usedSkill;
         }
 
@@ -672,7 +672,7 @@ namespace Nekoyume.Model
 
             Simulator.TurnNumber++;
             Simulator.WaveTurn++;
-            Simulator.Log.Add(new WaveTurnEnd(this, Simulator.TurnNumber, Simulator.WaveTurn));
+            // Simulator.Log.Add(new WaveTurnEnd(this, Simulator.TurnNumber, Simulator.WaveTurn));
         }
     }
 }

--- a/Lib9c/Model/Quest/CollectQuest.cs
+++ b/Lib9c/Model/Quest/CollectQuest.cs
@@ -14,7 +14,7 @@ namespace Nekoyume.Model.Quest
 
         public readonly int ItemId;
 
-        public CollectQuest(CollectQuestSheet.Row data, QuestReward reward) 
+        public CollectQuest(CollectQuestSheet.Row data, QuestReward reward)
             : base(data, reward)
         {
             ItemId = data.ItemId;
@@ -54,11 +54,7 @@ namespace Nekoyume.Model.Quest
         }
 
         public override IValue Serialize() =>
-#pragma warning disable LAA1002
-            new Dictionary(new Dictionary<IKey, IValue>
-            {
-                [(Text)"itemId"] = (Integer)ItemId,
-            }.Union((Dictionary)base.Serialize()));
-#pragma warning restore LAA1002
+            ((Dictionary) base.Serialize())
+            .Add("itemId", ItemId);
     }
 }

--- a/Lib9c/Model/Quest/CombinationEquipmentQuest.cs
+++ b/Lib9c/Model/Quest/CombinationEquipmentQuest.cs
@@ -58,14 +58,9 @@ namespace Nekoyume.Model.Quest
 
         public override IValue Serialize()
         {
-            var dict = new Dictionary<IKey, IValue>
-            {
-                [(Text) "recipe_id"] = RecipeId.Serialize(),
-                [(Text) "stage_id"] = StageId.Serialize(),
-            };
-#pragma warning disable LAA1002
-            return new Dictionary(dict.Union((Dictionary) base.Serialize()));
-#pragma warning restore LAA1002
+            return ((Dictionary) base.Serialize())
+                .Add("recipe_id", RecipeId.Serialize())
+                .Add("stage_id", StageId.Serialize());
         }
     }
 }

--- a/Lib9c/Model/Quest/CombinationQuest.cs
+++ b/Lib9c/Model/Quest/CombinationQuest.cs
@@ -16,7 +16,7 @@ namespace Nekoyume.Model.Quest
 
         public override QuestType QuestType => QuestType.Craft;
 
-        public CombinationQuest(CombinationQuestSheet.Row data, QuestReward reward) 
+        public CombinationQuest(CombinationQuestSheet.Row data, QuestReward reward)
             : base(data, reward)
         {
             ItemType = data.ItemType;
@@ -58,13 +58,8 @@ namespace Nekoyume.Model.Quest
         }
 
         public override IValue Serialize() =>
-#pragma warning disable LAA1002
-            new Dictionary(new Dictionary<IKey, IValue>
-            {
-                [(Text)"itemType"] = (Integer)(int)ItemType,
-                [(Text)"itemSubType"] = (Integer)(int)ItemSubType,
-            }.Union((Dictionary)base.Serialize()));
-#pragma warning restore LAA1002
-
+            ((Dictionary) base.Serialize())
+            .Add("itemType", (int) ItemType)
+            .Add("itemSubType", (int) ItemSubType);
     }
 }

--- a/Lib9c/Model/Quest/GeneralQuest.cs
+++ b/Lib9c/Model/Quest/GeneralQuest.cs
@@ -74,12 +74,8 @@ namespace Nekoyume.Model.Quest
         }
 
         public override IValue Serialize() =>
-#pragma warning disable LAA1002
-            new Dictionary(new Dictionary<IKey, IValue>
-            {
-                [(Text)"event"] = (Integer)(int)Event,
-            }.Union((Dictionary)base.Serialize()));
-#pragma warning restore LAA1002
+            ((Dictionary) base.Serialize())
+            .Add("event", (int) Event);
 
     }
 }

--- a/Lib9c/Model/Quest/GoldQuest.cs
+++ b/Lib9c/Model/Quest/GoldQuest.cs
@@ -62,12 +62,7 @@ namespace Nekoyume.Model.Quest
         }
 
         public override IValue Serialize() =>
-#pragma warning disable LAA1002
-            new Dictionary(new Dictionary<IKey, IValue>
-            {
-                [(Text)"type"] = (Integer)(int)Type,
-            }.Union((Dictionary)base.Serialize()));
-#pragma warning restore LAA1002
-
+            ((Dictionary) base.Serialize())
+            .Add("type", (int) Type);
     }
 }

--- a/Lib9c/Model/Quest/ItemEnhancementQuest.cs
+++ b/Lib9c/Model/Quest/ItemEnhancementQuest.cs
@@ -16,7 +16,7 @@ namespace Nekoyume.Model.Quest
         public int Count => _count;
         public override float Progress => (float) _current / _count;
 
-        public ItemEnhancementQuest(ItemEnhancementQuestSheet.Row data, QuestReward reward) 
+        public ItemEnhancementQuest(ItemEnhancementQuestSheet.Row data, QuestReward reward)
             : base(data, reward)
         {
             _count = data.Count;
@@ -63,13 +63,8 @@ namespace Nekoyume.Model.Quest
         protected override string TypeId => "itemEnhancementQuest";
 
         public override IValue Serialize() =>
-#pragma warning disable LAA1002
-            new Dictionary(new Dictionary<IKey, IValue>
-            {
-                [(Text)"grade"] = (Integer)Grade,
-                [(Text)"count"] = (Integer)_count,
-            }.Union((Dictionary)base.Serialize()));
-#pragma warning restore LAA1002
-
+            ((Dictionary) base.Serialize())
+            .Add("grade", Grade)
+            .Add("count", _count);
     }
 }

--- a/Lib9c/Model/Quest/ItemGradeQuest.cs
+++ b/Lib9c/Model/Quest/ItemGradeQuest.cs
@@ -14,7 +14,7 @@ namespace Nekoyume.Model.Quest
     {
         public readonly int Grade;
         public readonly List<int> ItemIds = new List<int>();
-        public ItemGradeQuest(ItemGradeQuestSheet.Row data, QuestReward reward) 
+        public ItemGradeQuest(ItemGradeQuestSheet.Row data, QuestReward reward)
             : base(data, reward)
         {
             Grade = data.Grade;
@@ -62,13 +62,9 @@ namespace Nekoyume.Model.Quest
         protected override string TypeId => "itemGradeQuest";
 
         public override IValue Serialize() =>
-#pragma warning disable LAA1002
-            new Dictionary(new Dictionary<IKey, IValue>
-            {
-                [(Text)"grade"] = Grade.Serialize(),
-                [(Text)"itemIds"] = new List(ItemIds.OrderBy(i => i).Select(i => i.Serialize())),
-            }.Union((Dictionary)base.Serialize()));
-#pragma warning restore LAA1002
+            ((Dictionary)base.Serialize())
+            .Add("grade", Grade.Serialize())
+            .Add("itemIds", new List(ItemIds.OrderBy(i => i).Select(i => i.Serialize())));
 
     }
 }

--- a/Lib9c/Model/Quest/ItemTypeCollectQuest.cs
+++ b/Lib9c/Model/Quest/ItemTypeCollectQuest.cs
@@ -15,7 +15,7 @@ namespace Nekoyume.Model.Quest
         public readonly ItemType ItemType;
         public readonly List<int> ItemIds = new List<int>();
 
-        public ItemTypeCollectQuest(ItemTypeCollectQuestSheet.Row data, QuestReward reward) 
+        public ItemTypeCollectQuest(ItemTypeCollectQuestSheet.Row data, QuestReward reward)
             : base(data, reward)
         {
             ItemType = data.ItemType;
@@ -64,13 +64,9 @@ namespace Nekoyume.Model.Quest
         protected override string TypeId => "itemTypeCollectQuest";
 
         public override IValue Serialize() =>
-#pragma warning disable LAA1002
-            new Dictionary(new Dictionary<IKey, IValue>
-            {
-                [(Text)"itemType"] = ItemType.Serialize(),
-                [(Text)"itemIds"] = new List(ItemIds.OrderBy(i => i).Select(i => i.Serialize())),
-            }.Union((Dictionary)base.Serialize()));
-#pragma warning restore LAA1002
+            ((Dictionary) base.Serialize())
+            .Add("itemType", ItemType.Serialize())
+            .Add("itemIds", new List(ItemIds.OrderBy(i => i).Select(i => i.Serialize())));
 
     }
 }

--- a/Lib9c/Model/Quest/MonsterQuest.cs
+++ b/Lib9c/Model/Quest/MonsterQuest.cs
@@ -12,7 +12,7 @@ namespace Nekoyume.Model.Quest
     {
         public readonly int MonsterId;
 
-        public MonsterQuest(MonsterQuestSheet.Row data, QuestReward reward) 
+        public MonsterQuest(MonsterQuestSheet.Row data, QuestReward reward)
             : base(data, reward)
         {
             MonsterId = data.MonsterId;
@@ -54,11 +54,7 @@ namespace Nekoyume.Model.Quest
         }
 
         public override IValue Serialize() =>
-#pragma warning disable LAA1002
-            new Dictionary(new Dictionary<IKey, IValue>
-            {
-                [(Text)"monsterId"] = (Integer)MonsterId,
-            }.Union((Dictionary)base.Serialize()));
-#pragma warning restore LAA1002
+            ((Dictionary) base.Serialize())
+            .Add("monsterId", MonsterId);
     }
 }

--- a/Lib9c/Model/Quest/Quest.cs
+++ b/Lib9c/Model/Quest/Quest.cs
@@ -82,16 +82,14 @@ namespace Nekoyume.Model.Quest
         public abstract string GetProgressText();
 
         public virtual IValue Serialize() =>
-            new Dictionary(new Dictionary<IKey, IValue>
-            {
-                [(Text) "typeId"] = (Text) TypeId,
-                [(Text) "complete"] = new Bencodex.Types.Boolean(Complete),
-                [(Text) "goal"] = (Integer) Goal,
-                [(Text) "current"] = (Integer) _current,
-                [(Text) "id"] = (Integer) Id,
-                [(Text) "reward"] = Reward.Serialize(),
-                [(Text) "isPaidInAction"] = new Bencodex.Types.Boolean(IsPaidInAction),
-            });
+            Dictionary.Empty
+                .Add("typeId", (Text) TypeId)
+                .Add("complete", new Bencodex.Types.Boolean(Complete))
+                .Add("goal", (Integer) Goal)
+                .Add("current", (Integer) _current)
+                .Add("id", (Integer) Id)
+                .Add("reward", Reward.Serialize())
+                .Add("isPaidInAction", new Bencodex.Types.Boolean(IsPaidInAction));
 
         public static Quest Deserialize(Dictionary serialized)
         {

--- a/Lib9c/Model/Quest/TradeQuest.cs
+++ b/Lib9c/Model/Quest/TradeQuest.cs
@@ -14,7 +14,7 @@ namespace Nekoyume.Model.Quest
         public override QuestType QuestType => QuestType.Exchange;
         public readonly TradeType Type;
 
-        public TradeQuest(TradeQuestSheet.Row data, QuestReward reward) 
+        public TradeQuest(TradeQuestSheet.Row data, QuestReward reward)
             : base(data, reward)
         {
             Type = data.Type;
@@ -45,11 +45,7 @@ namespace Nekoyume.Model.Quest
 
         protected override string TypeId => "tradeQuest";
         public override IValue Serialize() =>
-#pragma warning disable LAA1002
-            new Dictionary(new Dictionary<IKey, IValue>
-            {
-                [(Text)"type"] = (Integer)(int)Type,
-            }.Union((Dictionary)base.Serialize()));
-#pragma warning restore LAA1002
+            ((Dictionary) base.Serialize())
+            .Add("type", (int) Type);
     }
 }

--- a/Lib9c/Model/Skill/AreaAttack.cs
+++ b/Lib9c/Model/Skill/AreaAttack.cs
@@ -17,12 +17,11 @@ namespace Nekoyume.Model.Skill
         {
         }
 
-        public override Model.BattleStatus.Skill Use(
-            CharacterBase caster, 
-            int simulatorWaveTurn, 
-            IEnumerable<Buff.Buff> buffs)
+        public override BattleStatus.Skill Use(CharacterBase caster,
+            int simulatorWaveTurn,
+            IEnumerable<Buff.Buff> buffs, bool b)
         {
-            var clone = (CharacterBase) caster.Clone();
+            var clone = b ? (CharacterBase) caster.Clone() : null;
             var damage = ProcessDamage(caster, simulatorWaveTurn);
             var buff = ProcessBuff(caster, simulatorWaveTurn, buffs);
 

--- a/Lib9c/Model/Skill/AreaAttack.cs
+++ b/Lib9c/Model/Skill/AreaAttack.cs
@@ -22,7 +22,7 @@ namespace Nekoyume.Model.Skill
             IEnumerable<Buff.Buff> buffs, bool copyCharacter)
         {
             var clone = copyCharacter ? (CharacterBase) caster.Clone() : null;
-            var damage = ProcessDamage(caster, simulatorWaveTurn);
+            var damage = ProcessDamage(caster, simulatorWaveTurn, copyCharacter: copyCharacter);
             var buff = ProcessBuff(caster, simulatorWaveTurn, buffs);
 
             return new Model.BattleStatus.AreaAttack(SkillRow.Id, clone, damage, buff);

--- a/Lib9c/Model/Skill/AreaAttack.cs
+++ b/Lib9c/Model/Skill/AreaAttack.cs
@@ -19,9 +19,9 @@ namespace Nekoyume.Model.Skill
 
         public override BattleStatus.Skill Use(CharacterBase caster,
             int simulatorWaveTurn,
-            IEnumerable<Buff.Buff> buffs, bool b)
+            IEnumerable<Buff.Buff> buffs, bool copyCharacter)
         {
-            var clone = b ? (CharacterBase) caster.Clone() : null;
+            var clone = copyCharacter ? (CharacterBase) caster.Clone() : null;
             var damage = ProcessDamage(caster, simulatorWaveTurn);
             var buff = ProcessBuff(caster, simulatorWaveTurn, buffs);
 

--- a/Lib9c/Model/Skill/AttackSkill.cs
+++ b/Lib9c/Model/Skill/AttackSkill.cs
@@ -29,7 +29,7 @@ namespace Nekoyume.Model.Skill
         /// <param name="isNormalAttack"></param>
         /// <returns></returns>
         protected IEnumerable<BattleStatus.Skill.SkillInfo> ProcessDamage(CharacterBase caster, int simulatorWaveTurn,
-            bool isNormalAttack = false)
+            bool isNormalAttack = false, bool b = false)
         {
             var infos = new List<BattleStatus.Skill.SkillInfo>();
             var targets = SkillRow.SkillTargetType.GetTarget(caster).ToList();
@@ -86,7 +86,8 @@ namespace Nekoyume.Model.Skill
                         target.CurrentHP -= damage;
                     }
 
-                    infos.Add(new BattleStatus.Skill.SkillInfo((CharacterBase) target.Clone(), damage, isCritical,
+                    var clone = b ? (CharacterBase) target.Clone() : null;
+                    infos.Add(new BattleStatus.Skill.SkillInfo(target.Id, target.IsDead, target.Thorn, damage, isCritical,
                         SkillRow.SkillCategory, simulatorWaveTurn, SkillRow.ElementalType,
                         SkillRow.SkillTargetType));
                 }

--- a/Lib9c/Model/Skill/AttackSkill.cs
+++ b/Lib9c/Model/Skill/AttackSkill.cs
@@ -27,9 +27,10 @@ namespace Nekoyume.Model.Skill
         /// <param name="caster"></param>
         /// <param name="simulatorWaveTurn"></param>
         /// <param name="isNormalAttack"></param>
+        /// <param name="copyCharacter"></param>
         /// <returns></returns>
         protected IEnumerable<BattleStatus.Skill.SkillInfo> ProcessDamage(CharacterBase caster, int simulatorWaveTurn,
-            bool isNormalAttack = false, bool b = false)
+            bool isNormalAttack = false, bool copyCharacter = true)
         {
             var infos = new List<BattleStatus.Skill.SkillInfo>();
             var targets = SkillRow.SkillTargetType.GetTarget(caster).ToList();
@@ -86,10 +87,10 @@ namespace Nekoyume.Model.Skill
                         target.CurrentHP -= damage;
                     }
 
-                    var clone = b ? (CharacterBase) target.Clone() : null;
+                    var clone = copyCharacter ? (CharacterBase) target.Clone() : null;
                     infos.Add(new BattleStatus.Skill.SkillInfo(target.Id, target.IsDead, target.Thorn, damage, isCritical,
                         SkillRow.SkillCategory, simulatorWaveTurn, SkillRow.ElementalType,
-                        SkillRow.SkillTargetType));
+                        SkillRow.SkillTargetType, target: clone));
                 }
             }
 

--- a/Lib9c/Model/Skill/BlowAttack.cs
+++ b/Lib9c/Model/Skill/BlowAttack.cs
@@ -17,12 +17,11 @@ namespace Nekoyume.Model.Skill
         {
         }
 
-        public override BattleStatus.Skill Use(
-            CharacterBase caster, 
+        public override BattleStatus.Skill Use(CharacterBase caster,
             int simulatorWaveTurn,
-            IEnumerable<Buff.Buff> buffs)
+            IEnumerable<Buff.Buff> buffs, bool b)
         {
-            var clone = (CharacterBase) caster.Clone();
+            var clone = b ? (CharacterBase) caster.Clone() : null;
             var damage = ProcessDamage(caster, simulatorWaveTurn);
             var buff = ProcessBuff(caster, simulatorWaveTurn, buffs);
 

--- a/Lib9c/Model/Skill/BlowAttack.cs
+++ b/Lib9c/Model/Skill/BlowAttack.cs
@@ -19,9 +19,9 @@ namespace Nekoyume.Model.Skill
 
         public override BattleStatus.Skill Use(CharacterBase caster,
             int simulatorWaveTurn,
-            IEnumerable<Buff.Buff> buffs, bool b)
+            IEnumerable<Buff.Buff> buffs, bool copyCharacter)
         {
-            var clone = b ? (CharacterBase) caster.Clone() : null;
+            var clone = copyCharacter ? (CharacterBase) caster.Clone() : null;
             var damage = ProcessDamage(caster, simulatorWaveTurn);
             var buff = ProcessBuff(caster, simulatorWaveTurn, buffs);
 

--- a/Lib9c/Model/Skill/BlowAttack.cs
+++ b/Lib9c/Model/Skill/BlowAttack.cs
@@ -22,7 +22,7 @@ namespace Nekoyume.Model.Skill
             IEnumerable<Buff.Buff> buffs, bool copyCharacter)
         {
             var clone = copyCharacter ? (CharacterBase) caster.Clone() : null;
-            var damage = ProcessDamage(caster, simulatorWaveTurn);
+            var damage = ProcessDamage(caster, simulatorWaveTurn, copyCharacter: copyCharacter);
             var buff = ProcessBuff(caster, simulatorWaveTurn, buffs);
 
             return new Model.BattleStatus.BlowAttack(SkillRow.Id, clone, damage, buff);

--- a/Lib9c/Model/Skill/BuffRemovalAttack.cs
+++ b/Lib9c/Model/Skill/BuffRemovalAttack.cs
@@ -17,12 +17,11 @@ namespace Nekoyume.Model.Skill
         {
         }
 
-        public override BattleStatus.Skill Use(
-            CharacterBase caster, 
+        public override BattleStatus.Skill Use(CharacterBase caster,
             int simulatorWaveTurn,
-            IEnumerable<Buff.Buff> buffs)
+            IEnumerable<Buff.Buff> buffs, bool b)
         {
-            var clone = (CharacterBase) caster.Clone();
+            var clone = b ? (CharacterBase) caster.Clone() : null;
             var damage = ProcessDamage(caster, simulatorWaveTurn);
             var buff = ProcessBuff(caster, simulatorWaveTurn, buffs);
             var targets = SkillRow.SkillTargetType.GetTarget(caster);

--- a/Lib9c/Model/Skill/BuffRemovalAttack.cs
+++ b/Lib9c/Model/Skill/BuffRemovalAttack.cs
@@ -19,9 +19,9 @@ namespace Nekoyume.Model.Skill
 
         public override BattleStatus.Skill Use(CharacterBase caster,
             int simulatorWaveTurn,
-            IEnumerable<Buff.Buff> buffs, bool b)
+            IEnumerable<Buff.Buff> buffs, bool copyCharacter)
         {
-            var clone = b ? (CharacterBase) caster.Clone() : null;
+            var clone = copyCharacter ? (CharacterBase) caster.Clone() : null;
             var damage = ProcessDamage(caster, simulatorWaveTurn);
             var buff = ProcessBuff(caster, simulatorWaveTurn, buffs);
             var targets = SkillRow.SkillTargetType.GetTarget(caster);

--- a/Lib9c/Model/Skill/BuffRemovalAttack.cs
+++ b/Lib9c/Model/Skill/BuffRemovalAttack.cs
@@ -22,7 +22,7 @@ namespace Nekoyume.Model.Skill
             IEnumerable<Buff.Buff> buffs, bool copyCharacter)
         {
             var clone = copyCharacter ? (CharacterBase) caster.Clone() : null;
-            var damage = ProcessDamage(caster, simulatorWaveTurn);
+            var damage = ProcessDamage(caster, simulatorWaveTurn, copyCharacter: copyCharacter);
             var buff = ProcessBuff(caster, simulatorWaveTurn, buffs);
             var targets = SkillRow.SkillTargetType.GetTarget(caster);
             foreach (var target in targets)

--- a/Lib9c/Model/Skill/BuffSkill.cs
+++ b/Lib9c/Model/Skill/BuffSkill.cs
@@ -18,9 +18,9 @@ namespace Nekoyume.Model.Skill
         }
 
         public override BattleStatus.Skill Use(CharacterBase caster, int simulatorWaveTurn,
-            IEnumerable<Buff.Buff> buffs)
+            IEnumerable<Buff.Buff> buffs, bool b)
         {
-            var clone = (CharacterBase) caster.Clone();
+            var clone = b ? (CharacterBase) caster.Clone() : null;
             var buff = ProcessBuff(caster, simulatorWaveTurn, buffs);
 
             return new BattleStatus.Buff(SkillRow.Id, clone, buff);

--- a/Lib9c/Model/Skill/BuffSkill.cs
+++ b/Lib9c/Model/Skill/BuffSkill.cs
@@ -18,9 +18,9 @@ namespace Nekoyume.Model.Skill
         }
 
         public override BattleStatus.Skill Use(CharacterBase caster, int simulatorWaveTurn,
-            IEnumerable<Buff.Buff> buffs, bool b)
+            IEnumerable<Buff.Buff> buffs, bool copyCharacter)
         {
-            var clone = b ? (CharacterBase) caster.Clone() : null;
+            var clone = copyCharacter ? (CharacterBase) caster.Clone() : null;
             var buff = ProcessBuff(caster, simulatorWaveTurn, buffs);
 
             return new BattleStatus.Buff(SkillRow.Id, clone, buff);

--- a/Lib9c/Model/Skill/DoubleAttack.cs
+++ b/Lib9c/Model/Skill/DoubleAttack.cs
@@ -17,12 +17,11 @@ namespace Nekoyume.Model.Skill
         {
         }
 
-        public override BattleStatus.Skill Use(
-            CharacterBase caster, 
+        public override BattleStatus.Skill Use(CharacterBase caster,
             int simulatorWaveTurn,
-            IEnumerable<Buff.Buff> buffs)
+            IEnumerable<Buff.Buff> buffs, bool b)
         {
-            var clone = (CharacterBase) caster.Clone();
+            var clone = b ? (CharacterBase) caster.Clone() : null;
             var damage = ProcessDamage(caster, simulatorWaveTurn);
             var buff = ProcessBuff(caster, simulatorWaveTurn, buffs);
 

--- a/Lib9c/Model/Skill/DoubleAttack.cs
+++ b/Lib9c/Model/Skill/DoubleAttack.cs
@@ -22,7 +22,7 @@ namespace Nekoyume.Model.Skill
             IEnumerable<Buff.Buff> buffs, bool copyCharacter)
         {
             var clone = copyCharacter ? (CharacterBase) caster.Clone() : null;
-            var damage = ProcessDamage(caster, simulatorWaveTurn);
+            var damage = ProcessDamage(caster, simulatorWaveTurn, copyCharacter: copyCharacter);
             var buff = ProcessBuff(caster, simulatorWaveTurn, buffs);
 
             return new Model.BattleStatus.DoubleAttack(SkillRow.Id, clone, damage, buff);

--- a/Lib9c/Model/Skill/DoubleAttack.cs
+++ b/Lib9c/Model/Skill/DoubleAttack.cs
@@ -19,9 +19,9 @@ namespace Nekoyume.Model.Skill
 
         public override BattleStatus.Skill Use(CharacterBase caster,
             int simulatorWaveTurn,
-            IEnumerable<Buff.Buff> buffs, bool b)
+            IEnumerable<Buff.Buff> buffs, bool copyCharacter)
         {
-            var clone = b ? (CharacterBase) caster.Clone() : null;
+            var clone = copyCharacter ? (CharacterBase) caster.Clone() : null;
             var damage = ProcessDamage(caster, simulatorWaveTurn);
             var buff = ProcessBuff(caster, simulatorWaveTurn, buffs);
 

--- a/Lib9c/Model/Skill/HealSkill.cs
+++ b/Lib9c/Model/Skill/HealSkill.cs
@@ -17,15 +17,14 @@ namespace Nekoyume.Model.Skill
         {
         }
 
-        public override BattleStatus.Skill Use(
-            CharacterBase caster, 
+        public override BattleStatus.Skill Use(CharacterBase caster,
             int simulatorWaveTurn,
-            IEnumerable<Buff.Buff> buffs)
+            IEnumerable<Buff.Buff> buffs, bool b)
         {
-            var clone = (CharacterBase) caster.Clone();
+            var clone = b ? (CharacterBase) caster.Clone() : null;
             var heal = ProcessHeal(caster, simulatorWaveTurn);
             var buff = ProcessBuff(caster, simulatorWaveTurn, buffs);
-            
+
             return new BattleStatus.HealSkill(SkillRow.Id, clone, heal, buff);
         }
 
@@ -42,7 +41,7 @@ namespace Nekoyume.Model.Skill
             foreach (var target in SkillRow.SkillTargetType.GetTarget(caster))
             {
                 target.Heal(healPoint);
-                infos.Add(new BattleStatus.Skill.SkillInfo((CharacterBase)target.Clone(), healPoint, caster.IsCritical(false),
+                infos.Add(new BattleStatus.Skill.SkillInfo(target.Id, target.IsDead, target.Thorn, healPoint, caster.IsCritical(false),
                     SkillRow.SkillCategory, simulatorWaveTurn));
             }
 

--- a/Lib9c/Model/Skill/HealSkill.cs
+++ b/Lib9c/Model/Skill/HealSkill.cs
@@ -19,9 +19,9 @@ namespace Nekoyume.Model.Skill
 
         public override BattleStatus.Skill Use(CharacterBase caster,
             int simulatorWaveTurn,
-            IEnumerable<Buff.Buff> buffs, bool b)
+            IEnumerable<Buff.Buff> buffs, bool copyCharacter)
         {
-            var clone = b ? (CharacterBase) caster.Clone() : null;
+            var clone = copyCharacter ? (CharacterBase) caster.Clone() : null;
             var heal = ProcessHeal(caster, simulatorWaveTurn);
             var buff = ProcessBuff(caster, simulatorWaveTurn, buffs);
 
@@ -42,7 +42,7 @@ namespace Nekoyume.Model.Skill
             {
                 target.Heal(healPoint);
                 infos.Add(new BattleStatus.Skill.SkillInfo(target.Id, target.IsDead, target.Thorn, healPoint, caster.IsCritical(false),
-                    SkillRow.SkillCategory, simulatorWaveTurn));
+                    SkillRow.SkillCategory, simulatorWaveTurn, target: target));
             }
 
             return infos;

--- a/Lib9c/Model/Skill/NormalAttack.cs
+++ b/Lib9c/Model/Skill/NormalAttack.cs
@@ -17,12 +17,11 @@ namespace Nekoyume.Model.Skill
         {
         }
 
-        public override Model.BattleStatus.Skill Use(
-            CharacterBase caster,
+        public override BattleStatus.Skill Use(CharacterBase caster,
             int simulatorWaveTurn,
-            IEnumerable<Buff.Buff> buffs)
+            IEnumerable<Buff.Buff> buffs, bool b)
         {
-            var clone = (CharacterBase) caster.Clone();
+            var clone = b ? (CharacterBase) caster.Clone() : null;
             var damage = ProcessDamage(caster, simulatorWaveTurn, true);
             var buff = ProcessBuff(caster, simulatorWaveTurn, buffs);
 

--- a/Lib9c/Model/Skill/NormalAttack.cs
+++ b/Lib9c/Model/Skill/NormalAttack.cs
@@ -22,7 +22,7 @@ namespace Nekoyume.Model.Skill
             IEnumerable<Buff.Buff> buffs, bool copyCharacter)
         {
             var clone = copyCharacter ? (CharacterBase) caster.Clone() : null;
-            var damage = ProcessDamage(caster, simulatorWaveTurn, true);
+            var damage = ProcessDamage(caster, simulatorWaveTurn, true, copyCharacter);
             var buff = ProcessBuff(caster, simulatorWaveTurn, buffs);
 
             return new Model.BattleStatus.NormalAttack(SkillRow.Id, clone, damage, buff);

--- a/Lib9c/Model/Skill/NormalAttack.cs
+++ b/Lib9c/Model/Skill/NormalAttack.cs
@@ -19,9 +19,9 @@ namespace Nekoyume.Model.Skill
 
         public override BattleStatus.Skill Use(CharacterBase caster,
             int simulatorWaveTurn,
-            IEnumerable<Buff.Buff> buffs, bool b)
+            IEnumerable<Buff.Buff> buffs, bool copyCharacter)
         {
-            var clone = b ? (CharacterBase) caster.Clone() : null;
+            var clone = copyCharacter ? (CharacterBase) caster.Clone() : null;
             var damage = ProcessDamage(caster, simulatorWaveTurn, true);
             var buff = ProcessBuff(caster, simulatorWaveTurn, buffs);
 

--- a/Lib9c/Model/Skill/Skill.cs
+++ b/Lib9c/Model/Skill/Skill.cs
@@ -36,11 +36,9 @@ namespace Nekoyume.Model.Skill
             ReferencedStatType = referencedStatType;
         }
 
-        public abstract BattleStatus.Skill Use(
-            CharacterBase caster,
+        public abstract BattleStatus.Skill Use(CharacterBase caster,
             int simulatorWaveTurn,
-            IEnumerable<Buff.Buff> buffs
-        );
+            IEnumerable<Buff.Buff> buffs, bool b);
 
         protected bool Equals(Skill other)
         {
@@ -83,7 +81,7 @@ namespace Nekoyume.Model.Skill
                 foreach (var target in targets.Where(target => target.GetChance(buff.BuffInfo.Chance)))
                 {
                     target.AddBuff(buff);
-                    infos.Add(new Model.BattleStatus.Skill.SkillInfo((CharacterBase) target.Clone(), 0, false,
+                    infos.Add(new Model.BattleStatus.Skill.SkillInfo(target.Id, target.IsDead, target.Thorn, 0, false,
                         SkillRow.SkillCategory, simulatorWaveTurn, ElementalType.Normal, SkillRow.SkillTargetType,
                         buff));
                 }

--- a/Lib9c/Model/Skill/Skill.cs
+++ b/Lib9c/Model/Skill/Skill.cs
@@ -38,7 +38,7 @@ namespace Nekoyume.Model.Skill
 
         public abstract BattleStatus.Skill Use(CharacterBase caster,
             int simulatorWaveTurn,
-            IEnumerable<Buff.Buff> buffs, bool b);
+            IEnumerable<Buff.Buff> buffs, bool copyCharacter);
 
         protected bool Equals(Skill other)
         {
@@ -83,7 +83,7 @@ namespace Nekoyume.Model.Skill
                     target.AddBuff(buff);
                     infos.Add(new Model.BattleStatus.Skill.SkillInfo(target.Id, target.IsDead, target.Thorn, 0, false,
                         SkillRow.SkillCategory, simulatorWaveTurn, ElementalType.Normal, SkillRow.SkillTargetType,
-                        buff));
+                        buff, target));
                 }
             }
 

--- a/Lib9c/Model/State/RedeemCodeState.cs
+++ b/Lib9c/Model/State/RedeemCodeState.cs
@@ -79,14 +79,12 @@ namespace Nekoyume.Model.State
         }
 
         public override IValue Serialize() =>
+            ((Dictionary) base.Serialize())
 #pragma warning disable LAA1002
-            new Dictionary(new Dictionary<IKey, IValue>
-            {
-                [(Text) "map"] = new Dictionary(_map.Select(kv => new KeyValuePair<IKey, IValue>(
-                    kv.Key,
-                    kv.Value.Serialize()
-                )))
-            }.Union((Dictionary) base.Serialize()));
+            .Add("map", new Dictionary(_map.Select(kv => new KeyValuePair<IKey, IValue>(
+                kv.Key,
+                kv.Value.Serialize()
+            ))));
 #pragma warning restore LAA1002
 
         public int Redeem(string code, Address userAddress)


### PR DESCRIPTION
<img width="2032" alt="image" src="https://github.com/planetarium/lib9c/assets/3193043/01772e56-f7d3-4d9c-bb2c-c4e2d2edea84">

<img width="2032" alt="image" src="https://github.com/planetarium/lib9c/assets/3193043/0bfa77d3-1c64-44c8-a13d-f168b76c60c3">

reduce Simulator.Simulate() from 123ms -> 39ms

- Optimize seriialization
- Reduce call duplicate object in loop
- Improve speed HitHelper, AttackCountHelper
- Disable client replay logic(skillInfo) in Execute
