### PR TITLE
Limit ClaimItems.ClaimData's size to 100

### DIFF
--- a/.Lib9c.Tests/Action/ClaimItemsTest.cs
+++ b/.Lib9c.Tests/Action/ClaimItemsTest.cs
@@ -2,6 +2,7 @@ namespace Lib9c.Tests.Action
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Linq;
     using Libplanet.Action.State;
     using Libplanet.Crypto;
@@ -180,6 +181,26 @@ namespace Lib9c.Tests.Action
             Assert.Equal(1, inventory2.Items.First(x => x.item.Id == _itemIds[0]).count);
             Assert.Equal(1, inventory2.Items.First(x => x.item.Id == _itemIds[1]).count);
             Assert.Equal(1, inventory2.Items.First(x => x.item.Id == _itemIds[2]).count);
+        }
+
+        [Fact]
+        public void Execute_WithIncorrectClaimData()
+        {
+            var fungibleAssetValues = _currencies.Select(currency => currency * 1).ToList();
+
+            var action = new ClaimItems(Enumerable.Repeat(0, 101)
+                .Select(_ => (new PrivateKey().ToAddress(),
+                    (IReadOnlyList<FungibleAssetValue>)fungibleAssetValues))
+                .ToImmutableList());
+
+            Assert.Throws<ArgumentOutOfRangeException>("ClaimData", () =>
+                action.Execute(new ActionContext
+                {
+                    PreviousState = _initialState,
+                    Signer = _signerAddress,
+                    BlockIndex = 0,
+                    RandomSeed = 0,
+                }));
         }
 
         private IAccount GenerateAvatar(IAccount state, out Address avatarAddress)

--- a/Lib9c/Action/ClaimItems.cs
+++ b/Lib9c/Action/ClaimItems.cs
@@ -19,6 +19,7 @@ namespace Nekoyume.Action
     public class ClaimItems : GameAction, IClaimItems
     {
         private const string ActionTypeText = "claim_items";
+        private const int MaxClaimDataCount = 100;
 
         public IReadOnlyList<(Address address, IReadOnlyList<FungibleAssetValue> fungibleAssetValues)> ClaimData { get; private set; }
 
@@ -56,6 +57,14 @@ namespace Nekoyume.Action
         public override IAccount Execute(IActionContext context)
         {
             context.UseGas(1);
+
+            if (ClaimData.Count > MaxClaimDataCount)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(ClaimData),
+                    ClaimData.Count,
+                    $"ClaimData should be less than {MaxClaimDataCount}");
+            }
 
             var states = context.PreviousState;
             var random = context.GetRandom();


### PR DESCRIPTION
See PDX-37 card and [internal slack conversation](https://planetariumhq.slack.com/archives/C03PJ5CG30C/p1698982821799689). The limitation prevents the `ClaimItems` to take too long evaluation time since 9c network doesn't have a fee model.