### PR TITLE
add txid to messagepack

### DIFF
--- a/.Lib9c.Tests/Action/ActionEvaluationTest.cs
+++ b/.Lib9c.Tests/Action/ActionEvaluationTest.cs
@@ -104,7 +104,8 @@ namespace Lib9c.Tests.Action
                 null,
                 _states.Trie.Hash,
                 0,
-                new Dictionary<string, IValue>()
+                new Dictionary<string, IValue>(),
+                null
             );
             var evaluation = ncEval.ToActionEvaluation();
             var b = MessagePackSerializer.Serialize(ncEval);

--- a/Lib9c.MessagePack/Action/NCActionEvaluation.cs
+++ b/Lib9c.MessagePack/Action/NCActionEvaluation.cs
@@ -7,6 +7,7 @@ using Lib9c.Formatters;
 using Lib9c.Renderers;
 using Libplanet.Crypto;
 using Libplanet.Common;
+using Libplanet.Types.Tx;
 using MessagePack;
 
 namespace Nekoyume.Action
@@ -16,6 +17,7 @@ namespace Nekoyume.Action
     {
 #pragma warning disable MsgPack003
         [Key(0)]
+
         [MessagePackFormatter(typeof(NCActionFormatter))]
         public ActionBase? Action { get; set; }
 
@@ -45,6 +47,9 @@ namespace Nekoyume.Action
         [Key(7)]
         public Dictionary<string, IValue> Extra { get; set; }
 
+        [Key(8)]
+        [MessagePackFormatter(typeof(TxIdFormatter))]
+        public TxId? TxId { get; set; }
 
         [SerializationConstructor]
         public NCActionEvaluation(
@@ -55,7 +60,8 @@ namespace Nekoyume.Action
             Exception? exception,
             HashDigest<SHA256> previousStates,
             int randomSeed,
-            Dictionary<string, IValue> extra
+            Dictionary<string, IValue> extra,
+            TxId? txId
         )
         {
             Action = action;
@@ -66,6 +72,7 @@ namespace Nekoyume.Action
             PreviousState = previousStates;
             RandomSeed = randomSeed;
             Extra = extra;
+            TxId = txId;
         }
 
         public ActionEvaluation<ActionBase> ToActionEvaluation()
@@ -79,7 +86,8 @@ namespace Nekoyume.Action
                 Exception = Exception,
                 PreviousState = PreviousState,
                 RandomSeed = RandomSeed,
-                Extra = Extra
+                Extra = Extra,
+                TxId = TxId
             };
         }
     }

--- a/Lib9c.MessagePack/Formatters/TxIdFormatter.cs
+++ b/Lib9c.MessagePack/Formatters/TxIdFormatter.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Buffers;
+using System.Collections.Immutable;
+using Libplanet.Types.Tx;
+using MessagePack;
+using MessagePack.Formatters;
+
+namespace Lib9c.Formatters
+{
+    public class TxIdFormatter : IMessagePackFormatter<TxId?>
+    {
+        public void Serialize(ref MessagePackWriter writer, TxId? value, MessagePackSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNil();
+                return;
+            }
+
+            writer.Write(value.Value.ToByteArray());
+        }
+
+        public TxId? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+        {
+            if (reader.TryReadNil())
+            {
+                return default;
+            }
+
+            options.Security.DepthStep(ref reader);
+
+            var bytes = reader.ReadBytes()?.ToArray();
+            if (bytes is null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            return new TxId(bytes.ToImmutableArray());
+        }
+    }
+}


### PR DESCRIPTION
So, the `ActionEvaluation` data provided during the `OnRender` call now includes `TxIds`.