### PR TITLE
Correct `@planetarium/lib9c` dev version suffix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: "@planetarium/lib9c"
         run: |
           if [[ ! "$GITHUB_REF" =~ ^refs/tags/[0-9]+.[0-9]+.[0-9]+$ ]]; then
-            suffix="dev+${{ github.sha }}"
+            suffix="-dev+${{ github.sha }}"
             jq ".version = .version + \"$suffix\"" jsr.json > jsr.json.tmp
             mv jsr.json.tmp jsr.json
           fi


### PR DESCRIPTION
```
error: Failed to publish @planetarium/lib9c@0.1.0dev+f83c9e91742439b513d53e62b2b52c12c2fc0587

Caused by:
    0: Failed to publish @planetarium/lib9c at 0.1.0dev+f83c9e91742439b513d53e62b2b52c[12](https://github.com/planetarium/lib9c/actions/runs/8928223465/job/24539098222#step:6:13)c2fc0587
    1: The provided OIDC token is invalid: failed to parse 'aud': version must be normalized: expected 0.1.0-dev+f83c9e91742439b5[13](https://github.com/planetarium/lib9c/actions/runs/8928223465/job/24539098222#step:6:14)d53e62b2b52c12c2fc0587, got 0.1.0dev+f83c9e91742439b513d53e62b2b52c12c2fc0587 at line 1 column 239 (invalidOidcToken)[x-deno-ray: 75a910283a2d4ff20ad8b81de618cbe7]
```