### PR TITLE
🔧 Do not allow negative gas price or negative gas limit

### DIFF
--- a/Lib9c.Policy/Policy/BlockPolicySource.cs
+++ b/Lib9c.Policy/Policy/BlockPolicySource.cs
@@ -229,12 +229,21 @@ namespace Nekoyume.Blockchain.Policy
                             return null;
                     }
                 }
-                if (transaction.MaxGasPrice is null || transaction.GasLimit is null)
+
+                if (!(transaction.MaxGasPrice is { } gasPrice && transaction.GasLimit is { } gasLimit))
                 {
-                    return new
-                        TxPolicyViolationException("Transaction has no gas price or limit.",
+                    return new TxPolicyViolationException(
+                        "Transaction has no gas price or limit.",
                         transaction.Id);
                 }
+
+                if (gasPrice.Sign < 0 || gasLimit < 0)
+                {
+                    return new TxPolicyViolationException(
+                        "Transaction has negative gas price or limit.",
+                        transaction.Id);
+                }
+
                 if (transaction.MaxGasPrice * transaction.GasLimit > blockChain.GetBalance(transaction.Signer, Currencies.Mead))
                 {
                     return new TxPolicyViolationException(


### PR DESCRIPTION
Thorough investigation on 9c chains (Both Odin and Heimdall) should be done before we block `Transaction`s with negative gas price or negative limit at Libplanet level. This is to prevent further possibility of such `Transaction`s sneaking into current chains.