### PR TITLE
update acc access check logic

### DIFF
--- a/Lib9c.Policy/AccessControlService/IAccessControlService.cs
+++ b/Lib9c.Policy/AccessControlService/IAccessControlService.cs
@@ -5,5 +5,7 @@ namespace Nekoyume.Blockchain
     public interface IAccessControlService
     {
         public bool IsAccessDenied(Address address);
+
+        public int GetAccessLevel(Address address);
     }
 }

--- a/Lib9c.Policy/NCStagePolicy.cs
+++ b/Lib9c.Policy/NCStagePolicy.cs
@@ -61,7 +61,18 @@ namespace Nekoyume.Blockchain
                     s.Add(tx);
                     if (s.Count > _quotaPerSigner)
                     {
-                        s.Remove(s.Max);
+                        var accessLevel = _accessControlService?.GetAccessLevel(tx.Signer);
+                        if (_accessControlService != null)
+                        {
+                            if (accessLevel <= 0)
+                            {
+                                s.Remove(s.Max);
+                            }
+                        }
+                        else
+                        {
+                            s.Remove(s.Max);
+                        }
                     }
                 }
 
@@ -77,7 +88,8 @@ namespace Nekoyume.Blockchain
 
         public bool Stage(BlockChain blockChain, Transaction transaction)
         {
-            if (_accessControlService != null && _accessControlService.IsAccessDenied(transaction.Signer))
+            var accessLevel = _accessControlService?.GetAccessLevel(transaction.Signer);
+            if (_accessControlService != null && accessLevel == 0)
             {
                 return false;
             }


### PR DESCRIPTION
Use `GetAccessLevel` instead of `IsAccessDenied` to determine whether an address should be allowed or denied.

p.s. Headless PR coming up soon.