### PR TITLE
Prepare 1.16.0

### DIFF
--- a/Lib9c/Lib9c.csproj
+++ b/Lib9c/Lib9c.csproj
@@ -9,7 +9,7 @@
     <IntermediateOutputPath>.obj</IntermediateOutputPath>
     <RootNamespace>Nekoyume</RootNamespace>
     <LangVersion>9</LangVersion>
-    <VersionPrefix>1.15.0</VersionPrefix>
+    <VersionPrefix>1.16.0</VersionPrefix>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>


### PR DESCRIPTION
Since [1.15.0](https://github.com/planetarium/lib9c/releases/tag/1.15.0) is released, this pull request bumps Lib9c version to 1.16.0