### PR TITLE
Correct i18n nav

### DIFF
--- a/@planetarium/lib9c/docs/.vitepress/config.ts
+++ b/@planetarium/lib9c/docs/.vitepress/config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     nav: [
-      { text: 'Docs', link: '/docs' },
+      { text: 'Docs', link: '/docs/index.md' },
       { text: 'API Reference', link: 'https://jsr.io/@planetarium/lib9c' },
     ],
 
@@ -47,7 +47,7 @@ export default defineConfig({
       themeConfig: {
         i18nRouting: true,
         nav: [
-          { text: '문서', link: '/docs.md' },
+          { text: '문서', link: '/ko/docs/index.md' },
           { text: 'API Reference', link: 'https://jsr.io/@planetarium/lib9c' },
         ],
         sidebar: [

--- a/@planetarium/lib9c/docs/ko/index.md
+++ b/@planetarium/lib9c/docs/ko/index.md
@@ -9,7 +9,7 @@ hero:
   actions:
     - theme: brand
       text: 문서
-      link: /docs
+      link: /ko/docs/index.md
 
 features:
   - title: 타입스크립트


### PR DESCRIPTION
Currently, it navigates to English `/docs` page even if you're in Korean page. This pull request fixes it.