### PR TITLE
Optimize HackAndSlash.Execute #2

### DIFF
--- a/.Lib9c.Tests/Action/BuyMultipleTest.cs
+++ b/.Lib9c.Tests/Action/BuyMultipleTest.cs
@@ -2,10 +2,8 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
     using System.Numerics;
-    using System.Runtime.Serialization.Formatters.Binary;
     using Libplanet.Action.State;
     using Libplanet.Crypto;
     using Libplanet.Types.Assets;
@@ -607,67 +605,6 @@
             var results = action.buyerResult.purchaseResults;
             var isAllFailed = results.Any(r => r.errorCode == BuyMultiple.ERROR_CODE_SHOPITEM_EXPIRED);
             Assert.True(isAllFailed);
-        }
-
-        [Fact]
-        public void SerializeWithDotnetAPI()
-        {
-            var sellerAvatarAddress = new PrivateKey().ToAddress();
-            var sellerAgentAddress = new PrivateKey().ToAddress();
-            CreateAvatarState(sellerAgentAddress, sellerAvatarAddress);
-
-            IAccountStateDelta previousStates = _initialState;
-            var shopState = previousStates.GetShopState();
-
-            var productId = Guid.NewGuid();
-            var equipment = ItemFactory.CreateItemUsable(
-                _tableSheets.EquipmentItemSheet.First,
-                Guid.NewGuid(),
-                0);
-            shopState.Register(new ShopItem(
-                sellerAgentAddress,
-                sellerAvatarAddress,
-                productId,
-                new FungibleAssetValue(_goldCurrencyState.Currency, 100, 0),
-                100,
-                equipment));
-            shopState.Register(new ShopItem(
-                sellerAgentAddress,
-                sellerAvatarAddress,
-                Guid.NewGuid(),
-                new FungibleAssetValue(_goldCurrencyState.Currency, 100, 0),
-                100,
-                equipment));
-            var products = shopState.Products.Values
-                .Select(p => new BuyMultiple.PurchaseInfo(
-                    p.ProductId,
-                    p.SellerAgentAddress,
-                    p.SellerAvatarAddress))
-                .ToList();
-
-            previousStates = previousStates
-                .SetState(Addresses.Shop, shopState.Serialize());
-
-            var action = new BuyMultiple
-            {
-                buyerAvatarAddress = _buyerAvatarAddress,
-                purchaseInfos = products,
-            };
-            action.Execute(new ActionContext()
-            {
-                BlockIndex = 1,
-                PreviousState = previousStates,
-                Random = new TestRandom(),
-                Signer = _buyerAgentAddress,
-            });
-
-            var formatter = new BinaryFormatter();
-            using var ms = new MemoryStream();
-            formatter.Serialize(ms, action);
-            ms.Seek(0, SeekOrigin.Begin);
-
-            var deserialized = (BuyMultiple)formatter.Deserialize(ms);
-            Assert.Equal(action.PlainValue, deserialized.PlainValue);
         }
 
         private (AvatarState AvatarState, AgentState AgentState) CreateAvatarState(

--- a/.Lib9c.Tests/Model/Item/ArmorTest.cs
+++ b/.Lib9c.Tests/Model/Item/ArmorTest.cs
@@ -1,9 +1,7 @@
 namespace Lib9c.Tests.Model.Item
 {
     using System;
-    using System.IO;
     using System.Linq;
-    using System.Runtime.Serialization.Formatters.Binary;
     using Nekoyume.Model.Item;
     using Nekoyume.TableData;
     using Xunit;
@@ -27,22 +25,6 @@ namespace Lib9c.Tests.Model.Item
             var costume = new Armor(_armorRow, Guid.NewGuid(), 0);
             var serialized = costume.Serialize();
             var deserialized = new Armor((Bencodex.Types.Dictionary)serialized);
-
-            Assert.Equal(costume, deserialized);
-        }
-
-        [Fact]
-        public void SerializeWithDotNetAPI()
-        {
-            Assert.NotNull(_armorRow);
-
-            var costume = new Armor(_armorRow, Guid.NewGuid(), 0);
-            var formatter = new BinaryFormatter();
-            using var ms = new MemoryStream();
-            formatter.Serialize(ms, costume);
-            ms.Seek(0, SeekOrigin.Begin);
-
-            var deserialized = (Armor)formatter.Deserialize(ms);
 
             Assert.Equal(costume, deserialized);
         }

--- a/.Lib9c.Tests/Model/Item/BeltTest.cs
+++ b/.Lib9c.Tests/Model/Item/BeltTest.cs
@@ -1,9 +1,7 @@
 namespace Lib9c.Tests.Model.Item
 {
     using System;
-    using System.IO;
     using System.Linq;
-    using System.Runtime.Serialization.Formatters.Binary;
     using Nekoyume.Model.Item;
     using Nekoyume.TableData;
     using Xunit;
@@ -27,22 +25,6 @@ namespace Lib9c.Tests.Model.Item
             var costume = new Belt(_beltRow, Guid.NewGuid(), 0);
             var serialized = costume.Serialize();
             var deserialized = new Belt((Bencodex.Types.Dictionary)serialized);
-
-            Assert.Equal(costume, deserialized);
-        }
-
-        [Fact]
-        public void SerializeWithDotNetAPI()
-        {
-            Assert.NotNull(_beltRow);
-
-            var costume = new Belt(_beltRow, Guid.NewGuid(), 0);
-            var formatter = new BinaryFormatter();
-            using var ms = new MemoryStream();
-            formatter.Serialize(ms, costume);
-            ms.Seek(0, SeekOrigin.Begin);
-
-            var deserialized = (Belt)formatter.Deserialize(ms);
 
             Assert.Equal(costume, deserialized);
         }

--- a/.Lib9c.Tests/Model/Item/ConsumableTest.cs
+++ b/.Lib9c.Tests/Model/Item/ConsumableTest.cs
@@ -1,8 +1,6 @@
 namespace Lib9c.Tests.Model.Item
 {
     using System;
-    using System.IO;
-    using System.Runtime.Serialization.Formatters.Binary;
     using Nekoyume.Model.Item;
     using Nekoyume.TableData;
     using Xunit;
@@ -25,22 +23,6 @@ namespace Lib9c.Tests.Model.Item
             var consumable = new Consumable(_consumableRow, Guid.NewGuid(), 0);
             var serialized = consumable.Serialize();
             var deserialized = new Consumable((Bencodex.Types.Dictionary)serialized);
-
-            Assert.Equal(consumable, deserialized);
-        }
-
-        [Fact]
-        public void SerializeWithDotNetAPI()
-        {
-            Assert.NotNull(_consumableRow);
-
-            var consumable = new Consumable(_consumableRow, Guid.NewGuid(), 0);
-            var formatter = new BinaryFormatter();
-            using var ms = new MemoryStream();
-            formatter.Serialize(ms, consumable);
-            ms.Seek(0, SeekOrigin.Begin);
-
-            var deserialized = (Consumable)formatter.Deserialize(ms);
 
             Assert.Equal(consumable, deserialized);
         }

--- a/.Lib9c.Tests/Model/Item/EquipmentTest.cs
+++ b/.Lib9c.Tests/Model/Item/EquipmentTest.cs
@@ -2,8 +2,6 @@ namespace Lib9c.Tests.Model.Item
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
-    using System.Runtime.Serialization.Formatters.Binary;
     using Nekoyume.Model.Item;
     using Nekoyume.TableData;
     using Xunit;
@@ -38,26 +36,6 @@ namespace Lib9c.Tests.Model.Item
             var serialized = costume.Serialize();
             var deserialized = new Equipment((Bencodex.Types.Dictionary)serialized);
             var reSerialized = deserialized.Serialize();
-
-            Assert.Equal(costume, deserialized);
-            Assert.Equal(serialized, reSerialized);
-        }
-
-        [Fact]
-        public void SerializeWithDotNetAPI()
-        {
-            Assert.NotNull(_equipmentRow);
-
-            var costume = new Equipment(_equipmentRow, Guid.NewGuid(), 0);
-            var formatter = new BinaryFormatter();
-            using var ms = new MemoryStream();
-            formatter.Serialize(ms, costume);
-            ms.Seek(0, SeekOrigin.Begin);
-            var serialized = ms.ToArray();
-            var deserialized = (Equipment)formatter.Deserialize(ms);
-            ms.Seek(0, SeekOrigin.Begin);
-            formatter.Serialize(ms, deserialized);
-            var reSerialized = ms.ToArray();
 
             Assert.Equal(costume, deserialized);
             Assert.Equal(serialized, reSerialized);

--- a/.Lib9c.Tests/Model/Item/InventoryTest.cs
+++ b/.Lib9c.Tests/Model/Item/InventoryTest.cs
@@ -2,9 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
-    using System.Runtime.Serialization.Formatters.Binary;
     using Lib9c.Tests.Action;
     using Nekoyume.Model.Item;
     using Nekoyume.TableData;
@@ -32,24 +30,6 @@
             inventory.AddItem(material, 1, new OrderLock(Guid.NewGuid()));
             var serialized = (BxList)inventory.Serialize();
             var deserialized = new Inventory(serialized);
-            Assert.Equal(inventory, deserialized);
-        }
-
-        [Fact]
-        public void Serialize_With_DotNet_Api()
-        {
-            var inventory = new Inventory();
-            var row = TableSheets.EquipmentItemSheet.First;
-            var itemUsable = ItemFactory.CreateItemUsable(row, Guid.NewGuid(), 0);
-            inventory.AddItem(itemUsable);
-            var row2 = TableSheets.MaterialItemSheet.First;
-            var material = ItemFactory.CreateMaterial(row2);
-            inventory.AddItem(material, 1, new OrderLock(Guid.NewGuid()));
-            var formatter = new BinaryFormatter();
-            using var ms = new MemoryStream();
-            formatter.Serialize(ms, inventory);
-            ms.Seek(0, SeekOrigin.Begin);
-            var deserialized = (Inventory)formatter.Deserialize(ms);
             Assert.Equal(inventory, deserialized);
         }
 

--- a/.Lib9c.Tests/Model/Item/NecklaceTest.cs
+++ b/.Lib9c.Tests/Model/Item/NecklaceTest.cs
@@ -1,9 +1,7 @@
 namespace Lib9c.Tests.Model.Item
 {
     using System;
-    using System.IO;
     using System.Linq;
-    using System.Runtime.Serialization.Formatters.Binary;
     using Nekoyume.Model.Item;
     using Nekoyume.TableData;
     using Xunit;
@@ -27,22 +25,6 @@ namespace Lib9c.Tests.Model.Item
             var costume = new Necklace(_necklaceRow, Guid.NewGuid(), 0);
             var serialized = costume.Serialize();
             var deserialized = new Necklace((Bencodex.Types.Dictionary)serialized);
-
-            Assert.Equal(costume, deserialized);
-        }
-
-        [Fact]
-        public void SerializeWithDotNetAPI()
-        {
-            Assert.NotNull(_necklaceRow);
-
-            var costume = new Necklace(_necklaceRow, Guid.NewGuid(), 0);
-            var formatter = new BinaryFormatter();
-            using var ms = new MemoryStream();
-            formatter.Serialize(ms, costume);
-            ms.Seek(0, SeekOrigin.Begin);
-
-            var deserialized = (Necklace)formatter.Deserialize(ms);
 
             Assert.Equal(costume, deserialized);
         }

--- a/.Lib9c.Tests/Model/Item/ShopItemTest.cs
+++ b/.Lib9c.Tests/Model/Item/ShopItemTest.cs
@@ -2,9 +2,7 @@ namespace Lib9c.Tests.Model.Item
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
-    using System.Runtime.Serialization.Formatters.Binary;
     using Bencodex.Types;
     using Libplanet.Crypto;
     using Libplanet.Types.Assets;
@@ -33,22 +31,6 @@ namespace Lib9c.Tests.Model.Item
             {
                 var serialized = shopItem.Serialize();
                 var deserialized = new ShopItem((BxDictionary)serialized);
-
-                Assert.Equal(shopItem, deserialized);
-            }
-        }
-
-        [Fact]
-        public void Serialize_With_DotNet_Api()
-        {
-            foreach (var shopItem in GetShopItems())
-            {
-                var formatter = new BinaryFormatter();
-                using var ms = new MemoryStream();
-                formatter.Serialize(ms, shopItem);
-                ms.Seek(0, SeekOrigin.Begin);
-
-                var deserialized = (ShopItem)formatter.Deserialize(ms);
 
                 Assert.Equal(shopItem, deserialized);
             }

--- a/.Lib9c.Tests/Model/ItemGradeQuestTest.cs
+++ b/.Lib9c.Tests/Model/ItemGradeQuestTest.cs
@@ -43,15 +43,6 @@ namespace Lib9c.Tests.Model
             var des = new ItemGradeQuest((Dictionary)quest.Serialize());
 
             Assert.Equal(expected, des.ItemIds);
-
-            var formatter = new BinaryFormatter();
-            using var ms = new MemoryStream();
-            formatter.Serialize(ms, quest);
-
-            ms.Seek(0, SeekOrigin.Begin);
-            var deserialized = (ItemGradeQuest)formatter.Deserialize(ms);
-
-            Assert.Equal(quest.ItemIds, deserialized.ItemIds);
         }
     }
 }

--- a/.Lib9c.Tests/Model/ItemTypeCollectQuestTest.cs
+++ b/.Lib9c.Tests/Model/ItemTypeCollectQuestTest.cs
@@ -43,15 +43,6 @@ namespace Lib9c.Tests.Model
             var des = new ItemTypeCollectQuest((Dictionary)quest.Serialize());
 
             Assert.Equal(expected, des.ItemIds);
-
-            var formatter = new BinaryFormatter();
-            using var ms = new MemoryStream();
-            formatter.Serialize(ms, quest);
-
-            ms.Seek(0, SeekOrigin.Begin);
-            var deserialized = (ItemTypeCollectQuest)formatter.Deserialize(ms);
-
-            Assert.Equal(quest.ItemIds, deserialized.ItemIds);
         }
     }
 }

--- a/.Lib9c.Tests/Model/QuestRewardTest.cs
+++ b/.Lib9c.Tests/Model/QuestRewardTest.cs
@@ -1,6 +1,8 @@
 namespace Lib9c.Tests.Model
 {
+    using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Bencodex.Types;
     using Nekoyume.Model.Quest;
     using Xunit;
@@ -16,19 +18,18 @@ namespace Lib9c.Tests.Model
                 [1] = 1,
             });
 
-            Assert.Equal(
-                new Dictionary<int, int>()
-                {
-                    [1] = 1,
-                    [2] = 1,
-                },
-                reward.ItemMap
-            );
+            var expected = new[]
+            {
+                new Tuple<int, int>(1, 1),
+                new Tuple<int, int>(2, 1),
+            };
+
+            Assert.Equal(expected.OrderBy(t => t.Item1), reward.ItemMap.OrderBy(t => t.Item1));
 
             var serialized = reward.Serialize();
             var des = new QuestReward((Dictionary)serialized);
 
-            Assert.Equal(reward.ItemMap, des.ItemMap);
+            Assert.Equal(reward.ItemMap.OrderBy(t => t.Item1), des.ItemMap.OrderBy(t => t.Item1));
 
             Assert.Equal(serialized, des.Serialize());
         }

--- a/Lib9c/Action/AccountStateExtensions.cs
+++ b/Lib9c/Action/AccountStateExtensions.cs
@@ -38,13 +38,6 @@ namespace Nekoyume.Action
                 return true;
             }
 
-            Log.Error(
-                "Expected a {0}, but got invalid state ({1}): ({2}) {3}",
-                typeof(T).Name,
-                address.ToHex(),
-                raw?.GetType().Name,
-                raw
-            );
             result = default;
             return false;
         }

--- a/Lib9c/Action/HackAndSlash.cs
+++ b/Lib9c/Action/HackAndSlash.cs
@@ -123,7 +123,7 @@ namespace Nekoyume.Action
 
             var addressesHex = $"[{signer.ToHex()}, {AvatarAddress.ToHex()}]";
             var started = DateTimeOffset.UtcNow;
-            Log.Debug("{AddressesHex}HAS exec started", addressesHex);
+            Log.Verbose("{AddressesHex}HAS exec started", addressesHex);
 
             if (ApStoneCount > UsableApStoneCount)
             {
@@ -534,8 +534,8 @@ namespace Nekoyume.Action
                 );
             }
             sw.Stop();
-            Log.Verbose("{AddressesHex}HAS loop Simulate: {Elapsed}, Count: {PlayCount}",
-                addressesHex, sw.Elapsed, TotalPlayCount);
+            Log.Verbose("{AddressesHex} {Source} loop Simulate: {Elapsed}, Count: {PlayCount}",
+                addressesHex, "HackAndSlash", sw.Elapsed, TotalPlayCount);
 
             // Update CrystalRandomSkillState.Stars by clearedWaveNumber. (add)
             skillState?.Update(starCount, crystalStageBuffSheet);
@@ -569,7 +569,7 @@ namespace Nekoyume.Action
             Log.Verbose("{AddressesHex}HAS Set States: {Elapsed}", addressesHex, sw.Elapsed);
 
             var totalElapsed = DateTimeOffset.UtcNow - started;
-            Log.Debug("{AddressesHex}HAS Total Executed Time: {Elapsed}", addressesHex, totalElapsed);
+            Log.Verbose("{AddressesHex}HAS Total Executed Time: {Elapsed}", addressesHex, totalElapsed);
             return states;
         }
 

--- a/Lib9c/Action/HackAndSlash.cs
+++ b/Lib9c/Action/HackAndSlash.cs
@@ -534,7 +534,7 @@ namespace Nekoyume.Action
                 );
             }
             sw.Stop();
-            Log.Verbose("{AddressesHex} {Source} loop Simulate: {Elapsed}, Count: {PlayCount}",
+            Log.Debug("{AddressesHex} {Source} loop Simulate: {Elapsed}, Count: {PlayCount}",
                 addressesHex, "HackAndSlash", sw.Elapsed, TotalPlayCount);
 
             // Update CrystalRandomSkillState.Stars by clearedWaveNumber. (add)

--- a/Lib9c/Action/HackAndSlash.cs
+++ b/Lib9c/Action/HackAndSlash.cs
@@ -123,7 +123,8 @@ namespace Nekoyume.Action
 
             var addressesHex = $"[{signer.ToHex()}, {AvatarAddress.ToHex()}]";
             var started = DateTimeOffset.UtcNow;
-            Log.Verbose("{AddressesHex}HAS exec started", addressesHex);
+            const string source = "HackAndSlash";
+            Log.Verbose("{AddressesHex} {Source} HAS exec started", addressesHex, source);
 
             if (ApStoneCount > UsableApStoneCount)
             {
@@ -157,7 +158,7 @@ namespace Nekoyume.Action
             }
 
             sw.Stop();
-            Log.Verbose("{AddressesHex}HAS Get AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Get AvatarState", sw.Elapsed.TotalMilliseconds);
 
             sw.Restart();
             var sheets = states.GetSheets(
@@ -186,7 +187,7 @@ namespace Nekoyume.Action
                         typeof(RuneListSheet),
                     });
             sw.Stop();
-            Log.Verbose("{AddressesHex}HAS Get Sheets: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Get Sheets", sw.Elapsed.TotalMilliseconds);
 
             sw.Restart();
             var stakingLevel = 0;
@@ -200,7 +201,7 @@ namespace Nekoyume.Action
             }
 
             sw.Stop();
-            Log.Verbose("{AddressesHex}HAS Check StakeState: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Check StateState", sw.Elapsed.TotalMilliseconds);
 
             var worldSheet = sheets.GetSheet<WorldSheet>();
             if (!worldSheet.TryGetValue(WorldId, out var worldRow, false))
@@ -223,7 +224,7 @@ namespace Nekoyume.Action
             }
 
             sw.Stop();
-            Log.Verbose("{AddressesHex}HAS Get StageSheet: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Get StageSheet", sw.Elapsed.TotalMilliseconds);
 
             sw.Restart();
             var worldInformation = avatarState.worldInformation;
@@ -263,15 +264,15 @@ namespace Nekoyume.Action
             }
 
             sw.Stop();
-            Log.Verbose("{AddressesHex}HAS Validate World: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Validate World", sw.Elapsed.TotalMilliseconds);
 
             sw.Restart();
             var equipmentList = avatarState.ValidateEquipmentsV2(Equipments, blockIndex);
             var foodIds = avatarState.ValidateConsumable(Foods, blockIndex);
             var costumeIds = avatarState.ValidateCostume(Costumes);
             sw.Stop();
-            Log.Verbose("{AddressesHex}HAS Validate Items: {Elapsed}", addressesHex, sw.Elapsed);
-
+            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Validate Items", sw.Elapsed.TotalMilliseconds);
+            sw.Restart();
             var materialItemSheet = sheets.GetSheet<MaterialItemSheet>();
             var apPlayCount = TotalPlayCount;
             var minimumCostAp = stageRow.CostAP;
@@ -313,11 +314,12 @@ namespace Nekoyume.Action
                 }
 
                 Log.Verbose(
-                    "{AddressesHex}TotalPlayCount: {TotalPlayCount}, " +
+                    "{AddressesHex} {Source} TotalPlayCount: {TotalPlayCount}, " +
                     "ApStoneCount: {ApStoneCount}, PlayCount by Ap stone: {ApStonePlayCount}, " +
                     "Ap cost per 1 play: {MinimumCostAp}, " +
                     "PlayCount by action point: {ApPlayCount}, Used AP: {UsedAp}",
                     addressesHex,
+                    source,
                     TotalPlayCount,
                     ApStoneCount,
                     apStonePlayCount,
@@ -347,12 +349,12 @@ namespace Nekoyume.Action
             var items = Equipments.Concat(Costumes);
             avatarState.EquipItems(items);
             sw.Stop();
-            Log.Verbose("{AddressesHex}HAS Unequip items: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Unequip items", sw.Elapsed.TotalMilliseconds);
 
             sw.Restart();
             var questSheet = sheets.GetQuestSheet();
             sw.Stop();
-            Log.Verbose("{AddressesHex}HAS GetQuestSheet: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Get QuestSheet", sw.Elapsed.TotalMilliseconds);
 
             // Update QuestList only when QuestSheet.Count is greater than QuestList.Count
             var questList = avatarState.questList;
@@ -365,7 +367,7 @@ namespace Nekoyume.Action
                     sheets.GetSheet<QuestItemRewardSheet>(),
                     sheets.GetSheet<EquipmentItemRecipeSheet>());
                 sw.Stop();
-                Log.Verbose("{AddressesHex}HAS Update QuestList: {Elapsed}", addressesHex, sw.Elapsed);
+                Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Update QuestList", sw.Elapsed.TotalMilliseconds);
             }
 
             sw.Restart();
@@ -404,7 +406,7 @@ namespace Nekoyume.Action
             }
 
             sw.Stop();
-            Log.Verbose("{AddressesHex}HAS Get skillState : {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Get skillState", sw.Elapsed.TotalMilliseconds);
 
             sw.Restart();
             var worldUnlockSheet = sheets.GetSheet<WorldUnlockSheet>();
@@ -439,6 +441,8 @@ namespace Nekoyume.Action
                     runeStates.Add(new RuneState(rawRuneState));
                 }
             }
+            sw.Stop();
+            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Update slotState", sw.Elapsed.TotalMilliseconds);
 
             var stageWaveRow =  sheets.GetSheet<StageWaveSheet>()[StageId];
             var enemySkillSheet = sheets.GetSheet<EnemySkillSheet>();
@@ -469,12 +473,12 @@ namespace Nekoyume.Action
                     rewards,
                     false);
                 sw.Stop();
-                Log.Verbose("{AddressesHex}HAS Initialize Simulator: {Elapsed}", addressesHex, sw.Elapsed);
+                Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Initialize Simulator", sw.Elapsed.TotalMilliseconds);
 
                 sw.Restart();
                 simulator.Simulate();
                 sw.Stop();
-                Log.Verbose("{AddressesHex}HAS Simulator.Simulate(): {Elapsed}", addressesHex, sw.Elapsed);
+                Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Simulator.Simulate()", sw.Elapsed.TotalMilliseconds);
 
                 sw.Restart();
                 if (simulator.Log.IsClear)
@@ -491,7 +495,7 @@ namespace Nekoyume.Action
                         stageCleared = true;
                     }
                     sw.Stop();
-                    Log.Verbose("{AddressesHex}HAS ClearStage: {Elapsed}", addressesHex, sw.Elapsed);
+                    Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "ClearStage", sw.Elapsed.TotalMilliseconds);
                 }
 
                 sw.Restart();
@@ -521,10 +525,12 @@ namespace Nekoyume.Action
 
                 sw.Stop();
                 Log.Verbose(
-                    "{AddressesHex}Update avatar by simulator({AvatarAddress}); " +
+                    "{AddressesHex} {Source} {Process} by simulator({AvatarAddress}); " +
                     "worldId: {WorldId}, stageId: {StageId}, result: {Result}, " +
                     "clearWave: {ClearWave}, totalWave: {TotalWave}",
                     addressesHex,
+                    source,
+                    "Update avatar",
                     AvatarAddress,
                     WorldId,
                     StageId,
@@ -534,8 +540,8 @@ namespace Nekoyume.Action
                 );
             }
             sw.Stop();
-            Log.Debug("{AddressesHex} {Source} loop Simulate: {Elapsed}, Count: {PlayCount}",
-                addressesHex, "HackAndSlash", sw.Elapsed, TotalPlayCount);
+            Log.Debug("{AddressesHex} {Source} {Process}: {Elapsed}, Count: {PlayCount}",
+                addressesHex, source, "loop Simulate", sw.Elapsed.TotalMilliseconds, TotalPlayCount);
 
             // Update CrystalRandomSkillState.Stars by clearedWaveNumber. (add)
             skillState?.Update(starCount, crystalStageBuffSheet);
@@ -544,7 +550,7 @@ namespace Nekoyume.Action
             avatarState.updatedAt = blockIndex;
             avatarState.mailBox.CleanUp();
             sw.Stop();
-            Log.Verbose("{AddressesHex}HAS Update AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Update AvatarState", sw.Elapsed.TotalMilliseconds);
 
             sw.Restart();
             if (isNotClearedStage)
@@ -566,10 +572,10 @@ namespace Nekoyume.Action
                 .SetState(worldInformationAddress, avatarState.worldInformation.Serialize())
                 .SetState(questListAddress, avatarState.questList.Serialize());
             sw.Stop();
-            Log.Verbose("{AddressesHex}HAS Set States: {Elapsed}", addressesHex, sw.Elapsed);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Set States", sw.Elapsed.TotalMilliseconds);
 
             var totalElapsed = DateTimeOffset.UtcNow - started;
-            Log.Verbose("{AddressesHex}HAS Total Executed Time: {Elapsed}", addressesHex, totalElapsed);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Total Executed Time", totalElapsed.TotalMilliseconds);
             return states;
         }
 

--- a/Lib9c/Action/HackAndSlash.cs
+++ b/Lib9c/Action/HackAndSlash.cs
@@ -124,7 +124,8 @@ namespace Nekoyume.Action
             var addressesHex = $"[{signer.ToHex()}, {AvatarAddress.ToHex()}]";
             var started = DateTimeOffset.UtcNow;
             const string source = "HackAndSlash";
-            Log.Verbose("{AddressesHex} {Source} HAS exec started", addressesHex, source);
+            Log.Verbose("{AddressesHex} {Source} from #{BlockIndex} exec started",
+                addressesHex, source, blockIndex);
 
             if (ApStoneCount > UsableApStoneCount)
             {
@@ -158,7 +159,8 @@ namespace Nekoyume.Action
             }
 
             sw.Stop();
-            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Get AvatarState", sw.Elapsed.TotalMilliseconds);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process} from #{BlockIndex}: {Elapsed}",
+                addressesHex, source, "Get AvatarState", blockIndex, sw.Elapsed.TotalMilliseconds);
 
             sw.Restart();
             var sheets = states.GetSheets(
@@ -187,7 +189,8 @@ namespace Nekoyume.Action
                         typeof(RuneListSheet),
                     });
             sw.Stop();
-            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Get Sheets", sw.Elapsed.TotalMilliseconds);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process} from #{BlockIndex}: {Elapsed}",
+                addressesHex, source, "Get Sheets", blockIndex, sw.Elapsed.TotalMilliseconds);
 
             sw.Restart();
             var stakingLevel = 0;
@@ -201,7 +204,8 @@ namespace Nekoyume.Action
             }
 
             sw.Stop();
-            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Check StateState", sw.Elapsed.TotalMilliseconds);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process} from #{BlockIndex}: {Elapsed}",
+                addressesHex, source, "Check StateState", blockIndex, sw.Elapsed.TotalMilliseconds);
 
             var worldSheet = sheets.GetSheet<WorldSheet>();
             if (!worldSheet.TryGetValue(WorldId, out var worldRow, false))
@@ -224,7 +228,8 @@ namespace Nekoyume.Action
             }
 
             sw.Stop();
-            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Get StageSheet", sw.Elapsed.TotalMilliseconds);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process} from #{BlockIndex}: {Elapsed}",
+                addressesHex, source, "Get StageSheet", blockIndex, sw.Elapsed.TotalMilliseconds);
 
             sw.Restart();
             var worldInformation = avatarState.worldInformation;
@@ -264,14 +269,16 @@ namespace Nekoyume.Action
             }
 
             sw.Stop();
-            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Validate World", sw.Elapsed.TotalMilliseconds);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process} from #{BlockIndex}: {Elapsed}",
+                addressesHex, source, "Validate World", blockIndex, sw.Elapsed.TotalMilliseconds);
 
             sw.Restart();
             var equipmentList = avatarState.ValidateEquipmentsV2(Equipments, blockIndex);
             var foodIds = avatarState.ValidateConsumable(Foods, blockIndex);
             var costumeIds = avatarState.ValidateCostume(Costumes);
             sw.Stop();
-            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Validate Items", sw.Elapsed.TotalMilliseconds);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process} from #{BlockIndex}: {Elapsed}",
+                addressesHex, source, "Validate Items", blockIndex, sw.Elapsed.TotalMilliseconds);
             sw.Restart();
             var materialItemSheet = sheets.GetSheet<MaterialItemSheet>();
             var apPlayCount = TotalPlayCount;
@@ -317,6 +324,7 @@ namespace Nekoyume.Action
                     "{AddressesHex} {Source} TotalPlayCount: {TotalPlayCount}, " +
                     "ApStoneCount: {ApStoneCount}, PlayCount by Ap stone: {ApStonePlayCount}, " +
                     "Ap cost per 1 play: {MinimumCostAp}, " +
+                    "BlockIndex: {BlockIndex}, " +
                     "PlayCount by action point: {ApPlayCount}, Used AP: {UsedAp}",
                     addressesHex,
                     source,
@@ -349,12 +357,14 @@ namespace Nekoyume.Action
             var items = Equipments.Concat(Costumes);
             avatarState.EquipItems(items);
             sw.Stop();
-            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Unequip items", sw.Elapsed.TotalMilliseconds);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process} from #{BlockIndex}: {Elapsed}",
+                addressesHex, source, "Unequip items", blockIndex, sw.Elapsed.TotalMilliseconds);
 
             sw.Restart();
             var questSheet = sheets.GetQuestSheet();
             sw.Stop();
-            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Get QuestSheet", sw.Elapsed.TotalMilliseconds);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process} from #{BlockIndex}: {Elapsed}",
+                addressesHex, source, "Get QuestSheet", blockIndex, sw.Elapsed.TotalMilliseconds);
 
             // Update QuestList only when QuestSheet.Count is greater than QuestList.Count
             var questList = avatarState.questList;
@@ -367,7 +377,8 @@ namespace Nekoyume.Action
                     sheets.GetSheet<QuestItemRewardSheet>(),
                     sheets.GetSheet<EquipmentItemRecipeSheet>());
                 sw.Stop();
-                Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Update QuestList", sw.Elapsed.TotalMilliseconds);
+                Log.Verbose("{AddressesHex} {Source} HAS {Process} from #{BlockIndex}: {Elapsed}",
+                    addressesHex, source, "Update QuestList", blockIndex, sw.Elapsed.TotalMilliseconds);
             }
 
             sw.Restart();
@@ -406,7 +417,8 @@ namespace Nekoyume.Action
             }
 
             sw.Stop();
-            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Get skillState", sw.Elapsed.TotalMilliseconds);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process} from #{BlockIndex}: {Elapsed}",
+                addressesHex, source, "Get skillState", blockIndex, sw.Elapsed.TotalMilliseconds);
 
             sw.Restart();
             var worldUnlockSheet = sheets.GetSheet<WorldUnlockSheet>();
@@ -442,7 +454,8 @@ namespace Nekoyume.Action
                 }
             }
             sw.Stop();
-            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Update slotState", sw.Elapsed.TotalMilliseconds);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process} from #{BlockIndex}: {Elapsed}",
+                addressesHex, source, "Update slotState", blockIndex, sw.Elapsed.TotalMilliseconds);
 
             var stageWaveRow =  sheets.GetSheet<StageWaveSheet>()[StageId];
             var enemySkillSheet = sheets.GetSheet<EnemySkillSheet>();
@@ -473,12 +486,14 @@ namespace Nekoyume.Action
                     rewards,
                     false);
                 sw.Stop();
-                Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Initialize Simulator", sw.Elapsed.TotalMilliseconds);
+                Log.Verbose("{AddressesHex} {Source} HAS {Process} from #{BlockIndex}: {Elapsed}",
+                    addressesHex, source, "Initialize Simulator", blockIndex, sw.Elapsed.TotalMilliseconds);
 
                 sw.Restart();
                 simulator.Simulate();
                 sw.Stop();
-                Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Simulator.Simulate()", sw.Elapsed.TotalMilliseconds);
+                Log.Verbose("{AddressesHex} {Source} HAS {Process} from #{BlockIndex}: {Elapsed}",
+                    addressesHex, source, "Simulator.Simulate()", blockIndex, sw.Elapsed.TotalMilliseconds);
 
                 sw.Restart();
                 if (simulator.Log.IsClear)
@@ -495,7 +510,8 @@ namespace Nekoyume.Action
                         stageCleared = true;
                     }
                     sw.Stop();
-                    Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "ClearStage", sw.Elapsed.TotalMilliseconds);
+                    Log.Verbose("{AddressesHex} {Source} HAS {Process} from #{BlockIndex}: {Elapsed}",
+                        addressesHex, source, "ClearStage", blockIndex, sw.Elapsed.TotalMilliseconds);
                 }
 
                 sw.Restart();
@@ -526,6 +542,7 @@ namespace Nekoyume.Action
                 sw.Stop();
                 Log.Verbose(
                     "{AddressesHex} {Source} {Process} by simulator({AvatarAddress}); " +
+                    "blockIndex: {BlockIndex} " +
                     "worldId: {WorldId}, stageId: {StageId}, result: {Result}, " +
                     "clearWave: {ClearWave}, totalWave: {TotalWave}",
                     addressesHex,
@@ -540,8 +557,8 @@ namespace Nekoyume.Action
                 );
             }
             sw.Stop();
-            Log.Debug("{AddressesHex} {Source} {Process}: {Elapsed}, Count: {PlayCount}",
-                addressesHex, source, "loop Simulate", sw.Elapsed.TotalMilliseconds, TotalPlayCount);
+            Log.Debug("{AddressesHex} {Source} {Process} from #{BlockIndex}: {Elapsed}, Count: {PlayCount}",
+                addressesHex, source, "loop Simulate", blockIndex, sw.Elapsed.TotalMilliseconds, TotalPlayCount);
 
             // Update CrystalRandomSkillState.Stars by clearedWaveNumber. (add)
             skillState?.Update(starCount, crystalStageBuffSheet);
@@ -550,7 +567,8 @@ namespace Nekoyume.Action
             avatarState.updatedAt = blockIndex;
             avatarState.mailBox.CleanUp();
             sw.Stop();
-            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Update AvatarState", sw.Elapsed.TotalMilliseconds);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process} from #{BlockIndex}: {Elapsed}",
+                addressesHex, source, "Update AvatarState", blockIndex, sw.Elapsed.TotalMilliseconds);
 
             sw.Restart();
             if (isNotClearedStage)
@@ -572,10 +590,11 @@ namespace Nekoyume.Action
                 .SetState(worldInformationAddress, avatarState.worldInformation.Serialize())
                 .SetState(questListAddress, avatarState.questList.Serialize());
             sw.Stop();
-            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Set States", sw.Elapsed.TotalMilliseconds);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process} from #{BlockIndex}: {Elapsed}",
+                addressesHex, source, "Set States", blockIndex, sw.Elapsed.TotalMilliseconds);
 
             var totalElapsed = DateTimeOffset.UtcNow - started;
-            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}", addressesHex, source, "Total Executed Time", totalElapsed.TotalMilliseconds);
+            Log.Verbose("{AddressesHex} {Source} HAS {Process}: {Elapsed}, blockIndex: {BlockIndex}", addressesHex, source, "Total Executed Time", totalElapsed.TotalMilliseconds, blockIndex);
             return states;
         }
 

--- a/Lib9c/Model/Item/ItemBase.cs
+++ b/Lib9c/Model/Item/ItemBase.cs
@@ -13,50 +13,126 @@ namespace Nekoyume.Model.Item
     {
         protected static readonly Codec Codec = new Codec();
 
-        public int Id { get; }
-        public int Grade { get; }
-        public ItemType ItemType { get; }
-        public ItemSubType ItemSubType { get; }
-        public ElementalType ElementalType { get; }
+        private int _id;
+        private int _grade;
+        private ItemType _itemType;
+        private ItemSubType _itemSubType;
+        private ElementalType _elementalType;
+        private Text? _serializedId;
+        private Text? _serializedGrade;
+        private Text? _serializedItemType;
+        private Text? _serializedItemSubType;
+        private Text? _serializedElementalType;
+
+        public int Id
+        {
+            get
+            {
+                if (_serializedId is { })
+                {
+                    _id = _serializedId.ToInteger();
+                    _serializedId = null;
+                }
+
+                return _id;
+            }
+        }
+
+        public int Grade
+        {
+            get
+            {
+                if (_serializedGrade is { })
+                {
+                    _grade = _serializedGrade.ToInteger();
+                    _serializedGrade = null;
+                }
+
+                return _grade;
+            }
+        }
+
+        public ItemType ItemType
+        {
+            get
+            {
+                if (_serializedItemType is { })
+                {
+                    _itemType = _serializedItemType.ToEnum<ItemType>();
+                    _serializedItemType = null;
+                }
+
+                return _itemType;
+            }
+        }
+
+        public ItemSubType ItemSubType
+        {
+            get
+            {
+                if (_serializedItemSubType is { })
+                {
+                    _itemSubType = _serializedItemSubType.ToEnum<ItemSubType>();
+                    _serializedItemSubType = null;
+                }
+
+                return _itemSubType;
+            }
+        }
+
+        public ElementalType ElementalType
+        {
+            get
+            {
+                if (_serializedElementalType is { })
+                {
+                    _elementalType = _serializedElementalType.ToEnum<ElementalType>();
+                    _serializedElementalType = null;
+                }
+
+                return _elementalType;
+            }
+        }
+
         protected ItemBase(ItemSheet.Row data)
         {
-            Id = data.Id;
-            Grade = data.Grade;
-            ItemType = data.ItemType;
-            ItemSubType = data.ItemSubType;
-            ElementalType = data.ElementalType;
+            _id = data.Id;
+            _grade = data.Grade;
+            _itemType = data.ItemType;
+            _itemSubType = data.ItemSubType;
+            _elementalType = data.ElementalType;
         }
 
         protected ItemBase(ItemBase other)
         {
-            Id = other.Id;
-            Grade = other.Grade;
-            ItemType = other.ItemType;
-            ItemSubType = other.ItemSubType;
-            ElementalType = other.ElementalType;
+            _id = other.Id;
+            _grade = other.Grade;
+            _itemType = other.ItemType;
+            _itemSubType = other.ItemSubType;
+            _elementalType = other.ElementalType;
         }
 
         protected ItemBase(Dictionary serialized)
         {
             if (serialized.TryGetValue((Text) "id", out var id))
             {
-                Id = id.ToInteger();
+                _serializedId = (Text) id;
             }
             if (serialized.TryGetValue((Text) "grade", out var grade))
             {
-                Grade = grade.ToInteger();
+                _serializedGrade = (Text) grade;
             }
             if (serialized.TryGetValue((Text) "item_type", out var type))
             {
-                ItemType = type.ToEnum<ItemType>();
+                _serializedItemType = (Text) type;
             }
             if (serialized.TryGetValue((Text) "item_sub_type", out var subType))
             {
-                ItemSubType = subType.ToEnum<ItemSubType>();
+                _serializedItemSubType = (Text) subType;
             }
             if (serialized.TryGetValue((Text) "elemental_type", out var elementalType))
             {
-                ElementalType = elementalType.ToEnum<ElementalType>();
+                _serializedElementalType = (Text) elementalType;
             }
         }
 
@@ -94,11 +170,11 @@ namespace Nekoyume.Model.Item
 
         public virtual IValue Serialize() =>
             Dictionary.Empty
-                .Add("id", Id.Serialize())
-                .Add("item_type", ItemType.Serialize())
-                .Add("item_sub_type", ItemSubType.Serialize())
-                .Add("grade", Grade.Serialize())
-                .Add("elemental_type", ElementalType.Serialize());
+                .Add("id", _serializedId ?? Id.Serialize())
+                .Add("item_type", _serializedItemType ?? ItemType.Serialize())
+                .Add("item_sub_type", _serializedItemSubType ?? ItemSubType.Serialize())
+                .Add("grade", _serializedGrade ?? Grade.Serialize())
+                .Add("elemental_type", _serializedElementalType ?? ElementalType.Serialize());
 
         public override string ToString()
         {

--- a/Lib9c/Model/Mail/Mail.cs
+++ b/Lib9c/Model/Mail/Mail.cs
@@ -113,7 +113,7 @@ namespace Nekoyume.Model.Mail
         {
             get
             {
-                if (_deserialized is null)
+                if (_serialized is { })
                 {
                     _deserialized = _serialized.Select(
                         d => Mail.Deserialize((Dictionary)d)
@@ -131,6 +131,7 @@ namespace Nekoyume.Model.Mail
 
         public MailBox()
         {
+            _deserialized = new List<Mail>();
         }
 
         public MailBox(List serialized) : this()

--- a/Lib9c/Model/Quest/CombinationEquipmentQuest.cs
+++ b/Lib9c/Model/Quest/CombinationEquipmentQuest.cs
@@ -10,20 +10,48 @@ namespace Nekoyume.Model.Quest
 {
     public class CombinationEquipmentQuest : Quest
     {
-        public readonly int RecipeId;
-        public readonly int StageId;
+        public int RecipeId
+        {
+            get
+            {
+                if (_serializedRecipeId is { })
+                {
+                    _recipeId = _serializedRecipeId.ToInteger();
+                    _serializedRecipeId = null;
+                }
+
+                return _recipeId;
+            }
+        }
+
+        public int StageId {
+            get
+            {
+                if (_serializedStageId is { })
+                {
+                    _stageId = _serializedStageId.ToInteger();
+                    _serializedStageId = null;
+                }
+
+                return _stageId;
+            }
+        }
+        private IValue _serializedRecipeId;
+        private int _recipeId;
+        private IValue _serializedStageId;
+        private int _stageId;
 
         public CombinationEquipmentQuest(QuestSheet.Row data, QuestReward reward, int stageId) : base(data, reward)
         {
             var row = (CombinationEquipmentQuestSheet.Row) data;
-            RecipeId = row.RecipeId;
-            StageId = stageId;
+            _recipeId = row.RecipeId;
+            _stageId = stageId;
         }
 
         public CombinationEquipmentQuest(Dictionary serialized) : base(serialized)
         {
-            RecipeId = serialized["recipe_id"].ToInteger();
-            StageId = serialized["stage_id"].ToInteger();
+            _serializedStageId = serialized["stage_id"];
+            _serializedRecipeId = serialized["recipe_id"];
         }
 
         //임시처리. 새 타입을 만들어서 위젯에 띄워줘야합니다.
@@ -59,8 +87,8 @@ namespace Nekoyume.Model.Quest
         public override IValue Serialize()
         {
             return ((Dictionary) base.Serialize())
-                .Add("recipe_id", RecipeId.Serialize())
-                .Add("stage_id", StageId.Serialize());
+                .Add("recipe_id", _serializedRecipeId ?? RecipeId.Serialize())
+                .Add("stage_id", _serializedStageId ?? StageId.Serialize());
         }
     }
 }

--- a/Lib9c/Model/Quest/CombinationQuest.cs
+++ b/Lib9c/Model/Quest/CombinationQuest.cs
@@ -11,22 +11,50 @@ namespace Nekoyume.Model.Quest
     [Serializable]
     public class CombinationQuest : Quest
     {
-        public readonly ItemType ItemType;
-        public readonly ItemSubType ItemSubType;
+        public ItemType ItemType
+        {
+            get
+            {
+                if (_serializedItemType is { })
+                {
+                    _itemType = (ItemType) (int) _serializedItemType;
+                    _serializedItemType = null;
+                }
 
+                return _itemType;
+            }
+        }
+
+        public ItemSubType ItemSubType
+        {
+            get
+            {
+                if (_serializedItemSubType is { })
+                {
+                    _itemSubType = (ItemSubType) (int) _serializedItemSubType;
+                    _serializedItemSubType = null;
+                }
+
+                return _itemSubType;
+            }
+        }
+        private Integer? _serializedItemType;
+        private ItemType _itemType;
+        private Integer? _serializedItemSubType;
+        private ItemSubType _itemSubType;
         public override QuestType QuestType => QuestType.Craft;
 
         public CombinationQuest(CombinationQuestSheet.Row data, QuestReward reward)
             : base(data, reward)
         {
-            ItemType = data.ItemType;
-            ItemSubType = data.ItemSubType;
+            _itemType = data.ItemType;
+            _itemSubType = data.ItemSubType;
         }
 
         public CombinationQuest(Dictionary serialized) : base(serialized)
         {
-            ItemType = (ItemType)(int)((Integer)serialized["itemType"]).Value;
-            ItemSubType = (ItemSubType)(int)((Integer)serialized["itemSubType"]).Value;
+            _serializedItemType = (Integer)serialized["itemType"];
+            _serializedItemSubType = (Integer)serialized["itemSubType"];
         }
 
         public override void Check()
@@ -59,7 +87,7 @@ namespace Nekoyume.Model.Quest
 
         public override IValue Serialize() =>
             ((Dictionary) base.Serialize())
-            .Add("itemType", (int) ItemType)
-            .Add("itemSubType", (int) ItemSubType);
+            .Add("itemType", _serializedItemType ?? (int) ItemType)
+            .Add("itemSubType", _serializedItemSubType ?? (int) ItemSubType);
     }
 }

--- a/Lib9c/Model/Quest/GoldQuest.cs
+++ b/Lib9c/Model/Quest/GoldQuest.cs
@@ -12,17 +12,32 @@ namespace Nekoyume.Model.Quest
     [Serializable]
     public class GoldQuest : Quest
     {
-        public readonly TradeType Type;
+        public TradeType Type
+        {
+            get
+            {
+                if (_serializedType is { })
+                {
+                    _type = (TradeType) (int) _serializedType;
+                    _serializedType = null;
+                }
+
+                return _type;
+            }
+        }
+        private TradeType _type;
+        private Integer? _serializedType;
+
 
         public GoldQuest(GoldQuestSheet.Row data, QuestReward reward)
             : base(data, reward)
         {
-            Type = data.Type;
+            _type = data.Type;
         }
 
         public GoldQuest(Dictionary serialized) : base(serialized)
         {
-            Type = (TradeType)(int)((Integer)serialized["type"]).Value;
+            _serializedType = (Integer) serialized["type"];
         }
 
         public override QuestType QuestType => QuestType.Exchange;
@@ -62,6 +77,6 @@ namespace Nekoyume.Model.Quest
 
         public override IValue Serialize() =>
             ((Dictionary) base.Serialize())
-            .Add("type", (int) Type);
+            .Add("type", _serializedType ?? (int) Type);
     }
 }

--- a/Lib9c/Model/Quest/ItemEnhancementQuest.cs
+++ b/Lib9c/Model/Quest/ItemEnhancementQuest.cs
@@ -11,22 +11,52 @@ namespace Nekoyume.Model.Quest
     [Serializable]
     public class ItemEnhancementQuest : Quest
     {
-        public readonly int Grade;
-        private readonly int _count;
-        public int Count => _count;
-        public override float Progress => (float) _current / _count;
+        public int Grade
+        {
+            get
+            {
+                if (_serializedGrade is { })
+                {
+                    _grade = (int) _serializedGrade;
+                    _serializedGrade = null;
+                }
+
+                return _grade;
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                if (_serializedCount is { })
+                {
+                    _count = (int) _serializedCount;
+                    _serializedCount = null;
+                }
+
+                return _count;
+            }
+        }
+
+        private Integer? _serializedGrade;
+        private int _grade;
+        private Integer? _serializedCount;
+        // Do not use this field. it can be different check result
+        private int _count;
+        public override float Progress => (float) _current / Count;
 
         public ItemEnhancementQuest(ItemEnhancementQuestSheet.Row data, QuestReward reward)
             : base(data, reward)
         {
             _count = data.Count;
-            Grade = data.Grade;
+            _grade = data.Grade;
         }
 
         public ItemEnhancementQuest(Dictionary serialized) : base(serialized)
         {
-            Grade = (int)((Integer)serialized["grade"]).Value;
-            _count = (int)((Integer)serialized["count"]).Value;
+            _serializedGrade = (Integer) serialized["grade"];
+            _serializedCount = (Integer) serialized["count"];
         }
 
         public override QuestType QuestType => QuestType.Craft;
@@ -36,15 +66,15 @@ namespace Nekoyume.Model.Quest
             if (Complete)
                 return;
 
-            Complete = _count == _current;
+            Complete = Count == _current;
         }
 
         public override string GetProgressText() =>
             string.Format(
                 CultureInfo.InvariantCulture,
                 GoalFormat,
-                Math.Min(_count, _current),
-               _count
+                Math.Min(Count, _current),
+               Count
             );
 
         public void Update(Equipment equipment)
@@ -64,7 +94,7 @@ namespace Nekoyume.Model.Quest
 
         public override IValue Serialize() =>
             ((Dictionary) base.Serialize())
-            .Add("grade", Grade)
-            .Add("count", _count);
+            .Add("grade", _serializedGrade ?? Grade)
+            .Add("count", _serializedCount ?? Count);
     }
 }

--- a/Lib9c/Model/Quest/QuestReward.cs
+++ b/Lib9c/Model/Quest/QuestReward.cs
@@ -10,29 +10,28 @@ namespace Nekoyume.Model.Quest
     [Serializable]
     public class QuestReward : IState
     {
-        public readonly Dictionary<int, int> ItemMap;
+        public readonly IEnumerable<Tuple<int, int>> ItemMap;
 
         public QuestReward(Dictionary<int, int> map)
         {
-            ItemMap = map
-                .ToDictionary(kv => kv.Key, kv => kv.Value
-            );
+#pragma warning disable LAA1002
+            ItemMap = map.Select(kv => new Tuple<int, int>(kv.Key, kv.Value));
         }
 
         public QuestReward(Dictionary serialized)
         {
-            ItemMap = serialized.ToDictionary(
-                kv => kv.Key.ToInteger(),
-                kv => kv.Value.ToInteger()
+            ItemMap = serialized.Select(
+                kv => new Tuple<int, int>(kv.Key.ToInteger(), kv.Value.ToInteger())
             );
+#pragma warning restore LAA1002
         }
 
         public IValue Serialize() => new Dictionary(
 #pragma warning disable LAA1002
             ItemMap.Select(kv =>
                 new KeyValuePair<IKey, IValue>(
-                    (Text)kv.Key.ToString(CultureInfo.InvariantCulture),
-                    (Text)kv.Value.ToString(CultureInfo.InvariantCulture)
+                    (Text)kv.Item1.ToString(CultureInfo.InvariantCulture),
+                    (Text)kv.Item2.ToString(CultureInfo.InvariantCulture)
                 )
             )
 #pragma warning restore LAA1002

--- a/Lib9c/Model/Quest/TradeQuest.cs
+++ b/Lib9c/Model/Quest/TradeQuest.cs
@@ -12,17 +12,32 @@ namespace Nekoyume.Model.Quest
     public class TradeQuest : Quest
     {
         public override QuestType QuestType => QuestType.Exchange;
-        public readonly TradeType Type;
+
+        public TradeType Type
+        {
+            get
+            {
+                if (_serializedType is { })
+                {
+                    _type = (TradeType) (int) _serializedType;
+                    _serializedType = null;
+                }
+
+                return _type;
+            }
+        }
+        private TradeType _type;
+        private Integer? _serializedType;
 
         public TradeQuest(TradeQuestSheet.Row data, QuestReward reward)
             : base(data, reward)
         {
-            Type = data.Type;
+            _type = data.Type;
         }
 
         public TradeQuest(Dictionary serialized) : base(serialized)
         {
-            Type = (TradeType)(int)((Integer)serialized["type"]).Value;
+            _serializedType = (Integer) serialized["type"];
         }
 
         public override void Check()
@@ -46,6 +61,6 @@ namespace Nekoyume.Model.Quest
         protected override string TypeId => "tradeQuest";
         public override IValue Serialize() =>
             ((Dictionary) base.Serialize())
-            .Add("type", (int) Type);
+            .Add("type", _serializedType ?? (int) Type);
     }
 }

--- a/Lib9c/Model/State/AvatarState.cs
+++ b/Lib9c/Model/State/AvatarState.cs
@@ -487,11 +487,11 @@ namespace Nekoyume.Model.State
         public void UpdateFromQuestReward(Quest.Quest quest, MaterialItemSheet materialItemSheet)
         {
             var items = new List<Material>();
-            foreach (var pair in quest.Reward.ItemMap.OrderBy(kv => kv.Key))
+            foreach (var pair in quest.Reward.ItemMap.OrderBy(kv => kv.Item1))
             {
-                var row = materialItemSheet.OrderedList.First(itemRow => itemRow.Id == pair.Key);
+                var row = materialItemSheet.OrderedList.First(itemRow => itemRow.Id == pair.Item1);
                 var item = ItemFactory.CreateMaterial(row);
-                var map = inventory.AddItem(item, count: pair.Value);
+                var map = inventory.AddItem(item, count: pair.Item2);
                 itemMap.Add(map);
                 items.Add(item);
             }
@@ -506,11 +506,11 @@ namespace Nekoyume.Model.State
         public void UpdateFromQuestReward2(Quest.Quest quest, MaterialItemSheet materialItemSheet)
         {
             var items = new List<Material>();
-            foreach (var pair in quest.Reward.ItemMap.OrderBy(kv => kv.Key))
+            foreach (var pair in quest.Reward.ItemMap.OrderBy(kv => kv.Item1))
             {
-                var row = materialItemSheet.OrderedList.First(itemRow => itemRow.Id == pair.Key);
+                var row = materialItemSheet.OrderedList.First(itemRow => itemRow.Id == pair.Item2);
                 var item = ItemFactory.CreateMaterial(row);
-                var map = inventory.AddItem2(item, count: pair.Value);
+                var map = inventory.AddItem2(item, count: pair.Item2);
                 itemMap.Add(map);
                 items.Add(item);
             }

--- a/Lib9c/Model/State/AvatarState.cs
+++ b/Lib9c/Model/State/AvatarState.cs
@@ -508,7 +508,7 @@ namespace Nekoyume.Model.State
             var items = new List<Material>();
             foreach (var pair in quest.Reward.ItemMap.OrderBy(kv => kv.Item1))
             {
-                var row = materialItemSheet.OrderedList.First(itemRow => itemRow.Id == pair.Item2);
+                var row = materialItemSheet.OrderedList.First(itemRow => itemRow.Id == pair.Item1);
                 var item = ItemFactory.CreateMaterial(row);
                 var map = inventory.AddItem2(item, count: pair.Item2);
                 itemMap.Add(map);


### PR DESCRIPTION
AS-IS
<img width="2032" alt="image" src="https://github.com/planetarium/lib9c/assets/3193043/657385a2-57e8-4d35-8fee-f0ebece562c1">
<img width="2032" alt="image" src="https://github.com/planetarium/lib9c/assets/3193043/ad9e205c-9571-4816-8220-1c739718f0f6">

TO-BE
<img width="2032" alt="image" src="https://github.com/planetarium/lib9c/assets/3193043/41185499-76be-407f-8c9d-52e6048269a7">
<img width="2032" alt="image" src="https://github.com/planetarium/lib9c/assets/3193043/145e6c49-09be-4741-9d97-edaca6427107">
---
reduce HackAndSlash.Execute from avg 134.7ms -> 60.5ms(in target block) with AvatarState deserialize / serialize with lazy-load
