### PR TITLE
Support decimal rates of 3 or more digits

### DIFF
--- a/Lib9c/Model/State/StakeRewardCalculator.cs
+++ b/Lib9c/Model/State/StakeRewardCalculator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Numerics;
 using Bencodex.Types;
 using Lib9c;
 using Libplanet.Action;
@@ -32,14 +33,13 @@ namespace Nekoyume.Model.State
 
         public static (Dictionary<ItemBase, int> itemResult, List<FungibleAssetValue> favResult) CalculateRewards(Currency ncg, FungibleAssetValue stakedNcg, int stakingLevel, int rewardSteps, StakeRegularRewardSheet stakeRegularRewardSheet, ItemSheet itemSheet, IRandom random)
         {
+            var stakedNcgDecimal = TableExtensions.ParseDecimal(stakedNcg.GetQuantityString());
             var itemResult = new Dictionary<ItemBase, int>();
             var favResult = new List<FungibleAssetValue>();
             foreach (var reward in stakeRegularRewardSheet[stakingLevel].Rewards)
             {
-                var rateFav = FungibleAssetValue.Parse(
-                    ncg,
-                    reward.DecimalRate.ToString(CultureInfo.InvariantCulture));
-                var rewardQuantityForSingleStep = stakedNcg.DivRem(rateFav, out _);
+                var rewardQuantityForSingleStep =
+                    new BigInteger(stakedNcgDecimal / reward.DecimalRate);
                 if (rewardQuantityForSingleStep <= 0)
                 {
                     continue;


### PR DESCRIPTION
Before this pull request, it doesn't support `0.025` as decimal rates in `StakeRegularRewardSheet`. There was an error while parsing it as NCG FAV. But it is not necessary to parse the value as NCG FAV. I think it is just to use `FungibleAssetValue.DivRem` method. I replaced the logic with `new BigInteger(decimal / decimal)` to remove digits.

```
Unhandled exception. System.FormatException: The currency NCG (50778d9d92d8d76b325cc572dceb7d30d9887472) does not allow more than 2 decimal places
   at Libplanet.Types.Assets.FungibleAssetValue.Parse(Currency currency, String value) in /path/tolib9c/.Libplanet/Libplanet.Types/Assets/FungibleAssetValue.cs:line 480
   at Lib9c.Tools.Program.Main(String[] args) in /path/to/lib9c/.Lib9c.Tools/Program.cs:line 24
```