### PR TITLE
Introduce ExplorerList model

### DIFF
--- a/.Lib9c.Tests/Action/AdventureBoss/ClaimAdventureBossRewardTest.cs
+++ b/.Lib9c.Tests/Action/AdventureBoss/ClaimAdventureBossRewardTest.cs
@@ -554,13 +554,15 @@ namespace Lib9c.Tests.Action.AdventureBoss
             // Explore : just add data to avoid explore reward
             // Manipulate used AP Potion to calculate reward above zero
             var board = state.GetExploreBoard(1);
+            var lst = state.GetExplorerList(1);
             var exp = state.TryGetExplorer(1, TesterAvatarAddress, out var e)
                 ? e
                 : new Explorer(TesterAvatarAddress, TesterAvatarState.name);
-            board.ExplorerList.Add((TesterAvatarAddress, TesterAvatarState.name));
+            lst.Explorers.Add((TesterAvatarAddress, TesterAvatarState.name));
             board.UsedApPotion += 100;
+            board.ExplorerCount += 1;
             exp.UsedApPotion += 100;
-            state = state.SetExploreBoard(1, board).SetExplorer(1, exp);
+            state = state.SetExploreBoard(1, board).SetExplorerList(1, lst).SetExplorer(1, exp);
 
             var materialSheet = state.GetSheet<MaterialItemSheet>();
             var materialRow =
@@ -590,9 +592,11 @@ namespace Lib9c.Tests.Action.AdventureBoss
                 // Manipulate used AP Potion to calculate reward above zero
                 board = state.GetExploreBoard(1);
                 board.UsedApPotion += 99;
+                lst = state.GetExplorerList(1);
+                lst.AddExplorer(ExplorerAvatarAddress, ExplorerAvatarState.name);
                 exp = state.GetExplorer(1, ExplorerAvatarAddress);
                 exp.UsedApPotion += 99;
-                state = state.SetExploreBoard(1, board).SetExplorer(1, exp);
+                state = state.SetExploreBoard(1, board).SetExplorerList(1, lst).SetExplorer(1, exp);
             }
 
             // Burn all remaining NCG to make test easier
@@ -628,6 +632,9 @@ namespace Lib9c.Tests.Action.AdventureBoss
                 Assert.Equal(TesterAvatarState.name, exploreBoard.RaffleWinnerName);
             }
 
+            var explorerList = resultState.GetExplorerList(1);
+            Assert.Equal(anotherExplorerCount == 0 ? 1 : 2, explorerList.Explorers.Count);
+            Assert.Equal(exploreBoard.ExplorerCount, explorerList.Explorers.Count);
             Assert.Equal((int)(bounty * 0.05) * NCG, exploreBoard.RaffleReward);
             Assert.True(resultState.GetExplorer(1, TesterAvatarAddress).Claimed);
 
@@ -681,13 +688,14 @@ namespace Lib9c.Tests.Action.AdventureBoss
 
             // Manipulate used AP Potion to calculate reward above zero
             var board = state.GetExploreBoard(1);
-            board.ExplorerList.Add((TesterAvatarAddress, TesterAvatarState.name));
+            var lst = state.GetExplorerList(1);
+            lst.Explorers.Add((TesterAvatarAddress, TesterAvatarState.name));
             board.UsedApPotion += 100;
             var exp = state.TryGetExplorer(1, TesterAvatarAddress, out var e)
                 ? e
                 : new Explorer(TesterAvatarAddress, TesterAvatarState.name);
             exp.UsedApPotion += 100;
-            state = state.SetExploreBoard(1, board).SetExplorer(1, exp);
+            state = state.SetExploreBoard(1, board).SetExplorerList(1, lst).SetExplorer(1, exp);
 
             // No Explore
             state = new Wanted
@@ -719,13 +727,13 @@ namespace Lib9c.Tests.Action.AdventureBoss
 
             // Manipulate used AP Potion to calculate reward above zero
             board = state.GetExploreBoard(3);
-            board.ExplorerList.Add((TesterAvatarAddress, TesterAvatarState.name));
+            lst.Explorers.Add((TesterAvatarAddress, TesterAvatarState.name));
             board.UsedApPotion += 100;
             exp = state.TryGetExplorer(3, TesterAvatarAddress, out e)
                 ? e
                 : new Explorer(TesterAvatarAddress, TesterAvatarState.name);
             exp.UsedApPotion += 100;
-            state = state.SetExploreBoard(3, board).SetExplorer(3, exp);
+            state = state.SetExploreBoard(3, board).SetExplorerList(3, lst).SetExplorer(3, exp);
 
             // Burn remaining NCG
             state = state.BurnAsset(
@@ -804,13 +812,14 @@ namespace Lib9c.Tests.Action.AdventureBoss
             // Explore : just add data to avoid explore reward
             // Manipulate used AP Potion to calculate reward above zero
             var board = state.GetExploreBoard(1);
+            var lst = state.GetExplorerList(1);
             board.UsedApPotion += 100;
-            board.ExplorerList.Add((TesterAvatarAddress, TesterAvatarState.name));
+            lst.Explorers.Add((TesterAvatarAddress, TesterAvatarState.name));
             var exp = state.TryGetExplorer(1, TesterAvatarAddress, out var e)
                 ? e
                 : new Explorer(TesterAvatarAddress, TesterAvatarState.name);
             exp.UsedApPotion += 100;
-            state = state.SetExploreBoard(1, board).SetExplorer(1, exp);
+            state = state.SetExploreBoard(1, board).SetExplorerList(1, lst).SetExplorer(1, exp);
 
             // Burn
             state = state.BurnAsset(
@@ -872,8 +881,9 @@ namespace Lib9c.Tests.Action.AdventureBoss
             // Explore : just add data to avoid explore reward
             // Manipulate used AP Potion to calculate reward above zero
             var board = state.GetExploreBoard(1);
+            var lst = state.GetExplorerList(1);
             board.UsedApPotion += 100;
-            board.ExplorerList.Add(explore
+            lst.Explorers.Add(explore
                 ? (TesterAvatarAddress, TesterAvatarState.name)
                 : (ExplorerAvatarAddress, ExplorerAvatarState.name));
             var exp =
@@ -886,7 +896,8 @@ namespace Lib9c.Tests.Action.AdventureBoss
                         explore ? TesterAvatarState.name : ExplorerAvatarState.name
                     );
             exp.UsedApPotion += 100;
-            state = state.SetExploreBoard(1, board).SetExplorer(1, exp);
+            state = state.SetExploreBoard(1, board).SetExplorerList(1, lst).SetExplorerList(1, lst)
+                .SetExplorer(1, exp);
 
             // Next Season
             state = new Wanted

--- a/.Lib9c.Tests/Helper/AdventureBossHelperTest.cs
+++ b/.Lib9c.Tests/Helper/AdventureBossHelperTest.cs
@@ -67,14 +67,20 @@ namespace Lib9c.Tests.Helper
             bountyBoard.AddOrUpdate(_avatarAddress, _name, 100 * NCG);
 
             var exploreBoard = new ExploreBoard(1);
+            var explorerList = new ExplorerList(1);
             var explorer = new Explorer(_avatarAddress, _name);
-            exploreBoard.ExplorerList.Add((_avatarAddress, _name));
+            explorerList.Explorers.Add((_avatarAddress, _name));
             exploreBoard.FixedRewardFavId = 20001;
             exploreBoard.UsedApPotion = 100;
 
             explorer.UsedApPotion = 100;
 
-            AdventureBossHelper.PickExploreRaffle(bountyBoard, exploreBoard, new TestRandom());
+            AdventureBossHelper.PickExploreRaffle(
+                bountyBoard,
+                exploreBoard,
+                explorerList,
+                new TestRandom()
+            );
 
             if (!winner)
             {

--- a/Lib9c/Action/AdventureBoss/ExploreAdventureBoss.cs
+++ b/Lib9c/Action/AdventureBoss/ExploreAdventureBoss.cs
@@ -110,10 +110,19 @@ namespace Nekoyume.Action.AdventureBoss
             }
 
             var exploreBoard = states.GetExploreBoard(Season);
-            var explorer = states.TryGetExplorer(Season, AvatarAddress, out var exp)
-                ? exp
-                : new Explorer(AvatarAddress, avatarState.name);
-            exploreBoard.AddExplorer(AvatarAddress, avatarState.name);
+            Explorer explorer;
+            if (states.TryGetExplorer(Season, AvatarAddress, out var exp))
+            {
+                explorer = exp;
+            }
+            else
+            {
+                explorer = new Explorer(AvatarAddress, avatarState.name);
+                var explorerList = states.GetExplorerList(Season);
+                explorerList.AddExplorer(AvatarAddress, avatarState.name);
+                exploreBoard.ExplorerCount = explorerList.Explorers.Count;
+                states = states.SetExplorerList(Season, explorerList);
+            }
 
             if (explorer.Floor == UnlockFloor.TotalFloor)
             {

--- a/Lib9c/Action/AdventureBoss/SweepAdventureBoss.cs
+++ b/Lib9c/Action/AdventureBoss/SweepAdventureBoss.cs
@@ -167,7 +167,6 @@ namespace Nekoyume.Action.AdventureBoss
             itemSlotState.UpdateCostumes(Costumes);
             states = states.SetLegacyState(itemSlotStateAddress, itemSlotState.Serialize());
 
-            exploreBoard.AddExplorer(AvatarAddress, avatarState.name);
             exploreBoard.UsedApPotion += requiredPotion;
             explorer.UsedApPotion += requiredPotion;
 

--- a/Lib9c/Action/AdventureBoss/Wanted.cs
+++ b/Lib9c/Action/AdventureBoss/Wanted.cs
@@ -122,6 +122,7 @@ namespace Nekoyume.Action.AdventureBoss
                     gameConfig.AdventureBossInactiveInterval);
                 bountyBoard = new BountyBoard(Season);
                 var exploreBoard = new ExploreBoard(Season);
+                var explorerList = new ExplorerList(Season);
 
                 // Set season info: boss and reward
                 var random = context.GetRandom();
@@ -139,10 +140,11 @@ namespace Nekoyume.Action.AdventureBoss
                     .OrderedList.First(row => row.AdventureBossId == boss.Id);
                 exploreBoard.SetReward(contribReward, random);
 
-                states = states.SetSeasonInfo(seasonInfo);
-                states = states.SetLatestAdventureBossSeason(seasonInfo);
-                states = states.SetBountyBoard(Season, bountyBoard);
-                states = states.SetExploreBoard(Season, exploreBoard);
+                states = states.SetSeasonInfo(seasonInfo)
+                    .SetLatestAdventureBossSeason(seasonInfo)
+                    .SetBountyBoard(Season, bountyBoard)
+                    .SetExploreBoard(Season, exploreBoard)
+                    .SetExplorerList(Season, explorerList);
             }
 
             // Just update bounty board

--- a/Lib9c/Addresses.cs
+++ b/Lib9c/Addresses.cs
@@ -53,6 +53,7 @@ namespace Nekoyume
         public static readonly Address AdventureBoss         = new Address("0000000000000000000000000000000000000100");
         public static readonly Address BountyBoard           = new Address("0000000000000000000000000000000000000101");
         public static readonly Address ExploreBoard          = new Address("0000000000000000000000000000000000000102");
+        public static readonly Address ExplorerList          = new Address("0000000000000000000000000000000000000103");
 
         public static Address GetSheetAddress<T>() where T : ISheet => GetSheetAddress(typeof(T).Name);
 

--- a/Lib9c/Helper/AdventureBossHelper.cs
+++ b/Lib9c/Helper/AdventureBossHelper.cs
@@ -102,14 +102,14 @@ namespace Nekoyume.Helper
         }
 
         public static ExploreBoard PickExploreRaffle(BountyBoard bountyBoard,
-            ExploreBoard exploreBoard, IRandom random)
+            ExploreBoard exploreBoard, ExplorerList explorerList, IRandom random)
         {
             exploreBoard.RaffleReward = CalculateRaffleReward(bountyBoard);
 
-            if (exploreBoard.ExplorerList.Count > 0)
+            if (explorerList.Explorers.Count > 0)
             {
-                var winner = exploreBoard.ExplorerList.ToImmutableSortedSet()[
-                    random.Next(exploreBoard.ExplorerList.Count)
+                var winner = explorerList.Explorers.ToImmutableSortedSet()[
+                    random.Next(explorerList.Explorers.Count)
                 ];
                 exploreBoard.RaffleWinner = winner.Item1;
                 exploreBoard.RaffleWinnerName = winner.Item2;
@@ -131,9 +131,10 @@ namespace Nekoyume.Helper
                 // Explore raffle
                 var bountyBoard = states.GetBountyBoard(szn);
                 var exploreBoard = states.GetExploreBoard(szn);
+                var explorerList = states.GetExplorerList(szn);
                 if (exploreBoard.RaffleWinner is null)
                 {
-                    exploreBoard = PickExploreRaffle(bountyBoard, exploreBoard, random);
+                    exploreBoard = PickExploreRaffle(bountyBoard, exploreBoard, explorerList, random);
                     states = states.SetExploreBoard(szn, exploreBoard);
                 }
             }
@@ -388,9 +389,10 @@ namespace Nekoyume.Helper
                 }
 
                 var exploreBoard = states.GetExploreBoard(szn);
+                var explorerList = states.GetExplorerList(szn);
 
                 // Not explored
-                if (!exploreBoard.ExplorerList.OrderBy(e => e.Item1)
+                if (!explorerList.Explorers.OrderBy(e => e.Item1)
                         .Select(e => e.Item1)
                         .Contains(avatarAddress)
                    )

--- a/Lib9c/Model/AdventureBoss/ExploreBoard.cs
+++ b/Lib9c/Model/AdventureBoss/ExploreBoard.cs
@@ -14,7 +14,7 @@ namespace Nekoyume.Model.AdventureBoss
     public class ExploreBoard
     {
         public long Season;
-        public HashSet<(Address, string)> ExplorerList = new ();
+        public int ExplorerCount;
 
         public long UsedApPotion;
         public long UsedGoldenDust;
@@ -35,9 +35,7 @@ namespace Nekoyume.Model.AdventureBoss
         public ExploreBoard(List bencoded)
         {
             Season = (Integer)bencoded[0];
-            ExplorerList = bencoded[1].ToHashSet(
-                i => (((List)i)[0].ToAddress(), ((List)i)[1].ToDotnetString())
-            );
+            ExplorerCount = (Integer)bencoded[1];
             UsedApPotion = (Integer)bencoded[2];
             UsedGoldenDust = (Integer)bencoded[3];
             UsedNcg = (Integer)bencoded[4];
@@ -62,18 +60,11 @@ namespace Nekoyume.Model.AdventureBoss
                 AdventureBossHelper.PickReward(random, rewardInfo.Rewards);
         }
 
-        public void AddExplorer(Address avatarAddress, string name)
-        {
-            ExplorerList.Add((avatarAddress, name));
-        }
 
         public IValue Bencoded()
         {
             var bencoded = List.Empty
-                .Add(Season)
-                .Add(new List(ExplorerList.OrderBy(e => e)
-                    .Select(e => new List(e.Item1.Serialize(), (Text)e.Item2)))
-                )
+                .Add(Season).Add(ExplorerCount)
                 .Add(UsedApPotion).Add(UsedGoldenDust).Add(UsedNcg).Add(TotalPoint);
 
             if (FixedRewardFavId is not null || FixedRewardItemId is not null)

--- a/Lib9c/Model/AdventureBoss/ExplorerList.cs
+++ b/Lib9c/Model/AdventureBoss/ExplorerList.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Linq;
+using Bencodex.Types;
+using Libplanet.Crypto;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Model.AdventureBoss
+{
+    public class ExplorerList
+    {
+        public long Season;
+        public HashSet<(Address, string)> Explorers = new ();
+
+        public ExplorerList(long season)
+        {
+            Season = season;
+        }
+
+        public ExplorerList(List bencoded)
+        {
+            Season = (Integer)bencoded[0];
+            Explorers = bencoded[1].ToHashSet(
+                i => (((List)i)[0].ToAddress(), ((List)i)[1].ToDotnetString())
+            );
+        }
+
+        public void AddExplorer(Address avatarAddress, string name)
+        {
+            Explorers.Add((avatarAddress, name));
+        }
+
+        public IValue Bencoded => List.Empty.Add(Season).Add(new List(Explorers.OrderBy(e => e)
+            .Select(e => new List(e.Item1.Serialize(), (Text)e.Item2)))
+        );
+    }
+}

--- a/Lib9c/Module/AdventureBossModule.cs
+++ b/Lib9c/Module/AdventureBossModule.cs
@@ -117,6 +117,29 @@ namespace Nekoyume.Module
             return world.SetAccount(Addresses.ExploreBoard, account);
         }
 
+        public static ExplorerList GetExplorerList(this IWorldState worldState, long season)
+        {
+            var account = worldState.GetAccountState(Addresses.ExplorerList);
+            if (account.GetState(new Address(AdventureBossHelper.GetSeasonAsAddressForm(season))) is { } a)
+            {
+                return new ExplorerList((List)a);
+            }
+
+            throw new FailedLoadStateException("");
+        }
+
+        public static IWorld SetExplorerList(this IWorld world, long season,
+            ExplorerList explorerList)
+        {
+            var account = world.GetAccount(Addresses.ExplorerList);
+            account = account.SetState(
+                new Address(AdventureBossHelper.GetSeasonAsAddressForm(season)),
+                explorerList.Bencoded
+            );
+            return world.SetAccount(Addresses.ExplorerList, account);
+
+        }
+
         // Use `Addresses.AdventureBossExplore` for AccountState to store all adventurer's data
         // Use `Address.Derive(AvatarAddress, SeasonAddress)` for individual avatar's explore info.
         public static bool TryGetExplorer(this IWorldState worldState, long season,


### PR DESCRIPTION
- New model : ExplorerList
    - In only has `HashSet<(Address, string)>` to store Explorers in this season.
- Move `ExploreBoard.ExplorerList` to `ExplorerList.Explorers`
- Introduce `ExplorerCount` into `ExploreBoard` model.
    - This is kind of duplication but for efficiency.