### PR TITLE
Fix failing test by adding UseGas in DPoS

### DIFF
--- a/Lib9c/Action/DPoS/CancelUndelegation.cs
+++ b/Lib9c/Action/DPoS/CancelUndelegation.cs
@@ -66,6 +66,7 @@ namespace Nekoyume.Action.DPoS
         /// <inheritdoc cref="IAction.Execute(IActionContext)"/>
         public override IWorld Execute(IActionContext context)
         {
+            context.UseGas(1);
             IActionContext ctx = context;
             var states = ctx.PreviousState;
             var nativeTokens = ImmutableHashSet.Create(

--- a/Lib9c/Action/DPoS/Delegate.cs
+++ b/Lib9c/Action/DPoS/Delegate.cs
@@ -60,6 +60,7 @@ namespace Nekoyume.Action.DPoS
         /// <inheritdoc cref="IAction.Execute(IActionContext)"/>
         public override IWorld Execute(IActionContext context)
         {
+            context.UseGas(1);
             IActionContext ctx = context;
             var states = ctx.PreviousState;
 

--- a/Lib9c/Action/DPoS/PromoteValidator.cs
+++ b/Lib9c/Action/DPoS/PromoteValidator.cs
@@ -66,6 +66,7 @@ namespace Nekoyume.Action.DPoS
         /// <inheritdoc cref="IAction.Execute(IActionContext)"/>
         public override IWorld Execute(IActionContext context)
         {
+            context.UseGas(1);
             IActionContext ctx = context;
             if (!ctx.Signer.Equals(Validator.Address))
             {

--- a/Lib9c/Action/DPoS/Redelegate.cs
+++ b/Lib9c/Action/DPoS/Redelegate.cs
@@ -34,7 +34,7 @@ namespace Nekoyume.Action.DPoS
             ShareAmount = amount;
         }
 
-        internal Redelegate()
+        public Redelegate()
         {
             // Used only for deserialization.  See also class Libplanet.Action.Sys.Registry.
         }
@@ -73,6 +73,7 @@ namespace Nekoyume.Action.DPoS
         /// <inheritdoc cref="IAction.Execute(IActionContext)"/>
         public override IWorld Execute(IActionContext context)
         {
+            context.UseGas(1);
             IActionContext ctx = context;
             var states = ctx.PreviousState;
             var nativeTokens = ImmutableHashSet.Create(

--- a/Lib9c/Action/DPoS/Undelegate.cs
+++ b/Lib9c/Action/DPoS/Undelegate.cs
@@ -31,7 +31,7 @@ namespace Nekoyume.Action.DPoS
             ShareAmount = amount;
         }
 
-        internal Undelegate()
+        public Undelegate()
         {
             // Used only for deserialization.  See also class Libplanet.Action.Sys.Registry.
         }
@@ -63,6 +63,7 @@ namespace Nekoyume.Action.DPoS
         /// <inheritdoc cref="IAction.Execute(IActionContext)"/>
         public override IWorld Execute(IActionContext context)
         {
+            context.UseGas(1);
             IActionContext ctx = context;
             var states = ctx.PreviousState;
             var nativeTokens = ImmutableHashSet.Create(

--- a/Lib9c/Action/DPoS/WithdrawDelegator.cs
+++ b/Lib9c/Action/DPoS/WithdrawDelegator.cs
@@ -54,6 +54,7 @@ namespace Nekoyume.Action.DPoS
         /// <inheritdoc cref="IAction.Execute(IActionContext)"/>
         public override IWorld Execute(IActionContext context)
         {
+            context.UseGas(1);
             IActionContext ctx = context;
             var states = ctx.PreviousState;
             var nativeTokens = ImmutableHashSet.Create(

--- a/Lib9c/Action/DPoS/WithdrawValidator.cs
+++ b/Lib9c/Action/DPoS/WithdrawValidator.cs
@@ -38,6 +38,7 @@ namespace Nekoyume.Action.DPoS
         /// <inheritdoc cref="IAction.Execute(IActionContext)"/>
         public override IWorld Execute(IActionContext context)
         {
+            context.UseGas(1);
             IActionContext ctx = context;
             var states = ctx.PreviousState;
             var nativeTokens = ImmutableHashSet.Create(


### PR DESCRIPTION
* Added the code `UseGas` to all DPoS-related Action.Execute
* The constructor access modifier for some actions is changed from internal to public.