### PR TITLE
Fix not to use GetNextWorldState() on tx validation

### DIFF
--- a/.Lib9c.Tests/Policy/BlockPolicyTest.cs
+++ b/.Lib9c.Tests/Policy/BlockPolicyTest.cs
@@ -100,7 +100,9 @@ namespace Lib9c.Tests
                     0,
                     newActivatedPrivateKey,
                     genesis.Hash,
-                    Array.Empty<IValue>()
+                    Array.Empty<IValue>(),
+                    gasLimit: 1,
+                    maxGasPrice: new FungibleAssetValue(Currencies.Mead, 0, 0)
                 );
 
             // Test success because the key is activated.
@@ -120,14 +122,18 @@ namespace Lib9c.Tests
                     0,
                     newActivatedPrivateKey,
                     genesis.Hash,
-                    singleAction.ToPlainValues()
+                    singleAction.ToPlainValues(),
+                    gasLimit: 1,
+                    maxGasPrice: new FungibleAssetValue(Currencies.Mead, 0, 0)
                 );
             Transaction txWithManyActions =
                 Transaction.Create(
                     0,
                     newActivatedPrivateKey,
                     genesis.Hash,
-                    manyActions.ToPlainValues()
+                    manyActions.ToPlainValues(),
+                    gasLimit: 1,
+                    maxGasPrice: new FungibleAssetValue(Currencies.Mead, 0, 0)
                 );
 
             // Transaction with more than two actions is rejected.
@@ -450,7 +456,9 @@ namespace Lib9c.Tests
                         nonce++,
                         adminPrivateKey,
                         genesis.Hash,
-                        Array.Empty<IValue>()
+                        Array.Empty<IValue>(),
+                        gasLimit: 1,
+                        maxGasPrice: new FungibleAssetValue(Currencies.Mead, 0, 0)
                     ));
                 }
 
@@ -552,7 +560,9 @@ namespace Lib9c.Tests
                         nonce++,
                         adminPrivateKey,
                         genesis.Hash,
-                        Array.Empty<IValue>()
+                        Array.Empty<IValue>(),
+                        gasLimit: 1,
+                        maxGasPrice: new FungibleAssetValue(Currencies.Mead, 0, 0)
                     ));
                 }
 

--- a/Lib9c.Policy/Policy/BlockPolicySource.cs
+++ b/Lib9c.Policy/Policy/BlockPolicySource.cs
@@ -174,69 +174,14 @@ namespace Nekoyume.Blockchain.Policy
             try
             {
                 if (blockChain
-                    .GetNextWorldState()!
+                    .GetWorldState()
                     .GetBalance(MeadConfig.PatronAddress, Currencies.Mead) < 1 * Currencies.Mead)
                 {
-                    // Check Activation
-                    try
-                    {
-                        if (transaction.Actions is { } rawActions &&
-                            rawActions.Count == 1 &&
-                            actionLoader.LoadAction(index, rawActions.First()) is ActionBase action &&
-                            action is IActivateAccount activate)
-                        {
-                            return transaction.Nonce == 0 &&
-                                blockChain
-                                    .GetNextWorldState()!
-                                    .GetAccountState(ReservedAddresses.LegacyAccount)
-                                    .GetState(activate.PendingAddress) is Dictionary rawPending &&
-                                new PendingActivationState(rawPending).Verify(activate.Signature)
-                                    ? null
-                                    : new TxPolicyViolationException(
-                                        $"Transaction {transaction.Id} has an invalid activate action.",
-                                        transaction.Id);
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        return new TxPolicyViolationException(
-                            $"Transaction {transaction.Id} has an invalid action.",
-                            transaction.Id,
-                            e);
-                    }
-
                     // Check admin
                     if (IsAdminTransaction(blockChain, transaction))
                     {
                         return null;
-                    }
-
-                    switch (blockChain
-                        .GetNextWorldState()!
-                        .GetAccountState(ReservedAddresses.LegacyAccount)
-                        .GetState(transaction.Signer.Derive(ActivationKey.DeriveKey)))
-                    {
-                        case null:
-                            // Fallback for pre-migration.
-                            if (blockChain
-                                .GetNextWorldState()!
-                                .GetAccountState(ReservedAddresses.LegacyAccount)
-                                .GetState(ActivatedAccountsState.Address) is Dictionary asDict)
-                            {
-                                IImmutableSet<Address> activatedAccounts =
-                                    new ActivatedAccountsState(asDict).Accounts;
-                                return !activatedAccounts.Any() ||
-                                    activatedAccounts.Contains(transaction.Signer)
-                                        ? null
-                                        : new TxPolicyViolationException(
-                                            $"Transaction {transaction.Id} is by a signer " +
-                                            $"without account activation: {transaction.Signer}",
-                                            transaction.Id);
-                            }
-                            return null;
-                        case Bencodex.Types.Boolean _:
-                            return null;
-                    }
+                    }           
                 }
 
                 if (!(transaction.MaxGasPrice is { } gasPrice && transaction.GasLimit is { } gasLimit))


### PR DESCRIPTION
### Changes

- Fix not to use `GetNextWorldState()` on tx validation
- Reduce cache size of `HashNodeCache`