### PR TITLE
Fix missing statCP by rune level bonus

### DIFF
--- a/Lib9c/Action/HackAndSlashSweep.cs
+++ b/Lib9c/Action/HackAndSlashSweep.cs
@@ -229,9 +229,18 @@ namespace Nekoyume.Action
             {
                 states = states.SetRuneState(avatarAddress, runeStates);
             }
+
+            var equippedRune = new List<RuneState>();
+            foreach (var runeInfo in runeSlotState.GetEquippedRuneSlotInfos())
+            {
+                if (runeStates.TryGetRuneState(runeInfo.RuneId, out var runeState))
+                {
+                    equippedRune.Add(runeState);
+                }
+            }
             var runeOptionSheet = sheets.GetSheet<RuneOptionSheet>();
             var runeOptions = new List<RuneOptionSheet.Row.RuneOptionInfo>();
-            foreach (var runeState in runeStates.Runes.Values)
+            foreach (var runeState in equippedRune)
             {
                 if (!runeOptionSheet.TryGetValue(runeState.RuneId, out var optionRow))
                 {

--- a/Lib9c/Action/Raid.cs
+++ b/Lib9c/Action/Raid.cs
@@ -246,9 +246,17 @@ namespace Nekoyume.Action
                 }
             }
 
+            var equippedRune = new List<RuneState>();
+            foreach (var runeInfo in runeSlotState.GetEquippedRuneSlotInfos())
+            {
+                if (runeStates.TryGetRuneState(runeInfo.RuneId, out var runeState))
+                {
+                    equippedRune.Add(runeState);
+                }
+            }
             var runeOptionSheet = sheets.GetSheet<RuneOptionSheet>();
             var runeOptions = new List<RuneOptionSheet.Row.RuneOptionInfo>();
-            foreach (var runeState in runeStates.Runes.Values)
+            foreach (var runeState in equippedRune)
             {
                 if (!runeOptionSheet.TryGetValue(runeState.RuneId, out var optionRow))
                 {

--- a/Lib9c/Battle/CPHelper.cs
+++ b/Lib9c/Battle/CPHelper.cs
@@ -20,7 +20,7 @@ namespace Nekoyume.Battle
             CostumeStatSheet costumeStatSheet,
             List<StatModifier> collectionStatModifiers,
             int runeLevelBonus
-            )
+        )
         {
             decimal levelStatsCp = GetStatsCP(row.ToStats(level), level);
             var collectionCp = 0m;
@@ -39,21 +39,32 @@ namespace Nekoyume.Battle
             var equipmentsCp = 0;
             var costumeCp = 0;
             var runeCp = 0;
+            var runeLevelBonusCp = 0m;
 
             foreach (var equipment in equipments)
             {
                 equipmentsCp += GetCP(equipment);
             }
+
             foreach (var costume in costumes)
             {
                 costumeCp += GetCP(costume, costumeStatSheet);
             }
+
             foreach (var runeOption in runeOptions)
             {
                 runeCp += runeOption.Cp;
+                runeLevelBonusCp += runeOption.Stats.Sum(optionInfo =>
+                    GetStatCP(
+                        optionInfo.stat.StatType,
+                        optionInfo.stat.BaseValue * runeLevelBonus / 100_000m
+                    )
+                );
             }
 
-            var totalCp = DecimalToInt(levelStatsCp + equipmentsCp + costumeCp + runeCp + collectionCp);
+            var totalCp = DecimalToInt(
+                levelStatsCp + equipmentsCp + costumeCp + runeCp + runeLevelBonusCp + collectionCp
+            );
             return totalCp;
         }
 


### PR DESCRIPTION
Stat increase by rune level bonus only affects to stat, not to CP.
This PR calculates stat CP based on rune level bonus.