### PR TITLE
🐛 Fix `ValidatorSetOperate`

### DIFF
--- a/.Lib9c.Tests/Action/ValidatorSetOperateTest.cs
+++ b/.Lib9c.Tests/Action/ValidatorSetOperateTest.cs
@@ -2,11 +2,13 @@ namespace Lib9c.Tests.Action
 {
     using System;
     using System.Numerics;
+    using Bencodex.Types;
     using Libplanet.Action.State;
     using Libplanet.Crypto;
     using Libplanet.Types.Consensus;
     using Nekoyume;
     using Nekoyume.Action;
+    using Nekoyume.Action.Loader;
     using Nekoyume.Model.State;
     using Serilog;
     using Xunit;
@@ -176,8 +178,11 @@ namespace Lib9c.Tests.Action
             var deserialized = new ValidatorSetOperate();
             deserialized.LoadPlainValue(action.PlainValue);
 
+            var dict = Assert.IsType<Dictionary>(action.PlainValue);
+            Assert.Equal(new Text("op_validator_set"), dict["type_id"]);
             Assert.Equal(ValidatorSetOperatorType.Append, action.Operator);
             Assert.Equal(_validator, action.Operand);
+            Assert.Null(deserialized.Error);
         }
 
         [Fact]
@@ -187,8 +192,11 @@ namespace Lib9c.Tests.Action
             var deserialized = new ValidatorSetOperate();
             deserialized.LoadPlainValue(action.PlainValue);
 
+            var dict = Assert.IsType<Dictionary>(action.PlainValue);
+            Assert.Equal(new Text("op_validator_set"), dict["type_id"]);
             Assert.Equal(ValidatorSetOperatorType.Update, action.Operator);
             Assert.Equal(_validator, action.Operand);
+            Assert.Null(deserialized.Error);
         }
 
         [Fact]
@@ -198,8 +206,24 @@ namespace Lib9c.Tests.Action
             var deserialized = new ValidatorSetOperate();
             deserialized.LoadPlainValue(action.PlainValue);
 
+            var dict = Assert.IsType<Dictionary>(action.PlainValue);
+            Assert.Equal(new Text("op_validator_set"), dict["type_id"]);
             Assert.Equal(ValidatorSetOperatorType.Remove, action.Operator);
             Assert.Equal(_validator, action.Operand);
+            Assert.Null(deserialized.Error);
+        }
+
+        [Fact]
+        public void LoadPlainValueViaActionLoader()
+        {
+            var loader = new NCActionLoader();
+            var action = ValidatorSetOperate.Append(_validator);
+            var loaded = loader.LoadAction(0, action.PlainValue);
+
+            var deserialized = Assert.IsType<ValidatorSetOperate>(loaded);
+            Assert.Equal(ValidatorSetOperatorType.Append, deserialized.Operator);
+            Assert.Equal(_validator, deserialized.Operand);
+            Assert.Null(deserialized.Error);
         }
     }
 }

--- a/Lib9c/Action/GameAction.cs
+++ b/Lib9c/Action/GameAction.cs
@@ -13,7 +13,8 @@ namespace Nekoyume.Action
     public abstract class GameAction : ActionBase
     {
         public Guid Id { get; private set; }
-        public override IValue PlainValue => Dictionary.Empty
+
+        public override sealed IValue PlainValue => Dictionary.Empty
             .Add("type_id", this.GetType().GetCustomAttribute<ActionTypeAttribute>() is { } attribute
                 ? attribute.TypeIdentifier
                 : throw new NullReferenceException($"Type is missing {nameof(ActionTypeAttribute)}: {this.GetType()}"))
@@ -31,7 +32,7 @@ namespace Nekoyume.Action
             Id = Guid.NewGuid();
         }
 
-        public override void LoadPlainValue(IValue plainValue)
+        public override sealed void LoadPlainValue(IValue plainValue)
         {
 #pragma warning disable LAA1002
             var dict = ((Dictionary)((Dictionary)plainValue)["values"])


### PR DESCRIPTION
Quick notes:
- Changed `GameAction.PlainValue` and `GameAction.LoadPlainValue()` to be `sealed` to prevent future mistakes.
- `ValidatorSetOperator` now inherits directly from `ActionBase` instead of `GameAction`.
  - If any `ValidatorSetOperator` has seeped into existing chain since `TypedActionLoader` was introduced, we'll have modify `BlockPolicy` to retroactively comply with policy. This issue becomes substantially more complicated to deal with.