### PR TITLE
Bump VersionPrefix to 1.8.0

### DIFF
--- a/Lib9c/Lib9c.csproj
+++ b/Lib9c/Lib9c.csproj
@@ -9,7 +9,7 @@
     <IntermediateOutputPath>.obj</IntermediateOutputPath>
     <RootNamespace>Nekoyume</RootNamespace>
     <LangVersion>9</LangVersion>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.8.0</VersionPrefix>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>


### PR DESCRIPTION
Currently, the GitHub Actions workflow deploys NuGet package when a commit is pushed to `development` and `main` branches. The published version is determined as `{VersionPrefix}-dev.{github.sha}`. So previous versions were `1.1.0-dev.somecommithash`. This pull request makes it correct.