### PR TITLE
feat(Dashboard): use 9c-headless instead of empty-chronicle

### DIFF
--- a/Dashboard/src/App.tsx
+++ b/Dashboard/src/App.tsx
@@ -2,12 +2,26 @@ import { useQueries } from "@tanstack/react-query";
 import axios from "axios";
 import { useMemo } from "react";
 
-interface Block { index: number }
+interface GraphQLTipIndexResponse {
+  data: {
+    chainQuery: {
+      blockQuery: {
+        block: {
+          index: number,
+        }
+      }
+    }
+  }
+};
 interface Action { id: string, obsoleteAt: number }
 
 const fetchLatestBlock = async () => {
-  const response = await axios.get<Block>(`${import.meta.env.VITE_API_PATH}/api/blocks/latest`);
-  return response.data;
+  const response = await axios.post<GraphQLTipIndexResponse>(`${import.meta.env.VITE_API_PATH}/graphql`, {
+    query: `query { chainQuery { blockQuery { block(index: -1) { index } } } }`,
+    variables: {},
+    operationName: null,
+  });
+  return response.data.data.chainQuery.blockQuery.block;
 };
 
 const fetchActions = async () => {


### PR DESCRIPTION
SSIA. It resolves https://github.com/planetarium/lib9c/issues/2140. After this pull request, the `VITE_API_PATH` secret should be updated.