### PR TITLE
add GetTxQuota to ACS

### DIFF
--- a/Lib9c.Policy/AccessControlService/IAccessControlService.cs
+++ b/Lib9c.Policy/AccessControlService/IAccessControlService.cs
@@ -4,7 +4,7 @@ namespace Nekoyume.Blockchain
 {
     public interface IAccessControlService
     {
-        public bool IsAccessDenied(Address address);
+        public bool IsListed(Address address);
 
         public int? GetTxQuota(Address address);
     }

--- a/Lib9c.Policy/AccessControlService/IAccessControlService.cs
+++ b/Lib9c.Policy/AccessControlService/IAccessControlService.cs
@@ -5,5 +5,7 @@ namespace Nekoyume.Blockchain
     public interface IAccessControlService
     {
         public bool IsAccessDenied(Address address);
+
+        public int? GetTxQuota(Address address);
     }
 }

--- a/Lib9c.Policy/AccessControlService/IAccessControlService.cs
+++ b/Lib9c.Policy/AccessControlService/IAccessControlService.cs
@@ -4,8 +4,6 @@ namespace Nekoyume.Blockchain
 {
     public interface IAccessControlService
     {
-        public bool IsListed(Address address);
-
         public int? GetTxQuota(Address address);
     }
 }

--- a/Lib9c.Policy/NCStagePolicy.cs
+++ b/Lib9c.Policy/NCStagePolicy.cs
@@ -64,7 +64,7 @@ namespace Nekoyume.Blockchain
                     {
                         // update txQuotaPerSigner if ACS returns a value for the signer.
                         int? acsTxQuota = _accessControlService.GetTxQuota(tx.Signer);
-                        if (acsTxQuota != null)
+                        if (acsTxQuota.HasValue)
                         {
                             txQuotaPerSigner = (int)acsTxQuota;
                         }

--- a/Lib9c.Policy/NCStagePolicy.cs
+++ b/Lib9c.Policy/NCStagePolicy.cs
@@ -63,10 +63,9 @@ namespace Nekoyume.Blockchain
                     if (_accessControlService != null)
                     {
                         // update txQuotaPerSigner if ACS returns a value for the signer.
-                        int? acsTxQuota = _accessControlService.GetTxQuota(tx.Signer);
-                        if (acsTxQuota.HasValue)
+                        if (_accessControlService.GetTxQuota(tx.Signer) is { } acsTxQuota)
                         {
-                            txQuotaPerSigner = (int)acsTxQuota;
+                            txQuotaPerSigner = acsTxQuota;
                         }
                     }
 
@@ -89,7 +88,7 @@ namespace Nekoyume.Blockchain
         public bool Stage(BlockChain blockChain, Transaction transaction)
         {
             var acsTxQuota = _accessControlService?.GetTxQuota(transaction.Signer);
-            if (_accessControlService != null && acsTxQuota == 0)
+            if (acsTxQuota == 0)
             {
                 return false;
             }

--- a/Lib9c.Policy/NCStagePolicy.cs
+++ b/Lib9c.Policy/NCStagePolicy.cs
@@ -60,14 +60,13 @@ namespace Nekoyume.Blockchain
 
                     s.Add(tx);
                     int txQuotaPerSigner = _quotaPerSigner;
-                    if (_accessControlService != null)
+
+                    // update txQuotaPerSigner if ACS returns a value for the signer.
+                    if (_accessControlService?.GetTxQuota(tx.Signer) is { } acsTxQuota)
                     {
-                        // update txQuotaPerSigner if ACS returns a value for the signer.
-                        if (_accessControlService.GetTxQuota(tx.Signer) is { } acsTxQuota)
-                        {
-                            txQuotaPerSigner = acsTxQuota;
-                        }
+                        txQuotaPerSigner = acsTxQuota;
                     }
+
 
                     if (s.Count > txQuotaPerSigner)
                     {
@@ -87,8 +86,8 @@ namespace Nekoyume.Blockchain
 
         public bool Stage(BlockChain blockChain, Transaction transaction)
         {
-            var acsTxQuota = _accessControlService?.GetTxQuota(transaction.Signer);
-            if (acsTxQuota == 0)
+            if (_accessControlService?.GetTxQuota(transaction.Signer) is { } acsTxQuota
+                && acsTxQuota == 0)
             {
                 return false;
             }


### PR DESCRIPTION
### Changes
- Add `GetTxQuota` method to `ACS` to check a signer's individual `txQuotaPerSigner` when staging txs.

Replaces https://github.com/planetarium/lib9c/pull/2191.