### PR TITLE
Do not sort `ClaimItems.ClaimData` in tests

### DIFF
--- a/.Lib9c.Tests/Action/ClaimItemsTest.cs
+++ b/.Lib9c.Tests/Action/ClaimItemsTest.cs
@@ -66,12 +66,10 @@ namespace Lib9c.Tests.Action
             var deserialized = new ClaimItems();
             deserialized.LoadPlainValue(action.PlainValue);
 
-            var orderedClaimData = action.ClaimData.OrderBy(x => x.address).ToList();
-
             foreach (var i in Enumerable.Range(0, 2))
             {
-                Assert.Equal(orderedClaimData[i].address, deserialized.ClaimData[i].address);
-                Assert.True(orderedClaimData[i].fungibleAssetValues
+                Assert.Equal(action.ClaimData[i].address, deserialized.ClaimData[i].address);
+                Assert.True(action.ClaimData[i].fungibleAssetValues
                     .SequenceEqual(deserialized.ClaimData[i].fungibleAssetValues));
             }
         }


### PR DESCRIPTION
Since https://github.com/planetarium/lib9c/pull/2169, `ClaimItems.ClaimData` doesn't sort its `ClaimData` anymore. The pull request didn't apply that change to tests either. This pull request does it.