### PR TITLE
Move ITradableItem from ItemUsable to each items

### DIFF
--- a/.Lib9c.Tests/Action/Buy10Test.cs
+++ b/.Lib9c.Tests/Action/Buy10Test.cs
@@ -239,7 +239,7 @@ namespace Lib9c.Tests.Action
                         _tableSheets.EquipmentItemSheet.First,
                         itemId,
                         0);
-                    tradableItem = itemUsable;
+                    tradableItem = (ITradableItem)itemUsable;
                     itemSubType = itemUsable.ItemSubType;
                 }
                 else if (orderData.ItemType == ItemType.Costume)

--- a/.Lib9c.Tests/Action/Buy11Test.cs
+++ b/.Lib9c.Tests/Action/Buy11Test.cs
@@ -245,7 +245,7 @@ namespace Lib9c.Tests.Action
                         _tableSheets.EquipmentItemSheet.First,
                         itemId,
                         0);
-                    tradableItem = itemUsable;
+                    tradableItem = (ITradableItem)itemUsable;
                     itemSubType = itemUsable.ItemSubType;
                 }
                 else if (orderData.ItemType == ItemType.Costume)

--- a/.Lib9c.Tests/Action/Buy2Test.cs
+++ b/.Lib9c.Tests/Action/Buy2Test.cs
@@ -98,7 +98,7 @@ namespace Lib9c.Tests.Action
                 _sellerAvatarAddress,
                 Guid.NewGuid(),
                 new FungibleAssetValue(_goldCurrencyState.Currency, 100, 0),
-                equipment));
+                (ITradableItem)equipment));
 
             var result = new CombinationConsumable5.ResultModel()
             {

--- a/.Lib9c.Tests/Action/Buy3Test.cs
+++ b/.Lib9c.Tests/Action/Buy3Test.cs
@@ -108,14 +108,14 @@
                 _sellerAvatarAddress,
                 Guid.NewGuid(),
                 new FungibleAssetValue(_goldCurrencyState.Currency, ProductPrice, 0),
-                equipment));
+                (ITradableItem)equipment));
 
             shopState.Register(new ShopItem(
                 _sellerAgentAddress,
                 _sellerAvatarAddress,
                 Guid.NewGuid(),
                 new FungibleAssetValue(_goldCurrencyState.Currency, ProductPrice, 0),
-                consumable));
+                (ITradableItem)consumable));
 
             shopState.Register(new ShopItem(
                 _sellerAgentAddress,

--- a/.Lib9c.Tests/Action/Buy4Test.cs
+++ b/.Lib9c.Tests/Action/Buy4Test.cs
@@ -110,14 +110,14 @@
                 _sellerAvatarAddress,
                 Guid.NewGuid(),
                 new FungibleAssetValue(_goldCurrencyState.Currency, ProductPrice, 0),
-                equipment));
+                (ITradableItem)equipment));
 
             shopState.Register(new ShopItem(
                 _sellerAgentAddress,
                 _sellerAvatarAddress,
                 Guid.NewGuid(),
                 new FungibleAssetValue(_goldCurrencyState.Currency, ProductPrice, 0),
-                consumable));
+                (ITradableItem)consumable));
 
             shopState.Register(new ShopItem(
                 _sellerAgentAddress,

--- a/.Lib9c.Tests/Action/Buy5Test.cs
+++ b/.Lib9c.Tests/Action/Buy5Test.cs
@@ -210,7 +210,7 @@ namespace Lib9c.Tests.Action
                     productId,
                     new FungibleAssetValue(_goldCurrencyState.Currency, shopItemData.Price, 0),
                     requiredBlockIndex,
-                    nonFungibleItem);
+                    (ITradableItem)nonFungibleItem);
 
                 // Case for backward compatibility.
                 if (shopItemData.ContainsInInventory)
@@ -454,7 +454,7 @@ namespace Lib9c.Tests.Action
                 _productId,
                 new FungibleAssetValue(_goldCurrencyState.Currency, 100, 0),
                 Sell6.ExpiredBlockIndex,
-                itemUsable);
+                (ITradableItem)itemUsable);
 
             ShardedShopState shopState = new ShardedShopState(shardedShopAddress);
             shopState.Register(shopItem);
@@ -506,7 +506,7 @@ namespace Lib9c.Tests.Action
                 _productId,
                 new FungibleAssetValue(_goldCurrencyState.Currency, 100, 0),
                 Sell6.ExpiredBlockIndex,
-                itemUsable);
+                (ITradableItem)itemUsable);
 
             ShardedShopState shopState = new ShardedShopState(shardedShopAddress);
             shopState.Register(shopItem);

--- a/.Lib9c.Tests/Action/Buy6Test.cs
+++ b/.Lib9c.Tests/Action/Buy6Test.cs
@@ -213,7 +213,7 @@ namespace Lib9c.Tests.Action
                         _tableSheets.EquipmentItemSheet.First,
                         itemId,
                         requiredBlockIndex);
-                    tradableItem = itemUsable;
+                    tradableItem = (ITradableItem)itemUsable;
                     itemSubType = itemUsable.ItemSubType;
                 }
                 else if (shopItemData.ItemType == ItemType.Costume)
@@ -581,7 +581,7 @@ namespace Lib9c.Tests.Action
                 _productId,
                 new FungibleAssetValue(_goldCurrencyState.Currency, 100, 0),
                 Sell6.ExpiredBlockIndex,
-                itemUsable);
+                (ITradableItem)itemUsable);
 
             ShardedShopState shopState = new ShardedShopState(shardedShopAddress);
             shopState.Register(shopItem);

--- a/.Lib9c.Tests/Action/Buy7Test.cs
+++ b/.Lib9c.Tests/Action/Buy7Test.cs
@@ -213,7 +213,7 @@ namespace Lib9c.Tests.Action
                         _tableSheets.EquipmentItemSheet.First,
                         itemId,
                         requiredBlockIndex);
-                    tradableItem = itemUsable;
+                    tradableItem = (ITradableItem)itemUsable;
                     itemSubType = itemUsable.ItemSubType;
                 }
                 else if (shopItemData.ItemType == ItemType.Costume)
@@ -652,7 +652,7 @@ namespace Lib9c.Tests.Action
                 _productId,
                 new FungibleAssetValue(_goldCurrencyState.Currency, 100, 0),
                 Sell6.ExpiredBlockIndex,
-                itemUsable);
+                (ITradableItem)itemUsable);
 
             ShardedShopState shopState = new ShardedShopState(shardedShopAddress);
             shopState.Register(shopItem);

--- a/.Lib9c.Tests/Action/Buy8Test.cs
+++ b/.Lib9c.Tests/Action/Buy8Test.cs
@@ -207,7 +207,7 @@
                         _tableSheets.EquipmentItemSheet.First,
                         itemId,
                         0);
-                    tradableItem = itemUsable;
+                    tradableItem = (ITradableItem)itemUsable;
                     itemSubType = itemUsable.ItemSubType;
                 }
                 else if (orderData.ItemType == ItemType.Costume)

--- a/.Lib9c.Tests/Action/Buy9Test.cs
+++ b/.Lib9c.Tests/Action/Buy9Test.cs
@@ -294,7 +294,7 @@
                         _tableSheets.EquipmentItemSheet.First,
                         itemId,
                         0);
-                    tradableItem = itemUsable;
+                    tradableItem = (ITradableItem)itemUsable;
                     itemSubType = itemUsable.ItemSubType;
                 }
                 else if (orderData.ItemType == ItemType.Costume)

--- a/.Lib9c.Tests/Action/BuyMultipleTest.cs
+++ b/.Lib9c.Tests/Action/BuyMultipleTest.cs
@@ -275,7 +275,7 @@
                     shopItemId,
                     new FungibleAssetValue(_goldCurrencyState.Currency, product.Price, 0),
                     product.RequiredBlockIndex,
-                    nonFungibleItem);
+                    (ITradableItem)nonFungibleItem);
                 shopState.Register(shopItem);
 
                 if (product.Buy)
@@ -504,7 +504,7 @@
                 Guid.NewGuid(),
                 new FungibleAssetValue(_goldCurrencyState.Currency, 1, 0),
                 100,
-                equipment));
+                (ITradableItem)equipment));
 
             var costume = ItemFactory.CreateCostume(
                 _tableSheets.CostumeItemSheet.First,
@@ -574,7 +574,7 @@
                 productId,
                 new FungibleAssetValue(_goldCurrencyState.Currency, 100, 0),
                 10,
-                equipment));
+                (ITradableItem)equipment));
 
             previousStates = previousStates
                 .SetState(Addresses.Shop, shopState.Serialize());

--- a/.Lib9c.Tests/Action/BuyProduct0Test.cs
+++ b/.Lib9c.Tests/Action/BuyProduct0Test.cs
@@ -28,7 +28,7 @@ namespace Lib9c.Tests.Action
         private static readonly Currency Gold = Currency.Legacy("NCG", 2, null);
         private static readonly TableSheets TableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
         private static readonly ITradableItem TradableItem =
-            ItemFactory.CreateItemUsable(TableSheets.EquipmentItemSheet.OrderedList.First(r => r.ItemSubType == ItemSubType.Armor), Guid.NewGuid(), 1L);
+            (ITradableItem)ItemFactory.CreateItemUsable(TableSheets.EquipmentItemSheet.OrderedList.First(r => r.ItemSubType == ItemSubType.Armor), Guid.NewGuid(), 1L);
 
         private readonly Address _sellerAgentAddress2;
         private readonly Address _sellerAvatarAddress2;

--- a/.Lib9c.Tests/Action/BuyProductTest.cs
+++ b/.Lib9c.Tests/Action/BuyProductTest.cs
@@ -28,7 +28,7 @@ namespace Lib9c.Tests.Action
         private static readonly Currency Gold = Currency.Legacy("NCG", 2, null);
         private static readonly TableSheets TableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
         private static readonly ITradableItem TradableItem =
-            ItemFactory.CreateItemUsable(TableSheets.EquipmentItemSheet.OrderedList.First(r => r.ItemSubType == ItemSubType.Armor), Guid.NewGuid(), 1L);
+            (ITradableItem)ItemFactory.CreateItemUsable(TableSheets.EquipmentItemSheet.OrderedList.First(r => r.ItemSubType == ItemSubType.Armor), Guid.NewGuid(), 1L);
 
         private readonly Address _sellerAgentAddress2;
         private readonly Address _sellerAvatarAddress2;

--- a/.Lib9c.Tests/Action/BuyTest.cs
+++ b/.Lib9c.Tests/Action/BuyTest.cs
@@ -240,7 +240,7 @@ namespace Lib9c.Tests.Action
                         _tableSheets.EquipmentItemSheet.First,
                         itemId,
                         0);
-                    tradableItem = itemUsable;
+                    tradableItem = (ITradableItem)itemUsable;
                     itemSubType = itemUsable.ItemSubType;
                 }
                 else if (orderData.ItemType == ItemType.Costume)

--- a/.Lib9c.Tests/Action/ItemEnhancement10Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement10Test.cs
@@ -192,8 +192,8 @@ namespace Lib9c.Tests.Action
                     break;
             }
 
-            Assert.Equal(preItemUsable.TradableId, slotResult.preItemUsable.TradableId);
-            Assert.Equal(preItemUsable.TradableId, resultEquipment.TradableId);
+            Assert.Equal(preItemUsable.ItemId, slotResult.preItemUsable.ItemId);
+            Assert.Equal(preItemUsable.ItemId, resultEquipment.ItemId);
             Assert.Equal(costRow.Cost, slotResult.gold);
         }
 

--- a/.Lib9c.Tests/Action/ItemEnhancement9Test.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancement9Test.cs
@@ -186,8 +186,8 @@ namespace Lib9c.Tests.Action
                     break;
             }
 
-            Assert.Equal(preItemUsable.TradableId, slotResult.preItemUsable.TradableId);
-            Assert.Equal(preItemUsable.TradableId, resultEquipment.TradableId);
+            Assert.Equal(preItemUsable.ItemId, slotResult.preItemUsable.ItemId);
+            Assert.Equal(preItemUsable.ItemId, resultEquipment.ItemId);
             Assert.Equal(costRow.Cost, slotResult.gold);
         }
 

--- a/.Lib9c.Tests/Action/ItemEnhancementTest.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancementTest.cs
@@ -225,8 +225,8 @@ namespace Lib9c.Tests.Action
                     break;
             }
 
-            Assert.Equal(preItemUsable.TradableId, slotResult.preItemUsable.TradableId);
-            Assert.Equal(preItemUsable.TradableId, resultEquipment.TradableId);
+            Assert.Equal(preItemUsable.ItemId, slotResult.preItemUsable.ItemId);
+            Assert.Equal(preItemUsable.ItemId, resultEquipment.ItemId);
             Assert.Equal(costRow.Cost, slotResult.gold);
             Assert.Equal(expectedCrystal * CrystalCalculator.CRYSTAL, slotResult.CRYSTAL);
         }

--- a/.Lib9c.Tests/Action/ReRegisterProduct0Test.cs
+++ b/.Lib9c.Tests/Action/ReRegisterProduct0Test.cs
@@ -120,7 +120,7 @@
                         _tableSheets.EquipmentItemSheet.First,
                         itemId,
                         requiredBlockIndex);
-                    tradableItem = itemUsable;
+                    tradableItem = (ITradableItem)itemUsable;
                     itemSubType = itemUsable.ItemSubType;
                     break;
                 }

--- a/.Lib9c.Tests/Action/ReRegisterProductTest.cs
+++ b/.Lib9c.Tests/Action/ReRegisterProductTest.cs
@@ -120,7 +120,7 @@
                         _tableSheets.EquipmentItemSheet.First,
                         itemId,
                         requiredBlockIndex);
-                    tradableItem = itemUsable;
+                    tradableItem = (ITradableItem)itemUsable;
                     itemSubType = itemUsable.ItemSubType;
                     break;
                 }

--- a/.Lib9c.Tests/Action/RegisterProduct0Test.cs
+++ b/.Lib9c.Tests/Action/RegisterProduct0Test.cs
@@ -227,7 +227,7 @@ namespace Lib9c.Tests.Action
                         AvatarAddress = AvatarAddress,
                         ItemCount = 1,
                         Price = 1 * Gold,
-                        TradableId = equipment.TradableId,
+                        TradableId = equipment.ItemId,
                         Type = ProductType.NonFungible,
                     },
                     new AssetInfo
@@ -329,7 +329,7 @@ namespace Lib9c.Tests.Action
                 {
                     var equipmentRow = _tableSheets.EquipmentItemSheet.Values.First();
                     var id = Guid.NewGuid();
-                    tradableItem = ItemFactory.CreateItemUsable(equipmentRow, id, requiredBlockIndex);
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(equipmentRow, id, requiredBlockIndex);
                     break;
                 }
 

--- a/.Lib9c.Tests/Action/RegisterProductTest.cs
+++ b/.Lib9c.Tests/Action/RegisterProductTest.cs
@@ -227,7 +227,7 @@ namespace Lib9c.Tests.Action
                         AvatarAddress = AvatarAddress,
                         ItemCount = 1,
                         Price = 1 * Gold,
-                        TradableId = equipment.TradableId,
+                        TradableId = equipment.ItemId,
                         Type = ProductType.NonFungible,
                     },
                     new AssetInfo
@@ -330,7 +330,7 @@ namespace Lib9c.Tests.Action
                 {
                     var equipmentRow = _tableSheets.EquipmentItemSheet.Values.First();
                     var id = Guid.NewGuid();
-                    tradableItem = ItemFactory.CreateItemUsable(equipmentRow, id, requiredBlockIndex);
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(equipmentRow, id, requiredBlockIndex);
                     break;
                 }
 

--- a/.Lib9c.Tests/Action/Scenario/AuraScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/AuraScenarioTest.cs
@@ -14,6 +14,7 @@ namespace Lib9c.Tests.Action.Scenario
     using Nekoyume.Model.BattleStatus.Arena;
     using Nekoyume.Model.EnumType;
     using Nekoyume.Model.Item;
+    using Nekoyume.Model.Market;
     using Nekoyume.Model.Skill;
     using Nekoyume.Model.Stat;
     using Nekoyume.Model.State;
@@ -29,6 +30,7 @@ namespace Lib9c.Tests.Action.Scenario
         private readonly IAccountStateDelta _initialState;
         private readonly Aura _aura;
         private readonly TableSheets _tableSheets;
+        private readonly Currency _currency;
 
         public AuraScenarioTest()
         {
@@ -74,11 +76,12 @@ namespace Lib9c.Tests.Action.Scenario
                         avatarState.questList.Serialize());
             }
 
+            _currency = Currency.Legacy("NCG", 2, minters: null);
             _initialState = _initialState
                 .SetState(_agentAddress, agentState.Serialize())
                 .SetState(
                     Addresses.GoldCurrency,
-                    new GoldCurrencyState(Currency.Legacy("NCG", 2, minters: null)).Serialize())
+                    new GoldCurrencyState(_currency).Serialize())
                 .SetState(gameConfigState.address, gameConfigState.Serialize())
                 .MintAsset(new ActionContext(), _agentAddress, Currencies.Crystal * 2);
             foreach (var (key, value) in sheets)
@@ -291,6 +294,48 @@ namespace Lib9c.Tests.Action.Scenario
             Assert.False(nextAvatarState.inventory.TryGetNonFungibleItem(_aura.ItemId, out _));
             var previousCrystal = _initialState.GetBalance(_agentAddress, Currencies.Crystal);
             Assert.True(nextState.GetBalance(_agentAddress, Currencies.Crystal) > previousCrystal);
+        }
+
+        [Fact]
+        public void Market()
+        {
+            var avatarState = _initialState.GetAvatarStateV2(_avatarAddress);
+            avatarState.inventory.TryGetNonFungibleItem(_aura.ItemId, out Aura aura);
+            Assert.NotNull(aura);
+            Assert.IsAssignableFrom<Equipment>(aura);
+            Assert.Null(aura as ITradableItem);
+            for (int i = 0; i < GameConfig.RequireClearedStageLevel.ActionsInShop; i++)
+            {
+                avatarState.worldInformation.ClearStage(1, i + 1, 0, _tableSheets.WorldSheet, _tableSheets.WorldUnlockSheet);
+            }
+
+            var previousState = _initialState.SetState(
+                _avatarAddress.Derive(LegacyWorldInformationKey),
+                avatarState.worldInformation.Serialize());
+
+            var register = new RegisterProduct
+            {
+                AvatarAddress = _avatarAddress,
+                RegisterInfos = new List<IRegisterInfo>
+                {
+                    new RegisterInfo
+                    {
+                        AvatarAddress = _avatarAddress,
+                        Price = 1 * _currency,
+                        TradableId = _aura.ItemId,
+                        ItemCount = 1,
+                        Type = ProductType.NonFungible,
+                    },
+                },
+                ChargeAp = false,
+            };
+            // Because Aura is not ITradableItem.
+            Assert.Throws<ItemDoesNotExistException>(() => register.Execute(new ActionContext
+            {
+                Signer = _agentAddress,
+                PreviousState = previousState,
+                BlockIndex = 0L,
+            }));
         }
 
         private void Assert_Player(AvatarState avatarState, IAccountStateDelta state, Address avatarAddress, Address itemSlotStateAddress)

--- a/.Lib9c.Tests/Action/Scenario/MarketScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/MarketScenarioTest.cs
@@ -219,7 +219,7 @@ namespace Lib9c.Tests.Action.Scenario
                         AvatarAddress = _sellerAvatarAddress2,
                         ItemCount = 1,
                         Price = 1 * _currency,
-                        TradableId = equipment.TradableId,
+                        TradableId = equipment.ItemId,
                         Type = ProductType.NonFungible,
                     },
                     new AssetInfo
@@ -376,7 +376,7 @@ namespace Lib9c.Tests.Action.Scenario
                         AvatarAddress = _sellerAvatarAddress,
                         ItemCount = 1,
                         Price = 1 * _currency,
-                        TradableId = equipment.TradableId,
+                        TradableId = equipment.ItemId,
                         Type = ProductType.NonFungible,
                     },
                     new AssetInfo
@@ -464,7 +464,7 @@ namespace Lib9c.Tests.Action.Scenario
                         ProductId = nonFungibleProductId,
                         Type = ProductType.NonFungible,
                         ItemSubType = equipment.ItemSubType,
-                        TradableId = equipment.TradableId,
+                        TradableId = equipment.ItemId,
                     },
                     new FavProductInfo
                     {
@@ -548,7 +548,7 @@ namespace Lib9c.Tests.Action.Scenario
                         AvatarAddress = _sellerAvatarAddress,
                         ItemCount = 1,
                         Price = 1 * _currency,
-                        TradableId = equipment.TradableId,
+                        TradableId = equipment.ItemId,
                         Type = ProductType.NonFungible,
                     },
                     new AssetInfo
@@ -654,14 +654,14 @@ namespace Lib9c.Tests.Action.Scenario
                             ProductId = nonFungibleProductId,
                             Type = ProductType.NonFungible,
                             ItemSubType = equipment.ItemSubType,
-                            TradableId = equipment.TradableId,
+                            TradableId = equipment.ItemId,
                         },
                         new RegisterInfo
                         {
                             AvatarAddress = _sellerAvatarAddress,
                             ItemCount = 1,
                             Price = 1 * _currency,
-                            TradableId = equipment.TradableId,
+                            TradableId = equipment.ItemId,
                             Type = ProductType.NonFungible,
                         }
                     ),
@@ -875,7 +875,7 @@ namespace Lib9c.Tests.Action.Scenario
                         AvatarAddress = _sellerAvatarAddress,
                         ItemCount = 1,
                         Price = 1 * _currency,
-                        TradableId = equipment.TradableId,
+                        TradableId = equipment.ItemId,
                         Type = ProductType.NonFungible,
                     },
                     new AssetInfo
@@ -948,7 +948,7 @@ namespace Lib9c.Tests.Action.Scenario
                     ProductId = nonFungibleProductId,
                     Type = ProductType.NonFungible,
                     ItemSubType = equipment.ItemSubType,
-                    TradableId = equipment.TradableId,
+                    TradableId = equipment.ItemId,
                 },
                 new FavProductInfo
                 {
@@ -975,7 +975,7 @@ namespace Lib9c.Tests.Action.Scenario
             var avatarState = canceledState.GetAvatarStateV2(_sellerAvatarAddress);
             Assert.Equal(2, avatarState.inventory.Items.Count);
             Assert.True(avatarState.inventory.TryGetTradableItem(tradableMaterial.TradableId, 0L, 1, out var materialItem));
-            Assert.True(avatarState.inventory.TryGetNonFungibleItem(equipment.TradableId, out var equipmentItem));
+            Assert.True(avatarState.inventory.TryGetNonFungibleItem(equipment.ItemId, out var equipmentItem));
             var canceledEquipment = Assert.IsAssignableFrom<ItemUsable>(equipmentItem.item);
             Assert.Equal(100L, canceledEquipment.RequiredBlockIndex);
             Assert.Equal(
@@ -1018,14 +1018,14 @@ namespace Lib9c.Tests.Action.Scenario
                             ProductId = nonFungibleProductId,
                             Type = ProductType.NonFungible,
                             ItemSubType = equipment.ItemSubType,
-                            TradableId = equipment.TradableId,
+                            TradableId = equipment.ItemId,
                         },
                         new RegisterInfo
                         {
                             AvatarAddress = _sellerAvatarAddress,
                             ItemCount = 1,
                             Price = 2 * _currency,
-                            TradableId = equipment.TradableId,
+                            TradableId = equipment.ItemId,
                             Type = ProductType.NonFungible,
                         }
                     ),

--- a/.Lib9c.Tests/Action/Sell10Test.cs
+++ b/.Lib9c.Tests/Action/Sell10Test.cs
@@ -99,7 +99,7 @@ namespace Lib9c.Tests.Action
             switch (itemType)
             {
                 case ItemType.Consumable:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.ConsumableItemSheet.First,
                         Guid.NewGuid(),
                         0);
@@ -110,7 +110,7 @@ namespace Lib9c.Tests.Action
                         Guid.NewGuid());
                     break;
                 case ItemType.Equipment:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.EquipmentItemSheet.First,
                         Guid.NewGuid(),
                         0);

--- a/.Lib9c.Tests/Action/Sell11Test.cs
+++ b/.Lib9c.Tests/Action/Sell11Test.cs
@@ -99,7 +99,7 @@ namespace Lib9c.Tests.Action
             switch (itemType)
             {
                 case ItemType.Consumable:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.ConsumableItemSheet.First,
                         Guid.NewGuid(),
                         0);
@@ -110,7 +110,7 @@ namespace Lib9c.Tests.Action
                         Guid.NewGuid());
                     break;
                 case ItemType.Equipment:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.EquipmentItemSheet.First,
                         Guid.NewGuid(),
                         0);

--- a/.Lib9c.Tests/Action/Sell4Test.cs
+++ b/.Lib9c.Tests/Action/Sell4Test.cs
@@ -135,7 +135,7 @@
                     productId,
                     new FungibleAssetValue(currencyState, 100, 0),
                     blockIndex,
-                    nonFungibleItem);
+                    (ITradableItem)nonFungibleItem);
                 ShardedShopState shardedShopState =
                     new ShardedShopState(shopAddress);
                 shardedShopState.Register(si);

--- a/.Lib9c.Tests/Action/Sell5Test.cs
+++ b/.Lib9c.Tests/Action/Sell5Test.cs
@@ -105,7 +105,7 @@ namespace Lib9c.Tests.Action
             switch (itemType)
             {
                 case ItemType.Consumable:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.ConsumableItemSheet.First,
                         Guid.NewGuid(),
                         0);
@@ -116,7 +116,7 @@ namespace Lib9c.Tests.Action
                         Guid.NewGuid());
                     break;
                 case ItemType.Equipment:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.EquipmentItemSheet.First,
                         Guid.NewGuid(),
                         0);
@@ -211,7 +211,7 @@ namespace Lib9c.Tests.Action
             {
                 case ItemType.Consumable:
                 case ItemType.Equipment:
-                    nextTradableItemInShopItem = nextShopItem.ItemUsable;
+                    nextTradableItemInShopItem = (ITradableItem)nextShopItem.ItemUsable;
                     break;
                 case ItemType.Costume:
                     nextTradableItemInShopItem = nextShopItem.Costume;
@@ -242,8 +242,8 @@ namespace Lib9c.Tests.Action
                 case ItemType.Consumable:
                 case ItemType.Equipment:
                     Assert.NotNull(mail.attachment.itemUsable);
-                    attachmentItem = mail.attachment.itemUsable;
-                    Assert.Equal(tradableItem, mail.attachment.itemUsable);
+                    attachmentItem = (ITradableItem)mail.attachment.itemUsable;
+                    Assert.Equal((ItemUsable)tradableItem, mail.attachment.itemUsable);
                     break;
                 case ItemType.Costume:
                     Assert.NotNull(mail.attachment.costume);

--- a/.Lib9c.Tests/Action/Sell6Test.cs
+++ b/.Lib9c.Tests/Action/Sell6Test.cs
@@ -105,7 +105,7 @@ namespace Lib9c.Tests.Action
             switch (itemType)
             {
                 case ItemType.Consumable:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.ConsumableItemSheet.First,
                         Guid.NewGuid(),
                         0);
@@ -116,7 +116,7 @@ namespace Lib9c.Tests.Action
                         Guid.NewGuid());
                     break;
                 case ItemType.Equipment:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.EquipmentItemSheet.First,
                         Guid.NewGuid(),
                         0);
@@ -212,7 +212,7 @@ namespace Lib9c.Tests.Action
             {
                 case ItemType.Consumable:
                 case ItemType.Equipment:
-                    nextTradableItemInShopItem = nextShopItem.ItemUsable;
+                    nextTradableItemInShopItem = (ITradableItem)nextShopItem.ItemUsable;
                     break;
                 case ItemType.Costume:
                     nextTradableItemInShopItem = nextShopItem.Costume;
@@ -244,8 +244,8 @@ namespace Lib9c.Tests.Action
                 case ItemType.Consumable:
                 case ItemType.Equipment:
                     Assert.NotNull(mail.attachment.itemUsable);
-                    attachmentItem = mail.attachment.itemUsable;
-                    Assert.Equal(tradableItem, mail.attachment.itemUsable);
+                    attachmentItem = (ITradableItem)mail.attachment.itemUsable;
+                    Assert.Equal((ItemUsable)tradableItem, mail.attachment.itemUsable);
                     break;
                 case ItemType.Costume:
                     Assert.NotNull(mail.attachment.costume);
@@ -455,7 +455,7 @@ namespace Lib9c.Tests.Action
             switch (itemSubType)
             {
                 case ItemSubType.Weapon:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.EquipmentItemSheet.OrderedList.First(row => row.ItemSubType == ItemSubType.Weapon),
                         Guid.NewGuid(),
                         1);
@@ -542,7 +542,7 @@ namespace Lib9c.Tests.Action
             int fungibleCount = itemCount;
             if (itemSubType == ItemSubType.Weapon)
             {
-                innerShopItem = nextShopItem.ItemUsable;
+                innerShopItem = (ITradableItem)nextShopItem.ItemUsable;
                 fungibleCount = 0;
             }
 

--- a/.Lib9c.Tests/Action/Sell7Test.cs
+++ b/.Lib9c.Tests/Action/Sell7Test.cs
@@ -104,7 +104,7 @@
             switch (itemType)
             {
                 case ItemType.Consumable:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.ConsumableItemSheet.First,
                         Guid.NewGuid(),
                         0);
@@ -115,7 +115,7 @@
                         Guid.NewGuid());
                     break;
                 case ItemType.Equipment:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.EquipmentItemSheet.First,
                         Guid.NewGuid(),
                         0);

--- a/.Lib9c.Tests/Action/Sell8Test.cs
+++ b/.Lib9c.Tests/Action/Sell8Test.cs
@@ -104,7 +104,7 @@ namespace Lib9c.Tests.Action
             switch (itemType)
             {
                 case ItemType.Consumable:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.ConsumableItemSheet.First,
                         Guid.NewGuid(),
                         0);
@@ -115,7 +115,7 @@ namespace Lib9c.Tests.Action
                         Guid.NewGuid());
                     break;
                 case ItemType.Equipment:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.EquipmentItemSheet.First,
                         Guid.NewGuid(),
                         0);

--- a/.Lib9c.Tests/Action/Sell9Test.cs
+++ b/.Lib9c.Tests/Action/Sell9Test.cs
@@ -99,7 +99,7 @@
             switch (itemType)
             {
                 case ItemType.Consumable:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.ConsumableItemSheet.First,
                         Guid.NewGuid(),
                         0);
@@ -110,7 +110,7 @@
                         Guid.NewGuid());
                     break;
                 case ItemType.Equipment:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.EquipmentItemSheet.First,
                         Guid.NewGuid(),
                         0);

--- a/.Lib9c.Tests/Action/SellCancellation0Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation0Test.cs
@@ -72,7 +72,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress,
                 Guid.NewGuid(),
                 new FungibleAssetValue(goldCurrencyState.Currency, 100, 0),
-                equipment));
+                (ITradableItem)equipment));
 
             _initialState = _initialState
                 .SetState(GoldCurrencyState.Address, goldCurrencyState.Serialize())

--- a/.Lib9c.Tests/Action/SellCancellation2Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation2Test.cs
@@ -74,7 +74,7 @@ namespace Lib9c.Tests.Action
                 _avatarAddress,
                 Guid.NewGuid(),
                 new FungibleAssetValue(goldCurrencyState.Currency, 100, 0),
-                equipment));
+                (ITradableItem)equipment));
 
             var result = new CombinationConsumable5.ResultModel()
             {

--- a/.Lib9c.Tests/Action/SellCancellation3Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation3Test.cs
@@ -82,14 +82,14 @@
                 _avatarAddress,
                 Guid.NewGuid(),
                 new FungibleAssetValue(goldCurrencyState.Currency, 100, 0),
-                equipment));
+                (ITradableItem)equipment));
 
             shopState.Register(new ShopItem(
                 _agentAddress,
                 _avatarAddress,
                 Guid.NewGuid(),
                 new FungibleAssetValue(goldCurrencyState.Currency, 100, 0),
-                consumable));
+                (ITradableItem)consumable));
 
             shopState.Register(new ShopItem(
                 _agentAddress,

--- a/.Lib9c.Tests/Action/SellCancellation4Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation4Test.cs
@@ -82,14 +82,14 @@
                 _avatarAddress,
                 Guid.NewGuid(),
                 new FungibleAssetValue(goldCurrencyState.Currency, 100, 0),
-                equipment));
+                (ITradableItem)equipment));
 
             shopState.Register(new ShopItem(
                 _agentAddress,
                 _avatarAddress,
                 Guid.NewGuid(),
                 new FungibleAssetValue(goldCurrencyState.Currency, 100, 0),
-                consumable));
+                (ITradableItem)consumable));
 
             shopState.Register(new ShopItem(
                 _agentAddress,

--- a/.Lib9c.Tests/Action/SellCancellation5Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation5Test.cs
@@ -124,7 +124,7 @@ namespace Lib9c.Tests.Action
                 productId,
                 new FungibleAssetValue(_goldCurrencyState.Currency, 100, 0),
                 requiredBlockIndex,
-                nonFungibleItem);
+                (ITradableItem)nonFungibleItem);
 
             if (contain)
             {
@@ -240,7 +240,7 @@ namespace Lib9c.Tests.Action
                 productId,
                 new FungibleAssetValue(_goldCurrencyState.Currency, 100, 0),
                 Sell6.ExpiredBlockIndex,
-                itemUsable);
+                (ITradableItem)itemUsable);
 
             IAccountStateDelta prevState = _initialState
                 .SetState(shardedShopAddress, shopState.Serialize());
@@ -279,7 +279,7 @@ namespace Lib9c.Tests.Action
                 productId,
                 new FungibleAssetValue(_goldCurrencyState.Currency, 100, 0),
                 Sell6.ExpiredBlockIndex,
-                itemUsable);
+                (ITradableItem)itemUsable);
             shopState.Register(shopItem);
 
             IAccountStateDelta prevState = _initialState
@@ -319,7 +319,7 @@ namespace Lib9c.Tests.Action
                 productId,
                 new FungibleAssetValue(_goldCurrencyState.Currency, 100, 0),
                 Sell6.ExpiredBlockIndex,
-                itemUsable);
+                (ITradableItem)itemUsable);
             shopState.Register(shopItem);
 
             IAccountStateDelta prevState = _initialState

--- a/.Lib9c.Tests/Action/SellCancellation6Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation6Test.cs
@@ -98,7 +98,7 @@ namespace Lib9c.Tests.Action
                     _tableSheets.EquipmentItemSheet.First,
                     itemId,
                     requiredBlockIndex);
-                tradableItem = itemUsable;
+                tradableItem = (ITradableItem)itemUsable;
                 itemSubType = itemUsable.ItemSubType;
             }
             else if (itemType == ItemType.Costume)
@@ -365,7 +365,7 @@ namespace Lib9c.Tests.Action
                 productId,
                 new FungibleAssetValue(_goldCurrencyState.Currency, 100, 0),
                 Sell6.ExpiredBlockIndex,
-                itemUsable);
+                (ITradableItem)itemUsable);
             shopState.Register(shopItem);
 
             IAccountStateDelta prevState = _initialState
@@ -405,7 +405,7 @@ namespace Lib9c.Tests.Action
                 productId,
                 new FungibleAssetValue(_goldCurrencyState.Currency, 100, 0),
                 Sell6.ExpiredBlockIndex,
-                itemUsable);
+                (ITradableItem)itemUsable);
             shopState.Register(shopItem);
 
             IAccountStateDelta prevState = _initialState

--- a/.Lib9c.Tests/Action/SellCancellation7Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation7Test.cs
@@ -110,7 +110,7 @@
                     _tableSheets.EquipmentItemSheet.First,
                     itemId,
                     requiredBlockIndex);
-                tradableItem = itemUsable;
+                tradableItem = (ITradableItem)itemUsable;
                 itemSubType = itemUsable.ItemSubType;
             }
             else if (itemType == ItemType.Costume)
@@ -411,7 +411,7 @@
                 avatarAddress,
                 orderId,
                 new FungibleAssetValue(_goldCurrencyState.Currency, 100, 0),
-                itemUsable.TradableId,
+                itemUsable.ItemId,
                 0,
                 itemUsable.ItemSubType,
                 1
@@ -421,7 +421,7 @@
                 order.StartedBlockIndex,
                 order.ExpiredBlockIndex,
                 orderId,
-                itemUsable.TradableId,
+                itemUsable.ItemId,
                 order.Price,
                 0,
                 0,
@@ -439,7 +439,7 @@
                 orderId = orderId,
                 sellerAvatarAddress = _avatarAddress,
                 itemSubType = itemUsable.ItemSubType,
-                tradableId = itemUsable.TradableId,
+                tradableId = itemUsable.ItemId,
             };
 
             Assert.Throws<InvalidAddressException>(() => action.Execute(new ActionContext()

--- a/.Lib9c.Tests/Action/SellCancellation8Test.cs
+++ b/.Lib9c.Tests/Action/SellCancellation8Test.cs
@@ -110,7 +110,7 @@
                     _tableSheets.EquipmentItemSheet.First,
                     itemId,
                     requiredBlockIndex);
-                tradableItem = itemUsable;
+                tradableItem = (ITradableItem)itemUsable;
                 itemSubType = itemUsable.ItemSubType;
             }
             else if (itemType == ItemType.Costume)
@@ -429,7 +429,7 @@
                 avatarAddress,
                 orderId,
                 new FungibleAssetValue(_goldCurrencyState.Currency, 100, 0),
-                itemUsable.TradableId,
+                itemUsable.ItemId,
                 0,
                 itemUsable.ItemSubType,
                 1
@@ -439,7 +439,7 @@
                 order.StartedBlockIndex,
                 order.ExpiredBlockIndex,
                 orderId,
-                itemUsable.TradableId,
+                itemUsable.ItemId,
                 order.Price,
                 0,
                 0,
@@ -460,7 +460,7 @@
                 orderId = orderId,
                 sellerAvatarAddress = _avatarAddress,
                 itemSubType = itemUsable.ItemSubType,
-                tradableId = itemUsable.TradableId,
+                tradableId = itemUsable.ItemId,
             };
 
             Assert.Throws<InvalidAddressException>(() => action.Execute(new ActionContext()
@@ -555,7 +555,7 @@
                     _tableSheets.EquipmentItemSheet.First,
                     itemId,
                     requiredBlockIndex);
-                tradableItem = itemUsable;
+                tradableItem = (ITradableItem)itemUsable;
                 itemSubType = itemUsable.ItemSubType;
             }
             else if (itemType == ItemType.Costume)

--- a/.Lib9c.Tests/Action/SellCancellationTest.cs
+++ b/.Lib9c.Tests/Action/SellCancellationTest.cs
@@ -114,7 +114,7 @@ namespace Lib9c.Tests.Action
                     _tableSheets.EquipmentItemSheet.First,
                     itemId,
                     requiredBlockIndex);
-                tradableItem = itemUsable;
+                tradableItem = (ITradableItem)itemUsable;
                 itemSubType = itemUsable.ItemSubType;
             }
             else if (itemType == ItemType.Costume)
@@ -464,7 +464,7 @@ namespace Lib9c.Tests.Action
                 avatarAddress,
                 orderId,
                 new FungibleAssetValue(_goldCurrencyState.Currency, 100, 0),
-                itemUsable.TradableId,
+                itemUsable.ItemId,
                 0,
                 itemUsable.ItemSubType,
                 1
@@ -474,7 +474,7 @@ namespace Lib9c.Tests.Action
                 order.StartedBlockIndex,
                 order.ExpiredBlockIndex,
                 orderId,
-                itemUsable.TradableId,
+                itemUsable.ItemId,
                 order.Price,
                 0,
                 0,
@@ -495,7 +495,7 @@ namespace Lib9c.Tests.Action
                 orderId = orderId,
                 sellerAvatarAddress = _avatarAddress,
                 itemSubType = itemUsable.ItemSubType,
-                tradableId = itemUsable.TradableId,
+                tradableId = itemUsable.ItemId,
             };
 
             Assert.Throws<InvalidAddressException>(() => action.Execute(new ActionContext()
@@ -590,7 +590,7 @@ namespace Lib9c.Tests.Action
                     _tableSheets.EquipmentItemSheet.First,
                     itemId,
                     requiredBlockIndex);
-                tradableItem = itemUsable;
+                tradableItem = (ITradableItem)itemUsable;
                 itemSubType = itemUsable.ItemSubType;
             }
             else if (itemType == ItemType.Costume)

--- a/.Lib9c.Tests/Action/SellTest.cs
+++ b/.Lib9c.Tests/Action/SellTest.cs
@@ -98,7 +98,7 @@ namespace Lib9c.Tests.Action
             switch (itemType)
             {
                 case ItemType.Consumable:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.ConsumableItemSheet.First,
                         Guid.NewGuid(),
                         0);
@@ -109,7 +109,7 @@ namespace Lib9c.Tests.Action
                         Guid.NewGuid());
                     break;
                 case ItemType.Equipment:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.EquipmentItemSheet.First,
                         Guid.NewGuid(),
                         0);

--- a/.Lib9c.Tests/Action/UpdateSell0Test.cs
+++ b/.Lib9c.Tests/Action/UpdateSell0Test.cs
@@ -127,7 +127,7 @@
                         _tableSheets.EquipmentItemSheet.First,
                         itemId,
                         requiredBlockIndex);
-                    tradableItem = itemUsable;
+                    tradableItem = (ITradableItem)itemUsable;
                     itemSubType = itemUsable.ItemSubType;
                     break;
                 }

--- a/.Lib9c.Tests/Action/UpdateSell2Test.cs
+++ b/.Lib9c.Tests/Action/UpdateSell2Test.cs
@@ -116,7 +116,7 @@
                         _tableSheets.EquipmentItemSheet.First,
                         itemId,
                         requiredBlockIndex);
-                    tradableItem = itemUsable;
+                    tradableItem = (ITradableItem)itemUsable;
                     itemSubType = itemUsable.ItemSubType;
                     break;
                 }

--- a/.Lib9c.Tests/Action/UpdateSell3Test.cs
+++ b/.Lib9c.Tests/Action/UpdateSell3Test.cs
@@ -116,7 +116,7 @@
                         _tableSheets.EquipmentItemSheet.First,
                         itemId,
                         requiredBlockIndex);
-                    tradableItem = itemUsable;
+                    tradableItem = (ITradableItem)itemUsable;
                     itemSubType = itemUsable.ItemSubType;
                     break;
                 }

--- a/.Lib9c.Tests/Action/UpdateSell4Test.cs
+++ b/.Lib9c.Tests/Action/UpdateSell4Test.cs
@@ -116,7 +116,7 @@
                         _tableSheets.EquipmentItemSheet.First,
                         itemId,
                         requiredBlockIndex);
-                    tradableItem = itemUsable;
+                    tradableItem = (ITradableItem)itemUsable;
                     itemSubType = itemUsable.ItemSubType;
                     break;
                 }

--- a/.Lib9c.Tests/Action/UpdateSellTest.cs
+++ b/.Lib9c.Tests/Action/UpdateSellTest.cs
@@ -116,7 +116,7 @@
                         _tableSheets.EquipmentItemSheet.First,
                         itemId,
                         requiredBlockIndex);
-                    tradableItem = itemUsable;
+                    tradableItem = (ITradableItem)itemUsable;
                     itemSubType = itemUsable.ItemSubType;
                     break;
                 }

--- a/.Lib9c.Tests/Model/Item/InventoryTest.cs
+++ b/.Lib9c.Tests/Model/Item/InventoryTest.cs
@@ -408,7 +408,7 @@
             var equipment = (Equipment)ItemFactory.CreateItem(equipmentRow, random);
             inventory.AddItem(equipment);
             Assert.Equal(2, inventory.Items.Count);
-            tradableItems.Add(equipment);
+            tradableItems.Add((ITradableItem)equipment);
             Assert.Equal(2, tradableItems.Count);
 
             var costumeRow = TableSheets.CostumeItemSheet.First;
@@ -464,7 +464,7 @@
             Assert.Empty(inventory.Items);
             inventory.AddItem(itemUsable);
             Assert.Single(inventory.Equipments);
-            var tradableId = nonFungibleItem.TradableId;
+            var tradableId = nonFungibleItem.NonFungibleId;
             Assert.False(inventory.RemoveTradableItem(tradableId, 1));
             Assert.True(inventory.RemoveTradableItem(tradableId, 0));
             Assert.Empty(inventory.Equipments);

--- a/.Lib9c.Tests/Model/Item/ShopItemTest.cs
+++ b/.Lib9c.Tests/Model/Item/ShopItemTest.cs
@@ -55,14 +55,14 @@ namespace Lib9c.Tests.Model.Item
         public void Serialize_With_ExpiredBlockIndex(long expiredBlockIndex, bool contain)
         {
             var equipmentRow = _tableSheets.EquipmentItemSheet.First;
-            var equipment = new Equipment(equipmentRow, Guid.NewGuid(), 0);
+            var equipment = ItemFactory.CreateItemUsable(equipmentRow, Guid.NewGuid(), 0);
             var shopItem = new ShopItem(
                 new PrivateKey().ToAddress(),
                 new PrivateKey().ToAddress(),
                 Guid.NewGuid(),
                 new FungibleAssetValue(_currency, 100, 0),
                 expiredBlockIndex,
-                equipment);
+                (ITradableItem)equipment);
             Assert.Null(shopItem.Costume);
             Assert.NotNull(shopItem.ItemUsable);
             var serialized = (BxDictionary)shopItem.Serialize();
@@ -77,28 +77,28 @@ namespace Lib9c.Tests.Model.Item
         public void ThrowArgumentOurOfRangeException()
         {
             var equipmentRow = _tableSheets.EquipmentItemSheet.First;
-            var equipment = new Equipment(equipmentRow, Guid.NewGuid(), 0);
+            var equipment = ItemFactory.CreateItemUsable(equipmentRow, Guid.NewGuid(), 0);
             Assert.Throws<ArgumentOutOfRangeException>(() => new ShopItem(
                 new PrivateKey().ToAddress(),
                 new PrivateKey().ToAddress(),
                 Guid.NewGuid(),
                 new FungibleAssetValue(_currency, 100, 0),
                 -1,
-                equipment));
+                (ITradableItem)equipment));
         }
 
         [Fact]
         public void DeserializeThrowArgumentOurOfRangeException()
         {
             var equipmentRow = _tableSheets.EquipmentItemSheet.First;
-            var equipment = new Equipment(equipmentRow, Guid.NewGuid(), 0);
+            var equipment = ItemFactory.CreateItemUsable(equipmentRow, Guid.NewGuid(), 0);
             var shopItem = new ShopItem(
                 new PrivateKey().ToAddress(),
                 new PrivateKey().ToAddress(),
                 Guid.NewGuid(),
                 new FungibleAssetValue(_currency, 100, 0),
                 0,
-                equipment);
+                (ITradableItem)equipment);
             Dictionary serialized = (Dictionary)shopItem.Serialize();
             serialized = serialized.SetItem(ShopItem.ExpiredBlockIndexKey, "-1");
             Assert.Throws<ArgumentOutOfRangeException>(() => new ShopItem(serialized));
@@ -114,7 +114,7 @@ namespace Lib9c.Tests.Model.Item
         private static ShopItem GetShopItemWithFirstCostume()
         {
             var costumeRow = _tableSheets.CostumeItemSheet.First;
-            var costume = new Costume(costumeRow, Guid.NewGuid());
+            var costume = ItemFactory.CreateCostume(costumeRow, Guid.NewGuid());
             return new ShopItem(
                 new PrivateKey().ToAddress(),
                 new PrivateKey().ToAddress(),
@@ -126,19 +126,19 @@ namespace Lib9c.Tests.Model.Item
         private static ShopItem GetShopItemWithFirstEquipment()
         {
             var equipmentRow = _tableSheets.EquipmentItemSheet.First;
-            var equipment = new Equipment(equipmentRow, Guid.NewGuid(), 0);
+            var equipment = ItemFactory.CreateItemUsable(equipmentRow, Guid.NewGuid(), 0);
             return new ShopItem(
                 new PrivateKey().ToAddress(),
                 new PrivateKey().ToAddress(),
                 Guid.NewGuid(),
                 new FungibleAssetValue(_currency, 100, 0),
-                equipment);
+                (ITradableItem)equipment);
         }
 
         private static ShopItem GetShopItemWithFirstMaterial()
         {
             var row = _tableSheets.MaterialItemSheet.First;
-            var tradableMaterial = new TradableMaterial(row);
+            var tradableMaterial = ItemFactory.CreateTradableMaterial(row);
             return new ShopItem(
                 new PrivateKey().ToAddress(),
                 new PrivateKey().ToAddress(),

--- a/.Lib9c.Tests/Model/Order/NonFungibleOrderTest.cs
+++ b/.Lib9c.Tests/Model/Order/NonFungibleOrderTest.cs
@@ -290,7 +290,7 @@ namespace Lib9c.Tests.Model.Order
 
             if (exc is null)
             {
-                int cp = CPHelper.GetCP(tradableItem, _tableSheets.CostumeStatSheet);
+                int cp = tradableItem is INonFungibleItem nonFungibleItem ? CPHelper.GetCP(nonFungibleItem, _tableSheets.CostumeStatSheet) : 0;
                 Assert.True(cp > 0);
                 OrderDigest digest = order.Digest2(_avatarState, _tableSheets.CostumeStatSheet);
 

--- a/.Lib9c.Tests/Model/Order/OrderFactoryTest.cs
+++ b/.Lib9c.Tests/Model/Order/OrderFactoryTest.cs
@@ -31,7 +31,7 @@ namespace Lib9c.Tests.Model.Order
             switch (itemType)
             {
                 case ItemType.Consumable:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.ConsumableItemSheet.First,
                         itemId,
                         0);
@@ -42,7 +42,7 @@ namespace Lib9c.Tests.Model.Order
                         itemId);
                     break;
                 case ItemType.Equipment:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.EquipmentItemSheet.First,
                         itemId,
                         0);
@@ -109,7 +109,7 @@ namespace Lib9c.Tests.Model.Order
             switch (itemType)
             {
                 case ItemType.Consumable:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.ConsumableItemSheet.First,
                         Guid.NewGuid(),
                         0);
@@ -120,7 +120,7 @@ namespace Lib9c.Tests.Model.Order
                         Guid.NewGuid());
                     break;
                 case ItemType.Equipment:
-                    tradableItem = ItemFactory.CreateItemUsable(
+                    tradableItem = (ITradableItem)ItemFactory.CreateItemUsable(
                         _tableSheets.EquipmentItemSheet.First,
                         Guid.NewGuid(),
                         0);

--- a/Lib9c/Action/Buy6.cs
+++ b/Lib9c/Action/Buy6.cs
@@ -251,7 +251,7 @@ namespace Nekoyume.Action
                 int count = 1;
                 if (!(shopItem.ItemUsable is null))
                 {
-                    tradableItem = shopItem.ItemUsable;
+                    tradableItem = (ITradableItem)shopItem.ItemUsable;
                 }
                 else if (!(shopItem.Costume is null))
                 {

--- a/Lib9c/Action/Buy7.cs
+++ b/Lib9c/Action/Buy7.cs
@@ -378,7 +378,7 @@ namespace Nekoyume.Action
                 int count = 1;
                 if (!(shopItem.ItemUsable is null))
                 {
-                    tradableItem = shopItem.ItemUsable;
+                    tradableItem = (ITradableItem)shopItem.ItemUsable;
                 }
                 else if (!(shopItem.Costume is null))
                 {

--- a/Lib9c/Action/RegisterProduct.cs
+++ b/Lib9c/Action/RegisterProduct.cs
@@ -163,7 +163,7 @@ namespace Nekoyume.Action
                                             out var item) &&
                                         avatarState.inventory.RemoveNonFungibleItem(tradableId))
                                     {
-                                        tradableItem = (ITradableItem) item.item;
+                                        tradableItem = item.item as ITradableItem;
                                     }
 
                                     break;

--- a/Lib9c/Action/Sell0.cs
+++ b/Lib9c/Action/Sell0.cs
@@ -123,7 +123,7 @@ namespace Nekoyume.Action
                 sellerAvatarAddress,
                 productId,
                 price,
-                nonFungibleItem);
+                (ITradableItem)nonFungibleItem);
 
             IValue shopItemSerialized = shopItem.Serialize();
             IKey productIdSerialized = (IKey)productId.Serialize();

--- a/Lib9c/Action/Sell2.cs
+++ b/Lib9c/Action/Sell2.cs
@@ -117,7 +117,7 @@ namespace Nekoyume.Action
                     sellerAvatarAddress,
                     productId,
                     price,
-                    equipment);
+                    (ITradableItem)equipment);
             }
             else if (avatarState.inventory.TryGetNonFungibleItem<Costume>(itemId, out var costume))
             {

--- a/Lib9c/Action/Sell3.cs
+++ b/Lib9c/Action/Sell3.cs
@@ -113,7 +113,7 @@ namespace Nekoyume.Action
                 avatarState.inventory.RemoveNonFungibleItem(itemId);
                 return itemUsable is null
                     ? new ShopItem(ctx.Signer, sellerAvatarAddress, productId, price, costume)
-                    : new ShopItem(ctx.Signer, sellerAvatarAddress, productId, price, itemUsable);
+                    : new ShopItem(ctx.Signer, sellerAvatarAddress, productId, price, (ITradableItem)itemUsable);
             }
 
             // Select an item to sell from the inventory and adjust the quantity.

--- a/Lib9c/Action/Sell4.cs
+++ b/Lib9c/Action/Sell4.cs
@@ -130,7 +130,7 @@ namespace Nekoyume.Action
             }
             nonFungibleItem.RequiredBlockIndex = expiredBlockIndex;
 
-            ShopItem shopItem = new ShopItem(ctx.Signer, sellerAvatarAddress, productId, price, expiredBlockIndex, nonFungibleItem);
+            ShopItem shopItem = new ShopItem(ctx.Signer, sellerAvatarAddress, productId, price, expiredBlockIndex, (ITradableItem)nonFungibleItem);
             Address shardedShopAddress = ShardedShopState.DeriveAddress(itemSubType, productId);
             if (!states.TryGetState(shardedShopAddress, out Bencodex.Types.Dictionary shopStateDict))
             {

--- a/Lib9c/Action/SellCancellation6.cs
+++ b/Lib9c/Action/SellCancellation6.cs
@@ -157,7 +157,7 @@ namespace Nekoyume.Action
             int itemCount = 1;
             if (!(shopItem.ItemUsable is null))
             {
-                tradableItem = shopItem.ItemUsable;
+                tradableItem = (ITradableItem)shopItem.ItemUsable;
             }
             else if (!(shopItem.Costume is null))
             {

--- a/Lib9c/Battle/CPHelper.cs
+++ b/Lib9c/Battle/CPHelper.cs
@@ -108,7 +108,7 @@ namespace Nekoyume.Battle
         }
 
         [Obsolete("Use GetCp")]
-        public static int GetCP(ITradableItem tradableItem, CostumeStatSheet sheet)
+        public static int GetCP(INonFungibleItem tradableItem, CostumeStatSheet sheet)
         {
             if (tradableItem is ItemUsable itemUsable)
             {

--- a/Lib9c/Model/Item/Armor.cs
+++ b/Lib9c/Model/Item/Armor.cs
@@ -6,8 +6,10 @@ using Nekoyume.TableData;
 namespace Nekoyume.Model.Item
 {
     [Serializable]
-    public class Armor : Equipment
+    public class Armor : Equipment, ITradableItem
     {
+        public Guid TradableId => ItemId;
+
         public Armor(EquipmentItemSheet.Row data, Guid id, long requiredBlockIndex,
             bool madeWithMimisbrunnrRecipe = false) : base(data, id, requiredBlockIndex, madeWithMimisbrunnrRecipe)
         {

--- a/Lib9c/Model/Item/Belt.cs
+++ b/Lib9c/Model/Item/Belt.cs
@@ -6,8 +6,10 @@ using Nekoyume.TableData;
 namespace Nekoyume.Model.Item
 {
     [Serializable]
-    public class Belt : Equipment
+    public class Belt : Equipment, ITradableItem
     {
+        public Guid TradableId => ItemId;
+
         public Belt(EquipmentItemSheet.Row data, Guid id, long requiredBlockIndex,
             bool madeWithMimisbrunnrRecipe = false) : base(data, id, requiredBlockIndex,
             madeWithMimisbrunnrRecipe)

--- a/Lib9c/Model/Item/Consumable.cs
+++ b/Lib9c/Model/Item/Consumable.cs
@@ -10,8 +10,10 @@ using Nekoyume.TableData;
 namespace Nekoyume.Model.Item
 {
     [Serializable]
-    public class Consumable : ItemUsable
+    public class Consumable : ItemUsable, ITradableItem
     {
+        public Guid TradableId => ItemId;
+
         public StatType MainStat => Stats.Any() ? Stats[0].StatType : StatType.NONE;
 
         public List<DecimalStat> Stats { get; }

--- a/Lib9c/Model/Item/Costume.cs
+++ b/Lib9c/Model/Item/Costume.cs
@@ -10,7 +10,7 @@ using static Lib9c.SerializeKeys;
 namespace Nekoyume.Model.Item
 {
     [Serializable]
-    public class Costume : ItemBase, INonFungibleItem, IEquippableItem
+    public class Costume : ItemBase, INonFungibleItem, IEquippableItem, ITradableItem
     {
         // FIXME: Whether the equipment is equipped or not has no asset value and must be removed from the state.
         public bool equipped = false;

--- a/Lib9c/Model/Item/INonFungibleItem.cs
+++ b/Lib9c/Model/Item/INonFungibleItem.cs
@@ -2,8 +2,9 @@ using System;
 
 namespace Nekoyume.Model.Item
 {
-    public interface INonFungibleItem: ITradableItem
+    public interface INonFungibleItem: IItem
     {
         Guid NonFungibleId { get; }
+        long RequiredBlockIndex { get; set; }
     }
 }

--- a/Lib9c/Model/Item/ItemUsable.cs
+++ b/Lib9c/Model/Item/ItemUsable.cs
@@ -28,7 +28,6 @@ namespace Nekoyume.Model.Item
             }
         }
 
-        public Guid TradableId => ItemId;
         public Guid NonFungibleId => ItemId;
 
         public StatsMap StatsMap

--- a/Lib9c/Model/Item/Necklace.cs
+++ b/Lib9c/Model/Item/Necklace.cs
@@ -6,8 +6,10 @@ using Nekoyume.TableData;
 namespace Nekoyume.Model.Item
 {
     [Serializable]
-    public class Necklace : Equipment
+    public class Necklace : Equipment, ITradableItem
     {
+        public Guid TradableId => ItemId;
+
         public Necklace(EquipmentItemSheet.Row data, Guid id, long requiredBlockIndex,
             bool madeWithMimisbrunnrRecipe = false) : base(data, id, requiredBlockIndex,
             madeWithMimisbrunnrRecipe)

--- a/Lib9c/Model/Item/Ring.cs
+++ b/Lib9c/Model/Item/Ring.cs
@@ -6,8 +6,10 @@ using Nekoyume.TableData;
 namespace Nekoyume.Model.Item
 {
     [Serializable]
-    public class Ring : Equipment
+    public class Ring : Equipment, ITradableItem
     {
+        public Guid TradableId => ItemId;
+
         public Ring(EquipmentItemSheet.Row data, Guid id, long requiredBlockIndex,
             bool madeWithMimisbrunnrRecipe = false) : base(data, id, requiredBlockIndex,
             madeWithMimisbrunnrRecipe)

--- a/Lib9c/Model/Item/Weapon.cs
+++ b/Lib9c/Model/Item/Weapon.cs
@@ -6,8 +6,10 @@ using Nekoyume.TableData;
 namespace Nekoyume.Model.Item
 {
     [Serializable]
-    public class Weapon : Equipment
+    public class Weapon : Equipment, ITradableItem
     {
+        public Guid TradableId => ItemId;
+
         public Weapon(EquipmentItemSheet.Row data, Guid id, long requiredBlockIndex,
             bool madeWithMimisbrunnrRecipe = false) : base(data, id, requiredBlockIndex,
             madeWithMimisbrunnrRecipe)

--- a/Lib9c/Model/Order/FungibleOrder.cs
+++ b/Lib9c/Model/Order/FungibleOrder.cs
@@ -213,7 +213,7 @@ namespace Lib9c.Model.Order
             if (avatarState.inventory.TryGetLockedItem(new OrderLock(OrderId), out Inventory.Item inventoryItem))
             {
                 ItemBase item = inventoryItem.item;
-                int cp = CPHelper.GetCP((ITradableItem) item, costumeStatSheet);
+                int cp = 0;
                 int level = item is Equipment equipment ? equipment.level : 0;
                 return new OrderDigest(
                     SellerAgentAddress,
@@ -368,7 +368,7 @@ namespace Lib9c.Model.Order
                 out Inventory.Item inventoryItem))
             {
                 ItemBase item = inventoryItem.item;
-                int cp = CPHelper.GetCP((ITradableItem) item, costumeStatSheet);
+                int cp = 0;
                 int level = item is Equipment equipment ? equipment.level : 0;
                 return new OrderDigest(
                     SellerAgentAddress,

--- a/Lib9c/Model/Order/NonFungibleOrder.cs
+++ b/Lib9c/Model/Order/NonFungibleOrder.cs
@@ -79,7 +79,7 @@ namespace Lib9c.Model.Order
                     equippableItem.Unequip();
                 }
 
-                return nonFungibleItem;
+                return (ITradableItem)nonFungibleItem;
             }
 
             throw new ItemDoesNotExistException(
@@ -97,7 +97,7 @@ namespace Lib9c.Model.Order
                     equippableItem.Unequip();
                 }
 
-                return nonFungibleItem;
+                return (ITradableItem)nonFungibleItem;
             }
 
             throw new ItemDoesNotExistException(
@@ -313,7 +313,7 @@ namespace Lib9c.Model.Order
             if (avatarState.inventory.TryGetNonFungibleItem(TradableId, out INonFungibleItem nonFungibleItem))
             {
                 nonFungibleItem.RequiredBlockIndex = blockIndex;
-                return nonFungibleItem;
+                return (ITradableItem)nonFungibleItem;
             }
             throw new ItemDoesNotExistException(
                 $"Aborted because the tradable item({TradableId}) was failed to load from avatar's inventory.");


### PR DESCRIPTION
- Move ITradableItem interface from ItemUsable to each items(Equipments, Consumable, Costume)
- Prevent Aura trading.