### PR TITLE
Bugfix/stake

### DIFF
--- a/.Lib9c.Tests/Action/Stake2Test.cs
+++ b/.Lib9c.Tests/Action/Stake2Test.cs
@@ -1,11 +1,13 @@
 namespace Lib9c.Tests.Action
 {
+    using System;
     using Bencodex.Types;
     using Libplanet.Action.State;
     using Libplanet.Crypto;
     using Libplanet.Types.Assets;
     using Nekoyume;
     using Nekoyume.Action;
+    using Nekoyume.Model.Stake;
     using Nekoyume.Model.State;
     using Nekoyume.TableData;
     using Serilog;
@@ -242,6 +244,26 @@ namespace Lib9c.Tests.Action
             Assert.Equal(0, stakeState.ReceivedBlockIndex);
             Assert.Equal(_currency * 100, states.GetBalance(stakeState.address, _currency));
             Assert.Equal(_currency * 0, states.GetBalance(_signerAddress, _currency));
+        }
+
+        [Fact]
+        public void RestrictForStakeStateV2()
+        {
+            var action = new Stake2(50);
+            Assert.Throws<InvalidOperationException>(() => action.Execute(new ActionContext
+            {
+                PreviousState = _initialState.SetState(
+                    StakeState.DeriveAddress(_signerAddress),
+                    new StakeStateV2(
+                        new Contract(
+                            "StakeRegularFixedRewardSheet_V1",
+                            "StakeRegularRewardSheet_V1",
+                            50400,
+                            201600),
+                        0).Serialize()),
+                Signer = _signerAddress,
+                BlockIndex = 0,
+            }));
         }
 
         [Fact]

--- a/.Lib9c.Tests/Action/TransferAsset4Test.cs
+++ b/.Lib9c.Tests/Action/TransferAsset4Test.cs
@@ -16,7 +16,7 @@ namespace Lib9c.Tests.Action
     using Nekoyume.Model.State;
     using Xunit;
 
-    public class TransferAssetTest
+    public class TransferAsset4Test
     {
         private static readonly Address _sender = new Address(
             new byte[]
@@ -42,7 +42,7 @@ namespace Lib9c.Tests.Action
         public void Constructor_ThrowsMemoLengthOverflowException()
         {
             Assert.Throws<MemoLengthOverflowException>(() =>
-                new TransferAsset(_sender, _recipient, _currency * 100, new string(' ', 100)));
+                new TransferAsset4(_sender, _recipient, _currency * 100, new string(' ', 100)));
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace Lib9c.Tests.Action
                 MockState.Empty
                     .SetBalance(_sender, _currency * 1000)
                     .SetBalance(_recipient, _currency * 10));
-            var action = new TransferAsset(
+            var action = new TransferAsset4(
                 sender: _sender,
                 recipient: _recipient,
                 amount: _currency * 100
@@ -79,7 +79,7 @@ namespace Lib9c.Tests.Action
                     .SetBalance(_sender, _currency * 1000)
                     .SetBalance(_recipient, _currency * 10)
                     .SetBalance(_sender, Currencies.Mead * 1));
-            var action = new TransferAsset(
+            var action = new TransferAsset4(
                 sender: _sender,
                 recipient: _recipient,
                 amount: _currency * 100
@@ -110,7 +110,7 @@ namespace Lib9c.Tests.Action
                     .SetBalance(_sender, _currency * 1000)
                     .SetBalance(_sender, Currencies.Mead * 1));
             // Should not allow TransferAsset with same sender and recipient.
-            var action = new TransferAsset(
+            var action = new TransferAsset4(
                 sender: _sender,
                 recipient: _sender,
                 amount: _currency * 100
@@ -139,7 +139,7 @@ namespace Lib9c.Tests.Action
                     .SetState(_recipient, new AgentState(_recipient).Serialize())
                     .SetBalance(_sender, _currency * 1000)
                     .SetBalance(_recipient, _currency * 10));
-            var action = new TransferAsset(
+            var action = new TransferAsset4(
                 sender: _sender,
                 recipient: _recipient,
                 amount: _currency * 100000
@@ -176,7 +176,7 @@ namespace Lib9c.Tests.Action
                     .SetBalance(_sender, currencyBySender * 1000)
                     .SetBalance(_recipient, currencyBySender * 10)
                     .SetBalance(_sender, Currencies.Mead * 1));
-            var action = new TransferAsset(
+            var action = new TransferAsset4(
                 sender: _sender,
                 recipient: _recipient,
                 amount: currencyBySender * 100
@@ -200,7 +200,7 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void Rehearsal()
         {
-            var action = new TransferAsset(
+            var action = new TransferAsset4(
                 sender: _sender,
                 recipient: _recipient,
                 amount: _currency * 100
@@ -232,7 +232,7 @@ namespace Lib9c.Tests.Action
         [InlineData("Nine Chronicles")]
         public void PlainValue(string memo)
         {
-            var action = new TransferAsset(_sender, _recipient, _currency * 100, memo);
+            var action = new TransferAsset4(_sender, _recipient, _currency * 100, memo);
             Dictionary plainValue = (Dictionary)action.PlainValue;
             Dictionary values = (Dictionary)plainValue["values"];
 
@@ -265,7 +265,7 @@ namespace Lib9c.Tests.Action
             var plainValue = Dictionary.Empty
                 .Add("type_id", "transfer_asset3")
                 .Add("values", new Dictionary(pairs));
-            var action = new TransferAsset();
+            var action = new TransferAsset4();
             action.LoadPlainValue(plainValue);
 
             Assert.Equal(_sender, action.Sender);
@@ -283,7 +283,7 @@ namespace Lib9c.Tests.Action
                     .SetState(_recipient.Derive(ActivationKey.DeriveKey), true.Serialize())
                     .SetBalance(_sender, crystal * 1000)
                     .SetBalance(_sender, Currencies.Mead * 1));
-            var action = new TransferAsset(
+            var action = new TransferAsset4(
                 sender: _sender,
                 recipient: _recipient,
                 amount: 1000 * crystal
@@ -300,7 +300,7 @@ namespace Lib9c.Tests.Action
         [Fact]
         public void LoadPlainValue_ThrowsMemoLengthOverflowException()
         {
-            var action = new TransferAsset();
+            var action = new TransferAsset4();
             var plainValue = Dictionary.Empty
                 .Add("type_id", "transfer_asset3")
                 .Add("values", new Dictionary(new[]
@@ -320,13 +320,13 @@ namespace Lib9c.Tests.Action
         public void SerializeWithDotnetAPI(string memo)
         {
             var formatter = new BinaryFormatter();
-            var action = new TransferAsset(_sender, _recipient, _currency * 100, memo);
+            var action = new TransferAsset4(_sender, _recipient, _currency * 100, memo);
 
             using var ms = new MemoryStream();
             formatter.Serialize(ms, action);
 
             ms.Seek(0, SeekOrigin.Begin);
-            var deserialized = (TransferAsset)formatter.Deserialize(ms);
+            var deserialized = (TransferAsset4)formatter.Deserialize(ms);
 
             Assert.Equal(_sender, deserialized.Sender);
             Assert.Equal(_recipient, deserialized.Recipient);

--- a/.Lib9c.Tests/Action/TransferAssetTest.cs
+++ b/.Lib9c.Tests/Action/TransferAssetTest.cs
@@ -1,5 +1,6 @@
 namespace Lib9c.Tests.Action
 {
+    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.IO;
@@ -13,7 +14,9 @@ namespace Lib9c.Tests.Action
     using Nekoyume.Action;
     using Nekoyume.Helper;
     using Nekoyume.Model;
+    using Nekoyume.Model.Stake;
     using Nekoyume.Model.State;
+    using Nekoyume.TableData;
     using Xunit;
 
     public class TransferAssetTest
@@ -312,6 +315,78 @@ namespace Lib9c.Tests.Action
                 }));
 
             Assert.Throws<MemoLengthOverflowException>(() => action.LoadPlainValue(plainValue));
+        }
+
+        [Fact]
+        public void Execute_Throw_ArgumentException()
+        {
+            var baseState = new MockStateDelta(
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000));
+            var action = new TransferAsset(
+                sender: _sender,
+                recipient: StakeState.DeriveAddress(_recipient),
+                amount: _currency * 100
+            );
+            // 스테이킹 주소에 송금하려고 하면 실패합니다.
+            Assert.Throws<ArgumentException>("Recipient", () => action.Execute(new ActionContext()
+            {
+                PreviousState = baseState
+                    .SetState(
+                        StakeState.DeriveAddress(_recipient),
+                        new StakeState(StakeState.DeriveAddress(_recipient), 0).SerializeV2()),
+                Signer = _sender,
+                Rehearsal = false,
+                BlockIndex = 1,
+            }));
+            Assert.Throws<ArgumentException>("Recipient", () => action.Execute(new ActionContext()
+            {
+                PreviousState = baseState
+                    .SetState(
+                        StakeState.DeriveAddress(_recipient),
+                        new StakeStateV2(
+                            new Contract(
+                                "StakeRegularFixedRewardSheet_V1",
+                                "StakeRegularRewardSheet_V1",
+                                50400,
+                                201600),
+                            0).Serialize()),
+                Signer = _sender,
+                Rehearsal = false,
+                BlockIndex = 1,
+            }));
+            Assert.Throws<ArgumentException>("Recipient", () => action.Execute(new ActionContext()
+            {
+                PreviousState = baseState
+                    .SetState(
+                        StakeState.DeriveAddress(_recipient),
+                        new MonsterCollectionState(
+                                MonsterCollectionState.DeriveAddress(_sender, 0),
+                                1,
+                                0)
+                            .Serialize()),
+                Signer = _sender,
+                Rehearsal = false,
+                BlockIndex = 1,
+            }));
+            var monsterCollectionRewardSheet = new MonsterCollectionRewardSheet();
+            monsterCollectionRewardSheet.Set(
+                "level,required_gold,reward_id\n1,500,1\n2,1800,2\n3,7200,3\n4,54000,4\n5,270000,5\n6,480000,6\n7,1500000,7\n");
+            Assert.Throws<ArgumentException>("Recipient", () => action.Execute(new ActionContext()
+            {
+                PreviousState = baseState
+                    .SetState(
+                        StakeState.DeriveAddress(_recipient),
+                        new MonsterCollectionState0(
+                                MonsterCollectionState.DeriveAddress(_sender, 0),
+                                1,
+                                0,
+                                monsterCollectionRewardSheet)
+                            .Serialize()),
+                Signer = _sender,
+                Rehearsal = false,
+                BlockIndex = 1,
+            }));
         }
 
         [Theory]

--- a/.Lib9c.Tests/Action/TransferAssetTest.cs
+++ b/.Lib9c.Tests/Action/TransferAssetTest.cs
@@ -1,0 +1,337 @@
+namespace Lib9c.Tests.Action
+{
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.IO;
+    using System.Linq;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using Bencodex.Types;
+    using Libplanet.Action.State;
+    using Libplanet.Crypto;
+    using Libplanet.Types.Assets;
+    using Nekoyume;
+    using Nekoyume.Action;
+    using Nekoyume.Helper;
+    using Nekoyume.Model;
+    using Nekoyume.Model.State;
+    using Xunit;
+
+    public class TransferAssetTest
+    {
+        private static readonly Address _sender = new Address(
+            new byte[]
+            {
+                 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+                 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+            }
+        );
+
+        private static readonly Address _recipient = new Address(new byte[]
+            {
+                 0x02, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+                 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+            }
+        );
+
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+        private static readonly Currency _currency = Currency.Legacy("NCG", 2, null);
+#pragma warning restore CS0618
+
+        [Fact]
+        public void Constructor_ThrowsMemoLengthOverflowException()
+        {
+            Assert.Throws<MemoLengthOverflowException>(() =>
+                new TransferAsset(_sender, _recipient, _currency * 100, new string(' ', 100)));
+        }
+
+        [Fact]
+        public void Execute()
+        {
+            var contractAddress = _sender.Derive(nameof(RequestPledge));
+            var patronAddress = new PrivateKey().ToAddress();
+            var prevState = new MockStateDelta(
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_recipient, _currency * 10));
+            var action = new TransferAsset(
+                sender: _sender,
+                recipient: _recipient,
+                amount: _currency * 100
+            );
+            IAccount nextState = action.Execute(new ActionContext()
+            {
+                PreviousState = prevState,
+                Signer = _sender,
+                Rehearsal = false,
+                BlockIndex = 1,
+            });
+
+            Assert.Equal(_currency * 900, nextState.GetBalance(_sender, _currency));
+            Assert.Equal(_currency * 110, nextState.GetBalance(_recipient, _currency));
+        }
+
+        [Fact]
+        public void Execute_Throw_InvalidTransferSignerException()
+        {
+            var prevState = new MockStateDelta(
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_recipient, _currency * 10)
+                    .SetBalance(_sender, Currencies.Mead * 1));
+            var action = new TransferAsset(
+                sender: _sender,
+                recipient: _recipient,
+                amount: _currency * 100
+            );
+
+            var exc = Assert.Throws<InvalidTransferSignerException>(() =>
+            {
+                _ = action.Execute(new ActionContext()
+                {
+                    PreviousState = prevState,
+                    // 송금자가 직접 사인하지 않으면 실패해야 합니다.
+                    Signer = _recipient,
+                    Rehearsal = false,
+                    BlockIndex = 1,
+                });
+            });
+
+            Assert.Equal(exc.Sender, _sender);
+            Assert.Equal(exc.Recipient, _recipient);
+            Assert.Equal(exc.TxSigner, _recipient);
+        }
+
+        [Fact]
+        public void Execute_Throw_InvalidTransferRecipientException()
+        {
+            var prevState = new MockStateDelta(
+                MockState.Empty
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_sender, Currencies.Mead * 1));
+            // Should not allow TransferAsset with same sender and recipient.
+            var action = new TransferAsset(
+                sender: _sender,
+                recipient: _sender,
+                amount: _currency * 100
+            );
+
+            var exc = Assert.Throws<InvalidTransferRecipientException>(() =>
+            {
+                _ = action.Execute(new ActionContext()
+                {
+                    PreviousState = prevState,
+                    Signer = _sender,
+                    Rehearsal = false,
+                    BlockIndex = 1,
+                });
+            });
+
+            Assert.Equal(exc.Sender, _sender);
+            Assert.Equal(exc.Recipient, _sender);
+        }
+
+        [Fact]
+        public void Execute_Throw_InsufficientBalanceException()
+        {
+            var prevState = new MockStateDelta(
+                MockState.Empty
+                    .SetState(_recipient, new AgentState(_recipient).Serialize())
+                    .SetBalance(_sender, _currency * 1000)
+                    .SetBalance(_recipient, _currency * 10));
+            var action = new TransferAsset(
+                sender: _sender,
+                recipient: _recipient,
+                amount: _currency * 100000
+            );
+
+            InsufficientBalanceException exc = Assert.Throws<InsufficientBalanceException>(() =>
+            {
+                action.Execute(new ActionContext()
+                {
+                    PreviousState = prevState,
+                    Signer = _sender,
+                    Rehearsal = false,
+                    BlockIndex = 1,
+                });
+            });
+
+            Assert.Equal(_sender, exc.Address);
+            Assert.Equal(_currency, exc.Balance.Currency);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Execute_Throw_InvalidTransferMinterException(bool minterAsSender)
+        {
+            Address minter = minterAsSender ? _sender : _recipient;
+#pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currencyBySender = Currency.Legacy("NCG", 2, minter);
+#pragma warning restore CS0618
+            var prevState = new MockStateDelta(
+                MockState.Empty
+                    .SetState(_recipient, new AgentState(_recipient).Serialize())
+                    .SetBalance(_sender, currencyBySender * 1000)
+                    .SetBalance(_recipient, currencyBySender * 10)
+                    .SetBalance(_sender, Currencies.Mead * 1));
+            var action = new TransferAsset(
+                sender: _sender,
+                recipient: _recipient,
+                amount: currencyBySender * 100
+            );
+            var ex = Assert.Throws<InvalidTransferMinterException>(() =>
+            {
+                action.Execute(new ActionContext()
+                {
+                    PreviousState = prevState,
+                    Signer = _sender,
+                    Rehearsal = false,
+                    BlockIndex = 1,
+                });
+            });
+
+            Assert.Equal(new[] { minter }, ex.Minters);
+            Assert.Equal(_sender, ex.Sender);
+            Assert.Equal(_recipient, ex.Recipient);
+        }
+
+        [Fact]
+        public void Rehearsal()
+        {
+            var action = new TransferAsset(
+                sender: _sender,
+                recipient: _recipient,
+                amount: _currency * 100
+            );
+
+            var context = new ActionContext();
+            IAccount nextState = action.Execute(new ActionContext()
+            {
+                PreviousState = new MockStateDelta().MintAsset(context, _sender, Currencies.Mead * 1),
+                Signer = default,
+                Rehearsal = true,
+                BlockIndex = 1,
+            });
+
+            Assert.Equal(
+                ImmutableHashSet.Create(
+                    _sender,
+                    _recipient
+                ),
+                nextState.Delta.UpdatedFungibleAssets.Select(pair => pair.Item1).ToImmutableHashSet()
+            );
+            Assert.Equal(
+                new[] { _currency, Currencies.Mead, }.ToImmutableHashSet(),
+                nextState.Delta.UpdatedFungibleAssets.Select(pair => pair.Item2).ToImmutableHashSet());
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("Nine Chronicles")]
+        public void PlainValue(string memo)
+        {
+            var action = new TransferAsset(_sender, _recipient, _currency * 100, memo);
+            Dictionary plainValue = (Dictionary)action.PlainValue;
+            Dictionary values = (Dictionary)plainValue["values"];
+
+            Assert.Equal((Text)"transfer_asset5", plainValue["type_id"]);
+            Assert.Equal(_sender, values["sender"].ToAddress());
+            Assert.Equal(_recipient, values["recipient"].ToAddress());
+            Assert.Equal(_currency * 100, values["amount"].ToFungibleAssetValue());
+            if (!(memo is null))
+            {
+                Assert.Equal(memo, values["memo"].ToDotnetString());
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("Nine Chronicles")]
+        public void LoadPlainValue(string memo)
+        {
+            IEnumerable<KeyValuePair<IKey, IValue>> pairs = new[]
+            {
+                new KeyValuePair<IKey, IValue>((Text)"sender", _sender.Serialize()),
+                new KeyValuePair<IKey, IValue>((Text)"recipient", _recipient.Serialize()),
+                new KeyValuePair<IKey, IValue>((Text)"amount", (_currency * 100).Serialize()),
+            };
+            if (!(memo is null))
+            {
+                pairs = pairs.Append(new KeyValuePair<IKey, IValue>((Text)"memo", memo.Serialize()));
+            }
+
+            var plainValue = Dictionary.Empty
+                .Add("type_id", "transfer_asset5")
+                .Add("values", new Dictionary(pairs));
+            var action = new TransferAsset();
+            action.LoadPlainValue(plainValue);
+
+            Assert.Equal(_sender, action.Sender);
+            Assert.Equal(_recipient, action.Recipient);
+            Assert.Equal(_currency * 100, action.Amount);
+            Assert.Equal(memo, action.Memo);
+        }
+
+        [Fact]
+        public void Execute_Throw_InvalidTransferCurrencyException()
+        {
+            var crystal = CrystalCalculator.CRYSTAL;
+            var prevState = new MockStateDelta(
+                MockState.Empty
+                    .SetState(_recipient.Derive(ActivationKey.DeriveKey), true.Serialize())
+                    .SetBalance(_sender, crystal * 1000)
+                    .SetBalance(_sender, Currencies.Mead * 1));
+            var action = new TransferAsset(
+                sender: _sender,
+                recipient: _recipient,
+                amount: 1000 * crystal
+            );
+            Assert.Throws<InvalidTransferCurrencyException>(() => action.Execute(new ActionContext()
+            {
+                PreviousState = prevState,
+                Signer = _sender,
+                Rehearsal = false,
+                BlockIndex = TransferAsset3.CrystalTransferringRestrictionStartIndex,
+            }));
+        }
+
+        [Fact]
+        public void LoadPlainValue_ThrowsMemoLengthOverflowException()
+        {
+            var action = new TransferAsset();
+            var plainValue = Dictionary.Empty
+                .Add("type_id", "transfer_asset5")
+                .Add("values", new Dictionary(new[]
+                {
+                    new KeyValuePair<IKey, IValue>((Text)"sender", _sender.Serialize()),
+                    new KeyValuePair<IKey, IValue>((Text)"recipient", _recipient.Serialize()),
+                    new KeyValuePair<IKey, IValue>((Text)"amount", (_currency * 100).Serialize()),
+                    new KeyValuePair<IKey, IValue>((Text)"memo", new string(' ', 81).Serialize()),
+                }));
+
+            Assert.Throws<MemoLengthOverflowException>(() => action.LoadPlainValue(plainValue));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("Nine Chronicles")]
+        public void SerializeWithDotnetAPI(string memo)
+        {
+            var formatter = new BinaryFormatter();
+            var action = new TransferAsset(_sender, _recipient, _currency * 100, memo);
+
+            using var ms = new MemoryStream();
+            formatter.Serialize(ms, action);
+
+            ms.Seek(0, SeekOrigin.Begin);
+            var deserialized = (TransferAsset)formatter.Deserialize(ms);
+
+            Assert.Equal(_sender, deserialized.Sender);
+            Assert.Equal(_recipient, deserialized.Recipient);
+            Assert.Equal(_currency * 100, deserialized.Amount);
+            Assert.Equal(memo, deserialized.Memo);
+        }
+    }
+}

--- a/.Lib9c.Tests/Action/TransferAssetTest0.cs
+++ b/.Lib9c.Tests/Action/TransferAssetTest0.cs
@@ -40,7 +40,7 @@ namespace Lib9c.Tests.Action
         public void Constructor_ThrowsMemoLengthOverflowException()
         {
             Assert.Throws<MemoLengthOverflowException>(() =>
-                new TransferAsset(_sender, _recipient, _currency * 100, new string(' ', 100)));
+                new TransferAsset0(_sender, _recipient, _currency * 100, new string(' ', 100)));
         }
 
         [Fact]

--- a/.Lib9c.Tools/SubCommand/Account.cs
+++ b/.Lib9c.Tools/SubCommand/Account.cs
@@ -70,7 +70,7 @@ namespace Lib9c.Tools.SubCommand
                     .Select(txId => store.GetTransaction(new TxId(txId.ToArray())))
                     .SelectMany(tx => tx.Actions is { } ca
                         ? ca.Select(a => actionLoader.LoadAction(digest.Index, a))
-                            .SelectMany(a => a is TransferAsset t
+                            .SelectMany(a => a is ITransferAsset t
                                 ? new[] { t.Sender, t.Recipient }
                                 : a is InitializeStates i &&
                                     i.GoldDistributions is Bencodex.Types.List l

--- a/Lib9c/Action/AccountStateExtensions.cs
+++ b/Lib9c/Action/AccountStateExtensions.cs
@@ -961,6 +961,14 @@ namespace Nekoyume.Action
             return false;
         }
 
+        public static FungibleAssetValue GetStakedAmount(
+            this IAccountState state,
+            Address agentAddr)
+        {
+            var goldCurrency = state.GetGoldCurrency();
+            return state.GetBalance(StakeState.DeriveAddress(agentAddr), goldCurrency);
+        }
+
         public static bool TryGetStakeStateV2(
             this IAccountState state,
             Address agentAddr,

--- a/Lib9c/Action/Grinding.cs
+++ b/Lib9c/Action/Grinding.cs
@@ -86,17 +86,11 @@ namespace Nekoyume.Action
             });
 
             Currency currency = states.GetGoldCurrency();
-            FungibleAssetValue stakedAmount = 0 * currency;
-            if (states.TryGetStakeState(context.Signer, out StakeState stakeState))
+            FungibleAssetValue stakedAmount = states.GetStakedAmount(context.Signer);
+            if (stakedAmount == currency * 0 &&
+                states.TryGetState(monsterCollectionAddress, out Dictionary _))
             {
-                 stakedAmount = states.GetBalance(stakeState.address, currency);
-            }
-            else
-            {
-                if (states.TryGetState(monsterCollectionAddress, out Dictionary _))
-                {
-                    stakedAmount = states.GetBalance(monsterCollectionAddress, currency);
-                }
+                stakedAmount = states.GetBalance(monsterCollectionAddress, currency);
             }
 
             if (avatarState.actionPoint < CostAp)

--- a/Lib9c/Action/Grinding0.cs
+++ b/Lib9c/Action/Grinding0.cs
@@ -86,17 +86,10 @@ namespace Nekoyume.Action
             });
 
             Currency currency = states.GetGoldCurrency();
-            FungibleAssetValue stakedAmount = 0 * currency;
-            if (states.TryGetStakeState(context.Signer, out StakeState stakeState))
+            FungibleAssetValue stakedAmount = states.GetStakedAmount(context.Signer);
+            if (stakedAmount == currency * 0 && states.TryGetState(monsterCollectionAddress, out Dictionary _))
             {
-                 stakedAmount = states.GetBalance(stakeState.address, currency);
-            }
-            else
-            {
-                if (states.TryGetState(monsterCollectionAddress, out Dictionary _))
-                {
-                    stakedAmount = states.GetBalance(monsterCollectionAddress, currency);
-                }
+                stakedAmount = states.GetBalance(monsterCollectionAddress, currency);
             }
 
             if (avatarState.actionPoint < CostAp)

--- a/Lib9c/Action/HackAndSlash.cs
+++ b/Lib9c/Action/HackAndSlash.cs
@@ -195,11 +195,12 @@ namespace Nekoyume.Action
             sw.Restart();
             var stakingLevel = 0;
             StakeActionPointCoefficientSheet actionPointCoefficientSheet = null;
-            if (states.TryGetStakeState(signer, out var stakeState) &&
+
+            var goldCurrency = states.GetGoldCurrency();
+            var stakedAmount = states.GetStakedAmount(signer);
+            if (stakedAmount > goldCurrency * 0 &&
                 sheets.TryGetSheet(out actionPointCoefficientSheet))
             {
-                var currency = states.GetGoldCurrency();
-                var stakedAmount = states.GetBalance(stakeState.address, currency);
                 stakingLevel = actionPointCoefficientSheet.FindLevelByStakedAmount(signer, stakedAmount);
             }
 

--- a/Lib9c/Action/HackAndSlash18.cs
+++ b/Lib9c/Action/HackAndSlash18.cs
@@ -195,11 +195,11 @@ namespace Nekoyume.Action
             sw.Restart();
             var stakingLevel = 0;
             StakeActionPointCoefficientSheet actionPointCoefficientSheet = null;
-            if (states.TryGetStakeState(signer, out var stakeState) &&
+            var goldCurrency = states.GetGoldCurrency();
+            var stakedAmount = states.GetStakedAmount(signer);
+            if (stakedAmount > goldCurrency * 0 &&
                 sheets.TryGetSheet(out actionPointCoefficientSheet))
             {
-                var currency = states.GetGoldCurrency();
-                var stakedAmount = states.GetBalance(stakeState.address, currency);
                 stakingLevel = actionPointCoefficientSheet.FindLevelByStakedAmount(signer, stakedAmount);
             }
 

--- a/Lib9c/Action/HackAndSlash19.cs
+++ b/Lib9c/Action/HackAndSlash19.cs
@@ -174,11 +174,11 @@ namespace Nekoyume.Action
             sw.Restart();
             var stakingLevel = 0;
             StakeActionPointCoefficientSheet actionPointCoefficientSheet = null;
-            if (states.TryGetStakeState(signer, out var stakeState) &&
+            var goldCurrency = states.GetGoldCurrency();
+            var stakedAmount = states.GetStakedAmount(signer);
+            if (stakedAmount > goldCurrency * 0 &&
                 sheets.TryGetSheet(out actionPointCoefficientSheet))
             {
-                var currency = states.GetGoldCurrency();
-                var stakedAmount = states.GetBalance(stakeState.address, currency);
                 stakingLevel = actionPointCoefficientSheet.FindLevelByStakedAmount(signer, stakedAmount);
             }
 

--- a/Lib9c/Action/HackAndSlash20.cs
+++ b/Lib9c/Action/HackAndSlash20.cs
@@ -193,11 +193,11 @@ namespace Nekoyume.Action
             sw.Restart();
             var stakingLevel = 0;
             StakeActionPointCoefficientSheet actionPointCoefficientSheet = null;
-            if (states.TryGetStakeState(signer, out var stakeState) &&
+            var goldCurrency = states.GetGoldCurrency();
+            var stakedAmount = states.GetStakedAmount(signer);
+            if (stakedAmount > goldCurrency * 0 &&
                 sheets.TryGetSheet(out actionPointCoefficientSheet))
             {
-                var currency = states.GetGoldCurrency();
-                var stakedAmount = states.GetBalance(stakeState.address, currency);
                 stakingLevel = actionPointCoefficientSheet.FindLevelByStakedAmount(signer, stakedAmount);
             }
 

--- a/Lib9c/Action/HackAndSlashSweep.cs
+++ b/Lib9c/Action/HackAndSlashSweep.cs
@@ -285,10 +285,10 @@ namespace Nekoyume.Action
             // burn ap
             avatarState.actionPoint -= actionPoint;
             var costAp = sheets.GetSheet<StageSheet>()[stageId].CostAP;
-            if (states.TryGetStakeState(context.Signer, out var stakeState))
+            var goldCurrency = states.GetGoldCurrency();
+            var stakedAmount = states.GetStakedAmount(context.Signer);
+            if (stakedAmount > goldCurrency * 0)
             {
-                var currency = states.GetGoldCurrency();
-                var stakedAmount = states.GetBalance(stakeState.address, currency);
                 var actionPointCoefficientSheet =
                     sheets.GetSheet<StakeActionPointCoefficientSheet>();
                 var stakingLevel =

--- a/Lib9c/Action/HackAndSlashSweep6.cs
+++ b/Lib9c/Action/HackAndSlashSweep6.cs
@@ -210,10 +210,10 @@ namespace Nekoyume.Action
             // burn ap
             avatarState.actionPoint -= actionPoint;
             var costAp = sheets.GetSheet<StageSheet>()[stageId].CostAP;
-            if (states.TryGetStakeState(context.Signer, out var stakeState))
+            var goldCurrency = states.GetGoldCurrency();
+            var stakedAmount = states.GetStakedAmount(context.Signer);
+            if (stakedAmount > goldCurrency * 0)
             {
-                var currency = states.GetGoldCurrency();
-                var stakedAmount = states.GetBalance(stakeState.address, currency);
                 var actionPointCoefficientSheet = sheets.GetSheet<StakeActionPointCoefficientSheet>();
                 var stakingLevel = actionPointCoefficientSheet.FindLevelByStakedAmount(context.Signer, stakedAmount);
                 costAp = actionPointCoefficientSheet.GetActionPointByStaking(

--- a/Lib9c/Action/HackAndSlashSweep7.cs
+++ b/Lib9c/Action/HackAndSlashSweep7.cs
@@ -219,10 +219,10 @@ namespace Nekoyume.Action
             // burn ap
             avatarState.actionPoint -= actionPoint;
             var costAp = sheets.GetSheet<StageSheet>()[stageId].CostAP;
-            if (states.TryGetStakeState(context.Signer, out var stakeState))
+            var goldCurrency = states.GetGoldCurrency();
+            var stakedAmount = states.GetStakedAmount(context.Signer);
+            if (stakedAmount > goldCurrency * 0)
             {
-                var currency = states.GetGoldCurrency();
-                var stakedAmount = states.GetBalance(stakeState.address, currency);
                 var actionPointCoefficientSheet =
                     sheets.GetSheet<StakeActionPointCoefficientSheet>();
                 var stakingLevel =

--- a/Lib9c/Action/HackAndSlashSweep8.cs
+++ b/Lib9c/Action/HackAndSlashSweep8.cs
@@ -288,10 +288,10 @@ namespace Nekoyume.Action
             // burn ap
             avatarState.actionPoint -= actionPoint;
             var costAp = sheets.GetSheet<StageSheet>()[stageId].CostAP;
-            if (states.TryGetStakeState(context.Signer, out var stakeState))
+            var goldCurrency = states.GetGoldCurrency();
+            var stakedAmount = states.GetStakedAmount(context.Signer);
+            if (stakedAmount > goldCurrency * 0)
             {
-                var currency = states.GetGoldCurrency();
-                var stakedAmount = states.GetBalance(stakeState.address, currency);
                 var actionPointCoefficientSheet =
                     sheets.GetSheet<StakeActionPointCoefficientSheet>();
                 var stakingLevel =

--- a/Lib9c/Action/ItemEnhancement11.cs
+++ b/Lib9c/Action/ItemEnhancement11.cs
@@ -318,17 +318,10 @@ namespace Nekoyume.Action
                 );
 
                 Currency currency = states.GetGoldCurrency();
-                FungibleAssetValue stakedAmount = 0 * currency;
-                if (states.TryGetStakeState(context.Signer, out StakeState stakeState))
+                FungibleAssetValue stakedAmount = states.GetStakedAmount(context.Signer);
+                if (stakedAmount == currency * 0 && states.TryGetState(monsterCollectionAddress, out Dictionary _))
                 {
-                    stakedAmount = states.GetBalance(stakeState.address, currency);
-                }
-                else
-                {
-                    if (states.TryGetState(monsterCollectionAddress, out Dictionary _))
-                    {
-                        stakedAmount = states.GetBalance(monsterCollectionAddress, currency);
-                    }
+                    stakedAmount = states.GetBalance(monsterCollectionAddress, currency);
                 }
 
                 crystal = CrystalCalculator.CalculateCrystal(

--- a/Lib9c/Action/Stake2.cs
+++ b/Lib9c/Action/Stake2.cs
@@ -98,6 +98,12 @@ namespace Nekoyume.Action
             // Stake if it doesn't exist yet.
             if (!states.TryGetStakeState(context.Signer, out StakeState stakeState))
             {
+                if (states.TryGetStakeStateV2(context.Signer, out _))
+                {
+                    throw new InvalidOperationException(
+                        $"{context.Signer} has already staked as versions above 2.");
+                }
+
                 stakeState = new StakeState(stakeStateAddress, context.BlockIndex);
                 return states
                     .SetState(

--- a/Lib9c/Action/TransferAsset.cs
+++ b/Lib9c/Action/TransferAsset.cs
@@ -13,6 +13,7 @@ using Lib9c;
 using Lib9c.Abstractions;
 using Nekoyume.Helper;
 using Nekoyume.Model;
+using Nekoyume.Model.Stake;
 using Serilog;
 
 namespace Nekoyume.Action
@@ -117,11 +118,82 @@ namespace Nekoyume.Action
             }
 
             TransferAsset3.CheckCrystalSender(currency, context.BlockIndex, Sender);
-            if (state.TryGetStakeStateV2(Recipient, out _))
+            if (state.TryGetState(Recipient, out IValue serializedStakeState))
             {
-                throw new ArgumentException(
-                    "You can't send assets to StakeState.",
-                    nameof(Recipient));
+                bool isStakeStateOrMonsterCollectionState;
+                if (serializedStakeState is Dictionary dictionary)
+                {
+                    try
+                    {
+                        _ = new StakeState(dictionary);
+                        isStakeStateOrMonsterCollectionState = true;
+                    }
+                    catch (Exception)
+                    {
+                        isStakeStateOrMonsterCollectionState = false;
+                    }
+
+                    if (isStakeStateOrMonsterCollectionState)
+                    {
+                        throw new ArgumentException(
+                            "You can't send assets to staking state.",
+                            nameof(Recipient));
+                    }
+
+                    try
+                    {
+                        _ = new MonsterCollectionState0(dictionary);
+                        isStakeStateOrMonsterCollectionState = true;
+                    }
+                    catch (Exception)
+                    {
+                        isStakeStateOrMonsterCollectionState = false;
+                    }
+
+                    if (isStakeStateOrMonsterCollectionState)
+                    {
+                        throw new ArgumentException(
+                            "You can't send assets to staking state.",
+                            nameof(Recipient));
+                    }
+
+                    try
+                    {
+                        _ = new MonsterCollectionState(dictionary);
+                        isStakeStateOrMonsterCollectionState = true;
+                    }
+                    catch (Exception)
+                    {
+                        isStakeStateOrMonsterCollectionState = false;
+                    }
+
+                    if (isStakeStateOrMonsterCollectionState)
+                    {
+                        throw new ArgumentException(
+                            "You can't send assets to staking state.",
+                            nameof(Recipient));
+                    }
+                }
+
+                if (serializedStakeState is List serializedStakeStateV2)
+                {
+                    try
+                    {
+                        _ = new StakeStateV2(serializedStakeStateV2);
+                        isStakeStateOrMonsterCollectionState = true;
+                    }
+                    catch (Exception)
+                    {
+                        isStakeStateOrMonsterCollectionState = false;
+                    }
+
+                    if (isStakeStateOrMonsterCollectionState)
+                    {
+                        throw new ArgumentException(
+                            "You can't send assets to staking state.",
+                            nameof(Recipient));
+                    }
+                }
             }
 
             var ended = DateTimeOffset.UtcNow;

--- a/Lib9c/Action/TransferAsset.cs
+++ b/Lib9c/Action/TransferAsset.cs
@@ -1,0 +1,159 @@
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Action.State;
+using Libplanet.Crypto;
+using Libplanet.Types.Assets;
+using Nekoyume.Model.State;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using Lib9c;
+using Lib9c.Abstractions;
+using Nekoyume.Helper;
+using Nekoyume.Model;
+using Serilog;
+
+namespace Nekoyume.Action
+{
+    /// <summary>
+    /// Hard forked at https://github.com/planetarium/lib9c/pull/2143
+    /// Updated at https://github.com/planetarium/lib9c/pull/2143
+    /// </summary>
+    [Serializable]
+    [ActionType(TypeIdentifier)]
+    public class TransferAsset : ActionBase, ISerializable, ITransferAsset, ITransferAssetV1
+    {
+        private const int MemoMaxLength = 80;
+        public const string TypeIdentifier = "transfer_asset5";
+
+        public TransferAsset()
+        {
+        }
+
+        public TransferAsset(Address sender, Address recipient, FungibleAssetValue amount, string memo = null)
+        {
+            Sender = sender;
+            Recipient = recipient;
+            Amount = amount;
+
+            CheckMemoLength(memo);
+            Memo = memo;
+        }
+
+        protected TransferAsset(SerializationInfo info, StreamingContext context)
+        {
+            var rawBytes = (byte[])info.GetValue("serialized", typeof(byte[]));
+            Dictionary pv = (Dictionary) new Codec().Decode(rawBytes);
+
+            LoadPlainValue(pv);
+        }
+
+        public Address Sender { get; private set; }
+        public Address Recipient { get; private set; }
+        public FungibleAssetValue Amount { get; private set; }
+        public string Memo { get; private set; }
+
+        Address ITransferAssetV1.Sender => Sender;
+        Address ITransferAssetV1.Recipient => Recipient;
+        FungibleAssetValue ITransferAssetV1.Amount => Amount;
+        string ITransferAssetV1.Memo => Memo;
+
+        public override IValue PlainValue
+        {
+            get
+            {
+                IEnumerable<KeyValuePair<IKey, IValue>> pairs = new[]
+                {
+                    new KeyValuePair<IKey, IValue>((Text) "sender", Sender.Serialize()),
+                    new KeyValuePair<IKey, IValue>((Text) "recipient", Recipient.Serialize()),
+                    new KeyValuePair<IKey, IValue>((Text) "amount", Amount.Serialize()),
+                };
+
+                if (!(Memo is null))
+                {
+                    pairs = pairs.Append(new KeyValuePair<IKey, IValue>((Text) "memo", Memo.Serialize()));
+                }
+
+                return Dictionary.Empty
+                    .Add("type_id", TypeIdentifier)
+                    .Add("values", new Dictionary(pairs));
+            }
+        }
+
+        public override IAccount Execute(IActionContext context)
+        {
+            context.UseGas(4);
+            Address signer = context.Signer;
+            var state = context.PreviousState;
+            if (context.Rehearsal)
+            {
+                return state.MarkBalanceChanged(context, Amount.Currency, new[] {Sender, Recipient});
+            }
+
+            var addressesHex = GetSignerAndOtherAddressesHex(context, signer);
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}TransferAsset5 exec started", addressesHex);
+            if (Sender != signer)
+            {
+                throw new InvalidTransferSignerException(signer, Sender, Recipient);
+            }
+
+            if (Sender == Recipient)
+            {
+                throw new InvalidTransferRecipientException(Sender, Recipient);
+            }
+
+            Currency currency = Amount.Currency;
+            if (!(currency.Minters is null) &&
+                (currency.Minters.Contains(Sender) || currency.Minters.Contains(Recipient)))
+            {
+                throw new InvalidTransferMinterException(
+                    currency.Minters,
+                    Sender,
+                    Recipient
+               );
+            }
+
+            TransferAsset3.CheckCrystalSender(currency, context.BlockIndex, Sender);
+            if (state.TryGetStakeStateV2(Recipient, out _))
+            {
+                throw new ArgumentException(
+                    "You can't send assets to StakeState.",
+                    nameof(Recipient));
+            }
+
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}TransferAsset5 Total Executed Time: {Elapsed}", addressesHex, ended - started);
+            return state.TransferAsset(context, Sender, Recipient, Amount);
+        }
+
+        public override void LoadPlainValue(IValue plainValue)
+        {
+            var asDict = (Dictionary)((Dictionary)plainValue)["values"];
+
+            Sender = asDict["sender"].ToAddress();
+            Recipient = asDict["recipient"].ToAddress();
+            Amount = asDict["amount"].ToFungibleAssetValue();
+            Memo = asDict.TryGetValue((Text) "memo", out IValue memo) ? memo.ToDotnetString() : null;
+
+            CheckMemoLength(Memo);
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue("serialized", new Codec().Encode(PlainValue));
+        }
+
+        private void CheckMemoLength(string memo)
+        {
+            if (memo?.Length > MemoMaxLength)
+            {
+                string msg = $"The length of the memo, {memo.Length}, " +
+                             $"is overflowed than the max length, {MemoMaxLength}.";
+                throw new MemoLengthOverflowException(msg);
+            }
+        }
+    }
+}

--- a/Lib9c/Action/TransferAsset4.cs
+++ b/Lib9c/Action/TransferAsset4.cs
@@ -19,20 +19,22 @@ namespace Nekoyume.Action
 {
     /// <summary>
     /// Hard forked at https://github.com/planetarium/lib9c/pull/636
-    /// Updated at https://github.com/planetarium/lib9c/pull/1718
+    /// Updated at https://github.com/planetarium/lib9c/pull/2143
     /// </summary>
     [Serializable]
     [ActionType(TypeIdentifier)]
-    public class TransferAsset : ActionBase, ISerializable, ITransferAsset, ITransferAssetV1
+    [ActionObsolete(ObsoleteBlockIndex)]
+    public class TransferAsset4 : ActionBase, ISerializable, ITransferAsset, ITransferAssetV1
     {
         private const int MemoMaxLength = 80;
         public const string TypeIdentifier = "transfer_asset4";
+        public const long ObsoleteBlockIndex = ActionObsoleteConfig.V200080ObsoleteIndex;
 
-        public TransferAsset()
+        public TransferAsset4()
         {
         }
 
-        public TransferAsset(Address sender, Address recipient, FungibleAssetValue amount, string memo = null)
+        public TransferAsset4(Address sender, Address recipient, FungibleAssetValue amount, string memo = null)
         {
             Sender = sender;
             Recipient = recipient;
@@ -42,7 +44,7 @@ namespace Nekoyume.Action
             Memo = memo;
         }
 
-        protected TransferAsset(SerializationInfo info, StreamingContext context)
+        protected TransferAsset4(SerializationInfo info, StreamingContext context)
         {
             var rawBytes = (byte[])info.GetValue("serialized", typeof(byte[]));
             Dictionary pv = (Dictionary) new Codec().Decode(rawBytes);


### PR DESCRIPTION
This pull request updates the below items:

- Obsolete `transfer_asset4` action. (hard fork)
- Introduce `transfer_asset5` action. (hard fork)
  - Restrict assets to addresses having `StakeState`, `StakeStateV2`. Guessing addresses by trying deserializing as `StakeState` and `StakeStateV2`.
- Restrict executing `stake2` action when `StakeStateV2` already exists to prevent unexpected behaviour.
  - This pull request doesn't consider `claim_stake_reward*` actions for this case.
- Refactor getting staked amount with a new extension method `GetStakedAmount(Address)`. With the method, they can focus only its balance, not its state.