### PR TITLE
Remove duplicated floor reward

### DIFF
--- a/.Lib9c.Tests/Action/AdventureBoss/ExploreAdventureBossTest.cs
+++ b/.Lib9c.Tests/Action/AdventureBoss/ExploreAdventureBossTest.cs
@@ -106,9 +106,9 @@ namespace Lib9c.Tests.Action.AdventureBoss
                 0, 5, 5, 10, 5, null,
                 new[]
                 {
-                    (600301, 85), // 50 first Reward + 35 floor reward
+                    (600301, 76), // 50 first Reward + 26 floor reward
                     (600302, 50), // 50 first reward
-                    (600303, 3), // 3 floor reward
+                    (600303, 0),
                     (600304, 0),
                 },
             };
@@ -117,9 +117,9 @@ namespace Lib9c.Tests.Action.AdventureBoss
             {
                 0, 5, 3, 3, 0, null, new[]
                 {
-                    (600301, 53), // 30 first reward + 23 floor reward
+                    (600301, 47), // 30 first reward + 17 floor reward
                     (600302, 30), // 30 first reward
-                    (600303, 3),  // 3 floor reward
+                    (600303, 0),
                     (600304, 0),
                 },
             };
@@ -128,9 +128,9 @@ namespace Lib9c.Tests.Action.AdventureBoss
             {
                 2, 5, 5, 5, 2, null, new[]
                 {
-                    (600301, 46), // 30 first reward + 16 floor reward
+                    (600301, 40), // 30 first reward + 10 floor reward
                     (600302, 39), // 30 first reward + 9 floor reward
-                    (600303, 3), // 3 floor reward
+                    (600303, 0),
                     (600304, 0),
                 },
             };
@@ -140,9 +140,9 @@ namespace Lib9c.Tests.Action.AdventureBoss
                 5, 10, 10, 10, 5, null,
                 new[]
                 {
-                    (600301, 81), // 50 first reward + 31 floor reward
+                    (600301, 72), // 50 first reward + 22 floor reward
                     (600302, 50), // 50 first reward
-                    (600303, 3), // 3 floor reward
+                    (600303, 0),
                     (600304, 0),
                 },
             };

--- a/.Lib9c.Tests/Model/AdventureBoss/AdventureBossSimulatorTest.cs
+++ b/.Lib9c.Tests/Model/AdventureBoss/AdventureBossSimulatorTest.cs
@@ -79,7 +79,7 @@ namespace Lib9c.Tests.Model.AdventureBoss
 
             simulator.Simulate();
 
-            Assert.True(simulator.Log.OfType<DropBox>().Any());
+            Assert.False(simulator.Log.OfType<DropBox>().Any());
             var filtered =
                 simulator.Log
                     .Select(e => e.GetType())

--- a/Lib9c/Battle/AdventureBoss/AdventureBossSimulator.cs
+++ b/Lib9c/Battle/AdventureBoss/AdventureBossSimulator.cs
@@ -205,17 +205,6 @@ namespace Nekoyume.Battle.AdventureBoss
                     {
                         Result = BattleLog.Result.Win;
                         Log.clearedWaveNumber = WaveNumber;
-
-                        // Adventure boss has only one wave. Drop item box and clear.
-                        ItemMap = Player.GetRewards(_waveRewards);
-                        if (LogEvent)
-                        {
-                            var dropBox = new DropBox(null, _waveRewards);
-                            Log.Add(dropBox);
-                            var getReward = new GetReward(null, _waveRewards);
-                            Log.Add(getReward);
-                        }
-
                         Log.newlyCleared = true;
                         break;
                     }


### PR DESCRIPTION
Remove duplicated floor reward.
Remove reward inside simulator to calculate easier.
Also remove useless DropBox event log.