### PR TITLE
DailyReward 실행속도 향상

### DIFF
--- a/Lib9c/Action/DailyReward.cs
+++ b/Lib9c/Action/DailyReward.cs
@@ -55,7 +55,7 @@ namespace Nekoyume.Action
                 throw new InvalidAddressException();
             }
 
-            states.TryGetDailyRewardReceivedBlockIndex(context.Signer, avatarAddress,
+            states.TryGetDailyRewardReceivedBlockIndex(avatarAddress,
                 out var receivedBlockIndex);
 
             if (context.BlockIndex < receivedBlockIndex + DailyRewardInterval)

--- a/Lib9c/Addresses.cs
+++ b/Lib9c/Addresses.cs
@@ -45,6 +45,8 @@ namespace Nekoyume
         public static readonly Address WorldInformation      = new Address("000000000000000000000000000000000000001d");
         public static readonly Address QuestList             = new Address("000000000000000000000000000000000000001e");
         public static readonly Address Collection            = new Address("000000000000000000000000000000000000001f");
+        public static readonly Address DailyReward           = new Address("0000000000000000000000000000000000000020");
+        public static readonly Address ActionPoint           = new Address("0000000000000000000000000000000000000021");
 
         public static Address GetSheetAddress<T>() where T : ISheet => GetSheetAddress(typeof(T).Name);
 

--- a/Lib9c/Module/ActionPointModule.cs
+++ b/Lib9c/Module/ActionPointModule.cs
@@ -1,0 +1,27 @@
+using Bencodex.Types;
+using Libplanet.Action.State;
+using Libplanet.Crypto;
+
+namespace Nekoyume.Module
+{
+    public static class ActionPointModule
+    {
+        public static long GetActionPoint(this IWorldState worldState, Address address)
+        {
+            var value = worldState.GetAccountState(Addresses.ActionPoint).GetState(address);
+            if (value is Integer integer)
+            {
+                return integer;
+            }
+
+            return 0;
+        }
+
+        public static IWorld SetActionPoint(this IWorld world, Address address, long actionPoint)
+        {
+            var account = world.GetAccount(Addresses.ActionPoint);
+            account = account.SetState(address, (Integer)actionPoint);
+            return world.SetAccount(Addresses.ActionPoint, account);
+        }
+    }
+}

--- a/Lib9c/Module/ActionPointModule.cs
+++ b/Lib9c/Module/ActionPointModule.cs
@@ -6,9 +6,9 @@ namespace Nekoyume.Module
 {
     public static class ActionPointModule
     {
-        public static long GetActionPoint(this IWorldState worldState, Address address)
+        public static long GetActionPoint(this IWorldState worldState, Address avatarAddress)
         {
-            var value = worldState.GetAccountState(Addresses.ActionPoint).GetState(address);
+            var value = worldState.GetAccountState(Addresses.ActionPoint).GetState(avatarAddress);
             if (value is Integer integer)
             {
                 return integer;
@@ -17,10 +17,10 @@ namespace Nekoyume.Module
             return 0;
         }
 
-        public static IWorld SetActionPoint(this IWorld world, Address address, long actionPoint)
+        public static IWorld SetActionPoint(this IWorld world, Address avatarAddress, long actionPoint)
         {
             var account = world.GetAccount(Addresses.ActionPoint);
-            account = account.SetState(address, (Integer)actionPoint);
+            account = account.SetState(avatarAddress, (Integer)actionPoint);
             return world.SetAccount(Addresses.ActionPoint, account);
         }
     }

--- a/Lib9c/Module/DailyRewardModule.cs
+++ b/Lib9c/Module/DailyRewardModule.cs
@@ -1,0 +1,47 @@
+using Bencodex.Types;
+using Libplanet.Action.State;
+using Libplanet.Crypto;
+using Nekoyume.Action;
+
+namespace Nekoyume.Module
+{
+    public static class DailyRewardModule
+    {
+        public static long GetDailyRewardReceivedBlockIndex(this IWorldState worldState,
+            Address avatarAddress)
+        {
+            IAccountState account = worldState.GetAccountState(Addresses.DailyReward);
+            var value = account.GetState(avatarAddress);
+            if (value is Integer l)
+            {
+                return l;
+            }
+
+            throw new FailedLoadStateException("");
+        }
+
+        public static bool TryGetDailyRewardReceivedBlockIndex(this IWorldState worldState,
+            Address agentAddress, Address avatarAddress, out long receivedBlockIndex)
+        {
+            receivedBlockIndex = 0L;
+            try
+            {
+                var temp= GetDailyRewardReceivedBlockIndex(worldState, avatarAddress);
+                receivedBlockIndex = temp;
+                return true;
+            }
+            catch (FailedLoadStateException)
+            {
+                return false;
+            }
+        }
+
+        public static IWorld SetDailyRewardReceivedBlockIndex(this IWorld world, Address avatarAddress,
+            long blockIndex)
+        {
+            IAccount account = world.GetAccount(Addresses.DailyReward);
+            account = account.SetState(avatarAddress, (Integer)blockIndex);
+            return world.SetAccount(Addresses.DailyReward, account);
+        }
+    }
+}

--- a/Lib9c/Module/DailyRewardModule.cs
+++ b/Lib9c/Module/DailyRewardModule.cs
@@ -20,8 +20,7 @@ namespace Nekoyume.Module
             throw new FailedLoadStateException("");
         }
 
-        public static bool TryGetDailyRewardReceivedBlockIndex(this IWorldState worldState,
-            Address agentAddress, Address avatarAddress, out long receivedBlockIndex)
+        public static bool TryGetDailyRewardReceivedBlockIndex(this IWorldState worldState, Address avatarAddress, out long receivedBlockIndex)
         {
             receivedBlockIndex = 0L;
             try


### PR DESCRIPTION
- resolve #2478 
- AP충전을 위해 AgentState, AvatarState 상태를 호출하는대신 별도 어카운트에 저장된 값을 사용합니다.
- GameConfigState대신 현재 메인넷기준값들을 상수로 설정합니다.
- 속도향상과 마이그레이션 용이성을 위해 마이그레이션 이전 상태들의 최초 1회는 DailyRewardReceivedBlockIndex값을 0으로 통과시켜줍니다.
---
실행속도 비교(304ms -> 30ms)
AS-IS
![image](https://github.com/planetarium/lib9c/assets/3193043/9c04d51b-f297-4cf4-aa30-a0a5b286ebeb)

TO-BE
![image](https://github.com/planetarium/lib9c/assets/3193043/9d0c8fdb-4340-4257-b6e1-9d96945ef031)
