### PR TITLE
Fix nuget published lib9c dependency

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,9 +31,12 @@ jobs:
       if: github.event_name != 'pull_request'
       run: |
         if [[ "$NUGET_API_KEY" != "" ]]; then
-          dotnet nuget push ./Lib9c/.bin/Lib9c.*.nupkg \
-            --api-key "$NUGET_API_KEY" \
-            --source https://api.nuget.org/v3/index.json
+          for project in Lib9c Lib9c.Abstractions
+          do
+            dotnet nuget push ./$project/.bin/Lib9c.*.nupkg \
+              --api-key "$NUGET_API_KEY" \
+              --source https://api.nuget.org/v3/index.json
+          done
         fi
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,7 @@ jobs:
           do
             dotnet nuget push ./$project/.bin/Lib9c.*.nupkg \
               --api-key "$NUGET_API_KEY" \
+              --skip-duplicate \
               --source https://api.nuget.org/v3/index.json
           done
         fi


### PR DESCRIPTION
publish Lib9c.Abstractions for fix depedency exception use Lib9c in other projects.