### PR TITLE
ci(gh-actions): specify working directory

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.400
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
         with:
           version: 9
           run_install: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
           dotnet-version: 6.0.400
       - uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 9
           run_install: true
       - name: Build Lib9c.Tools
         run: dotnet build .Lib9c.Tools/Lib9c.Tools.csproj

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,12 +87,17 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 9
-          run_install: true
+          run_install: |
+            recursive: true
+            cwd: "@planetarium"
       - name: Build Lib9c.Tools
         run: dotnet build .Lib9c.Tools/Lib9c.Tools.csproj
       - run: pnpm -r build
+        working-directory: "@planetarium/lib9c"
       - run: pnpm -r fmt:ci
+        working-directory: "@planetarium/lib9c"
       - run: pnpm -r test
+        working-directory: "@planetarium/lib9c"
 
   release:
     if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,4 +47,4 @@ jobs:
     uses: planetarium/.github/.github/workflows/publish_jsr.yaml@7da1714cbc9554aa17a19bc6477b8b067f714ea7
     with:
       working_directory: "@planetarium/lib9c"
-      pnpm_version: "9.1.2"
+      pnpm_version: "9"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,8 @@ jobs:
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
   jsr:
-    uses: planetarium/.github/.github/workflows/publish_jsr.yaml@7da1714cbc9554aa17a19bc6477b8b067f714ea7
+    uses: planetarium/.github/.github/workflows/publish_jsr.yaml@34a5632831962232ffed9d4f4a5fc3de77ef5231
     with:
+      workspace_directory: "@planetarium"
       working_directory: "@planetarium/lib9c"
       pnpm_version: "9"


### PR DESCRIPTION
Previously, it used the latest packages instead of those in the lockfile because the working directory wasn't specified correctly. This pull request fixes it.