### PR TITLE
Refactor decimal places of currency used in dpos.

### DIFF
--- a/.Lib9c.Tests/Action/DPoS/Control/DelegateCtrlTest.cs
+++ b/.Lib9c.Tests/Action/DPoS/Control/DelegateCtrlTest.cs
@@ -42,7 +42,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     BlockIndex = 1,
                 },
                 _delegatorAddress,
-                Asset.ConsensusToken * 50);
+                Asset.ConsensusFromGovernance(50));
             Assert.Throws<InvalidCurrencyException>(
                     () => _states = DelegateCtrl.Execute(
                         _states,
@@ -53,7 +53,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                         },
                         _delegatorAddress,
                         _validatorAddress,
-                        Asset.ConsensusToken * 30,
+                        Asset.ConsensusFromGovernance(30),
                         _nativeTokens));
         }
 
@@ -86,7 +86,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     BlockIndex = 1,
                 },
                 _validatorAddress,
-                Asset.ConsensusToken * 100);
+                Asset.ConsensusFromGovernance(100));
             Assert.Throws<InvalidExchangeRateException>(
                 () => _states = DelegateCtrl.Execute(
                     _states,
@@ -126,19 +126,19 @@ namespace Lib9c.Tests.Action.DPoS.Control
                 Asset.GovernanceToken * 0,
                 _states.GetBalance(_validatorAddress, Asset.GovernanceToken));
             Assert.Equal(
-                Asset.ConsensusToken * 0,
+                Asset.ConsensusFromGovernance(0),
                 _states.GetBalance(_operatorAddress, Asset.ConsensusToken));
             Assert.Equal(
-                Asset.ConsensusToken * 0,
+                Asset.ConsensusFromGovernance(0),
                 _states.GetBalance(_delegatorAddress, Asset.ConsensusToken));
             Assert.Equal(
-                Asset.Share * 0,
+                ShareFromGovernance(0),
                 _states.GetBalance(_operatorAddress, Asset.Share));
             Assert.Equal(
-                Asset.Share * 0,
+                ShareFromGovernance(0),
                 _states.GetBalance(_delegatorAddress, Asset.Share));
             Assert.Equal(
-                Asset.ConsensusToken * (selfDelegateAmount + delegateAmount),
+                Asset.ConsensusFromGovernance(selfDelegateAmount + delegateAmount),
                 _states.GetBalance(_validatorAddress, Asset.ConsensusToken));
             Assert.Equal(
                 Asset.GovernanceToken * (operatorMintAmount - selfDelegateAmount),

--- a/.Lib9c.Tests/Action/DPoS/Control/RedelegateCtrlTest.cs
+++ b/.Lib9c.Tests/Action/DPoS/Control/RedelegateCtrlTest.cs
@@ -53,7 +53,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     BlockIndex = 1,
                 },
                 _delegatorAddress,
-                Asset.ConsensusToken * 50);
+                Asset.ConsensusFromGovernance(50));
             Assert.Throws<InvalidCurrencyException>(
                     () => _states = RedelegateCtrl.Execute(
                         _states,
@@ -65,7 +65,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                         _delegatorAddress,
                         _srcValidatorAddress,
                         _dstValidatorAddress,
-                        Asset.ConsensusToken * 30,
+                        Asset.ConsensusFromGovernance(30),
                         _nativeTokens));
             Assert.Throws<InvalidCurrencyException>(
                     () => _states = RedelegateCtrl.Execute(
@@ -97,7 +97,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     _delegatorAddress,
                     CreateAddress(),
                     _dstValidatorAddress,
-                    Asset.Share * 10,
+                    ShareFromGovernance(10),
                     _nativeTokens));
             Assert.Throws<NullValidatorException>(
                 () => _states = RedelegateCtrl.Execute(
@@ -110,7 +110,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     _delegatorAddress,
                     _srcValidatorAddress,
                     CreateAddress(),
-                    Asset.Share * 10,
+                    ShareFromGovernance(10),
                     _nativeTokens));
         }
 
@@ -130,7 +130,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     _delegatorAddress,
                     _srcValidatorAddress,
                     _dstValidatorAddress,
-                    Asset.Share * 1,
+                    ShareFromGovernance(1),
                     _nativeTokens);
             }
 
@@ -145,7 +145,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                         _delegatorAddress,
                         _srcValidatorAddress,
                         _dstValidatorAddress,
-                        Asset.Share * 1,
+                        ShareFromGovernance(1),
                         _nativeTokens));
         }
 
@@ -164,7 +164,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                         _delegatorAddress,
                         _srcValidatorAddress,
                         _dstValidatorAddress,
-                        Asset.Share * 101,
+                        ShareFromGovernance(101),
                         _nativeTokens));
         }
 
@@ -248,22 +248,22 @@ namespace Lib9c.Tests.Action.DPoS.Control
                 Asset.GovernanceToken * 0,
                 _states.GetBalance(_dstValidatorAddress, Asset.GovernanceToken));
             Assert.Equal(
-                Asset.ConsensusToken * 0,
+                Asset.ConsensusFromGovernance(0),
                 _states.GetBalance(_srcOperatorAddress, Asset.ConsensusToken));
             Assert.Equal(
-                Asset.ConsensusToken * 0,
+                Asset.ConsensusFromGovernance(0),
                 _states.GetBalance(_dstOperatorAddress, Asset.ConsensusToken));
             Assert.Equal(
-                Asset.ConsensusToken * 0,
+                Asset.ConsensusFromGovernance(0),
                 _states.GetBalance(_delegatorAddress, Asset.ConsensusToken));
             Assert.Equal(
-                Asset.Share * 0,
+                ShareFromGovernance(0),
                 _states.GetBalance(_srcOperatorAddress, Asset.Share));
             Assert.Equal(
-                Asset.Share * 0,
+                ShareFromGovernance(0),
                 _states.GetBalance(_dstOperatorAddress, Asset.Share));
             Assert.Equal(
-                Asset.Share * 0,
+                ShareFromGovernance(0),
                 _states.GetBalance(_delegatorAddress, Asset.Share));
             Assert.Equal(
                 Asset.GovernanceToken * (operatorMintAmount - selfDelegateAmount),
@@ -308,11 +308,11 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     RedelegateCtrl.GetRedelegation(_states, _redelegationAddress)!
                         .RedelegationEntryAddresses[0])!);
             Assert.Equal(
-                Asset.ConsensusToken * (selfDelegateAmount + delegateAmount)
+                Asset.ConsensusFromGovernance(selfDelegateAmount + delegateAmount)
                 - entry.UnbondingConsensusToken,
                 _states.GetBalance(_srcValidatorAddress, Asset.ConsensusToken));
             Assert.Equal(
-                Asset.ConsensusToken * selfDelegateAmount
+                Asset.ConsensusFromGovernance(selfDelegateAmount)
                 + entry.UnbondingConsensusToken,
                 _states.GetBalance(_dstValidatorAddress, Asset.ConsensusToken));
         }

--- a/.Lib9c.Tests/Action/DPoS/Control/UndelegateCtrlTest.cs
+++ b/.Lib9c.Tests/Action/DPoS/Control/UndelegateCtrlTest.cs
@@ -44,7 +44,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     BlockIndex = 1,
                 },
                 _delegatorAddress,
-                Asset.ConsensusToken * 50);
+                Asset.ConsensusFromGovernance(50));
             Assert.Throws<InvalidCurrencyException>(
                 () => _states = UndelegateCtrl.Execute(
                     _states,
@@ -55,7 +55,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     },
                     _delegatorAddress,
                     _validatorAddress,
-                    Asset.ConsensusToken * 30,
+                    Asset.ConsensusFromGovernance(30),
                     _nativeTokens));
             Assert.Throws<InvalidCurrencyException>(
                 () => _states = UndelegateCtrl.Execute(
@@ -85,7 +85,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     },
                     _delegatorAddress,
                     CreateAddress(),
-                    Asset.Share * 10,
+                    ShareFromGovernance(10),
                     _nativeTokens));
         }
 
@@ -104,7 +104,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     },
                     _delegatorAddress,
                     _validatorAddress,
-                    Asset.Share * 1,
+                    ShareFromGovernance(1),
                     _nativeTokens);
             }
 
@@ -118,7 +118,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     },
                     _delegatorAddress,
                     _validatorAddress,
-                    Asset.Share * 1,
+                    ShareFromGovernance(1),
                     _nativeTokens));
         }
 
@@ -136,7 +136,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     },
                     _delegatorAddress,
                     _validatorAddress,
-                    Asset.Share * 101,
+                    ShareFromGovernance(101),
                     _nativeTokens));
         }
 
@@ -160,7 +160,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                 },
                 _delegatorAddress,
                 _validatorAddress,
-                Asset.Share * undelegateAmount,
+                ShareFromGovernance(undelegateAmount),
                 _nativeTokens);
             Assert.Single(
                 UndelegateCtrl.GetUndelegation(_states, _undelegationAddress)!
@@ -226,13 +226,13 @@ namespace Lib9c.Tests.Action.DPoS.Control
                 },
                 _delegatorAddress,
                 _validatorAddress,
-                Asset.Share * undelegateAmount,
+                ShareFromGovernance(undelegateAmount),
                 _nativeTokens);
             Assert.Equal(
                 Asset.GovernanceToken * (delegatorMintAmount - delegateAmount),
                 _states.GetBalance(_delegatorAddress, Asset.GovernanceToken));
             Assert.Equal(
-                Asset.ConsensusToken * (selfDelegateAmount + delegateAmount - undelegateAmount),
+                Asset.ConsensusFromGovernance(selfDelegateAmount + delegateAmount - undelegateAmount),
                 _states.GetBalance(_validatorAddress, Asset.ConsensusToken));
             _states = UndelegateCtrl.Cancel(
                 _states,
@@ -242,14 +242,14 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     BlockIndex = 2,
                 },
                 _undelegationAddress,
-                Asset.ConsensusToken * cancelAmount,
+                Asset.ConsensusFromGovernance(cancelAmount),
                 _nativeTokens);
             Assert.Equal(
                 Asset.GovernanceToken * (delegatorMintAmount - delegateAmount),
                 _states.GetBalance(_delegatorAddress, Asset.GovernanceToken));
             Assert.Equal(
-                Asset.ConsensusToken
-                * (selfDelegateAmount + delegateAmount - undelegateAmount + cancelAmount),
+                Asset.ConsensusFromGovernance(
+                    selfDelegateAmount + delegateAmount - undelegateAmount + cancelAmount),
                 _states.GetBalance(_validatorAddress, Asset.ConsensusToken));
             _states = UndelegateCtrl.Complete(
                 _states,
@@ -263,8 +263,8 @@ namespace Lib9c.Tests.Action.DPoS.Control
                 Asset.GovernanceToken * (delegatorMintAmount - delegateAmount),
                 _states.GetBalance(_delegatorAddress, Asset.GovernanceToken));
             Assert.Equal(
-                Asset.ConsensusToken
-                * (selfDelegateAmount + delegateAmount - undelegateAmount + cancelAmount),
+                Asset.ConsensusFromGovernance(
+                    selfDelegateAmount + delegateAmount - undelegateAmount + cancelAmount),
                 _states.GetBalance(_validatorAddress, Asset.ConsensusToken));
             _states = UndelegateCtrl.Complete(
                 _states,
@@ -279,8 +279,8 @@ namespace Lib9c.Tests.Action.DPoS.Control
                 * (delegatorMintAmount - delegateAmount + undelegateAmount - cancelAmount),
                 _states.GetBalance(_delegatorAddress, Asset.GovernanceToken));
             Assert.Equal(
-                Asset.ConsensusToken
-                * (selfDelegateAmount + delegateAmount - undelegateAmount + cancelAmount),
+                Asset.ConsensusFromGovernance(
+                    selfDelegateAmount + delegateAmount - undelegateAmount + cancelAmount),
                 _states.GetBalance(_validatorAddress, Asset.ConsensusToken));
         }
 
@@ -304,22 +304,22 @@ namespace Lib9c.Tests.Action.DPoS.Control
                 },
                 _delegatorAddress,
                 _validatorAddress,
-                Asset.Share * undelegateAmount,
+                ShareFromGovernance(undelegateAmount),
                 _nativeTokens);
             Assert.Equal(
                 Asset.GovernanceToken * 0,
                 _states.GetBalance(_validatorAddress, Asset.GovernanceToken));
             Assert.Equal(
-                Asset.ConsensusToken * 0,
+                Asset.ConsensusFromGovernance(0),
                 _states.GetBalance(_operatorAddress, Asset.ConsensusToken));
             Assert.Equal(
-                Asset.ConsensusToken * 0,
+                Asset.ConsensusFromGovernance(0),
                 _states.GetBalance(_delegatorAddress, Asset.ConsensusToken));
             Assert.Equal(
-                Asset.Share * 0,
+                ShareFromGovernance(0),
                 _states.GetBalance(_operatorAddress, Asset.Share));
             Assert.Equal(
-                Asset.Share * 0,
+                ShareFromGovernance(0),
                 _states.GetBalance(_delegatorAddress, Asset.Share));
             Assert.Equal(
                 Asset.GovernanceToken * (operatorMintAmount - selfDelegateAmount),
@@ -344,7 +344,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                 ValidatorCtrl.GetValidator(_states, _validatorAddress)!.DelegatorShares,
                 balanceA + balanceB);
             Assert.Equal(
-                Asset.ConsensusToken * (selfDelegateAmount + delegateAmount - undelegateAmount),
+                Asset.ConsensusFromGovernance(selfDelegateAmount + delegateAmount - undelegateAmount),
                 _states.GetBalance(_validatorAddress, Asset.ConsensusToken));
         }
 

--- a/.Lib9c.Tests/Action/DPoS/Control/ValidatorCtrlTest.cs
+++ b/.Lib9c.Tests/Action/DPoS/Control/ValidatorCtrlTest.cs
@@ -40,7 +40,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     BlockIndex = 1,
                 },
                 _operatorAddress,
-                Asset.ConsensusToken * 50);
+                Asset.ConsensusFromGovernance(50));
             Assert.Throws<InvalidCurrencyException>(
                 () => _states = ValidatorCtrl.Create(
                     _states,
@@ -51,7 +51,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     },
                     _operatorAddress,
                     _operatorPublicKey,
-                    Asset.ConsensusToken * 30,
+                    Asset.ConsensusFromGovernance(30),
                     _nativeTokens));
         }
 
@@ -107,17 +107,17 @@ namespace Lib9c.Tests.Action.DPoS.Control
                 Asset.GovernanceToken * selfDelegateAmount,
                 _nativeTokens);
             Assert.Equal(
-                Asset.ConsensusToken * selfDelegateAmount,
+                Asset.ConsensusFromGovernance(selfDelegateAmount),
                 _states.GetBalance(_validatorAddress, Asset.ConsensusToken));
             Assert.Equal(
                 Asset.GovernanceToken * (mintAmount - selfDelegateAmount),
                 _states.GetBalance(_operatorAddress, Asset.GovernanceToken));
             Assert.Equal(
-                Asset.Share * selfDelegateAmount,
+                ShareFromGovernance(selfDelegateAmount),
                 _states.GetBalance(
                     Delegation.DeriveAddress(_operatorAddress, _validatorAddress), Asset.Share));
             Assert.Equal(
-                Asset.Share * selfDelegateAmount,
+                ShareFromGovernance(selfDelegateAmount),
                 ValidatorCtrl.GetValidator(_states, _validatorAddress)!.DelegatorShares);
         }
     }

--- a/.Lib9c.Tests/Action/DPoS/Control/ValidatorPowerIndexCtrlTest.cs
+++ b/.Lib9c.Tests/Action/DPoS/Control/ValidatorPowerIndexCtrlTest.cs
@@ -76,7 +76,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     BlockIndex = 1,
                 },
                 ValidatorAddresses[0],
-                Asset.ConsensusToken * 10);
+                Asset.ConsensusFromGovernance(10));
             _states = _states.MintAsset(
                 new ActionContext
                 {
@@ -84,7 +84,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     BlockIndex = 1,
                 },
                 ValidatorAddresses[1],
-                Asset.ConsensusToken * 30);
+                Asset.ConsensusFromGovernance(30));
             _states = _states.MintAsset(
                 new ActionContext
                 {
@@ -92,7 +92,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     BlockIndex = 1,
                 },
                 ValidatorAddresses[2],
-                Asset.ConsensusToken * 50);
+                Asset.ConsensusFromGovernance(50));
             _states = _states.MintAsset(
                 new ActionContext
                 {
@@ -100,7 +100,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     BlockIndex = 1,
                 },
                 ValidatorAddresses[3],
-                Asset.ConsensusToken * 40);
+                Asset.ConsensusFromGovernance(40));
             _states = _states.MintAsset(
                 new ActionContext
                 {
@@ -108,7 +108,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     BlockIndex = 1,
                 },
                 ValidatorAddresses[4],
-                Asset.ConsensusToken * 20);
+                Asset.ConsensusFromGovernance(20));
             _states = ValidatorPowerIndexCtrl.Update(_states, ValidatorAddresses);
             ValidatorPowerIndex validatorPowerIndex;
             (_states, validatorPowerIndex)
@@ -116,15 +116,15 @@ namespace Lib9c.Tests.Action.DPoS.Control
             List<ValidatorPower> index = validatorPowerIndex.Index.ToList();
             Assert.Equal(5, index.Count);
             Assert.Equal(ValidatorAddresses[2], index[0].ValidatorAddress);
-            Assert.Equal(Asset.ConsensusToken * 60, index[0].ConsensusToken);
+            Assert.Equal(Asset.ConsensusFromGovernance(60), index[0].ConsensusToken);
             Assert.Equal(ValidatorAddresses[3], index[1].ValidatorAddress);
-            Assert.Equal(Asset.ConsensusToken * 50, index[1].ConsensusToken);
+            Assert.Equal(Asset.ConsensusFromGovernance(50), index[1].ConsensusToken);
             Assert.Equal(ValidatorAddresses[1], index[2].ValidatorAddress);
-            Assert.Equal(Asset.ConsensusToken * 40, index[2].ConsensusToken);
+            Assert.Equal(Asset.ConsensusFromGovernance(40), index[2].ConsensusToken);
             Assert.Equal(ValidatorAddresses[4], index[3].ValidatorAddress);
-            Assert.Equal(Asset.ConsensusToken * 30, index[3].ConsensusToken);
+            Assert.Equal(Asset.ConsensusFromGovernance(30), index[3].ConsensusToken);
             Assert.Equal(ValidatorAddresses[0], index[4].ValidatorAddress);
-            Assert.Equal(Asset.ConsensusToken * 20, index[4].ConsensusToken);
+            Assert.Equal(Asset.ConsensusFromGovernance(20), index[4].ConsensusToken);
         }
 
         [Fact]
@@ -138,7 +138,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     BlockIndex = 1,
                 },
                 ValidatorAddresses[0],
-                Asset.ConsensusToken * 10);
+                Asset.ConsensusFromGovernance(10));
             _states = _states.MintAsset(
                 new ActionContext
                 {
@@ -146,7 +146,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     BlockIndex = 1,
                 },
                 ValidatorAddresses[1],
-                Asset.ConsensusToken * 10);
+                Asset.ConsensusFromGovernance(10));
             _states = _states.MintAsset(
                 new ActionContext
                 {
@@ -154,7 +154,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     BlockIndex = 1,
                 },
                 ValidatorAddresses[2],
-                Asset.ConsensusToken * 10);
+                Asset.ConsensusFromGovernance(10));
             _states = _states.MintAsset(
                 new ActionContext
                 {
@@ -162,7 +162,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     BlockIndex = 1,
                 },
                 ValidatorAddresses[3],
-                Asset.ConsensusToken * 10);
+                Asset.ConsensusFromGovernance(10));
             _states = _states.MintAsset(
                 new ActionContext
                 {
@@ -170,7 +170,7 @@ namespace Lib9c.Tests.Action.DPoS.Control
                     BlockIndex = 1,
                 },
                 ValidatorAddresses[4],
-                Asset.ConsensusToken * 10);
+                Asset.ConsensusFromGovernance(10));
             _states = ValidatorPowerIndexCtrl.Update(_states, ValidatorAddresses);
             ValidatorPowerIndex validatorPowerIndex;
             (_states, validatorPowerIndex)

--- a/.Lib9c.Tests/Action/DPoS/Control/ValidatorSetCtrlTest.cs
+++ b/.Lib9c.Tests/Action/DPoS/Control/ValidatorSetCtrlTest.cs
@@ -128,10 +128,10 @@ namespace Lib9c.Tests.Action.DPoS.Control
             Assert.Equal(
                 validatorAddressA, bondedSet.Set.ToList()[1].ValidatorAddress);
             Assert.Equal(
-                Asset.Share * (5 + 1 + 300),
+                ShareFromGovernance(5 + 1 + 300),
                 _states.GetBalance(delegationAddressB, Asset.Share));
             Assert.Equal(
-                Asset.ConsensusToken * (1 + 5 + 1 + 300),
+                Asset.ConsensusFromGovernance(1 + 5 + 1 + 300),
                 _states.GetBalance(ValidatorAddresses[5], Asset.ConsensusToken));
             Assert.Equal(
                 Asset.GovernanceToken
@@ -159,10 +159,10 @@ namespace Lib9c.Tests.Action.DPoS.Control
                 _nativeTokens);
 
             Assert.Equal(
-                Asset.Share * 0,
+                ShareFromGovernance(0),
                 _states.GetBalance(delegationAddressB, Asset.Share));
             Assert.Equal(
-                Asset.ConsensusToken * 1,
+                Asset.ConsensusFromGovernance(1),
                 _states.GetBalance(validatorAddressB, Asset.ConsensusToken));
             Assert.Equal(
                 Asset.GovernanceToken

--- a/.Lib9c.Tests/Action/DPoS/DistributeTest.cs
+++ b/.Lib9c.Tests/Action/DPoS/DistributeTest.cs
@@ -151,7 +151,7 @@ namespace Lib9c.Tests.Action.DPoS
                     OperatorPrivateKeys[5].PublicKey,
                     VoteFlag.PreCommit).Sign(OperatorPrivateKeys[5]),
             };
-            FungibleAssetValue blockReward = Asset.ConsensusToken * 50;
+            FungibleAssetValue blockReward = Asset.ConsensusFromGovernance(50);
             _states = _states.MintAsset(
                 new ActionContext
                 {
@@ -196,7 +196,7 @@ namespace Lib9c.Tests.Action.DPoS
                     .DivRem(Validator.CommissionDenominator);
 
             Assert.Equal(
-                Asset.ConsensusToken * 0,
+                Asset.ConsensusFromGovernance(0),
                 _states.GetBalance(ReservedAddress.RewardPool, Asset.ConsensusToken));
 
             Assert.Equal(
@@ -204,11 +204,11 @@ namespace Lib9c.Tests.Action.DPoS
                 _states.GetBalance(ReservedAddress.BondedPool, Asset.GovernanceToken));
 
             Assert.Equal(
-                Asset.ConsensusToken * 205,
+                Asset.ConsensusFromGovernance(205),
                 _states.GetBalance(validatorAddressA, Asset.ConsensusToken));
 
             Assert.Equal(
-                Asset.ConsensusToken * 307,
+                Asset.ConsensusFromGovernance(307),
                 _states.GetBalance(validatorAddressB, Asset.ConsensusToken));
 
             Assert.Equal(
@@ -225,7 +225,7 @@ namespace Lib9c.Tests.Action.DPoS
                 = Delegation.DeriveAddress(DelegatorAddress, validatorAddressA);
 
             Assert.Equal(
-                Asset.ConsensusToken * 0,
+                Asset.ConsensusFromGovernance(0),
                 _states.GetBalance(
                     AllocateReward.RewardAddress(DelegatorAddress), Asset.ConsensusToken));
 

--- a/.Lib9c.Tests/Action/DPoS/Model/RedelegationEntryTest.cs
+++ b/.Lib9c.Tests/Action/DPoS/Model/RedelegationEntryTest.cs
@@ -13,9 +13,9 @@ namespace Lib9c.Tests.Action.DPoS.Model
         {
             _redelegationEntry = new RedelegationEntry(
                 CreateAddress(),
-                Asset.Share * 1,
-                Asset.ConsensusToken * 1,
-                Asset.Share * 1,
+                ShareFromGovernance(1),
+                Asset.ConsensusFromGovernance(1),
+                ShareFromGovernance(1),
                 1,
                 1);
         }
@@ -26,15 +26,15 @@ namespace Lib9c.Tests.Action.DPoS.Model
             Assert.Throws<InvalidCurrencyException>(
                 () => _redelegationEntry.RedelegatingShare = Asset.GovernanceToken * 1);
             Assert.Throws<InvalidCurrencyException>(
-                () => _redelegationEntry.RedelegatingShare = Asset.ConsensusToken * 1);
+                () => _redelegationEntry.RedelegatingShare = Asset.ConsensusFromGovernance(1));
             Assert.Throws<InvalidCurrencyException>(
                 () => _redelegationEntry.UnbondingConsensusToken = Asset.GovernanceToken * 1);
             Assert.Throws<InvalidCurrencyException>(
-                () => _redelegationEntry.UnbondingConsensusToken = Asset.Share * 1);
+                () => _redelegationEntry.UnbondingConsensusToken = ShareFromGovernance(1));
             Assert.Throws<InvalidCurrencyException>(
                 () => _redelegationEntry.IssuedShare = Asset.GovernanceToken * 1);
             Assert.Throws<InvalidCurrencyException>(
-                () => _redelegationEntry.IssuedShare = Asset.ConsensusToken * 1);
+                () => _redelegationEntry.IssuedShare = Asset.ConsensusFromGovernance(1));
         }
 
         [Fact]

--- a/.Lib9c.Tests/Action/DPoS/Model/UndelegationEntryTest.cs
+++ b/.Lib9c.Tests/Action/DPoS/Model/UndelegationEntryTest.cs
@@ -12,7 +12,7 @@ namespace Lib9c.Tests.Action.DPoS.Model
         public UndelegationEntryTest()
         {
             _undelegationEntry = new UndelegationEntry(
-                CreateAddress(), Asset.ConsensusToken * 1, 1, 1);
+                CreateAddress(), Asset.ConsensusFromGovernance(1), 1, 1);
         }
 
         [Fact]
@@ -21,7 +21,7 @@ namespace Lib9c.Tests.Action.DPoS.Model
             Assert.Throws<InvalidCurrencyException>(
                 () => _undelegationEntry.UnbondingConsensusToken = Asset.GovernanceToken * 1);
             Assert.Throws<InvalidCurrencyException>(
-                () => _undelegationEntry.UnbondingConsensusToken = Asset.Share * 1);
+                () => _undelegationEntry.UnbondingConsensusToken = ShareFromGovernance(1));
         }
 
         [Fact]

--- a/.Lib9c.Tests/Action/DPoS/Model/ValidatorPowerTest.cs
+++ b/.Lib9c.Tests/Action/DPoS/Model/ValidatorPowerTest.cs
@@ -15,7 +15,7 @@ namespace Lib9c.Tests.Action.DPoS.Model
             _validatorPower = new ValidatorPower(
                 CreateAddress(),
                 new PrivateKey().PublicKey,
-                Asset.ConsensusToken * 10);
+                Asset.ConsensusFromGovernance(10));
         }
 
         [Fact]
@@ -24,7 +24,7 @@ namespace Lib9c.Tests.Action.DPoS.Model
             Assert.Throws<InvalidCurrencyException>(
                 () => _validatorPower.ConsensusToken = Asset.GovernanceToken * 1);
             Assert.Throws<InvalidCurrencyException>(
-                () => _validatorPower.ConsensusToken = Asset.Share * 1);
+                () => _validatorPower.ConsensusToken = ShareFromGovernance(1));
         }
 
         [Fact]

--- a/.Lib9c.Tests/Action/DPoS/Model/ValidatorTest.cs
+++ b/.Lib9c.Tests/Action/DPoS/Model/ValidatorTest.cs
@@ -19,7 +19,7 @@ namespace Lib9c.Tests.Action.DPoS.Model
         public void InvalidShareTypeTest()
         {
             Assert.Throws<InvalidCurrencyException>(
-                () => _validator.DelegatorShares = Asset.ConsensusToken * 1);
+                () => _validator.DelegatorShares = Asset.ConsensusFromGovernance(1));
             Assert.Throws<InvalidCurrencyException>(
                 () => _validator.DelegatorShares = Asset.GovernanceToken * 1);
         }

--- a/.Lib9c.Tests/Action/DPoS/PoSTest.cs
+++ b/.Lib9c.Tests/Action/DPoS/PoSTest.cs
@@ -1,7 +1,10 @@
 namespace Lib9c.Tests.Action.DPoS
 {
+    using System.Numerics;
     using Libplanet.Action.State;
     using Libplanet.Crypto;
+    using Libplanet.Types.Assets;
+    using Nekoyume.Action.DPoS.Misc;
 
     public class PoSTest
     {
@@ -15,5 +18,11 @@ namespace Lib9c.Tests.Action.DPoS
             PrivateKey privateKey = new PrivateKey();
             return privateKey.Address;
         }
+
+        protected static FungibleAssetValue ShareFromGovernance(FungibleAssetValue governanceToken)
+            => FungibleAssetValue.FromRawValue(Asset.Share, governanceToken.RawValue);
+
+        protected static FungibleAssetValue ShareFromGovernance(BigInteger amount)
+            => ShareFromGovernance(Asset.GovernanceToken * amount);
     }
 }

--- a/.Lib9c.Tests/Action/DPoS/ValidatorPowerComparerTest.cs
+++ b/.Lib9c.Tests/Action/DPoS/ValidatorPowerComparerTest.cs
@@ -14,9 +14,9 @@ namespace Lib9c.Tests.Action.DPoS
             PublicKey publicKeyA = new PrivateKey().PublicKey;
             PublicKey publicKeyB = new PrivateKey().PublicKey;
             ValidatorPower validatorPowerA = new ValidatorPower(
-                publicKeyA.Address, publicKeyA, Asset.ConsensusToken * 10);
+                publicKeyA.Address, publicKeyA, Asset.ConsensusFromGovernance(10));
             ValidatorPower validatorPowerB = new ValidatorPower(
-                publicKeyB.Address, publicKeyB, Asset.ConsensusToken * 11);
+                publicKeyB.Address, publicKeyB, Asset.ConsensusFromGovernance(11));
             Assert.True(((IComparable<ValidatorPower>)validatorPowerA)
                 .CompareTo(validatorPowerB) > 0);
         }
@@ -27,9 +27,9 @@ namespace Lib9c.Tests.Action.DPoS
             PublicKey publicKeyA = new PrivateKey().PublicKey;
             PublicKey publicKeyB = new PrivateKey().PublicKey;
             ValidatorPower validatorPowerA = new ValidatorPower(
-                publicKeyA.Address, publicKeyA, Asset.ConsensusToken * 10);
+                publicKeyA.Address, publicKeyA, Asset.ConsensusFromGovernance(10));
             ValidatorPower validatorPowerB = new ValidatorPower(
-                publicKeyB.Address, publicKeyB, Asset.ConsensusToken * 10);
+                publicKeyB.Address, publicKeyB, Asset.ConsensusFromGovernance(10));
             int sign = -((IComparable<Address>)publicKeyA.Address)
                 .CompareTo(publicKeyB.Address);
             Assert.True(((IComparable<ValidatorPower>)validatorPowerA)

--- a/Lib9c/Action/DPoS/Control/ValidatorCtrl.cs
+++ b/Lib9c/Action/DPoS/Control/ValidatorCtrl.cs
@@ -103,8 +103,8 @@ namespace Nekoyume.Action.DPoS.Control
 
             if (validator.DelegatorShares.Equals(Asset.Share * 0))
             {
-                return new FungibleAssetValue(
-                    Asset.Share, consensusToken.MajorUnit, consensusToken.MinorUnit);
+                return FungibleAssetValue.FromRawValue(
+                    Asset.Share, consensusToken.RawValue);
             }
 
             if (validatorConsensusToken.RawValue == 0)

--- a/Lib9c/Action/DPoS/Misc/Asset.cs
+++ b/Lib9c/Action/DPoS/Misc/Asset.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Libplanet.Types.Assets;
 
 namespace Nekoyume.Action.DPoS.Misc
@@ -8,21 +9,18 @@ namespace Nekoyume.Action.DPoS.Misc
             Currency.Legacy("NCG", 2, null);
 
         public static readonly Currency ConsensusToken =
-            Currency.Uncapped("ConsensusToken", 18, minters: null);
+            Currency.Uncapped("ConsensusToken", 0, minters: null);
 
         public static readonly Currency Share =
-            Currency.Uncapped("Share", 18, minters: null);
+            Currency.Uncapped("Share", 0, minters: null);
 
         public static FungibleAssetValue ConsensusFromGovernance(FungibleAssetValue governanceToken)
-        {
-            return new FungibleAssetValue(
-                ConsensusToken, governanceToken.MajorUnit, governanceToken.MinorUnit);
-        }
+            => FungibleAssetValue.FromRawValue(ConsensusToken, governanceToken.RawValue);
+
+        public static FungibleAssetValue ConsensusFromGovernance(BigInteger amount)
+            => ConsensusFromGovernance(GovernanceToken * amount);
 
         public static FungibleAssetValue GovernanceFromConsensus(FungibleAssetValue consensusToken)
-        {
-            return new FungibleAssetValue(
-                GovernanceToken, consensusToken.MajorUnit, consensusToken.MinorUnit);
-        }
+            => FungibleAssetValue.FromRawValue(GovernanceToken, consensusToken.RawValue);
     }
 }

--- a/Lib9c/Action/DPoS/Model/Validator.cs
+++ b/Lib9c/Action/DPoS/Model/Validator.cs
@@ -42,7 +42,7 @@ namespace Nekoyume.Action.DPoS.Model
         // TODO: Better structure
         // This hard coding will cause some problems when it's modified
         // May be it would be better to be serialized
-        public static FungibleAssetValue MinSelfDelegation => Asset.ConsensusToken * 1;
+        public static FungibleAssetValue MinSelfDelegation => Asset.ConsensusToken * 100;
 
         public static BigInteger CommissionNumerator => 1;
 


### PR DESCRIPTION
* Changed decimal places from 18 to 0 for ConsensusToken and Share 
  - Therefore 1 NCG == 100 ConsensusToken == 100 Share
* Fixed build errors and test failures casued by refactoring decimal places.