### PR TITLE
Prepare 1.15.0

### DIFF
--- a/Lib9c/Lib9c.csproj
+++ b/Lib9c/Lib9c.csproj
@@ -9,7 +9,7 @@
     <IntermediateOutputPath>.obj</IntermediateOutputPath>
     <RootNamespace>Nekoyume</RootNamespace>
     <LangVersion>9</LangVersion>
-    <VersionPrefix>1.12.0</VersionPrefix>
+    <VersionPrefix>1.15.0</VersionPrefix>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>


### PR DESCRIPTION
This pull request amends the `Version` property in `Lib9c/Lib9c.csproj` file to prepare the next release, `1.15.0`, because `1.14.0` version is already released.

It resolves #2682 