### PR TITLE
Remove all .Libplanet submodule codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-.Libplanet @boscohyun @sonohoshi @tyrosine1153


### PR DESCRIPTION
Since @boscohyun doesn't work for this project, NineChronicles actively, I thought that he will receive too many review-requests and those will be too noisy. So this pull request removes him from CODEOWNERS list.

Of course, if @boscohyun wants to receive the notification, please just close this pull request 😉 

-------

In insider chat, we decided to remove all .Libplanet submodule codeowners.