### PR TITLE
Add missing BuffLinkSheet to AdventureBossSimulator

### DIFF
--- a/.Lib9c.Tests/Model/AdventureBoss/AdventureBossSimulatorTest.cs
+++ b/.Lib9c.Tests/Model/AdventureBoss/AdventureBossSimulatorTest.cs
@@ -68,7 +68,8 @@ namespace Lib9c.Tests.Model.AdventureBoss
                 {
                     new (StatType.ATK, StatModifier.OperationType.Add, 100),
                 },
-                _tableSheets.DeBuffLimitSheet
+                _tableSheets.DeBuffLimitSheet,
+                _tableSheets.BuffLinkSheet
             );
 
             var player = simulator.Player;
@@ -146,7 +147,8 @@ namespace Lib9c.Tests.Model.AdventureBoss
                     {
                         new (StatType.ATK, StatModifier.OperationType.Add, 100),
                     },
-                    _tableSheets.DeBuffLimitSheet
+                    _tableSheets.DeBuffLimitSheet,
+                    _tableSheets.BuffLinkSheet
                 );
             }
 

--- a/Lib9c/Action/AdventureBoss/ExploreAdventureBoss.cs
+++ b/Lib9c/Action/AdventureBoss/ExploreAdventureBoss.cs
@@ -143,6 +143,7 @@ namespace Nekoyume.Action.AdventureBoss
                     typeof(EnemySkillSheet),
                     typeof(CostumeStatSheet),
                     typeof(DeBuffLimitSheet),
+                    typeof(BuffLinkSheet),
                     typeof(ItemRequirementSheet),
                     typeof(EquipmentItemRecipeSheet),
                     typeof(EquipmentItemSubRecipeSheetV2),
@@ -226,6 +227,7 @@ namespace Nekoyume.Action.AdventureBoss
             var costumeStatSheet = sheets.GetSheet<CostumeStatSheet>();
             var materialItemSheet = sheets.GetSheet<MaterialItemSheet>();
             var deBuffLimitSheet = sheets.GetSheet<DeBuffLimitSheet>();
+            var buffLinkSheet = sheets.GetSheet<BuffLinkSheet>();
             if (gameConfigState is null)
             {
                 throw new FailedLoadStateException(
@@ -289,6 +291,7 @@ namespace Nekoyume.Action.AdventureBoss
                     rewards,
                     collectionModifiers,
                     deBuffLimitSheet,
+                    buffLinkSheet,
                     false,
                     gameConfigState.ShatterStrikeMaxDamage
                 );

--- a/Lib9c/Battle/AdventureBoss/AdventureBossSimulator.cs
+++ b/Lib9c/Battle/AdventureBoss/AdventureBossSimulator.cs
@@ -67,6 +67,7 @@ namespace Nekoyume.Battle.AdventureBoss
             List<ItemBase> waveRewards,
             List<StatModifier> collectionModifiers,
             DeBuffLimitSheet deBuffLimitSheet,
+            BuffLinkSheet buffLinkSheet,
             bool logEvent = true,
             long shatterStrikeMaxDamage = 400_000
         )
@@ -80,6 +81,7 @@ namespace Nekoyume.Battle.AdventureBoss
             )
         {
             DeBuffLimitSheet = deBuffLimitSheet;
+            BuffLinkSheet = buffLinkSheet;
             var runeOptionSheet = simulatorSheets.RuneOptionSheet;
             var skillSheet = simulatorSheets.SkillSheet;
             var runeLevelBonus = RuneHelper.CalculateRuneLevelBonus(


### PR DESCRIPTION
New sheet (BuffLinkSheet) is required to run IceSield / FrostBite.