### PR TITLE
Allow empty NCG vault

### DIFF
--- a/.Lib9c.Tests/Action/RewardGoldTest.cs
+++ b/.Lib9c.Tests/Action/RewardGoldTest.cs
@@ -582,5 +582,32 @@ namespace Lib9c.Tests.Action
             Assert.Equal(0 * Currencies.Mead, nextState.GetBalance(patronAddress, Currencies.Mead));
             Assert.Equal(balance * Currencies.Mead, nextState.GetBalance(agentAddress, Currencies.Mead));
         }
+
+        [Fact]
+        public void NoRewardWhenEmptySupply()
+        {
+            var weekly = new WeeklyArenaState(0);
+            var gameConfigState = new GameConfigState();
+            gameConfigState.Set(_tableSheets.GameConfigSheet);
+
+            var currency = Currency.Legacy("NCG", 2, null);
+            IAccount states = new Account(MockState.Empty)
+                .SetState(GoldCurrencyState.Address, new GoldCurrencyState(currency, 0).Serialize())
+                .SetState(weekly.address, weekly.Serialize())
+                .SetState(Addresses.GoldDistribution, new List())
+                .SetState(gameConfigState.address, gameConfigState.Serialize());
+            var action = new RewardGold();
+
+            IAccount nextState = action.Execute(
+                new ActionContext()
+                {
+                    BlockIndex = 42,
+                    PreviousState = states,
+                    Miner = default,
+                }
+            );
+
+            Assert.Equal(0 * currency, nextState.GetBalance(default, currency));
+        }
     }
 }

--- a/.Lib9c.Tests/Model/State/GoldCurrencyStateTest.cs
+++ b/.Lib9c.Tests/Model/State/GoldCurrencyStateTest.cs
@@ -22,6 +22,7 @@ namespace Lib9c.Tests.Model.State
             GoldCurrencyState deserialized = new GoldCurrencyState(serialized);
 
             Assert.Equal(currency.Hash, deserialized.Currency.Hash);
+            Assert.Equal(1000000000, deserialized.InitialSupply);
         }
 
         [Fact]
@@ -41,6 +42,21 @@ namespace Lib9c.Tests.Model.State
             var deserialized = (GoldCurrencyState)formatter.Deserialize(ms);
 
             Assert.Equal(currency.Hash, deserialized.Currency.Hash);
+        }
+
+        [Fact]
+        public void SerializeWithInitialSupply()
+        {
+            #pragma warning disable CS0618
+            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
+            var currency = Currency.Legacy("NCG", 2, default(Address));
+#pragma warning restore CS0618
+            var state = new GoldCurrencyState(currency, 0L);
+            var serialized = (Dictionary)state.Serialize();
+            GoldCurrencyState deserialized = new GoldCurrencyState(serialized);
+
+            Assert.Equal(currency.Hash, deserialized.Currency.Hash);
+            Assert.Equal(0, deserialized.InitialSupply);
         }
     }
 }

--- a/Lib9c/Action/InitializeStates.cs
+++ b/Lib9c/Action/InitializeStates.cs
@@ -7,6 +7,7 @@ using Lib9c.Abstractions;
 using Libplanet.Action;
 using Libplanet.Action.State;
 using Nekoyume.Model.State;
+using System.Numerics;
 
 namespace Nekoyume.Action
 {
@@ -195,8 +196,16 @@ namespace Nekoyume.Action
                 states = states.SetState(CreditsState.Address, Credits);
             }
 
-            var currency = new GoldCurrencyState(GoldCurrency).Currency;
-            states = states.MintAsset(ctx, GoldCurrencyState.Address, currency * 1000000000);
+            var currencyState = new GoldCurrencyState(GoldCurrency);
+            if (currencyState.InitialSupply > 0)
+            {
+                states = states.MintAsset(
+                    ctx,
+                    GoldCurrencyState.Address,
+                    currencyState.Currency * currencyState.InitialSupply
+                );
+            }
+
             return states;
         }
 

--- a/Lib9c/Model/State/GoldCurrencyState.cs
+++ b/Lib9c/Model/State/GoldCurrencyState.cs
@@ -12,20 +12,38 @@ namespace Nekoyume.Model.State
     [Serializable]
     public class GoldCurrencyState : State, ISerializable
     {
+        public const long DEFAULT_INITIAL_SUPPLY = 1000000000;
+
         public static readonly Address Address = Addresses.GoldCurrency;
 
         public Currency Currency { get; private set; }
 
+        public long InitialSupply { get; private set; }
+
         public GoldCurrencyState(Currency currency)
+            : this(currency, DEFAULT_INITIAL_SUPPLY)
+        {
+        }
+
+        public GoldCurrencyState(Currency currency, long initialSupply)
             : base(Address)
         {
             Currency = currency;
+            InitialSupply = initialSupply;
         }
 
         public GoldCurrencyState(Dictionary serialized)
             : base(serialized)
         {
             Currency = CurrencyExtensions.Deserialize((Dictionary) serialized["currency"]);
+            if (serialized.TryGetValue((Text)"initialSupply", out IValue rawInitialSupply))
+            {
+                InitialSupply = (Integer)rawInitialSupply;
+            }
+            else
+            {
+                InitialSupply = DEFAULT_INITIAL_SUPPLY;
+            }
         }
 
         protected GoldCurrencyState(SerializationInfo info, StreamingContext context)
@@ -39,6 +57,11 @@ namespace Nekoyume.Model.State
             {
                 [(Text)"currency"] = CurrencyExtensions.Serialize(Currency)
             };
+
+            if (InitialSupply != DEFAULT_INITIAL_SUPPLY)
+            {
+                values.Add((Text)"initialSupply", (Integer)InitialSupply);
+            }
 #pragma warning disable LAA1002
             return new Dictionary(values.Union((Dictionary)base.Serialize()));
 #pragma warning restore LAA1002


### PR DESCRIPTION
This PR allows empty initial NCG supply, for planets governing under derived tokenomics.