### PR TITLE
✨  introduce: Pluggable ActionEvaluator

### DIFF
--- a/.Lib9c.Plugin.Shared/IPluginActionEvaluator.cs
+++ b/.Lib9c.Plugin.Shared/IPluginActionEvaluator.cs
@@ -1,0 +1,7 @@
+namespace Lib9c.Plugin.Shared
+{
+    public interface IPluginActionEvaluator
+    {
+        byte[][] Evaluate(byte[] blockBytes, byte[]? baseStateRootHashBytes);
+    }
+}

--- a/.Lib9c.Plugin.Shared/IPluginKeyValueStore.cs
+++ b/.Lib9c.Plugin.Shared/IPluginKeyValueStore.cs
@@ -1,0 +1,23 @@
+using System.Collections.Immutable;
+
+namespace Lib9c.Plugin.Shared
+{
+    public interface IPluginKeyValueStore
+    {
+        public byte[] Get(in ImmutableArray<byte> key);
+
+        public void Set(in ImmutableArray<byte> key, byte[] value);
+
+        public void Set(IDictionary<ImmutableArray<byte>, byte[]> values);
+
+        public void Delete(in ImmutableArray<byte> key);
+
+        public void Delete(IEnumerable<ImmutableArray<byte>> keys);
+
+        public bool Exists(in ImmutableArray<byte> key);
+
+        public IEnumerable<ImmutableArray<byte>> ListKeys();
+
+        public void Dispose();
+    }
+}

--- a/.Lib9c.Plugin.Shared/Lib9c.Plugin.Shared.csproj
+++ b/.Lib9c.Plugin.Shared/Lib9c.Plugin.Shared.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/.Lib9c.Plugin/Lib9c.Plugin.csproj
+++ b/.Lib9c.Plugin/Lib9c.Plugin.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Libplanet.RocksDBStore" Version="3.8.1" />
+    <ProjectReference Include="..\.Libplanet.Extensions.ActionEvaluatorCommonComponents\Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj" />
+    <ProjectReference Include="..\Lib9c\Lib9c.csproj" />
+    <ProjectReference Include="..\.Lib9c.Plugin.Shared\Lib9c.Plugin.Shared.csproj">
+      <Private>false</Private>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
+  </ItemGroup>
+  
+</Project>

--- a/.Lib9c.Plugin/PluginActionEvaluator.cs
+++ b/.Lib9c.Plugin/PluginActionEvaluator.cs
@@ -1,0 +1,36 @@
+using System.Security.Cryptography;
+using Lib9c.Plugin.Shared;
+using Libplanet.Action;
+using Libplanet.Common;
+using Libplanet.Extensions.ActionEvaluatorCommonComponents;
+using Libplanet.RocksDBStore;
+using Libplanet.Store;
+using Nekoyume.Action;
+using Nekoyume.Action.Loader;
+
+
+namespace Lib9c.Plugin
+{
+    public class PluginActionEvaluator : IPluginActionEvaluator
+    {
+        private readonly IActionEvaluator _actionEvaluator;
+        private readonly IStateStore _stateStore;
+
+        public PluginActionEvaluator(string stateStorePath)
+        {
+            _stateStore = new TrieStateStore(new RocksDBKeyValueStore(stateStorePath));
+            _actionEvaluator = new ActionEvaluator(
+                _ => new RewardGold(),
+                _stateStore,
+                new NCActionLoader());
+        }
+
+        public byte[][] Evaluate(byte[] blockBytes, byte[]? baseStateRootHashBytes)
+        {
+            return _actionEvaluator.Evaluate(
+                PreEvaluationBlockMarshaller.Deserialize(blockBytes),
+                baseStateRootHashBytes is { } bytes ? new HashDigest<SHA256>(bytes) : null)
+                .Select(eval => ActionEvaluationMarshaller.Serialize(eval)).ToArray();
+        }
+    }
+}

--- a/.Lib9c.Plugin/PluginActionEvaluator.cs
+++ b/.Lib9c.Plugin/PluginActionEvaluator.cs
@@ -14,14 +14,13 @@ namespace Lib9c.Plugin
     public class PluginActionEvaluator : IPluginActionEvaluator
     {
         private readonly IActionEvaluator _actionEvaluator;
-        private readonly IStateStore _stateStore;
 
-        public PluginActionEvaluator(string stateStorePath)
+        public PluginActionEvaluator(IPluginKeyValueStore keyValueStore)
         {
-            _stateStore = new TrieStateStore(new RocksDBKeyValueStore(stateStorePath));
+            var stateStore = new TrieStateStore(new WrappedKeyValueStore(keyValueStore));
             _actionEvaluator = new ActionEvaluator(
                 _ => new RewardGold(),
-                _stateStore,
+                stateStore,
                 new NCActionLoader());
         }
 

--- a/.Lib9c.Plugin/WrappedKeyValueStore.cs
+++ b/.Lib9c.Plugin/WrappedKeyValueStore.cs
@@ -1,0 +1,44 @@
+using Lib9c.Plugin.Shared;
+using Libplanet.Store.Trie;
+
+namespace Lib9c.Plugin
+{
+    public class WrappedKeyValueStore : IKeyValueStore
+    {
+        private readonly IPluginKeyValueStore _pluginKeyValueStore;
+
+        public WrappedKeyValueStore(IPluginKeyValueStore pluginKeyValueStore)
+        {
+            _pluginKeyValueStore = pluginKeyValueStore;
+        }
+
+        public void Dispose()
+        {
+            _pluginKeyValueStore.Dispose();
+        }
+
+        public byte[] Get(in KeyBytes key) =>
+            _pluginKeyValueStore.Get(key.ByteArray);
+
+        public void Set(in KeyBytes key, byte[] value) =>
+            _pluginKeyValueStore.Set(key.ByteArray, value);
+
+        public void Set(IDictionary<KeyBytes, byte[]> values) =>
+            _pluginKeyValueStore.Set(
+                values.ToDictionary(kv =>
+                    kv.Key.ByteArray, kv => kv.Value));
+
+        public void Delete(in KeyBytes key) =>
+            _pluginKeyValueStore.Delete(key.ByteArray);
+
+        public void Delete(IEnumerable<KeyBytes> keys) =>
+            _pluginKeyValueStore.Delete(
+                keys.Select(key => key.ByteArray));
+
+        public bool Exists(in KeyBytes key) =>
+            _pluginKeyValueStore.Exists(key.ByteArray);
+
+        public IEnumerable<KeyBytes> ListKeys() =>
+            _pluginKeyValueStore.ListKeys().Select(key => new KeyBytes(key));
+    }
+}

--- a/.Libplanet.Extensions.PluginActionEvaluator/PluginRocksDBKeyValueStore.cs
+++ b/.Libplanet.Extensions.PluginActionEvaluator/PluginRocksDBKeyValueStore.cs
@@ -1,0 +1,43 @@
+using System.Collections.Immutable;
+using Lib9c.PluginBase;
+using Libplanet.RocksDBStore;
+using Libplanet.Store.Trie;
+
+namespace Libplanet.Extensions.PluginActionEvaluator
+{
+    public class PluginRocksDBKeyValueStore : IPluginKeyValueStore
+    {
+        private readonly RocksDBKeyValueStore _rocksDbKeyValueStore;
+
+        public PluginRocksDBKeyValueStore(RocksDBKeyValueStore rocksDbKeyValueStore)
+        {
+            _rocksDbKeyValueStore = rocksDbKeyValueStore;
+        }
+        public byte[] Get(in ImmutableArray<byte> key) =>
+            _rocksDbKeyValueStore.Get(new KeyBytes(key));
+
+        public void Set(in ImmutableArray<byte> key, byte[] value) =>
+            _rocksDbKeyValueStore.Set(new KeyBytes(key), value);
+
+        public void Set(IDictionary<ImmutableArray<byte>, byte[]> values) =>
+            _rocksDbKeyValueStore.Set(
+                values.ToDictionary(kv =>
+                    new KeyBytes(kv.Key), kv => kv.Value));
+
+        public void Delete(in ImmutableArray<byte> key) =>
+            _rocksDbKeyValueStore.Delete(new KeyBytes(key));
+
+        public void Delete(IEnumerable<ImmutableArray<byte>> keys) =>
+            _rocksDbKeyValueStore.Delete(
+                keys.Select(key => new KeyBytes(key)));
+
+        public bool Exists(in ImmutableArray<byte> key) =>
+            _rocksDbKeyValueStore.Exists(new KeyBytes(key));
+
+        public IEnumerable<ImmutableArray<byte>> ListKeys() =>
+            _rocksDbKeyValueStore.ListKeys().Select(key => key.ByteArray);
+
+        public void Dispose() =>
+            _rocksDbKeyValueStore.Dispose();
+    }
+}

--- a/.github/workflows/lib9c_plugin_build_and_push_s3.yaml
+++ b/.github/workflows/lib9c_plugin_build_and_push_s3.yaml
@@ -1,0 +1,30 @@
+name: lib9c plugin build and push s3
+
+on:
+  workflow_dispatch:
+
+jobs:
+  s3-lib9c-plugin:
+    strategy:
+      matrix:
+        runtime: [ "osx-arm64", "linux-arm64", "linux-x64", "win-x64" ]
+    name: Publish Lib9c.Plugin (${{ matrix.runtime }})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.400
+      - name: Publish Lib9c.Plugin
+        run: dotnet publish ./.Lib9c.Plugin/Lib9c.Plugin.csproj -o out -r ${{ matrix.runtime }}
+      - name: Compress the build result
+        run: zip -r ../${{ matrix.runtime }}.zip .
+        working-directory: ./out
+      - name: Upload S3
+        run: aws s3 cp ${{ matrix.runtime }}.zip s3://9c-dx/Lib9c.Plugin/${{ github.sha }}/
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: "us-east-2"

--- a/Lib9c.sln
+++ b/Lib9c.sln
@@ -60,19 +60,23 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Types", ".Libplan
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Store", ".Libplanet\Libplanet.Store\Libplanet.Store.csproj", "{82BCD815-0AB6-4EEF-A12B-CDB9CD98EEA1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.ActionEvaluatorCommonComponents", ".Libplanet.Extensions.ActionEvaluatorCommonComponents\Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj", "{64C44AFB-1E14-44D3-B236-A4A37DF2C27A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Extensions.ActionEvaluatorCommonComponents", ".Libplanet.Extensions.ActionEvaluatorCommonComponents\Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj", "{64C44AFB-1E14-44D3-B236-A4A37DF2C27A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests", ".Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests\Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests.csproj", "{EACB2E8D-9A13-491C-BACD-5D79C6C13783}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests", ".Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests\Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests.csproj", "{EACB2E8D-9A13-491C-BACD-5D79C6C13783}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.RemoteActionEvaluator", ".Libplanet.Extensions.RemoteActionEvaluator\Libplanet.Extensions.RemoteActionEvaluator.csproj", "{0ED5DBA2-C334-40F2-8EB6-2B4D15C1AB4B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Extensions.RemoteActionEvaluator", ".Libplanet.Extensions.RemoteActionEvaluator\Libplanet.Extensions.RemoteActionEvaluator.csproj", "{0ED5DBA2-C334-40F2-8EB6-2B4D15C1AB4B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.RemoteActionEvaluator.Tests", ".Libplanet.Extensions.RemoteActionEvaluator.Tests\Libplanet.Extensions.RemoteActionEvaluator.Tests.csproj", "{3608A63A-A52D-4EB5-A96D-36C8F11CE603}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Extensions.RemoteActionEvaluator.Tests", ".Libplanet.Extensions.RemoteActionEvaluator.Tests\Libplanet.Extensions.RemoteActionEvaluator.Tests.csproj", "{3608A63A-A52D-4EB5-A96D-36C8F11CE603}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Extensions.RemoteBlockChainStates", ".Libplanet.Extensions.RemoteBlockChainStates\Libplanet.Extensions.RemoteBlockChainStates.csproj", "{63544447-4FCD-48D1-898C-974FBA6834AD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Extensions.RemoteBlockChainStates", ".Libplanet.Extensions.RemoteBlockChainStates\Libplanet.Extensions.RemoteBlockChainStates.csproj", "{63544447-4FCD-48D1-898C-974FBA6834AD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib9c.StateService", ".Lib9c.StateService\Lib9c.StateService.csproj", "{EB97AB26-1C8F-48F5-97FF-8A6DF8FAB879}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lib9c.StateService", ".Lib9c.StateService\Lib9c.StateService.csproj", "{EB97AB26-1C8F-48F5-97FF-8A6DF8FAB879}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib9c.StateService.Shared", ".Lib9c.StateService.Shared\Lib9c.StateService.Shared.csproj", "{5D3489AE-A403-4ADD-94E9-48463A42643E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lib9c.StateService.Shared", ".Lib9c.StateService.Shared\Lib9c.StateService.Shared.csproj", "{5D3489AE-A403-4ADD-94E9-48463A42643E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lib9c.Plugin", ".Lib9c.Plugin\Lib9c.Plugin.csproj", "{484A5A5B-D610-42D4-9CAC-B19EA1A71281}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lib9c.Plugin.Shared", ".Lib9c.Plugin.Shared\Lib9c.Plugin.Shared.csproj", "{76F6C25E-94D2-4EA9-B88D-0249F44D1D16}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -208,6 +212,14 @@ Global
 		{5D3489AE-A403-4ADD-94E9-48463A42643E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5D3489AE-A403-4ADD-94E9-48463A42643E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5D3489AE-A403-4ADD-94E9-48463A42643E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{484A5A5B-D610-42D4-9CAC-B19EA1A71281}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{484A5A5B-D610-42D4-9CAC-B19EA1A71281}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{484A5A5B-D610-42D4-9CAC-B19EA1A71281}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{484A5A5B-D610-42D4-9CAC-B19EA1A71281}.Release|Any CPU.Build.0 = Release|Any CPU
+		{76F6C25E-94D2-4EA9-B88D-0249F44D1D16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{76F6C25E-94D2-4EA9-B88D-0249F44D1D16}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{76F6C25E-94D2-4EA9-B88D-0249F44D1D16}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{76F6C25E-94D2-4EA9-B88D-0249F44D1D16}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
# Context
To ensure backward compatibility of `Action`, developing Lib9c Action was a challenging task. Therefore, to reduce development difficulty while implicitly maintaining backward compatibility, there was a need to change how `Action` is executed according to the height of the current `Block`. Therefore, we decided to name this project `Pluggable ActionEvaluator` and implement it.

# Rationale
[AssemblyLoadContext](https://learn.microsoft.com/en-us/dotnet/core/dependency-loading/understanding-assemblyloadcontext), for dynamic DLL loading, which we use for implementing `Puggable ActionEvaluator`.

We isolate `ActionEvaluator` as an `IPluginActionEvaluator` and use it on the `NineChronicles.Headless`. and get `IPluginKeyValueStore` for share `IKeyValueStore` with `NineChronicles.Headless`.

# Relative
- https://github.com/planetarium/lib9c/pull/2262
- https://github.com/planetarium/lib9c/commit/7ba6cb0050a539840dfb08e8bdf17576215f3671