### PR TITLE
Adjust planetarium guild owner address

### DIFF
--- a/.Lib9c.Tests/Action/Guild/MakeGuildTest.cs
+++ b/.Lib9c.Tests/Action/Guild/MakeGuildTest.cs
@@ -23,7 +23,7 @@ namespace Lib9c.Tests.Action.Guild
             },
             new object[]
             {
-                new AgentAddress(MeadConfig.PatronAddress),
+                GuildConfig.PlanetariumGuildOwner,
                 false,
             },
         };

--- a/.Lib9c.Tests/Action/Guild/Migration/GuildMigrationCtrlTest.cs
+++ b/.Lib9c.Tests/Action/Guild/Migration/GuildMigrationCtrlTest.cs
@@ -6,6 +6,7 @@ namespace Lib9c.Tests.Action.Guild.Migration
     using Libplanet.Mocks;
     using Nekoyume;
     using Nekoyume.Action;
+    using Nekoyume.Action.Guild;
     using Nekoyume.Action.Guild.Migration;
     using Nekoyume.Action.Guild.Migration.Controls;
     using Nekoyume.Extensions;
@@ -20,7 +21,7 @@ namespace Lib9c.Tests.Action.Guild.Migration
         [Fact]
         public void MigratePlanetariumPledgeToGuild_When_WithPledgeContract()
         {
-            var guildMasterAddress = new AgentAddress(MeadConfig.PatronAddress);
+            var guildMasterAddress = GuildConfig.PlanetariumGuildOwner;
             var guildAddress = AddressUtil.CreateGuildAddress();
             var target = AddressUtil.CreateAgentAddress();
             var pledgeAddress = target.GetPledgeAddress();
@@ -37,13 +38,13 @@ namespace Lib9c.Tests.Action.Guild.Migration
 
             var joinedGuildAddress = Assert.IsType<GuildAddress>(world.GetJoinedGuild(target));
             Assert.True(world.TryGetGuild(joinedGuildAddress, out var guild));
-            Assert.Equal(MeadConfig.PatronAddress, guild.GuildMasterAddress);
+            Assert.Equal(GuildConfig.PlanetariumGuildOwner, guild.GuildMasterAddress);
         }
 
         [Fact]
         public void MigratePlanetariumPledgeToGuild_When_WithoutPledgeContract()
         {
-            var guildMasterAddress = new AgentAddress(MeadConfig.PatronAddress);
+            var guildMasterAddress = GuildConfig.PlanetariumGuildOwner;
             var guildAddress = AddressUtil.CreateGuildAddress();
             var target = AddressUtil.CreateAgentAddress();
             var world = new World(MockUtil.MockModernWorldState)

--- a/.Lib9c.Tests/Action/Guild/Migration/MigratePledgeToGuildTest.cs
+++ b/.Lib9c.Tests/Action/Guild/Migration/MigratePledgeToGuildTest.cs
@@ -8,7 +8,9 @@ namespace Lib9c.Tests.Action.Guild.Migration
     using Libplanet.Mocks;
     using Nekoyume;
     using Nekoyume.Action;
+    using Nekoyume.Action.Guild;
     using Nekoyume.Action.Guild.Migration;
+    using Nekoyume.Action.Loader;
     using Nekoyume.Extensions;
     using Nekoyume.Model.State;
     using Nekoyume.Module;
@@ -19,9 +21,23 @@ namespace Lib9c.Tests.Action.Guild.Migration
     public class MigratePledgeToGuildTest
     {
         [Fact]
+        public void Serialization()
+        {
+            var agentAddress = AddressUtil.CreateAgentAddress();
+            var action = new MigratePledgeToGuild(agentAddress);
+            var plainValue = action.PlainValue;
+
+            var actionLoader = new NCActionLoader();
+            var deserialized =
+                Assert.IsType<MigratePledgeToGuild>(actionLoader.LoadAction(0, plainValue));
+
+            Assert.Equal(agentAddress, deserialized.Target);
+        }
+
+        [Fact]
         public void Execute_When_WithPledgeContract()
         {
-            var guildMasterAddress = new AgentAddress(MeadConfig.PatronAddress);
+            var guildMasterAddress = GuildConfig.PlanetariumGuildOwner;
             var guildAddress = AddressUtil.CreateGuildAddress();
             var target = AddressUtil.CreateAgentAddress();
             var caller = AddressUtil.CreateAgentAddress();
@@ -46,7 +62,7 @@ namespace Lib9c.Tests.Action.Guild.Migration
 
             var joinedGuildAddress = Assert.IsType<GuildAddress>(newWorld.GetJoinedGuild(target));
             Assert.True(newWorld.TryGetGuild(joinedGuildAddress, out var guild));
-            Assert.Equal(MeadConfig.PatronAddress, guild.GuildMasterAddress);
+            Assert.Equal(GuildConfig.PlanetariumGuildOwner, guild.GuildMasterAddress);
 
             // Migrate by itself.
             newWorld = action.Execute(new ActionContext
@@ -57,13 +73,13 @@ namespace Lib9c.Tests.Action.Guild.Migration
 
             joinedGuildAddress = Assert.IsType<GuildAddress>(newWorld.GetJoinedGuild(target));
             Assert.True(newWorld.TryGetGuild(joinedGuildAddress, out guild));
-            Assert.Equal(MeadConfig.PatronAddress, guild.GuildMasterAddress);
+            Assert.Equal(GuildConfig.PlanetariumGuildOwner, guild.GuildMasterAddress);
         }
 
         [Fact]
         public void Execute_When_WithoutPledgeContract()
         {
-            var guildMasterAddress = new AgentAddress(MeadConfig.PatronAddress);
+            var guildMasterAddress = GuildConfig.PlanetariumGuildOwner;
             var guildAddress = AddressUtil.CreateGuildAddress();
             var target = AddressUtil.CreateAgentAddress();
             var caller = AddressUtil.CreateAgentAddress();

--- a/.Lib9c.Tests/PolicyAction/Tx/Begin/AutoJoinGuildTest.cs
+++ b/.Lib9c.Tests/PolicyAction/Tx/Begin/AutoJoinGuildTest.cs
@@ -8,6 +8,7 @@ namespace Lib9c.Tests.PolicyAction.Tx.Begin
     using Libplanet.Mocks;
     using Nekoyume;
     using Nekoyume.Action;
+    using Nekoyume.Action.Guild;
     using Nekoyume.Extensions;
     using Nekoyume.Model.State;
     using Nekoyume.Module;
@@ -31,7 +32,7 @@ namespace Lib9c.Tests.PolicyAction.Tx.Begin
         [Fact]
         public void Execute_When_WithPledgeContract()
         {
-            var guildMasterAddress = new AgentAddress(MeadConfig.PatronAddress);
+            var guildMasterAddress = GuildConfig.PlanetariumGuildOwner;
             var guildAddress = AddressUtil.CreateGuildAddress();
             var agentAddress = AddressUtil.CreateAgentAddress();
             var pledgeAddress = agentAddress.GetPledgeAddress();
@@ -54,13 +55,13 @@ namespace Lib9c.Tests.PolicyAction.Tx.Begin
 
             var joinedGuildAddress = Assert.IsType<GuildAddress>(world.GetJoinedGuild(agentAddress));
             Assert.True(world.TryGetGuild(joinedGuildAddress, out var guild));
-            Assert.Equal(MeadConfig.PatronAddress, guild.GuildMasterAddress);
+            Assert.Equal(GuildConfig.PlanetariumGuildOwner, guild.GuildMasterAddress);
         }
 
         [Fact]
         public void Execute_When_WithoutPledgeContract()
         {
-            var guildMasterAddress = new AgentAddress(MeadConfig.PatronAddress);
+            var guildMasterAddress = GuildConfig.PlanetariumGuildOwner;
             var guildAddress = AddressUtil.CreateGuildAddress();
             var agentAddress = AddressUtil.CreateAgentAddress();
             var world = new World(MockUtil.MockModernWorldState)

--- a/Lib9c/Action/Guild/GuildConfig.cs
+++ b/Lib9c/Action/Guild/GuildConfig.cs
@@ -1,0 +1,10 @@
+using Nekoyume.TypedAddress;
+
+namespace Nekoyume.Action.Guild
+{
+    public static class GuildConfig
+    {
+        public static readonly AgentAddress PlanetariumGuildOwner =
+            new AgentAddress("0x7ac50B13A7AA08DeeF21532a526EBbabBA6d3e6A");
+    }
+}

--- a/Lib9c/Action/Guild/MakeGuild.cs
+++ b/Lib9c/Action/Guild/MakeGuild.cs
@@ -36,7 +36,7 @@ namespace Nekoyume.Action.Guild
             var random = context.GetRandom();
 
             // TODO: Remove this check when to deliver features to users.
-            if (context.Signer != MeadConfig.PatronAddress)
+            if (context.Signer != GuildConfig.PlanetariumGuildOwner)
             {
                 throw new InvalidOperationException(
                     $"This action is not allowed for {context.Signer}.");

--- a/Lib9c/Action/Guild/Migration/Controls/GuildMigrationCtrl.cs
+++ b/Lib9c/Action/Guild/Migration/Controls/GuildMigrationCtrl.cs
@@ -14,7 +14,7 @@ namespace Nekoyume.Action.Guild.Migration.Controls
     {
         /// <summary>
         /// Migrate the pledge to the guild if the <paramref name="target"/> has contracted pledge
-        /// with Planetarium (<see cref="MeadConfig.PatronAddress"/>).
+        /// with Planetarium (<see cref="GuildConfig.PlanetariumGuildOwner"/>).
         /// </summary>
         /// <param name="world"></param>
         /// <param name="target"></param>
@@ -22,8 +22,8 @@ namespace Nekoyume.Action.Guild.Migration.Controls
         /// <exception cref="GuildMigrationFailedException">Migration to guild from pledge failed.</exception>
         public static IWorld MigratePlanetariumPledgeToGuild(IWorld world, AgentAddress target)
         {
-            var planetariumPatronAddress = new AgentAddress(MeadConfig.PatronAddress);
-            if (world.GetJoinedGuild(planetariumPatronAddress) is not { } planetariumGuildAddress)
+            if (world.GetJoinedGuild(GuildConfig.PlanetariumGuildOwner) is not
+                { } planetariumGuildAddress)
             {
                 throw new GuildMigrationFailedException("Planetarium guild is not found.");
             }
@@ -33,7 +33,7 @@ namespace Nekoyume.Action.Guild.Migration.Controls
                 throw new GuildMigrationFailedException("Planetarium guild is not found.");
             }
 
-            if (planetariumGuild.GuildMasterAddress != planetariumPatronAddress)
+            if (planetariumGuild.GuildMasterAddress != GuildConfig.PlanetariumGuildOwner)
             {
                 throw new GuildMigrationFailedException("Unexpected guild master.");
             }

--- a/Lib9c/Action/Guild/Migration/MigratePledgeToGuild.cs
+++ b/Lib9c/Action/Guild/Migration/MigratePledgeToGuild.cs
@@ -32,7 +32,8 @@ namespace Nekoyume.Action.Guild.Migration
 
         public override IValue PlainValue => Dictionary.Empty
             .Add("type_id", TypeIdentifier)
-            .Add("values", Dictionary.Empty);
+            .Add("values", Dictionary.Empty
+                .Add(TargetKey, Target.Bencoded));
 
         public override void LoadPlainValue(IValue plainValue)
         {


### PR DESCRIPTION
This pull request:
 - Adjust Planetarium's guild owner address.
 - Fix a serialization bug in `MigratePledgeToGuild`	 action (active migration action)