### PR TITLE
Improve claim stake reward8

### DIFF
--- a/.Lib9c.Tests/Action/ClaimStakeRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimStakeRewardTest.cs
@@ -140,6 +140,7 @@ namespace Lib9c.Tests.Action
             0L
         )]
         // stake before currency as reward, non prev.
+        // receive v2(w/o currency) * 2, receive v2(w/ currency). check GARAGE.
         [InlineData(
             StakeState.CurrencyAsRewardStartIndex - StakeState.RewardInterval * 2,
             10_000_000L,
@@ -153,6 +154,7 @@ namespace Lib9c.Tests.Action
             100_000L
         )]
         // stake before currency as reward, prev.
+        // receive v2(w/o currency), receive v2(w/ currency). check GARAGE.
         [InlineData(
             StakeState.CurrencyAsRewardStartIndex - StakeState.RewardInterval * 2,
             10_000_000L,
@@ -165,7 +167,33 @@ namespace Lib9c.Tests.Action
             "GARAGE",
             100_000L
         )]
-        // stake before v3(crystal), non prev.
+        // stake before v3(crystal), non prev. receive v2. check CRYSTAL.
+        [InlineData(
+            StakeState.StakeRewardSheetV3Index - 1,
+            500L,
+            null,
+            StakeState.StakeRewardSheetV3Index - 1 + StakeState.RewardInterval,
+            125,
+            2,
+            0,
+            AgentAddressHex,
+            "CRYSTAL",
+            0L
+        )]
+        // stake after v3(crystal), non prev. receive v3. check CRYSTAL.
+        [InlineData(
+            StakeState.StakeRewardSheetV3Index,
+            500L,
+            null,
+            StakeState.StakeRewardSheetV3Index + StakeState.RewardInterval,
+            125,
+            2,
+            0,
+            AgentAddressHex,
+            "CRYSTAL",
+            5_000L
+        )]
+        // stake before v3(crystal), non prev. receive v2 * 2, receive v3. check CRYSTAL.
         [InlineData(
             StakeState.StakeRewardSheetV3Index - StakeState.RewardInterval * 2,
             10_000_000L,
@@ -178,7 +206,7 @@ namespace Lib9c.Tests.Action
             "CRYSTAL",
             1_000_000_000L
         )]
-        // stake before v3(crystal), prev.
+        // stake before v3(crystal), prev. receive v2, receive v3. check CRYSTAL.
         [InlineData(
             StakeState.StakeRewardSheetV3Index - StakeState.RewardInterval * 2,
             10_000_000L,
@@ -191,7 +219,7 @@ namespace Lib9c.Tests.Action
             "CRYSTAL",
             1_000_000_000L
         )]
-        // stake after v3(crystal), non prev.
+        // stake after v3(crystal), non prev. receive v2 * 2, receive v3. check CRYSTAL.
         [InlineData(
             StakeState.StakeRewardSheetV3Index,
             10_000_000L,
@@ -204,7 +232,7 @@ namespace Lib9c.Tests.Action
             "CRYSTAL",
             3_000_000_000L
         )]
-        // stake after v3(crystal), prev.
+        // stake after v3(crystal), prev. receive v2, receive v3. check CRYSTAL.
         [InlineData(
             StakeState.StakeRewardSheetV3Index,
             10_000_000L,

--- a/.Lib9c.Tests/Action/ClaimStakeRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimStakeRewardTest.cs
@@ -165,6 +165,58 @@ namespace Lib9c.Tests.Action
             "GARAGE",
             100_000L
         )]
+        // stake before v3(crystal), non prev.
+        [InlineData(
+            StakeState.StakeRewardSheetV3Index - StakeState.RewardInterval * 2,
+            10_000_000L,
+            null,
+            StakeState.StakeRewardSheetV3Index + StakeState.RewardInterval,
+            35_000_000,
+            175_006,
+            11_665,
+            AgentAddressHex,
+            "CRYSTAL",
+            1_000_000_000L
+        )]
+        // stake before v3(crystal), prev.
+        [InlineData(
+            StakeState.StakeRewardSheetV3Index - StakeState.RewardInterval * 2,
+            10_000_000L,
+            StakeState.StakeRewardSheetV3Index - StakeState.RewardInterval,
+            StakeState.StakeRewardSheetV3Index + StakeState.RewardInterval,
+            30_000_000,
+            150_004,
+            9_999,
+            AgentAddressHex,
+            "CRYSTAL",
+            1_000_000_000L
+        )]
+        // stake after v3(crystal), non prev.
+        [InlineData(
+            StakeState.StakeRewardSheetV3Index,
+            10_000_000L,
+            null,
+            StakeState.StakeRewardSheetV3Index + StakeState.RewardInterval * 3,
+            75_000_000,
+            375_006,
+            24_999,
+            AgentAddressHex,
+            "CRYSTAL",
+            3_000_000_000L
+        )]
+        // stake after v3(crystal), prev.
+        [InlineData(
+            StakeState.StakeRewardSheetV3Index,
+            10_000_000L,
+            StakeState.StakeRewardSheetV3Index + StakeState.RewardInterval,
+            StakeState.StakeRewardSheetV3Index + StakeState.RewardInterval * 3,
+            50_000_000,
+            250_004,
+            16_666,
+            AgentAddressHex,
+            "CRYSTAL",
+            2_000_000_000L
+        )]
         public void Execute_Success(
             long startedBlockIndex,
             long stakeAmount,

--- a/Lib9c/Action/ClaimStakeReward.cs
+++ b/Lib9c/Action/ClaimStakeReward.cs
@@ -437,24 +437,35 @@ namespace Nekoyume.Action
                             continue;
                         }
 
+                        // NOTE: prepare reward currency.
                         Currency rewardCurrency;
+                        // NOTE: this line covers the reward.CurrencyTicker is following cases:
+                        //       - Currencies.Crystal.Ticker
+                        //       - Currencies.Garage.Ticker
+                        //       - lower case is starting with "rune_" or "runestone_"
+                        //       - lower case is starting with "soulstone_"
                         try
                         {
                             rewardCurrency =
                                 Currencies.GetMinterlessCurrency(reward.CurrencyTicker);
                         }
+                        // NOTE: throw exception if reward.CurrencyTicker is null or empty.
                         catch (ArgumentNullException)
                         {
                             throw;
                         }
+                        // NOTE: handle the case that reward.CurrencyTicker isn't covered by
+                        //       Currencies.GetMinterlessCurrency().
                         catch (ArgumentException)
                         {
+                            // NOTE: throw exception if reward.CurrencyDecimalPlaces is null.
                             if (reward.CurrencyDecimalPlaces is null)
                             {
                                 throw new ArgumentException(
                                     $"Decimal places of {reward.CurrencyTicker} is null");
                             }
 
+                            // NOTE: new currency is created as uncapped currency.
                             rewardCurrency = Currency.Uncapped(
                                 reward.CurrencyTicker,
                                 Convert.ToByte(reward.CurrencyDecimalPlaces.Value),

--- a/Lib9c/Action/ClaimStakeReward7.cs
+++ b/Lib9c/Action/ClaimStakeReward7.cs
@@ -26,7 +26,7 @@ namespace Nekoyume.Action
     public class ClaimStakeReward7 : GameAction, IClaimStakeReward, IClaimStakeRewardV1
     {
         private const string ActionTypeText = "claim_stake_reward7";
-        public const long ObsoleteBlockIndex = ActionObsoleteConfig.V200062ObsoleteIndex;
+        public const long ObsoleteBlockIndex = ActionObsoleteConfig.V200063ObsoleteIndex;
 
         /// <summary>
         /// This is the version 1 of the stake reward sheet.

--- a/Lib9c/ActionObsoleteConfig.cs
+++ b/Lib9c/ActionObsoleteConfig.cs
@@ -74,7 +74,7 @@ namespace Nekoyume
 
         public const long V200061ObsoleteIndex = 7_660_000L;
 
-        public const long V200062ObsoleteIndex = 7_700_000L;
+        public const long V200063ObsoleteIndex = 7_700_000L;
 
         // While v200020, the action obsolete wasn't work well.
         // So other previous `V*ObsoletedIndex`s lost its meaning and

--- a/Lib9c/Currencies.cs
+++ b/Lib9c/Currencies.cs
@@ -44,6 +44,17 @@ namespace Lib9c
 
         public static readonly Currency Mead = Currency.Legacy("Mead", 18, null);
 
+        /// <summary>
+        /// Covers the reward.CurrencyTicker is following cases:
+        ///     - Currencies.Crystal.Ticker
+        ///     - Currencies.Garage.Ticker
+        ///     - lower case is starting with "rune_" or "runestone_"
+        ///     - lower case is starting with "soulstone_"
+        /// </summary>
+        /// <param name="ticker"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         public static Currency GetMinterlessCurrency(string? ticker)
         {
             if (string.IsNullOrEmpty(ticker))


### PR DESCRIPTION
- add summary to `Currencies.GetMinterlessCurrency()` method.
- add comments to "claim_stake_reward8" action.
- rename `ActionObsoleteConfig.V200062ObosleteIndex` to `V200063ObosleteIndex`.
- add unit test cases of "claim_stake_reward8" to check the v3 rewards.
