### PR TITLE
ci(gh-actions): check typos in GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,11 @@
+name: lint
+
+on: [push, pull_request]
+
+jobs:
+    typos:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Check typos
+              uses: crate-ci/typos@v1.15.5

--- a/Lib9c.Policy/Policy/IVariableSubPolicy.cs
+++ b/Lib9c.Policy/Policy/IVariableSubPolicy.cs
@@ -81,7 +81,7 @@ namespace Nekoyume.Blockchain.Policy
         /// to check.</param>
         /// <returns><c>true</c> if <paramref name="index"/> is target for any
         /// <see cref="SpannedSubPolicy{T}"/> in <see cref="SpannedSubPolicies"/>.  Otherwise,
-        /// <c>fase</c>.</returns>
+        /// <c>false</c>.</returns>
         /// <remarks>
         /// Call to this method must only be used <em>sparingly</em> and should be <em>avoided</em>
         /// if possible.  Usage of this method indicates dependency coupling between two

--- a/Lib9c/Action/EventMaterialItemCrafts.cs
+++ b/Lib9c/Action/EventMaterialItemCrafts.cs
@@ -187,7 +187,7 @@ namespace Nekoyume.Action
             var materialItemSheet = states.GetSheet<MaterialItemSheet>();
             if (!materialItemSheet.TryGetValue(
                     recipeRow.ResultMaterialItemId,
-                    out var resulMaterialRow))
+                    out var resultMaterialRow))
             {
                 throw new SheetRowNotFoundException(
                     addressesHex,
@@ -228,7 +228,7 @@ namespace Nekoyume.Action
             // ~Remove Required Materials
 
             // Create Material
-            var materialResult = ItemFactory.CreateMaterial(resulMaterialRow);
+            var materialResult = ItemFactory.CreateMaterial(resultMaterialRow);
             avatarState.inventory.AddItem(materialResult, recipeRow.ResultMaterialItemCount);
             // ~Create Material
 

--- a/Lib9c/Action/ValidatorSetOperate.cs
+++ b/Lib9c/Action/ValidatorSetOperate.cs
@@ -152,7 +152,7 @@ namespace Nekoyume.Action
 
             Operator = op;
             // FIXME: This is a temporary code for backward compatibility.
-            Operand = BackwardCompability(operandDict);
+            Operand = BackwardCompatibility(operandDict);
             Error = null;
         }
 
@@ -172,7 +172,7 @@ namespace Nekoyume.Action
                 $"The serialized dictionary lacks the key \"{nameof(ValidatorSetOperateKey)}\".";
         }
 
-        private Validator BackwardCompability(Bencodex.Types.Dictionary dict)
+        private Validator BackwardCompatibility(Bencodex.Types.Dictionary dict)
         {
             try
             {

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,19 @@
+[default]
+extend-ignore-re = [
+    "\\\"([a-zA-Z0-9][a-zA-Z0-9])+\\\"",  # for hexadecimal string values.
+    "2nd"
+]
+
+[default.extend-identifiers]
+fo = "fo"  # FungibleOrder
+
+[default.extend-words]
+ba = "ba"  # byte array
+oce = "oce"  # OperationCanceledException
+ist = "ist"  # ItemSubType
+Equipments = "Equipments"  # FIXME: Equipment is noncount word but our team doesn't have the policy about it.
+
+[files]
+extend-exclude = [
+    ".Libplanet/*"
+]


### PR DESCRIPTION
This pull request is related with https://github.com/planetarium/lib9c/pull/1155.
This pull request introduces a new GitHub Actions workflow to check typos automatically.

You can see the configuration file's spec at [crate-ci/typos@master/docs/reference.md#config-fields](https://github.com/crate-ci/typos/blob/master/docs/reference.md?rgh-link-date=2023-07-25T02%3A20%3A56Z#config-fields).
You can correct typos easily by running `typos . -w`.

## Reviewers

- Anyone related to lib9c 👀 