### PR TITLE
Revert "Remove 🧹 HackAndSlash3"

### DIFF
--- a/.Lib9c.Tests/Action/Scenario/WorldUnlockScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/WorldUnlockScenarioTest.cs
@@ -3,9 +3,9 @@ namespace Lib9c.Tests.Action.Scenario
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text;
     using Libplanet.Action.State;
     using Libplanet.Crypto;
-    using Libplanet.Types.Assets;
     using Nekoyume;
     using Nekoyume.Action;
     using Nekoyume.Model;
@@ -35,13 +35,12 @@ namespace Lib9c.Tests.Action.Scenario
 
             _avatarAddress = _agentAddress.Derive("avatar");
             _rankingMapAddress = _avatarAddress.Derive("ranking_map");
-            var gameConfigState = new GameConfigState(sheets[nameof(GameConfigSheet)]);
             var avatarState = new AvatarState(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
-                gameConfigState,
+                new GameConfigState(sheets[nameof(GameConfigSheet)]),
                 _rankingMapAddress
             )
             {
@@ -51,18 +50,11 @@ namespace Lib9c.Tests.Action.Scenario
 
             _weeklyArenaState = new WeeklyArenaState(0);
 
-#pragma warning disable CS0618
-            // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
-            var currency = Currency.Legacy("NCG", 2, null);
-#pragma warning restore CS0618
-            var goldCurrencyState = new GoldCurrencyState(currency);
             _initialState = new World(new MockWorldState())
-                .SetLegacyState(Addresses.GoldCurrency, goldCurrencyState.Serialize())
                 .SetLegacyState(_weeklyArenaState.address, _weeklyArenaState.Serialize())
                 .SetAgentState(_agentAddress, agentState)
                 .SetAvatarState(_avatarAddress, avatarState)
-                .SetLegacyState(_rankingMapAddress, new RankingMapState(_rankingMapAddress).Serialize())
-                .SetLegacyState(gameConfigState.address, gameConfigState.Serialize());
+                .SetLegacyState(_rankingMapAddress, new RankingMapState(_rankingMapAddress).Serialize());
 
             foreach (var (key, value) in sheets)
             {
@@ -98,20 +90,17 @@ namespace Lib9c.Tests.Action.Scenario
             var doomfist = Doomfist.GetOne(_tableSheets, avatarState.level, ItemSubType.Weapon);
             avatarState.inventory.AddItem(doomfist);
 
-            var nextState = _initialState
-                .SetAvatarState(_avatarAddress, avatarState)
-                .SetLegacyState(
-                    _avatarAddress.Derive("world_ids"),
-                    new Bencodex.Types.List(Enumerable.Range(1, worldIdToClear).Select(i => i.Serialize())));
-            var hackAndSlash = new HackAndSlash
+            var nextState = _initialState.SetAvatarState(_avatarAddress, avatarState);
+            var hackAndSlash = new HackAndSlash3
             {
-                WorldId = worldIdToClear,
-                StageId = stageIdToClear,
-                AvatarAddress = _avatarAddress,
-                Costumes = new List<Guid>(),
-                Equipments = new List<Guid> { doomfist.NonFungibleId },
-                Foods = new List<Guid>(),
-                RuneInfos = new List<RuneSlotInfo>(),
+                worldId = worldIdToClear,
+                stageId = stageIdToClear,
+                avatarAddress = _avatarAddress,
+                costumes = new List<int>(),
+                equipments = new List<Guid> { doomfist.NonFungibleId },
+                foods = new List<Guid>(),
+                WeeklyArenaAddress = _weeklyArenaState.address,
+                RankingMapAddress = _rankingMapAddress,
             };
             nextState = hackAndSlash.Execute(new ActionContext
             {
@@ -119,6 +108,7 @@ namespace Lib9c.Tests.Action.Scenario
                 Signer = _agentAddress,
                 RandomSeed = 0,
             });
+            Assert.True(hackAndSlash.Result.IsClear);
 
             avatarState = nextState.GetAvatarState(_avatarAddress);
             Assert.True(avatarState.worldInformation.IsStageCleared(stageIdToClear));
@@ -159,6 +149,7 @@ id,world_id,stage_id,world_id_to_unlock,required_crystal
                 Signer = _agentAddress,
                 RandomSeed = 0,
             });
+            Assert.True(hackAndSlash.Result.IsClear);
 
             avatarState = nextState.GetAvatarState(_avatarAddress);
             Assert.True(avatarState.worldInformation.IsWorldUnlocked(worldIdToUnlock));

--- a/Lib9c/Action/HackAndSlash.cs
+++ b/Lib9c/Action/HackAndSlash.cs
@@ -508,14 +508,17 @@ namespace Nekoyume.Action
                 sw.Restart();
                 if (simulator.Log.IsClear)
                 {
-                    avatarState.worldInformation.ClearStage(
-                        WorldId,
-                        StageId,
-                        blockIndex,
-                        worldSheet,
-                        worldUnlockSheet
-                    );
-                    stageCleared = true;
+                    if (!stageCleared)
+                    {
+                        avatarState.worldInformation.ClearStage(
+                            WorldId,
+                            StageId,
+                            blockIndex,
+                            worldSheet,
+                            worldUnlockSheet
+                        );
+                        stageCleared = true;
+                    }
                     sw.Stop();
                     Log.Verbose("{AddressesHex} {Source} HAS {Process} from #{BlockIndex}: {Elapsed}",
                         addressesHex, source, "ClearStage", blockIndex, sw.Elapsed.TotalMilliseconds);

--- a/Lib9c/Action/HackAndSlash3.cs
+++ b/Lib9c/Action/HackAndSlash3.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Bencodex.Types;
+using Lib9c.Abstractions;
+using Libplanet.Action;
+using Libplanet.Action.State;
+using Libplanet.Crypto;
+using Nekoyume.Battle;
+using Nekoyume.Model.BattleStatus;
+using Nekoyume.Model.State;
+using Nekoyume.Module;
+using Nekoyume.TableData;
+using Serilog;
+
+namespace Nekoyume.Action
+{
+    [Serializable]
+    [ActionObsolete(ActionObsoleteConfig.V200020AccidentObsoleteIndex)]
+    [ActionType("hack_and_slash3")]
+    public class HackAndSlash3 : GameAction, IHackAndSlashV1
+    {
+        public List<int> costumes;
+        public List<Guid> equipments;
+        public List<Guid> foods;
+        public int worldId;
+        public int stageId;
+        public Address avatarAddress;
+        public Address WeeklyArenaAddress;
+        public Address RankingMapAddress;
+        public BattleLog Result { get; private set; }
+
+        IEnumerable<int> IHackAndSlashV1.Costumes => costumes;
+        IEnumerable<Guid> IHackAndSlashV1.Equipments => equipments;
+        IEnumerable<Guid> IHackAndSlashV1.Foods => foods;
+        int IHackAndSlashV1.WorldId => worldId;
+        int IHackAndSlashV1.StageId => stageId;
+        Address IHackAndSlashV1.AvatarAddress => avatarAddress;
+        Address IHackAndSlashV1.WeeklyArenaAddress => WeeklyArenaAddress;
+        Address IHackAndSlashV1.RankingMapAddress => RankingMapAddress;
+
+        protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
+            new Dictionary<string, IValue>
+            {
+                ["costumes"] = new List(costumes.OrderBy(i => i).Select(e => e.Serialize())),
+                ["equipments"] = new List(equipments.OrderBy(i => i).Select(e => e.Serialize())),
+                ["foods"] = new List(foods.OrderBy(i => i).Select(e => e.Serialize())),
+                ["worldId"] = worldId.Serialize(),
+                ["stageId"] = stageId.Serialize(),
+                ["avatarAddress"] = avatarAddress.Serialize(),
+                ["weeklyArenaAddress"] = WeeklyArenaAddress.Serialize(),
+                ["rankingMapAddress"] = RankingMapAddress.Serialize(),
+            }.ToImmutableDictionary();
+
+
+        protected override void LoadPlainValueInternal(
+            IImmutableDictionary<string, IValue> plainValue)
+        {
+            costumes =  ((List) plainValue["costumes"]).Select(e => e.ToInteger()).ToList();
+            equipments = ((List) plainValue["equipments"]).Select(e => e.ToGuid()).ToList();
+            foods = ((List) plainValue["foods"]).Select(e => e.ToGuid()).ToList();
+            worldId = plainValue["worldId"].ToInteger();
+            stageId = plainValue["stageId"].ToInteger();
+            avatarAddress = plainValue["avatarAddress"].ToAddress();
+            WeeklyArenaAddress = plainValue["weeklyArenaAddress"].ToAddress();
+            RankingMapAddress = plainValue["rankingMapAddress"].ToAddress();
+        }
+
+        public override IWorld Execute(IActionContext context)
+        {
+            context.UseGas(1);
+            IActionContext ctx = context;
+            var states = ctx.PreviousState;
+
+            CheckObsolete(ActionObsoleteConfig.V100080ObsoleteIndex, context);
+
+            var addressesHex = GetSignerAndOtherAddressesHex(context, avatarAddress);
+
+            var sw = new Stopwatch();
+            sw.Start();
+            var started = DateTimeOffset.UtcNow;
+            Log.Verbose("{AddressesHex}HAS exec started", addressesHex);
+
+            if (!states.TryGetAvatarState(ctx.Signer, avatarAddress, out AvatarState avatarState))
+            {
+                throw new FailedLoadStateException($"{addressesHex}Aborted as the avatar state of the signer was failed to load.");
+            }
+
+            sw.Stop();
+            Log.Verbose("{AddressesHex}HAS Get AgentAvatarStates: {Elapsed}", addressesHex, sw.Elapsed);
+
+            sw.Restart();
+
+            if (avatarState.RankingMapAddress != RankingMapAddress)
+            {
+                throw new InvalidAddressException($"{addressesHex}Invalid ranking map address");
+            }
+
+            // worldId와 stageId가 유효한지 확인합니다.
+            var worldSheet = states.GetSheet<WorldSheet>();
+
+            if (!worldSheet.TryGetValue(worldId, out var worldRow, false))
+            {
+                throw new SheetRowNotFoundException(addressesHex, nameof(WorldSheet), worldId);
+            }
+
+            if (stageId < worldRow.StageBegin ||
+                stageId > worldRow.StageEnd)
+            {
+                throw new SheetRowColumnException(
+                    $"{addressesHex}{worldId} world is not contains {worldRow.Id} stage: " +
+                    $"{worldRow.StageBegin}-{worldRow.StageEnd}");
+            }
+
+            var stageSheet = states.GetSheet<StageSheet>();
+            if (!stageSheet.TryGetValue(stageId, out var stageRow))
+            {
+                throw new SheetRowNotFoundException(addressesHex, nameof(StageSheet), stageId);
+            }
+
+            var worldInformation = avatarState.worldInformation;
+            if (!worldInformation.TryGetWorld(worldId, out var world))
+            {
+                // NOTE: Add new World from WorldSheet
+                worldInformation.AddAndUnlockNewWorld(worldRow, ctx.BlockIndex, worldSheet);
+            }
+
+            if (!world.IsUnlocked)
+            {
+                throw new InvalidWorldException($"{addressesHex}{worldId} is locked.");
+            }
+
+            if (world.StageBegin != worldRow.StageBegin ||
+                world.StageEnd != worldRow.StageEnd)
+            {
+                worldInformation.UpdateWorld(worldRow);
+            }
+
+            if (world.IsStageCleared && stageId > world.StageClearedId + 1 ||
+                !world.IsStageCleared && stageId != world.StageBegin)
+            {
+                throw new InvalidStageException(
+                    $"{addressesHex}Aborted as the stage ({worldId}/{stageId}) is not cleared; " +
+                    $"cleared stage: {world.StageClearedId}"
+                );
+            }
+
+            avatarState.ValidateEquipments(equipments, context.BlockIndex);
+            avatarState.ValidateConsumable(foods, context.BlockIndex);
+            avatarState.ValidateCostume(new HashSet<int>(costumes));
+
+            var costumeStatSheet = states.GetSheet<CostumeStatSheet>();
+
+            sw.Restart();
+            if (avatarState.actionPoint < stageRow.CostAP)
+            {
+                throw new NotEnoughActionPointException(
+                    $"{addressesHex}Aborted due to insufficient action point: " +
+                    $"{avatarState.actionPoint} < {stageRow.CostAP}"
+                );
+            }
+
+            avatarState.actionPoint -= stageRow.CostAP;
+
+            avatarState.EquipCostumes(new HashSet<int>(costumes));
+
+            avatarState.EquipEquipments(equipments);
+            sw.Stop();
+            Log.Verbose("{AddressesHex}HAS Unequip items: {Elapsed}", addressesHex, sw.Elapsed);
+
+            sw.Restart();
+            var characterSheet = states.GetSheet<CharacterSheet>();
+            var random = ctx.GetRandom();
+            var simulator = new StageSimulatorV1(
+                random,
+                avatarState,
+                foods,
+                worldId,
+                stageId,
+                states.GetStageSimulatorSheetsV1(),
+                costumeStatSheet
+            );
+
+            sw.Stop();
+            Log.Verbose("{AddressesHex}HAS Initialize Simulator: {Elapsed}", addressesHex, sw.Elapsed);
+
+            sw.Restart();
+            simulator.SimulateV1();
+            sw.Stop();
+            Log.Verbose("{AddressesHex}HAS Simulator.Simulate(): {Elapsed}", addressesHex, sw.Elapsed);
+
+            Log.Verbose(
+                "{AddressesHex}Execute HackAndSlash({AvatarAddress}); worldId: {WorldId}, stageId: {StageId}, result: {Result}, " +
+                "clearWave: {ClearWave}, totalWave: {TotalWave}",
+                addressesHex,
+                avatarAddress,
+                worldId,
+                stageId,
+                simulator.Log.result,
+                simulator.Log.clearedWaveNumber,
+                simulator.Log.waveCount
+            );
+
+            sw.Restart();
+            if (simulator.Log.IsClear)
+            {
+                var worldUnlockSheet = states.GetSheet<WorldUnlockSheet>();
+                simulator.Player.worldInformation.ClearStage(
+                    worldId,
+                    stageId,
+                    ctx.BlockIndex,
+                    worldSheet,
+                    worldUnlockSheet
+                );
+            }
+
+            sw.Stop();
+            Log.Verbose("{AddressesHex}HAS ClearStage: {Elapsed}", addressesHex, sw.Elapsed);
+
+            sw.Restart();
+            avatarState.Update(simulator);
+
+            var materialSheet = states.GetSheet<MaterialItemSheet>();
+            avatarState.UpdateQuestRewards2(materialSheet);
+
+            avatarState.updatedAt = ctx.BlockIndex;
+            avatarState.mailBox.CleanUpV1();
+            states = states.SetAvatarState(avatarAddress, avatarState);
+
+            sw.Stop();
+            Log.Verbose("{AddressesHex}HAS Set AvatarState: {Elapsed}", addressesHex, sw.Elapsed);
+
+            sw.Restart();
+            if (states.TryGetLegacyState(RankingMapAddress, out Dictionary d) && simulator.Log.IsClear)
+            {
+                var ranking = new RankingMapState(d);
+                ranking.Update(avatarState);
+
+                sw.Stop();
+                Log.Verbose("{AddressesHex}HAS Update RankingState: {Elapsed}", addressesHex, sw.Elapsed);
+                sw.Restart();
+
+                var serialized = ranking.Serialize();
+
+                sw.Stop();
+                Log.Verbose("{AddressesHex}HAS Serialize RankingState: {Elapsed}", addressesHex, sw.Elapsed);
+                sw.Restart();
+                states = states.SetLegacyState(RankingMapAddress, serialized);
+            }
+
+            sw.Stop();
+            Log.Verbose("{AddressesHex}HAS Set RankingState: {Elapsed}", addressesHex, sw.Elapsed);
+
+            sw.Restart();
+            if (simulator.Log.stageId >= GameConfig.RequireClearedStageLevel.ActionsInRankingBoard &&
+                simulator.Log.IsClear &&
+                states.TryGetLegacyState(WeeklyArenaAddress, out Dictionary weeklyDict))
+            {
+                var weekly = new WeeklyArenaState(weeklyDict);
+                if (!weekly.Ended)
+                {
+                    if (weekly.ContainsKey(avatarAddress))
+                    {
+                        var info = weekly[avatarAddress];
+                        info.UpdateV2(avatarState, characterSheet, costumeStatSheet);
+                        weekly.Update(info);
+                    }
+                    else
+                    {
+                        weekly.SetV2(avatarState, characterSheet, costumeStatSheet);
+                    }
+
+                    sw.Stop();
+                    Log.Verbose("{AddressesHex}HAS Update WeeklyArenaState: {Elapsed}", addressesHex, sw.Elapsed);
+
+                    sw.Restart();
+                    var weeklySerialized = weekly.Serialize();
+                    sw.Stop();
+                    Log.Verbose("{AddressesHex}HAS Serialize RankingState: {Elapsed}", addressesHex, sw.Elapsed);
+
+                    states = states.SetLegacyState(weekly.address, weeklySerialized);
+                }
+            }
+
+            Result = simulator.Log;
+
+            var ended = DateTimeOffset.UtcNow;
+            Log.Verbose("{AddressesHex}HAS Total Executed Time: {Elapsed}", addressesHex, ended - started);
+            return states;
+        }
+    }
+}


### PR DESCRIPTION
Reverts planetarium/lib9c#2461

HAS 자체는 새 월드가 중간에 추가돼도 정상적으로 플레이 할 수 있어서 HAS 액션 코드는 리버트하고, 시나리오 테스트를 고치기로 다시 이야기했습니다.

2461번 PR을 리버트하고 시나리오 테스트를 고쳐서 머지하는 것을 목표로 합니다