### PR TITLE
🔨 Correct `RemoteBlockChainStates` implementation

### DIFF
--- a/.Libplanet.Extensions.RemoteBlockChainStates/RemoteBlockChainStates.cs
+++ b/.Libplanet.Extensions.RemoteBlockChainStates/RemoteBlockChainStates.cs
@@ -41,10 +41,7 @@ namespace Libplanet.Extensions.RemoteBlockChainStates
             return new RemoteBlockState(_explorerEndpoint, offset).GetValidatorSet();
         }
 
-        public IAccountState GetAccountState(BlockHash? offset) =>
-            throw new NotImplementedException();
-
-        public IAccountState GetBlockState(BlockHash? offset)
+        public IAccountState GetAccountState(BlockHash? offset)
         {
             return new RemoteBlockState(_explorerEndpoint, offset);
         }


### PR DESCRIPTION
In [this commit](https://github.com/planetarium/lib9c/commit/f64a986cafac7c58d6f8be3e43f3af9268f69ebc#diff-7f5f43e147607066a3205ef1e1faa8a6be1a08d45cf003b7bf50b4c373af0023L44-R47), `RemoteBlockChainStates.GetAccountState(BlockHash?)` was implemented as throwing not implemented exception. But the method seems equal to the `GetBlockState(BlockHash?)` method. So this PR renames `GetBlockState` to `GetAccountState`.