### PR TITLE
Apply heimdall internal snapshot reset

### DIFF
--- a/Lib9c.Policy/Policy/MaxTransactionsBytesPolicy.cs
+++ b/Lib9c.Policy/Policy/MaxTransactionsBytesPolicy.cs
@@ -66,7 +66,7 @@ namespace Nekoyume.Blockchain.Policy
                 // Note: Limit increase to patch table with big CSV.
                 // Issued for v200220
                 .Add(new SpannedSubPolicy<long>(
-                    startIndex: 3_051_001L,
+                    startIndex: 3_031_001L,
                     value: 1024L * 1024L));          // 1 MiB
 
         // Note: For internal testing.


### PR DESCRIPTION
Heimdall block is rolled back due to snapshot reset.
Apply new policy from rolled back block index.