### PR TITLE
Disable guild operation related actions except for MakeGuild

### DIFF
--- a/.Lib9c.Tests/Action/Guild/AcceptGuildApplicationTest.cs
+++ b/.Lib9c.Tests/Action/Guild/AcceptGuildApplicationTest.cs
@@ -5,7 +5,6 @@ namespace Lib9c.Tests.Action.Guild
     using Libplanet.Action.State;
     using Libplanet.Mocks;
     using Nekoyume.Action.Guild;
-    using Nekoyume.Action.Loader;
     using Nekoyume.Module.Guild;
     using Xunit;
 
@@ -18,10 +17,9 @@ namespace Lib9c.Tests.Action.Guild
             var action = new AcceptGuildApplication(agentAddress);
             var plainValue = action.PlainValue;
 
-            var actionLoader = new NCActionLoader();
-            var loadedRaw = actionLoader.LoadAction(0, plainValue);
-            var loadedAction = Assert.IsType<AcceptGuildApplication>(loadedRaw);
-            Assert.Equal(agentAddress, loadedAction.Target);
+            var deserialized = new AcceptGuildApplication();
+            deserialized.LoadPlainValue(plainValue);
+            Assert.Equal(agentAddress, deserialized.Target);
         }
 
         [Fact]

--- a/.Lib9c.Tests/Action/Guild/ApplyGuildTest.cs
+++ b/.Lib9c.Tests/Action/Guild/ApplyGuildTest.cs
@@ -18,10 +18,9 @@ namespace Lib9c.Tests.Action.Guild
             var action = new ApplyGuild(guildAddress);
             var plainValue = action.PlainValue;
 
-            var actionLoader = new NCActionLoader();
-            var loadedRaw = actionLoader.LoadAction(0, plainValue);
-            var loadedAction = Assert.IsType<ApplyGuild>(loadedRaw);
-            Assert.Equal(guildAddress, loadedAction.GuildAddress);
+            var deserialized = new ApplyGuild();
+            deserialized.LoadPlainValue(plainValue);
+            Assert.Equal(guildAddress, deserialized.GuildAddress);
         }
 
         [Fact]

--- a/.Lib9c.Tests/Action/Guild/BanGuildMemberTest.cs
+++ b/.Lib9c.Tests/Action/Guild/BanGuildMemberTest.cs
@@ -5,7 +5,6 @@ namespace Lib9c.Tests.Action.Guild
     using Libplanet.Action.State;
     using Libplanet.Mocks;
     using Nekoyume.Action.Guild;
-    using Nekoyume.Action.Loader;
     using Nekoyume.Module.Guild;
     using Xunit;
 
@@ -18,10 +17,9 @@ namespace Lib9c.Tests.Action.Guild
             var action = new BanGuildMember(guildMemberAddress);
             var plainValue = action.PlainValue;
 
-            var actionLoader = new NCActionLoader();
-            var loadedRaw = actionLoader.LoadAction(0, plainValue);
-            var loadedAction = Assert.IsType<BanGuildMember>(loadedRaw);
-            Assert.Equal(guildMemberAddress, loadedAction.Target);
+            var deserialized = new BanGuildMember();
+            deserialized.LoadPlainValue(plainValue);
+            Assert.Equal(guildMemberAddress, deserialized.Target);
         }
 
         // Expected use-case.

--- a/.Lib9c.Tests/Action/Guild/CancelGuildApplicationTest.cs
+++ b/.Lib9c.Tests/Action/Guild/CancelGuildApplicationTest.cs
@@ -6,7 +6,6 @@ namespace Lib9c.Tests.Action.Guild
     using Libplanet.Crypto;
     using Libplanet.Mocks;
     using Nekoyume.Action.Guild;
-    using Nekoyume.Action.Loader;
     using Nekoyume.Module.Guild;
     using Nekoyume.TypedAddress;
     using Xunit;
@@ -19,9 +18,8 @@ namespace Lib9c.Tests.Action.Guild
             var action = new CancelGuildApplication();
             var plainValue = action.PlainValue;
 
-            var actionLoader = new NCActionLoader();
-            var loadedRaw = actionLoader.LoadAction(0, plainValue);
-            Assert.IsType<CancelGuildApplication>(loadedRaw);
+            var deserialized = new CancelGuildApplication();
+            deserialized.LoadPlainValue(plainValue);
         }
 
         [Fact]

--- a/.Lib9c.Tests/Action/Guild/MakeGuildTest.cs
+++ b/.Lib9c.Tests/Action/Guild/MakeGuildTest.cs
@@ -1,15 +1,34 @@
 namespace Lib9c.Tests.Action.Guild
 {
+    using System;
+    using System.Collections.Generic;
     using Lib9c.Tests.Util;
     using Libplanet.Action.State;
     using Libplanet.Mocks;
+    using Nekoyume;
     using Nekoyume.Action.Guild;
     using Nekoyume.Action.Loader;
     using Nekoyume.Module.Guild;
+    using Nekoyume.TypedAddress;
     using Xunit;
 
     public class MakeGuildTest
     {
+        public static IEnumerable<object[]> TestCases => new[]
+        {
+            new object[]
+            {
+                AddressUtil.CreateAgentAddress(),
+                // TODO: Update to false when Guild features are enabled.
+                true,
+            },
+            new object[]
+            {
+                new AgentAddress(MeadConfig.PatronAddress),
+                false,
+            },
+        };
+
         [Fact]
         public void Serialization()
         {
@@ -21,23 +40,34 @@ namespace Lib9c.Tests.Action.Guild
             Assert.IsType<MakeGuild>(loadedRaw);
         }
 
-        [Fact]
-        public void Execute()
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void Execute(AgentAddress guildMasterAddress, bool fail)
         {
-            var guildMasterAddress = AddressUtil.CreateAgentAddress();
-
             var action = new MakeGuild();
             IWorld world = new World(MockUtil.MockModernWorldState);
-            world = action.Execute(new ActionContext
-            {
-                PreviousState = world,
-                Signer = guildMasterAddress,
-            });
 
-            var guildAddress = world.GetJoinedGuild(guildMasterAddress);
-            Assert.NotNull(guildAddress);
-            Assert.True(world.TryGetGuild(guildAddress.Value, out var guild));
-            Assert.Equal(guildMasterAddress, guild.GuildMasterAddress);
+            if (fail)
+            {
+                Assert.Throws<InvalidOperationException>(() => action.Execute(new ActionContext
+                {
+                    PreviousState = world,
+                    Signer = guildMasterAddress,
+                }));
+            }
+            else
+            {
+                world = action.Execute(new ActionContext
+                {
+                    PreviousState = world,
+                    Signer = guildMasterAddress,
+                });
+
+                var guildAddress = world.GetJoinedGuild(guildMasterAddress);
+                Assert.NotNull(guildAddress);
+                Assert.True(world.TryGetGuild(guildAddress.Value, out var guild));
+                Assert.Equal(guildMasterAddress, guild.GuildMasterAddress);
+            }
         }
     }
 }

--- a/.Lib9c.Tests/Action/Guild/MakeGuildTest.cs
+++ b/.Lib9c.Tests/Action/Guild/MakeGuildTest.cs
@@ -7,7 +7,6 @@ namespace Lib9c.Tests.Action.Guild
     using Libplanet.Mocks;
     using Nekoyume;
     using Nekoyume.Action.Guild;
-    using Nekoyume.Action.Loader;
     using Nekoyume.Module.Guild;
     using Nekoyume.TypedAddress;
     using Xunit;
@@ -35,9 +34,8 @@ namespace Lib9c.Tests.Action.Guild
             var action = new MakeGuild();
             var plainValue = action.PlainValue;
 
-            var actionLoader = new NCActionLoader();
-            var loadedRaw = actionLoader.LoadAction(0, plainValue);
-            Assert.IsType<MakeGuild>(loadedRaw);
+            var deserialized = new MakeGuild();
+            deserialized.LoadPlainValue(plainValue);
         }
 
         [Theory]

--- a/.Lib9c.Tests/Action/Guild/QuitGuildTest.cs
+++ b/.Lib9c.Tests/Action/Guild/QuitGuildTest.cs
@@ -5,7 +5,6 @@ namespace Lib9c.Tests.Action.Guild
     using Libplanet.Action.State;
     using Libplanet.Mocks;
     using Nekoyume.Action.Guild;
-    using Nekoyume.Action.Loader;
     using Nekoyume.Module.Guild;
     using Xunit;
 
@@ -17,9 +16,8 @@ namespace Lib9c.Tests.Action.Guild
             var action = new QuitGuild();
             var plainValue = action.PlainValue;
 
-            var actionLoader = new NCActionLoader();
-            var loadedRaw = actionLoader.LoadAction(0, plainValue);
-            Assert.IsType<QuitGuild>(loadedRaw);
+            var deserialized = new QuitGuild();
+            deserialized.LoadPlainValue(plainValue);
         }
 
         [Fact]

--- a/.Lib9c.Tests/Action/Guild/RejectGuildApplicationTest.cs
+++ b/.Lib9c.Tests/Action/Guild/RejectGuildApplicationTest.cs
@@ -18,10 +18,9 @@ namespace Lib9c.Tests.Action.Guild
             var action = new RejectGuildApplication(agentAddress);
             var plainValue = action.PlainValue;
 
-            var actionLoader = new NCActionLoader();
-            var loadedRaw = actionLoader.LoadAction(0, plainValue);
-            var loadedAction = Assert.IsType<RejectGuildApplication>(loadedRaw);
-            Assert.Equal(agentAddress, loadedAction.Target);
+            var deserialized = new RejectGuildApplication();
+            deserialized.LoadPlainValue(plainValue);
+            Assert.Equal(agentAddress, deserialized.Target);
         }
 
         [Fact]

--- a/.Lib9c.Tests/Action/Guild/RemoveGuildTest.cs
+++ b/.Lib9c.Tests/Action/Guild/RemoveGuildTest.cs
@@ -5,7 +5,6 @@ namespace Lib9c.Tests.Action.Guild
     using Libplanet.Action.State;
     using Libplanet.Mocks;
     using Nekoyume.Action.Guild;
-    using Nekoyume.Action.Loader;
     using Nekoyume.Module.Guild;
     using Xunit;
 
@@ -17,9 +16,8 @@ namespace Lib9c.Tests.Action.Guild
             var action = new RemoveGuild();
             var plainValue = action.PlainValue;
 
-            var actionLoader = new NCActionLoader();
-            var loadedRaw = actionLoader.LoadAction(0, plainValue);
-            Assert.IsType<RemoveGuild>(loadedRaw);
+            var deserialized = new RemoveGuild();
+            deserialized.LoadPlainValue(plainValue);
         }
 
         [Fact]

--- a/.Lib9c.Tests/Action/Guild/UnbanGuildMemberTest.cs
+++ b/.Lib9c.Tests/Action/Guild/UnbanGuildMemberTest.cs
@@ -6,7 +6,6 @@ namespace Lib9c.Tests.Action.Guild
     using Libplanet.Crypto;
     using Libplanet.Mocks;
     using Nekoyume.Action.Guild;
-    using Nekoyume.Action.Loader;
     using Nekoyume.Module.Guild;
     using Xunit;
 
@@ -19,10 +18,9 @@ namespace Lib9c.Tests.Action.Guild
             var action = new UnbanGuildMember(guildMemberAddress);
             var plainValue = action.PlainValue;
 
-            var actionLoader = new NCActionLoader();
-            var loadedRaw = actionLoader.LoadAction(0, plainValue);
-            var loadedAction = Assert.IsType<UnbanGuildMember>(loadedRaw);
-            Assert.Equal(guildMemberAddress, loadedAction.Target);
+            var deserialized = new UnbanGuildMember();
+            deserialized.LoadPlainValue(plainValue);
+            Assert.Equal(guildMemberAddress, deserialized.Target);
         }
 
         [Fact]

--- a/Lib9c/Action/Guild/AcceptGuildApplication.cs
+++ b/Lib9c/Action/Guild/AcceptGuildApplication.cs
@@ -8,7 +8,8 @@ using Nekoyume.TypedAddress;
 
 namespace Nekoyume.Action.Guild
 {
-    [ActionType(TypeIdentifier)]
+    // TODO(GUILD-FEATURE): Enable again when Guild features are enabled.
+    // [ActionType(TypeIdentifier)]
     public class AcceptGuildApplication : ActionBase
     {
         public const string TypeIdentifier = "accept_guild_application";

--- a/Lib9c/Action/Guild/ApplyGuild.cs
+++ b/Lib9c/Action/Guild/ApplyGuild.cs
@@ -8,7 +8,8 @@ using Nekoyume.TypedAddress;
 
 namespace Nekoyume.Action.Guild
 {
-    [ActionType(TypeIdentifier)]
+    // TODO(GUILD-FEATURE): Enable again when Guild features are enabled.
+    // [ActionType(TypeIdentifier)]
     public class ApplyGuild : ActionBase
     {
         public const string TypeIdentifier = "apply_guild";

--- a/Lib9c/Action/Guild/BanGuildMember.cs
+++ b/Lib9c/Action/Guild/BanGuildMember.cs
@@ -8,7 +8,8 @@ using Nekoyume.TypedAddress;
 
 namespace Nekoyume.Action.Guild
 {
-    [ActionType(TypeIdentifier)]
+    // TODO(GUILD-FEATURE): Enable again when Guild features are enabled.
+    // [ActionType(TypeIdentifier)]
     public class BanGuildMember : ActionBase
     {
         public const string TypeIdentifier = "ban_guild_member";

--- a/Lib9c/Action/Guild/CancelGuildApplication.cs
+++ b/Lib9c/Action/Guild/CancelGuildApplication.cs
@@ -7,7 +7,8 @@ using Nekoyume.Module.Guild;
 
 namespace Nekoyume.Action.Guild
 {
-    [ActionType(TypeIdentifier)]
+    // TODO(GUILD-FEATURE): Enable again when Guild features are enabled.
+    // [ActionType(TypeIdentifier)]
     public class CancelGuildApplication : ActionBase
     {
         public const string TypeIdentifier = "cancel_guild_application";

--- a/Lib9c/Action/Guild/MakeGuild.cs
+++ b/Lib9c/Action/Guild/MakeGuild.cs
@@ -35,6 +35,13 @@ namespace Nekoyume.Action.Guild
             var world = context.PreviousState;
             var random = context.GetRandom();
 
+            // TODO: Remove this check when to deliver features to users.
+            if (context.Signer != MeadConfig.PatronAddress)
+            {
+                throw new InvalidOperationException(
+                    $"This action is not allowed for {context.Signer}.");
+            }
+
             var guildAddress = new GuildAddress(random.GenerateAddress());
             var signer = context.GetAgentAddress();
 

--- a/Lib9c/Action/Guild/QuitGuild.cs
+++ b/Lib9c/Action/Guild/QuitGuild.cs
@@ -7,7 +7,8 @@ using Nekoyume.Module.Guild;
 
 namespace Nekoyume.Action.Guild
 {
-    [ActionType(TypeIdentifier)]
+    // TODO(GUILD-FEATURE): Enable again when Guild features are enabled.
+    // [ActionType(TypeIdentifier)]
     public class QuitGuild : ActionBase
     {
         public const string TypeIdentifier = "quit_guild";

--- a/Lib9c/Action/Guild/RejectGuildApplication.cs
+++ b/Lib9c/Action/Guild/RejectGuildApplication.cs
@@ -8,7 +8,8 @@ using Nekoyume.TypedAddress;
 
 namespace Nekoyume.Action.Guild
 {
-    [ActionType(TypeIdentifier)]
+    // TODO(GUILD-FEATURE): Enable again when Guild features are enabled.
+    // [ActionType(TypeIdentifier)]
     public class RejectGuildApplication : ActionBase
     {
         public const string TypeIdentifier = "reject_guild_application";

--- a/Lib9c/Action/Guild/RemoveGuild.cs
+++ b/Lib9c/Action/Guild/RemoveGuild.cs
@@ -10,7 +10,8 @@ namespace Nekoyume.Action.Guild
     /// <summary>
     /// An action to remove the guild.
     /// </summary>
-    [ActionType(TypeIdentifier)]
+    // TODO(GUILD-FEATURE): Enable again when Guild features are enabled.
+    // [ActionType(TypeIdentifier)]
     public class RemoveGuild : ActionBase
     {
         public const string TypeIdentifier = "remove_guild";

--- a/Lib9c/Action/Guild/UnbanGuildMember.cs
+++ b/Lib9c/Action/Guild/UnbanGuildMember.cs
@@ -9,7 +9,8 @@ using Nekoyume.Module.Guild;
 
 namespace Nekoyume.Action.Guild
 {
-    [ActionType(TypeIdentifier)]
+    // TODO(GUILD-FEATURE): Enable again when Guild features are enabled.
+    // [ActionType(TypeIdentifier)]
     public class UnbanGuildMember : ActionBase
     {
         public const string TypeIdentifier = "unban_guild_member";


### PR DESCRIPTION
It resolves #2726. When I created the issue, I thought that I should write code to check permission over all guild-related actions. But I turned to disable all guild-related actions except for `MakeGuild` and to make only `MakeGuild` check signer (`context.Signer == MeadConfig.PatronAddress`)