### PR TITLE
Refactor DPoS actions

### DIFF
--- a/.Lib9c.Tests/Action/DPoS/Control/RedelegateCtrlTest.cs
+++ b/.Lib9c.Tests/Action/DPoS/Control/RedelegateCtrlTest.cs
@@ -9,6 +9,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
     using Nekoyume.Action.DPoS.Exception;
     using Nekoyume.Action.DPoS.Misc;
     using Nekoyume.Action.DPoS.Model;
+    using Nekoyume.Action.DPoS.Util;
     using Nekoyume.Module;
     using Xunit;
 

--- a/Lib9c/Action/DPoS/Control/Bond.cs
+++ b/Lib9c/Action/DPoS/Control/Bond.cs
@@ -6,6 +6,7 @@ using Libplanet.Types.Assets;
 using Nekoyume.Action.DPoS.Exception;
 using Nekoyume.Action.DPoS.Misc;
 using Nekoyume.Action.DPoS.Model;
+using Nekoyume.Action.DPoS.Util;
 using Nekoyume.Module;
 
 namespace Nekoyume.Action.DPoS.Control

--- a/Lib9c/Action/DPoS/Control/DelegateCtrl.cs
+++ b/Lib9c/Action/DPoS/Control/DelegateCtrl.cs
@@ -7,6 +7,7 @@ using Libplanet.Types.Assets;
 using Nekoyume.Action.DPoS.Exception;
 using Nekoyume.Action.DPoS.Misc;
 using Nekoyume.Action.DPoS.Model;
+using Nekoyume.Action.DPoS.Util;
 using Nekoyume.Module;
 
 namespace Nekoyume.Action.DPoS.Control

--- a/Lib9c/Action/DPoS/Control/RedelegateCtrl.cs
+++ b/Lib9c/Action/DPoS/Control/RedelegateCtrl.cs
@@ -9,6 +9,7 @@ using Libplanet.Types.Assets;
 using Nekoyume.Action.DPoS.Exception;
 using Nekoyume.Action.DPoS.Misc;
 using Nekoyume.Action.DPoS.Model;
+using Nekoyume.Action.DPoS.Util;
 using Nekoyume.Module;
 
 namespace Nekoyume.Action.DPoS.Control

--- a/Lib9c/Action/DPoS/Control/UnbondingSetCtrl.cs
+++ b/Lib9c/Action/DPoS/Control/UnbondingSetCtrl.cs
@@ -4,6 +4,7 @@ using Libplanet.Action.State;
 using Libplanet.Crypto;
 using Nekoyume.Action.DPoS.Misc;
 using Nekoyume.Action.DPoS.Model;
+using Nekoyume.Action.DPoS.Util;
 
 namespace Nekoyume.Action.DPoS.Control
 {

--- a/Lib9c/Action/DPoS/Control/UndelegateCtrl.cs
+++ b/Lib9c/Action/DPoS/Control/UndelegateCtrl.cs
@@ -9,6 +9,7 @@ using Libplanet.Types.Assets;
 using Nekoyume.Action.DPoS.Exception;
 using Nekoyume.Action.DPoS.Misc;
 using Nekoyume.Action.DPoS.Model;
+using Nekoyume.Action.DPoS.Util;
 using Nekoyume.Module;
 
 namespace Nekoyume.Action.DPoS.Control

--- a/Lib9c/Action/DPoS/Control/ValidatorCtrl.cs
+++ b/Lib9c/Action/DPoS/Control/ValidatorCtrl.cs
@@ -7,6 +7,7 @@ using Libplanet.Types.Assets;
 using Nekoyume.Action.DPoS.Exception;
 using Nekoyume.Action.DPoS.Misc;
 using Nekoyume.Action.DPoS.Model;
+using Nekoyume.Action.DPoS.Util;
 using Nekoyume.Module;
 
 namespace Nekoyume.Action.DPoS.Control

--- a/Lib9c/Action/DPoS/Control/ValidatorDelegationSetCtrl.cs
+++ b/Lib9c/Action/DPoS/Control/ValidatorDelegationSetCtrl.cs
@@ -1,7 +1,9 @@
 #nullable enable
 using Libplanet.Action.State;
 using Libplanet.Crypto;
+using Nekoyume.Action.DPoS.Misc;
 using Nekoyume.Action.DPoS.Model;
+using Nekoyume.Action.DPoS.Util;
 
 namespace Nekoyume.Action.DPoS.Control
 {

--- a/Lib9c/Action/DPoS/Control/ValidatorPowerIndexCtrl.cs
+++ b/Lib9c/Action/DPoS/Control/ValidatorPowerIndexCtrl.cs
@@ -6,6 +6,7 @@ using Libplanet.Types.Assets;
 using Nekoyume.Action.DPoS.Exception;
 using Nekoyume.Action.DPoS.Misc;
 using Nekoyume.Action.DPoS.Model;
+using Nekoyume.Action.DPoS.Util;
 using Nekoyume.Module;
 
 namespace Nekoyume.Action.DPoS.Control

--- a/Lib9c/Action/DPoS/Control/ValidatorRewardsCtrl.cs
+++ b/Lib9c/Action/DPoS/Control/ValidatorRewardsCtrl.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using Libplanet.Action.State;
 using Libplanet.Crypto;
 using Libplanet.Types.Assets;
+using Nekoyume.Action.DPoS.Misc;
 using Nekoyume.Action.DPoS.Model;
+using Nekoyume.Action.DPoS.Util;
 
 namespace Nekoyume.Action.DPoS.Control
 {

--- a/Lib9c/Action/DPoS/Control/ValidatorSetCtrl.cs
+++ b/Lib9c/Action/DPoS/Control/ValidatorSetCtrl.cs
@@ -6,6 +6,7 @@ using Libplanet.Crypto;
 using Nekoyume.Action.DPoS.Exception;
 using Nekoyume.Action.DPoS.Misc;
 using Nekoyume.Action.DPoS.Model;
+using Nekoyume.Action.DPoS.Util;
 using Nekoyume.Module;
 
 namespace Nekoyume.Action.DPoS.Control

--- a/Lib9c/Action/DPoS/Delegate.cs
+++ b/Lib9c/Action/DPoS/Delegate.cs
@@ -5,48 +5,42 @@ using Libplanet.Action.State;
 using Libplanet.Crypto;
 using Libplanet.Types.Assets;
 using Nekoyume.Action.DPoS.Control;
-using Nekoyume.Action.DPoS.Exception;
 using Nekoyume.Action.DPoS.Misc;
 using Nekoyume.Action.DPoS.Util;
 
-namespace Nekoyume.Action.DPoS.Sys
+namespace Nekoyume.Action.DPoS
 {
     /// <summary>
-    /// A system action for DPoS that promotes non-validator node to a validator.
+    /// A system action for DPoS that <see cref="Delegate"/> specified <see cref="Amount"/>
+    /// of tokens to a given <see cref="Validator"/>.
     /// </summary>
     [ActionType(ActionTypeValue)]
-    public sealed class PromoteValidator : ActionBase
+    public sealed class Delegate : ActionBase
     {
-        private const string ActionTypeValue = "promote_validator";
+        private const string ActionTypeValue = "delegate";
 
         /// <summary>
-        /// Create a new instance of <see cref="PromoteValidator"/> action.
+        /// Creates a new instance of <see cref="Delegate"/> action.
         /// </summary>
-        /// <param name="validator">The <see cref="PublicKey"/> of the target
-        /// to promote validator.</param>
-        /// <param name="amount">The amount of the asset to be initialize delegation.</param>
-        public PromoteValidator(PublicKey validator, FungibleAssetValue amount)
+        /// <param name="validator">The <see cref="Address"/> of the validator
+        /// to delegate tokens.</param>
+        /// <param name="amount">The amount of the asset to be delegated.</param>
+        public Delegate(Address validator, FungibleAssetValue amount)
         {
             Validator = validator;
             Amount = amount;
         }
 
-        public PromoteValidator()
+        public Delegate()
         {
             // Used only for deserialization.  See also class Libplanet.Action.Sys.Registry.
-            // FIXME: do not fill ambiguous validator field.
-            // Suggestion: https://gist.github.com/riemannulus/7405e0d361364c6afa0ab433905ae81c
-            Validator = new PrivateKey().PublicKey;
         }
 
         /// <summary>
-        /// The <see cref="PublicKey"/> of the target promoting to a validator.
+        /// The <see cref="Address"/> of the validator to <see cref="Delegate"/>.
         /// </summary>
-        public PublicKey Validator { get; set; }
+        public Address Validator { get; set; }
 
-        /// <summary>
-        /// The amount of the asset to be initially delegated.
-        /// </summary>
         public FungibleAssetValue Amount { get; set; }
 
         /// <inheritdoc cref="IAction.PlainValue"/>
@@ -59,7 +53,7 @@ namespace Nekoyume.Action.DPoS.Sys
         public override void LoadPlainValue(IValue plainValue)
         {
             var dict = (Bencodex.Types.Dictionary)plainValue;
-            Validator = dict["validator"].ToPublicKey();
+            Validator = dict["validator"].ToAddress();
             Amount = dict["amount"].ToFungibleAssetValue();
         }
 
@@ -67,16 +61,13 @@ namespace Nekoyume.Action.DPoS.Sys
         public override IWorld Execute(IActionContext context)
         {
             IActionContext ctx = context;
-            if (!ctx.Signer.Equals(Validator.Address))
-            {
-                throw new PublicKeyAddressMatchingException(ctx.Signer, Validator);
-            }
-
             var states = ctx.PreviousState;
+
+            // if (ctx.Rehearsal)
+            // Rehearsal mode is not implemented
             var nativeTokens = ImmutableHashSet.Create(
                 Asset.GovernanceToken, Asset.ConsensusToken, Asset.Share);
-
-            states = ValidatorCtrl.Create(
+            states = DelegateCtrl.Execute(
                 states,
                 ctx,
                 ctx.Signer,

--- a/Lib9c/Action/DPoS/Redelegate.cs
+++ b/Lib9c/Action/DPoS/Redelegate.cs
@@ -8,7 +8,7 @@ using Nekoyume.Action.DPoS.Control;
 using Nekoyume.Action.DPoS.Misc;
 using Nekoyume.Action.DPoS.Util;
 
-namespace Nekoyume.Action.DPoS.Sys
+namespace Nekoyume.Action.DPoS
 {
     /// <summary>
     /// A system action for DPoS that <see cref="Redelegate"/> specified <see cref="ShareAmount"/>

--- a/Lib9c/Action/DPoS/Sys/AllocateReward.cs
+++ b/Lib9c/Action/DPoS/Sys/AllocateReward.cs
@@ -2,22 +2,20 @@ using System.Collections.Immutable;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Action.State;
-using Nekoyume.Action.DPoS.Control;
 using Nekoyume.Action.DPoS.Misc;
-using Nekoyume.Action.DPoS.Model;
-using Nekoyume.Module;
 
-namespace Nekoyume.Action.DPoS
+namespace Nekoyume.Action.DPoS.Sys
 {
     /// <summary>
-    /// A BeginBlock action for DPoS that updates <see cref="ValidatorSet"/>.
+    /// An action for allocate reward to validators and delegators in previous block.
+    /// Should be executed at the beginning of the block.
     /// </summary>
-    public sealed class DPoSBeginBlockAction : ActionBase
+    public sealed class AllocateReward : ActionBase
     {
         /// <summary>
-        /// Creates a new instance of <see cref="DPoSBeginBlockAction"/>.
+        /// Creates a new instance of <see cref="AllocateReward"/>.
         /// </summary>
-        public DPoSBeginBlockAction()
+        public AllocateReward()
         {
         }
 
@@ -34,11 +32,9 @@ namespace Nekoyume.Action.DPoS
         public override IWorld Execute(IActionContext context)
         {
             var states = context.PreviousState;
-
-            // Allocate reward
             var nativeTokens = ImmutableHashSet.Create(
                 Asset.GovernanceToken, Asset.ConsensusToken, Asset.Share);
-            states = AllocateReward.Execute(
+            states = Control.AllocateReward.Execute(
                 states,
                 context,
                 nativeTokens,

--- a/Lib9c/Action/DPoS/Sys/UpdateValidators.cs
+++ b/Lib9c/Action/DPoS/Sys/UpdateValidators.cs
@@ -1,23 +1,22 @@
-using System.Collections.Immutable;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Action.State;
 using Nekoyume.Action.DPoS.Control;
-using Nekoyume.Action.DPoS.Misc;
 using Nekoyume.Action.DPoS.Model;
 using Nekoyume.Module;
 
-namespace Nekoyume.Action.DPoS
+namespace Nekoyume.Action.DPoS.Sys
 {
     /// <summary>
-    /// A EndBlock action for DPoS that updates <see cref="ValidatorSet"/>.
+    /// An action for update validators.
+    /// Should be executed at the end of the block.
     /// </summary>
-    public sealed class DPoSEndBlockAction : ActionBase
+    public sealed class UpdateValidators : ActionBase
     {
         /// <summary>
-        /// Creates a new instance of <see cref="DPoSBeginBlockAction"/>.
+        /// Creates a new instance of <see cref="AllocateReward"/>.
         /// </summary>
-        public DPoSEndBlockAction()
+        public UpdateValidators()
         {
         }
 
@@ -34,8 +33,6 @@ namespace Nekoyume.Action.DPoS
         public override IWorld Execute(IActionContext context)
         {
             var states = context.PreviousState;
-
-            // Update ValidatorSet
             states = ValidatorSetCtrl.Update(states, context);
             ValidatorSet bondedSet;
             (states, bondedSet) = ValidatorSetCtrl.FetchBondedValidatorSet(states);

--- a/Lib9c/Action/DPoS/Undelegate.cs
+++ b/Lib9c/Action/DPoS/Undelegate.cs
@@ -8,53 +8,56 @@ using Nekoyume.Action.DPoS.Control;
 using Nekoyume.Action.DPoS.Misc;
 using Nekoyume.Action.DPoS.Util;
 
-namespace Nekoyume.Action.DPoS.Sys
+namespace Nekoyume.Action.DPoS
 {
     /// <summary>
-    /// A system action for DPoS that <see cref="Delegate"/> specified <see cref="Amount"/>
-    /// of tokens to a given <see cref="Validator"/>.
+    /// A system action for DPoS that cancels <see cref="Delegate"/> specified
+    /// <see cref="ShareAmount"/> of shared tokens to a given <see cref="Validator"/>.
     /// </summary>
     [ActionType(ActionTypeValue)]
-    public sealed class Delegate : ActionBase
+    public sealed class Undelegate : ActionBase
     {
-        private const string ActionTypeValue = "delegate";
+        private const string ActionTypeValue = "undelegate";
 
         /// <summary>
-        /// Creates a new instance of <see cref="Delegate"/> action.
+        /// Creates a new instance of <see cref="Undelegate"/> action.
         /// </summary>
-        /// <param name="validator">The <see cref="Address"/> of the validator
-        /// to delegate tokens.</param>
-        /// <param name="amount">The amount of the asset to be delegated.</param>
-        public Delegate(Address validator, FungibleAssetValue amount)
+        /// <param name="validator">The <see cref="amount"/> of the validator
+        /// to undelegate tokens.</param>
+        /// <param name="amount">The amount of the asset to be undelegated.</param>
+        public Undelegate(Address validator, FungibleAssetValue amount)
         {
             Validator = validator;
-            Amount = amount;
+            ShareAmount = amount;
         }
 
-        public Delegate()
+        internal Undelegate()
         {
             // Used only for deserialization.  See also class Libplanet.Action.Sys.Registry.
         }
 
         /// <summary>
-        /// The <see cref="Address"/> of the validator to <see cref="Delegate"/>.
+        /// The <see cref="Address"/> of the validator to cancel the <see cref="Delegate"/>.
         /// </summary>
         public Address Validator { get; set; }
 
-        public FungibleAssetValue Amount { get; set; }
+        /// <summary>
+        /// The amount of the asset to be undelegated.
+        /// </summary>
+        public FungibleAssetValue ShareAmount { get; set; }
 
         /// <inheritdoc cref="IAction.PlainValue"/>
         public override IValue PlainValue => Bencodex.Types.Dictionary.Empty
             .Add("type_id", new Text(ActionTypeValue))
             .Add("validator", Validator.Serialize())
-            .Add("amount", Amount.Serialize());
+            .Add("amount", ShareAmount.Serialize());
 
         /// <inheritdoc cref="IAction.LoadPlainValue(IValue)"/>
         public override void LoadPlainValue(IValue plainValue)
         {
             var dict = (Bencodex.Types.Dictionary)plainValue;
             Validator = dict["validator"].ToAddress();
-            Amount = dict["amount"].ToFungibleAssetValue();
+            ShareAmount = dict["amount"].ToFungibleAssetValue();
         }
 
         /// <inheritdoc cref="IAction.Execute(IActionContext)"/>
@@ -62,17 +65,17 @@ namespace Nekoyume.Action.DPoS.Sys
         {
             IActionContext ctx = context;
             var states = ctx.PreviousState;
+            var nativeTokens = ImmutableHashSet.Create(
+                Asset.GovernanceToken, Asset.ConsensusToken, Asset.Share);
 
             // if (ctx.Rehearsal)
             // Rehearsal mode is not implemented
-            var nativeTokens = ImmutableHashSet.Create(
-                Asset.GovernanceToken, Asset.ConsensusToken, Asset.Share);
-            states = DelegateCtrl.Execute(
+            states = UndelegateCtrl.Execute(
                 states,
                 ctx,
                 ctx.Signer,
                 Validator,
-                Amount,
+                ShareAmount,
                 nativeTokens);
 
             return states;

--- a/Lib9c/Action/DPoS/Util/DPoSModule.cs
+++ b/Lib9c/Action/DPoS/Util/DPoSModule.cs
@@ -4,7 +4,7 @@ using Libplanet.Action.State;
 using Libplanet.Crypto;
 using Nekoyume.Action.DPoS.Misc;
 
-namespace Nekoyume.Action.DPoS
+namespace Nekoyume.Action.DPoS.Util
 {
     public static class DPoSModule
     {

--- a/Lib9c/Action/DPoS/WithdrawDelegator.cs
+++ b/Lib9c/Action/DPoS/WithdrawDelegator.cs
@@ -6,58 +6,49 @@ using Libplanet.Crypto;
 using Libplanet.Types.Assets;
 using Nekoyume.Action.DPoS.Control;
 using Nekoyume.Action.DPoS.Misc;
+using Nekoyume.Action.DPoS.Model;
 using Nekoyume.Action.DPoS.Util;
+using Nekoyume.Module;
 
-namespace Nekoyume.Action.DPoS.Sys
+namespace Nekoyume.Action.DPoS
 {
     /// <summary>
-    /// A system action for DPoS that cancels <see cref="Delegate"/> specified
-    /// <see cref="ShareAmount"/> of shared tokens to a given <see cref="Validator"/>.
+    /// A system action for DPoS that withdraws reward tokens from given <see cref="Validator"/>.
     /// </summary>
     [ActionType(ActionTypeValue)]
-    public sealed class Undelegate : ActionBase
+    public sealed class WithdrawDelegator : ActionBase
     {
-        private const string ActionTypeValue = "undelegate";
+        private const string ActionTypeValue = "withdraw_delegator";
 
         /// <summary>
-        /// Creates a new instance of <see cref="Undelegate"/> action.
+        /// Creates a new instance of <see cref="WithdrawDelegator"/> action.
         /// </summary>
-        /// <param name="validator">The <see cref="amount"/> of the validator
-        /// to undelegate tokens.</param>
-        /// <param name="amount">The amount of the asset to be undelegated.</param>
-        public Undelegate(Address validator, FungibleAssetValue amount)
+        /// <param name="validator">The <see cref="Address"/> of the validator
+        /// from which to withdraw the tokens.</param>
+        public WithdrawDelegator(Address validator)
         {
             Validator = validator;
-            ShareAmount = amount;
         }
 
-        internal Undelegate()
+        public WithdrawDelegator()
         {
             // Used only for deserialization.  See also class Libplanet.Action.Sys.Registry.
         }
 
         /// <summary>
-        /// The <see cref="Address"/> of the validator to cancel the <see cref="Delegate"/>.
+        /// The <see cref="Address"/> of the validator to withdraw.
         /// </summary>
         public Address Validator { get; set; }
-
-        /// <summary>
-        /// The amount of the asset to be undelegated.
-        /// </summary>
-        public FungibleAssetValue ShareAmount { get; set; }
 
         /// <inheritdoc cref="IAction.PlainValue"/>
         public override IValue PlainValue => Bencodex.Types.Dictionary.Empty
             .Add("type_id", new Text(ActionTypeValue))
-            .Add("validator", Validator.Serialize())
-            .Add("amount", ShareAmount.Serialize());
+            .Add("validator", Validator.Serialize());
 
         /// <inheritdoc cref="IAction.LoadPlainValue(IValue)"/>
         public override void LoadPlainValue(IValue plainValue)
         {
-            var dict = (Bencodex.Types.Dictionary)plainValue;
-            Validator = dict["validator"].ToAddress();
-            ShareAmount = dict["amount"].ToFungibleAssetValue();
+            Validator = plainValue.ToAddress();
         }
 
         /// <inheritdoc cref="IAction.Execute(IActionContext)"/>
@@ -70,13 +61,27 @@ namespace Nekoyume.Action.DPoS.Sys
 
             // if (ctx.Rehearsal)
             // Rehearsal mode is not implemented
-            states = UndelegateCtrl.Execute(
+            states = DelegateCtrl.Distribute(
                 states,
                 ctx,
-                ctx.Signer,
-                Validator,
-                ShareAmount,
-                nativeTokens);
+                nativeTokens,
+                Delegation.DeriveAddress(ctx.Signer, Validator));
+
+#pragma warning disable LAA1002
+            foreach (Currency nativeToken in nativeTokens)
+            {
+                FungibleAssetValue reward = states.GetBalance(
+                    AllocateReward.RewardAddress(ctx.Signer), nativeToken);
+                if (reward.Sign > 0)
+                {
+                    states = states.TransferAsset(
+                        ctx,
+                        AllocateReward.RewardAddress(ctx.Signer),
+                        ctx.Signer,
+                        reward);
+                }
+            }
+#pragma warning restore LAA1002
 
             return states;
         }

--- a/Lib9c/Action/DPoS/WithdrawValidator.cs
+++ b/Lib9c/Action/DPoS/WithdrawValidator.cs
@@ -8,7 +8,7 @@ using Nekoyume.Action.DPoS.Misc;
 using Nekoyume.Action.DPoS.Model;
 using Nekoyume.Module;
 
-namespace Nekoyume.Action.DPoS.Sys
+namespace Nekoyume.Action.DPoS
 {
     /// <summary>
     /// A system action for DPoS that withdraws commission tokens from <see cref="Validator"/>.


### PR DESCRIPTION
- `DPoSModule` moved to `DPoS/Util`.
- `CancelUndelegation`, `Delegate`, `PromoteValidator`, `Relegate`, `Undelegate`, `WithdrawDelegator`, `WithdrawValidator` moved to `DPoS`.
- `DPoSBeginBlockAction` renamed to `AllocateReward` and moved to `DPoS/Sys`.
- `DPoSEndBlockAction` renamed to `UpdateValidators` and moved to `DPoS/Sys`. 