### PR TITLE
Refactor `AvatarState` constructor

### DIFF
--- a/.Lib9c.DevExtensions.Tests/Action/FaucetRuneTest.cs
+++ b/.Lib9c.DevExtensions.Tests/Action/FaucetRuneTest.cs
@@ -48,7 +48,7 @@ namespace Lib9c.DevExtensions.Tests.Action
             Address agentAddress = new PrivateKey().Address;
             _avatarAddress = new PrivateKey().Address;
             var agentState = new AgentState(agentAddress);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 agentAddress,
                 0,

--- a/.Lib9c.Tests/Action/AccountStateDeltaExtensionsTest.cs
+++ b/.Lib9c.Tests/Action/AccountStateDeltaExtensionsTest.cs
@@ -30,7 +30,7 @@ namespace Lib9c.Tests.Action
             _agentState = new AgentState(_agentAddress);
             _agentState.avatarAddresses[0] = _avatarAddress;
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,

--- a/.Lib9c.Tests/Action/AccountStateViewExtensionsTest.cs
+++ b/.Lib9c.Tests/Action/AccountStateViewExtensionsTest.cs
@@ -37,7 +37,7 @@ namespace Lib9c.Tests.Action
             _agentState = new AgentState(_agentAddress);
             _agentState.avatarAddresses[0] = _avatarAddress;
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,

--- a/.Lib9c.Tests/Action/ActivateCollectionTest.cs
+++ b/.Lib9c.Tests/Action/ActivateCollectionTest.cs
@@ -38,16 +38,15 @@ namespace Lib9c.Tests.Action
 
             _avatarAddress = _agentAddress.Derive("avatar");
             var gameConfigState = new GameConfigState(sheets[nameof(GameConfigSheet)]);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
                 default
-            )
-            {
-                level = 100,
-            };
+            );
+            avatarState.level = 100;
+
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
             _initialState = new World(MockUtil.MockModernWorldState)

--- a/.Lib9c.Tests/Action/AdventureBoss/ClaimAdventureBossRewardTest.cs
+++ b/.Lib9c.Tests/Action/AdventureBoss/ClaimAdventureBossRewardTest.cs
@@ -41,9 +41,13 @@ namespace Lib9c.Tests.Action.AdventureBoss
         private static readonly Address WantedAvatarAddress =
             Addresses.GetAvatarAddress(WantedAddress, 0);
 
-        private static readonly AvatarState WantedAvatarState = new (
-            WantedAvatarAddress, WantedAddress, 0L, TableSheets.GetAvatarSheets(),
-            new PrivateKey().Address, name: "wanted"
+        private static readonly AvatarState WantedAvatarState = AvatarState.Create(
+            WantedAvatarAddress,
+            WantedAddress,
+            0L,
+            TableSheets.GetAvatarSheets(),
+            new PrivateKey().Address,
+            name: "wanted"
         );
 
         private static readonly AgentState WantedState = new (WantedAddress)
@@ -58,9 +62,13 @@ namespace Lib9c.Tests.Action.AdventureBoss
         private static readonly Address ExplorerAvatarAddress =
             Addresses.GetAvatarAddress(ExplorerAddress, 0);
 
-        private static readonly AvatarState ExplorerAvatarState = new (
-            ExplorerAvatarAddress, ExplorerAddress, 0L, TableSheets.GetAvatarSheets(),
-            new PrivateKey().Address, name: "explorer"
+        private static readonly AvatarState ExplorerAvatarState = AvatarState.Create(
+            ExplorerAvatarAddress,
+            ExplorerAddress,
+            0L,
+            TableSheets.GetAvatarSheets(),
+            new PrivateKey().Address,
+            name: "explorer"
         );
 
         private static readonly AgentState ExplorerState = new (ExplorerAddress)
@@ -78,9 +86,13 @@ namespace Lib9c.Tests.Action.AdventureBoss
         private static readonly Address TesterAvatarAddress =
             Addresses.GetAvatarAddress(TesterAddress, 0);
 
-        private static readonly AvatarState TesterAvatarState = new (
-            TesterAvatarAddress, TesterAddress, 0L, TableSheets.GetAvatarSheets(),
-            new PrivateKey().Address, name: "Tester"
+        private static readonly AvatarState TesterAvatarState = AvatarState.Create(
+            TesterAvatarAddress,
+            TesterAddress,
+            0L,
+            TableSheets.GetAvatarSheets(),
+            new PrivateKey().Address,
+            name: "Tester"
         );
 
         private static readonly AgentState TesterState = new (TesterAddress)

--- a/.Lib9c.Tests/Action/AdventureBoss/ExploreAdventureBossTest.cs
+++ b/.Lib9c.Tests/Action/AdventureBoss/ExploreAdventureBossTest.cs
@@ -38,9 +38,13 @@ namespace Lib9c.Tests.Action.AdventureBoss
         private static readonly Address WantedAvatarAddress =
             Addresses.GetAvatarAddress(WantedAddress, 0);
 
-        private static readonly AvatarState WantedAvatarState = new (
-            WantedAvatarAddress, WantedAddress, 0L, TableSheets.GetAvatarSheets(),
-            new PrivateKey().Address, name: "wanted"
+        private static readonly AvatarState WantedAvatarState = AvatarState.Create(
+            WantedAvatarAddress,
+            WantedAddress,
+            0L,
+            TableSheets.GetAvatarSheets(),
+            new PrivateKey().Address,
+            name: "wanted"
         );
 
         private static readonly AgentState WantedState = new (WantedAddress)
@@ -55,10 +59,14 @@ namespace Lib9c.Tests.Action.AdventureBoss
         private static readonly Address TesterAvatarAddress =
             Addresses.GetAvatarAddress(TesterAddress, 0);
 
-        private static readonly AvatarState TesterAvatarState = new (
-            TesterAvatarAddress, TesterAddress, 0L, TableSheets.GetAvatarSheets(),
-            new PrivateKey().Address, name: "Tester"
-        ) { level = 500 };
+        private static readonly AvatarState TesterAvatarState = AvatarState.Create(
+            TesterAvatarAddress,
+            TesterAddress,
+            0L,
+            TableSheets.GetAvatarSheets(),
+            new PrivateKey().Address,
+            name: "Tester"
+        );
 
         private static readonly AgentState TesterState = new (TesterAddress)
         {
@@ -79,6 +87,11 @@ namespace Lib9c.Tests.Action.AdventureBoss
             .SetAvatarState(TesterAvatarAddress, TesterAvatarState)
             .SetAgentState(TesterAddress, TesterState)
             .MintAsset(new ActionContext(), WantedAddress, 1_000_000 * NCG);
+
+        static ExploreAdventureBossTest()
+        {
+            TesterAvatarState.level = 500;
+        }
 
         public ExploreAdventureBossTest()
         {

--- a/.Lib9c.Tests/Action/AdventureBoss/SweepAdventureBossTest.cs
+++ b/.Lib9c.Tests/Action/AdventureBoss/SweepAdventureBossTest.cs
@@ -37,9 +37,13 @@ namespace Lib9c.Tests.Action.AdventureBoss
         private static readonly Address WantedAvatarAddress =
             Addresses.GetAvatarAddress(WantedAddress, 0);
 
-        private static readonly AvatarState WantedAvatarState = new (
-            WantedAvatarAddress, WantedAddress, 0L, TableSheets.GetAvatarSheets(),
-            new PrivateKey().Address, name: "wanted"
+        private static readonly AvatarState WantedAvatarState = AvatarState.Create(
+            WantedAvatarAddress,
+            WantedAddress,
+            0L,
+            TableSheets.GetAvatarSheets(),
+            new PrivateKey().Address,
+            name: "wanted"
         );
 
         private static readonly AgentState WantedState = new (WantedAddress)
@@ -54,9 +58,13 @@ namespace Lib9c.Tests.Action.AdventureBoss
         private static readonly Address TesterAvatarAddress =
             Addresses.GetAvatarAddress(TesterAddress, 0);
 
-        private static readonly AvatarState TesterAvatarState = new (
-            TesterAvatarAddress, TesterAddress, 0L, TableSheets.GetAvatarSheets(),
-            new PrivateKey().Address, name: "Tester"
+        private static readonly AvatarState TesterAvatarState = AvatarState.Create(
+            TesterAvatarAddress,
+            TesterAddress,
+            0L,
+            TableSheets.GetAvatarSheets(),
+            new PrivateKey().Address,
+            name: "Tester"
         );
 
         private static readonly AgentState TesterState = new (TesterAddress)

--- a/.Lib9c.Tests/Action/AdventureBoss/UnlockFloorTest.cs
+++ b/.Lib9c.Tests/Action/AdventureBoss/UnlockFloorTest.cs
@@ -35,9 +35,13 @@ namespace Lib9c.Tests.Action.AdventureBoss
         private static readonly Address WantedAvatarAddress =
             Addresses.GetAvatarAddress(WantedAddress, 0);
 
-        private static readonly AvatarState WantedAvatarState = new (
-            WantedAvatarAddress, WantedAddress, 0L, TableSheets.GetAvatarSheets(),
-            new PrivateKey().Address, name: "wanted"
+        private static readonly AvatarState WantedAvatarState = AvatarState.Create(
+            WantedAvatarAddress,
+            WantedAddress,
+            0L,
+            TableSheets.GetAvatarSheets(),
+            new PrivateKey().Address,
+            name: "wanted"
         );
 
         private static readonly AgentState WantedState = new (WantedAddress)
@@ -52,9 +56,13 @@ namespace Lib9c.Tests.Action.AdventureBoss
         private static readonly Address TesterAvatarAddress =
             Addresses.GetAvatarAddress(TesterAddress, 0);
 
-        private static readonly AvatarState TesterAvatarState = new (
-            TesterAvatarAddress, TesterAddress, 0L, TableSheets.GetAvatarSheets(),
-            new PrivateKey().Address, name: "Tester"
+        private static readonly AvatarState TesterAvatarState = AvatarState.Create(
+            TesterAvatarAddress,
+            TesterAddress,
+            0L,
+            TableSheets.GetAvatarSheets(),
+            new PrivateKey().Address,
+            name: "Tester"
         );
 
         private static readonly AgentState TesterState = new (TesterAddress)

--- a/.Lib9c.Tests/Action/AdventureBoss/WantedTest.cs
+++ b/.Lib9c.Tests/Action/AdventureBoss/WantedTest.cs
@@ -35,8 +35,11 @@ namespace Lib9c.Tests.Action.AdventureBoss
         private static readonly Address AgentAddress = new PrivateKey().Address;
         private static readonly Address AvatarAddress = Addresses.GetAvatarAddress(AgentAddress, 0);
 
-        private static readonly AvatarState AvatarState = new (
-            AvatarAddress, AgentAddress, 0L, TableSheets.GetAvatarSheets(),
+        private static readonly AvatarState AvatarState = AvatarState.Create(
+            AvatarAddress,
+            AgentAddress,
+            0L,
+            TableSheets.GetAvatarSheets(),
             new PrivateKey().Address,
             name: "avatar1"
         );
@@ -44,8 +47,11 @@ namespace Lib9c.Tests.Action.AdventureBoss
         private static readonly Address
             AvatarAddress2 = Addresses.GetAvatarAddress(AgentAddress, 1);
 
-        private static readonly AvatarState AvatarState2 = new (
-            AvatarAddress2, AgentAddress, 0L, TableSheets.GetAvatarSheets(),
+        private static readonly AvatarState AvatarState2 = AvatarState.Create(
+            AvatarAddress2,
+            AgentAddress,
+            0L,
+            TableSheets.GetAvatarSheets(),
             new PrivateKey().Address,
             name: "avatar2"
         );

--- a/.Lib9c.Tests/Action/ArenahelperTest.cs
+++ b/.Lib9c.Tests/Action/ArenahelperTest.cs
@@ -92,18 +92,17 @@ namespace Lib9c.Tests.Action
             var agentState = new AgentState(agentAddress);
 
             var avatarAddress = agentAddress.Derive("avatar");
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,
                 tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    tableSheets.WorldSheet,
-                    clearStageId),
-            };
+                rankingMapAddress);
+            avatarState.worldInformation = new WorldInformation(
+                0,
+                tableSheets.WorldSheet,
+                clearStageId);
+
             agentState.avatarAddresses.Add(0, avatarAddress);
 
             return (agentState, avatarState);

--- a/.Lib9c.Tests/Action/BattleArenaTest.cs
+++ b/.Lib9c.Tests/Action/BattleArenaTest.cs
@@ -1061,18 +1061,17 @@ namespace Lib9c.Tests.Action
             var agentState = new AgentState(agentAddress);
 
             var avatarAddress = agentAddress.Derive("avatar");
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,
                 tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    tableSheets.WorldSheet,
-                    clearStageId),
-            };
+                rankingMapAddress);
+            avatarState.worldInformation = new WorldInformation(
+                0,
+                tableSheets.WorldSheet,
+                clearStageId);
+
             agentState.avatarAddresses.Add(0, avatarAddress);
 
             return (agentState, avatarState);

--- a/.Lib9c.Tests/Action/BuyMultipleTest.cs
+++ b/.Lib9c.Tests/Action/BuyMultipleTest.cs
@@ -58,18 +58,17 @@ namespace Lib9c.Tests.Action
             var buyerAgentState = new AgentState(_buyerAgentAddress);
             _buyerAvatarAddress = new PrivateKey().Address;
             var rankingMapAddress = new PrivateKey().Address;
-            _buyerAvatarState = new AvatarState(
+            _buyerAvatarState = AvatarState.Create(
                 _buyerAvatarAddress,
                 _buyerAgentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    _tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-            };
+                rankingMapAddress);
+            _buyerAvatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
+
             buyerAgentState.avatarAddresses[0] = _buyerAvatarAddress;
 
             var shopState = new ShopState();
@@ -613,18 +612,17 @@ namespace Lib9c.Tests.Action
             var agentState = new AgentState(agentAddress);
             var rankingMapAddress = new PrivateKey().Address;
 
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    _tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-            };
+                rankingMapAddress);
+            avatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
+
             agentState.avatarAddresses[0] = avatarAddress;
             _sellerAgentStateMap[avatarState] = agentState;
 

--- a/.Lib9c.Tests/Action/BuyProductTest.cs
+++ b/.Lib9c.Tests/Action/BuyProductTest.cs
@@ -62,50 +62,47 @@ namespace Lib9c.Tests.Action
 
             var sellerAgentState = new AgentState(SellerAgentAddress);
             var rankingMapAddress = new PrivateKey().Address;
-            var sellerAvatarState = new AvatarState(
+            var sellerAvatarState = AvatarState.Create(
                 SellerAvatarAddress,
                 SellerAgentAddress,
                 0,
                 TableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    TableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-            };
+                rankingMapAddress);
+            sellerAvatarState.worldInformation = new WorldInformation(
+                0,
+                TableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
+
             sellerAgentState.avatarAddresses[0] = SellerAvatarAddress;
 
             _sellerAgentAddress2 = new PrivateKey().Address;
             var agentState2 = new AgentState(_sellerAgentAddress2);
             _sellerAvatarAddress2 = new PrivateKey().Address;
-            var sellerAvatarState2 = new AvatarState(
+            var sellerAvatarState2 = AvatarState.Create(
                 _sellerAvatarAddress2,
                 _sellerAgentAddress2,
                 0,
                 TableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    TableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-            };
+                rankingMapAddress);
+            sellerAvatarState2.worldInformation = new WorldInformation(
+                0,
+                TableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
+
             agentState2.avatarAddresses[0] = _sellerAvatarAddress2;
 
             var buyerAgentState = new AgentState(BuyerAgentAddress);
-            _buyerAvatarState = new AvatarState(
+            _buyerAvatarState = AvatarState.Create(
                 BuyerAvatarAddress,
                 BuyerAgentAddress,
                 0,
                 TableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    TableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-            };
+                rankingMapAddress);
+            _buyerAvatarState.worldInformation = new WorldInformation(
+                0,
+                TableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
+
             buyerAgentState.avatarAddresses[0] = BuyerAvatarAddress;
 
             _orderId = new Guid("6d460c1a-755d-48e4-ad67-65d5f519dbc8");

--- a/.Lib9c.Tests/Action/BuyTest.cs
+++ b/.Lib9c.Tests/Action/BuyTest.cs
@@ -67,35 +67,33 @@ namespace Lib9c.Tests.Action
             var sellerAgentState = new AgentState(_sellerAgentAddress);
             _sellerAvatarAddress = new PrivateKey().Address;
             var rankingMapAddress = new PrivateKey().Address;
-            var sellerAvatarState = new AvatarState(
+            var sellerAvatarState = AvatarState.Create(
                 _sellerAvatarAddress,
                 _sellerAgentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    _tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-            };
+                rankingMapAddress);
+            sellerAvatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
+
             sellerAgentState.avatarAddresses[0] = _sellerAvatarAddress;
 
             _buyerAgentAddress = new PrivateKey().Address;
             var buyerAgentState = new AgentState(_buyerAgentAddress);
             _buyerAvatarAddress = new PrivateKey().Address;
-            _buyerAvatarState = new AvatarState(
+            _buyerAvatarState = AvatarState.Create(
                 _buyerAvatarAddress,
                 _buyerAgentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    _tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-            };
+                rankingMapAddress);
+            _buyerAvatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
+
             buyerAgentState.avatarAddresses[0] = _buyerAvatarAddress;
 
             _orderId = new Guid("6d460c1a-755d-48e4-ad67-65d5f519dbc8");
@@ -965,18 +963,17 @@ namespace Lib9c.Tests.Action
             var agentState = new AgentState(agentAddress);
             var rankingMapAddress = new PrivateKey().Address;
 
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    _tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-            };
+                rankingMapAddress);
+            avatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
+
             agentState.avatarAddresses[0] = avatarAddress;
 
             _initialState = _initialState

--- a/.Lib9c.Tests/Action/CancelProductRegistrationTest.cs
+++ b/.Lib9c.Tests/Action/CancelProductRegistrationTest.cs
@@ -55,18 +55,17 @@ namespace Lib9c.Tests.Action
             _avatarAddress = new PrivateKey().Address;
             _gameConfigState = new GameConfigState((Text)_tableSheets.GameConfigSheet.Serialize());
             var rankingMapAddress = new PrivateKey().Address;
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    _tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-            };
+                rankingMapAddress);
+            avatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
+
             agentState.avatarAddresses[0] = _avatarAddress;
 
             _initialState = _initialState

--- a/.Lib9c.Tests/Action/ChargeActionPointTest.cs
+++ b/.Lib9c.Tests/Action/ChargeActionPointTest.cs
@@ -34,7 +34,7 @@ namespace Lib9c.Tests.Action
 
             _avatarAddress = _agentAddress.Derive("avatar");
             var gameConfigState = new GameConfigState(_sheets[nameof(GameConfigSheet)]);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,

--- a/.Lib9c.Tests/Action/ClaimItemsTest.cs
+++ b/.Lib9c.Tests/Action/ClaimItemsTest.cs
@@ -330,18 +330,17 @@ namespace Lib9c.Tests.Action
             var agentState = new AgentState(agentAddress);
             avatarAddress = agentAddress.Derive("avatar");
             var rankingMapAddress = new PrivateKey().Address;
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    _tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-            };
+                rankingMapAddress);
+            avatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
+
             agentState.avatarAddresses[0] = avatarAddress;
 
             state = state

--- a/.Lib9c.Tests/Action/ClaimWorldBossKillRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimWorldBossKillRewardTest.cs
@@ -57,7 +57,7 @@ namespace Lib9c.Tests.Action
 
             var rankingMapAddress = avatarAddress.Derive("ranking_map");
             var gameConfigState = new GameConfigState(sheets[nameof(GameConfigSheet)]);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,

--- a/.Lib9c.Tests/Action/CombinationConsumableTest.cs
+++ b/.Lib9c.Tests/Action/CombinationConsumableTest.cs
@@ -42,7 +42,7 @@ namespace Lib9c.Tests.Action
             var agentState = new AgentState(_agentAddress);
             agentState.avatarAddresses[0] = _avatarAddress;
 
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 1,

--- a/.Lib9c.Tests/Action/CombinationEquipmentTest.cs
+++ b/.Lib9c.Tests/Action/CombinationEquipmentTest.cs
@@ -60,7 +60,7 @@ namespace Lib9c.Tests.Action
 
             var gameConfigState = new GameConfigState();
 
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 1,

--- a/.Lib9c.Tests/Action/CreateAvatarTest.cs
+++ b/.Lib9c.Tests/Action/CreateAvatarTest.cs
@@ -143,7 +143,7 @@ namespace Lib9c.Tests.Action
                 )
             );
 
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 _agentAddress,
                 0,
@@ -244,7 +244,7 @@ namespace Lib9c.Tests.Action
 10512000,2
 600201,2
 ");
-            var avatarState = new AvatarState(default, default, 0L, _tableSheets.GetAvatarSheets(), default, "test");
+            var avatarState = AvatarState.Create(default, default, 0L, _tableSheets.GetAvatarSheets(), default, "test");
             CreateAvatar.AddItem(itemSheet, createAvatarItemSheet, avatarState, new TestRandom());
             foreach (var row in createAvatarItemSheet.Values)
             {
@@ -269,7 +269,7 @@ RUNE_GOLDENLEAF,200000,Avatar
 ");
             var avatarAddress = new PrivateKey().Address;
             var agentAddress = new PrivateKey().Address;
-            var avatarState = new AvatarState(avatarAddress, agentAddress, 0L, _tableSheets.GetAvatarSheets(), default, "test");
+            var avatarState = AvatarState.Create(avatarAddress, agentAddress, 0L, _tableSheets.GetAvatarSheets(), default, "test");
             var nextState = CreateAvatar.MintAsset(createAvatarFavSheet, avatarState, new World(MockUtil.MockModernWorldState), new ActionContext());
             foreach (var row in createAvatarFavSheet.Values)
             {

--- a/.Lib9c.Tests/Action/CustomEquipmentCraft/CustomEquipmentCraftTest.cs
+++ b/.Lib9c.Tests/Action/CustomEquipmentCraft/CustomEquipmentCraftTest.cs
@@ -56,7 +56,7 @@ namespace Lib9c.Tests.Action.CustomEquipmentCraft
                 },
             };
 
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 _avatarAddress, _agentAddress, 0, _tableSheets.GetAvatarSheets(), default
             );
 #pragma warning disable CS0618

--- a/.Lib9c.Tests/Action/EventConsumableItemCraftsTest.cs
+++ b/.Lib9c.Tests/Action/EventConsumableItemCraftsTest.cs
@@ -42,16 +42,14 @@ namespace Lib9c.Tests.Action
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
             var gameConfigState = new GameConfigState(sheets[nameof(GameConfigSheet)]);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
                 new PrivateKey().Address
-            )
-            {
-                level = 100,
-            };
+            );
+            avatarState.level = 100;
 
             var allSlotState = new AllCombinationSlotState();
             for (var i = 0; i < AvatarState.DefaultCombinationSlotCount; i++)

--- a/.Lib9c.Tests/Action/EventDungeonBattleTest.cs
+++ b/.Lib9c.Tests/Action/EventDungeonBattleTest.cs
@@ -56,16 +56,14 @@ namespace Lib9c.Tests.Action
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
             var gameConfigState = new GameConfigState(sheets[nameof(GameConfigSheet)]);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
                 new PrivateKey().Address
-            )
-            {
-                level = 100,
-            };
+            );
+            avatarState.level = 100;
 
             _initialStates = _initialStates
                 .SetAgentState(_agentAddress, agentState)

--- a/.Lib9c.Tests/Action/EventMaterialItemCraftsTest.cs
+++ b/.Lib9c.Tests/Action/EventMaterialItemCraftsTest.cs
@@ -45,16 +45,14 @@ namespace Lib9c.Tests.Action
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
             var gameConfigState = new GameConfigState(sheets[nameof(GameConfigSheet)]);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
                 new PrivateKey().Address
-            )
-            {
-                level = 100,
-            };
+            );
+            avatarState.level = 100;
 
             _initialStates = _initialStates
                 .SetAgentState(_agentAddress, agentState)

--- a/.Lib9c.Tests/Action/GrindingTest.cs
+++ b/.Lib9c.Tests/Action/GrindingTest.cs
@@ -45,7 +45,7 @@ namespace Lib9c.Tests.Action
             var gameConfigState = new GameConfigState(sheets[nameof(GameConfigSheet)]);
 
             _agentState = new AgentState(_agentAddress);
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,

--- a/.Lib9c.Tests/Action/HackAndSlashRandomBuffTest.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashRandomBuffTest.cs
@@ -50,16 +50,15 @@ namespace Lib9c.Tests.Action
             var gameConfigState = new GameConfigState(_sheets[nameof(GameConfigSheet)]);
             _rankingMapAddress = _avatarAddress.Derive("ranking_map");
             _currency = CrystalCalculator.CRYSTAL;
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
                 _rankingMapAddress
-            )
-            {
-                level = 100,
-            };
+            );
+            _avatarState.level = 100;
+
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
             _weeklyArenaState = new WeeklyArenaState(0);
@@ -95,17 +94,16 @@ namespace Lib9c.Tests.Action
             var context = new ActionContext();
             var states = _initialState.MintAsset(context, _agentAddress, balance * _currency);
             var gameConfigState = _initialState.GetGameConfigState();
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _initialState.GetAvatarSheets(),
-                _rankingMapAddress)
-            {
-                worldInformation =
-                    new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), stageId),
-                level = 400,
-            };
+                _rankingMapAddress);
+            avatarState.worldInformation =
+                new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), stageId);
+            avatarState.level = 400;
+
             var gachaStateAddress = Addresses.GetSkillStateAddressFromAvatarAddress(_avatarAddress);
             var gachaState = new CrystalRandomSkillState(gachaStateAddress, stageId);
             states = states.SetAvatarState(_avatarAddress, avatarState);
@@ -156,17 +154,16 @@ namespace Lib9c.Tests.Action
             var context = new ActionContext();
             var states = _initialState.MintAsset(context, _agentAddress, 100_000_000 * _currency);
             var gameConfigState = _initialState.GetGameConfigState();
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _initialState.GetAvatarSheets(),
-                _rankingMapAddress)
-            {
-                worldInformation =
-                    new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 1),
-                level = 400,
-            };
+                _rankingMapAddress);
+            avatarState.worldInformation =
+                new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 1);
+            avatarState.level = 400;
+
             var gachaStateAddress = Addresses.GetSkillStateAddressFromAvatarAddress(_avatarAddress);
             var gachaState = new CrystalRandomSkillState(gachaStateAddress, 1);
             states = states.SetAvatarState(_avatarAddress, avatarState);

--- a/.Lib9c.Tests/Action/HackAndSlashSweepTest.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashSweepTest.cs
@@ -50,16 +50,15 @@ namespace Lib9c.Tests.Action
             _avatarAddress = _agentAddress.Derive("avatar");
             var gameConfigState = new GameConfigState(_sheets[nameof(GameConfigSheet)]);
             _rankingMapAddress = _avatarAddress.Derive("ranking_map");
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
                 _rankingMapAddress
-            )
-            {
-                level = 100,
-            };
+            );
+            _avatarState.level = 100;
+
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
 #pragma warning disable CS0618
@@ -230,16 +229,14 @@ namespace Lib9c.Tests.Action
         public void Execute_InvalidWorldException(int worldId, int stageId, bool unlockedIdsExist)
         {
             var gameConfigState = new GameConfigState(_sheets[nameof(GameConfigSheet)]);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _initialState.GetAvatarSheets(),
-                _rankingMapAddress)
-            {
-                worldInformation =
-                    new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 10000001),
-            };
+                _rankingMapAddress);
+            avatarState.worldInformation =
+                new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 10000001);
 
             IWorld state = _initialState.SetAvatarState(_avatarAddress, avatarState);
 
@@ -272,16 +269,14 @@ namespace Lib9c.Tests.Action
         public void Execute_UsageLimitExceedException()
         {
             var gameConfigState = new GameConfigState(_sheets[nameof(GameConfigSheet)]);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _initialState.GetAvatarSheets(),
-                _rankingMapAddress)
-            {
-                worldInformation =
-                    new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 25),
-            };
+                _rankingMapAddress);
+            avatarState.worldInformation =
+                new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 25);
 
             IWorld state = _initialState.SetAvatarState(_avatarAddress, avatarState);
 
@@ -308,17 +303,15 @@ namespace Lib9c.Tests.Action
         public void Execute_NotEnoughMaterialException(int useApStoneCount, int holdingApStoneCount)
         {
             var gameConfigState = _initialState.GetGameConfigState();
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _initialState.GetAvatarSheets(),
-                _rankingMapAddress)
-            {
-                worldInformation =
-                    new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 25),
-                level = 400,
-            };
+                _rankingMapAddress);
+            avatarState.worldInformation =
+                new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 25);
+            avatarState.level = 400;
 
             var row = _tableSheets.MaterialItemSheet.Values.First(r =>
                 r.ItemSubType == ItemSubType.ApStone);
@@ -368,17 +361,15 @@ namespace Lib9c.Tests.Action
         public void Execute_NotEnoughActionPointException()
         {
             var gameConfigState = _initialState.GetGameConfigState();
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _initialState.GetAvatarSheets(),
-                _rankingMapAddress)
-            {
-                worldInformation =
-                    new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 25),
-                level = 400,
-            };
+                _rankingMapAddress);
+            avatarState.worldInformation =
+                new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 25);
+            avatarState.level = 400;
 
             IWorld state = _initialState.SetAvatarState(_avatarAddress, avatarState)
                 .SetActionPoint(_avatarAddress, 0);
@@ -424,17 +415,15 @@ namespace Lib9c.Tests.Action
         public void Execute_PlayCountIsZeroException()
         {
             var gameConfigState = _initialState.GetGameConfigState();
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _initialState.GetAvatarSheets(),
-                _rankingMapAddress)
-            {
-                worldInformation =
-                    new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 25),
-                level = 400,
-            };
+                _rankingMapAddress);
+            avatarState.worldInformation =
+                new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 25);
+            avatarState.level = 400;
 
             IWorld state = _initialState.SetAvatarState(_avatarAddress, avatarState)
                 .SetActionPoint(_avatarAddress, 0);
@@ -480,17 +469,15 @@ namespace Lib9c.Tests.Action
         public void Execute_NotEnoughCombatPointException()
         {
             var gameConfigState = _initialState.GetGameConfigState();
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _initialState.GetAvatarSheets(),
-                _rankingMapAddress)
-            {
-                worldInformation =
-                    new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 25),
-                level = 1,
-            };
+                _rankingMapAddress);
+            avatarState.worldInformation =
+                new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 25);
+            avatarState.level = 1;
 
             IWorld state = _initialState.SetAvatarState(_avatarAddress, avatarState)
                 .SetActionPoint(_avatarAddress, 0);
@@ -543,17 +530,16 @@ namespace Lib9c.Tests.Action
             const int worldId = 1;
             const int stageId = 1;
             var gameConfigState = _initialState.GetGameConfigState();
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _initialState.GetAvatarSheets(),
-                _rankingMapAddress)
-            {
-                worldInformation =
-                    new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 25),
-                level = 3,
-            };
+                _rankingMapAddress);
+            avatarState.worldInformation =
+                new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 25);
+            avatarState.level = 3;
+
             var itemRow = _tableSheets.MaterialItemSheet.Values.First(r =>
                 r.ItemSubType == ItemSubType.ApStone);
             var apStone = ItemFactory.CreateTradableMaterial(itemRow);
@@ -620,17 +606,16 @@ namespace Lib9c.Tests.Action
             const int worldId = 1;
             const int stageId = 1;
             var gameConfigState = _initialState.GetGameConfigState();
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _initialState.GetAvatarSheets(),
-                _rankingMapAddress)
-            {
-                worldInformation =
-                    new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 25),
-                level = 3,
-            };
+                _rankingMapAddress);
+            avatarState.worldInformation =
+                new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 25);
+            avatarState.level = 3;
+
             var itemRow = _tableSheets.MaterialItemSheet.Values.First(r =>
                 r.ItemSubType == ItemSubType.ApStone);
             var apStone = ItemFactory.CreateTradableMaterial(itemRow);
@@ -713,17 +698,15 @@ namespace Lib9c.Tests.Action
         [InlineData(int.MinValue + 1, 0)]
         public void Execute_ArgumentOutOfRangeException(int ap, int apPotion)
         {
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _initialState.GetAvatarSheets(),
-                _rankingMapAddress)
-            {
-                worldInformation =
-                    new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 25),
-                level = 400,
-            };
+                _rankingMapAddress);
+            avatarState.worldInformation =
+                new WorldInformation(0, _initialState.GetSheet<WorldSheet>(), 25);
+            avatarState.level = 400;
 
             IWorld state = _initialState.SetAvatarState(_avatarAddress, avatarState)
                 .SetActionPoint(_avatarAddress, 0);

--- a/.Lib9c.Tests/Action/HackAndSlashTest.cs
+++ b/.Lib9c.Tests/Action/HackAndSlashTest.cs
@@ -59,16 +59,15 @@ namespace Lib9c.Tests.Action
             _avatarAddress = _agentAddress.Derive("avatar");
             var gameConfigState = new GameConfigState(_sheets[nameof(GameConfigSheet)]);
             _rankingMapAddress = _avatarAddress.Derive("ranking_map");
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
                 _rankingMapAddress
-            )
-            {
-                level = 100,
-            };
+            );
+            _avatarState.level = 100;
+
             _inventoryAddress = _avatarAddress.Derive(LegacyInventoryKey);
             _worldInformationAddress = _avatarAddress.Derive(LegacyWorldInformationKey);
             _questListAddress = _avatarAddress.Derive(LegacyQuestListKey);
@@ -212,17 +211,16 @@ namespace Lib9c.Tests.Action
             var targetRow = worldQuestSheet.OrderedList.FirstOrDefault(e => e.Goal == stageId);
             Assert.NotNull(targetRow);
             // Update new AvatarState
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 state.GetAvatarSheets(),
-                _rankingMapAddress)
-            {
-                level = 400,
-                exp = state.GetSheet<CharacterLevelSheet>().OrderedList.First(e => e.Level == 400).Exp,
-                worldInformation = new WorldInformation(0, state.GetSheet<WorldSheet>(), stageId),
-            };
+                _rankingMapAddress);
+            avatarState.level = 400;
+            avatarState.exp = state.GetSheet<CharacterLevelSheet>().OrderedList.First(e => e.Level == 400).Exp;
+            avatarState.worldInformation = new WorldInformation(0, state.GetSheet<WorldSheet>(), stageId);
+
             var equipments = Doomfist.GetAllParts(_tableSheets, avatarState.level);
             foreach (var equipment in equipments)
             {

--- a/.Lib9c.Tests/Action/ItemEnhancementTest.cs
+++ b/.Lib9c.Tests/Action/ItemEnhancementTest.cs
@@ -56,7 +56,7 @@ namespace Lib9c.Tests.Action
             var agentState = new AgentState(_agentAddress);
 
             _avatarAddress = _agentAddress.Derive("avatar");
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,

--- a/.Lib9c.Tests/Action/JoinArena1Test.cs
+++ b/.Lib9c.Tests/Action/JoinArena1Test.cs
@@ -55,18 +55,17 @@ namespace Lib9c.Tests.Action
             var tableSheets = new TableSheets(sheets);
             var rankingMapAddress = new PrivateKey().Address;
             var agentState = new AgentState(_signer);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _signer,
                 0,
                 tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInRankingBoard),
-            };
+                rankingMapAddress);
+            avatarState.worldInformation = new WorldInformation(
+                0,
+                tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInRankingBoard);
+
             agentState.avatarAddresses[0] = _avatarAddress;
             avatarState.level = GameConfig.RequireClearedStageLevel.ActionsInRankingBoard;
 
@@ -74,18 +73,17 @@ namespace Lib9c.Tests.Action
             _avatar2Address = _signer2.Derive("avatar");
             var agent2State = new AgentState(_signer2);
 
-            var avatar2State = new AvatarState(
+            var avatar2State = AvatarState.Create(
                 _avatar2Address,
                 _signer2,
                 0,
                 tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    tableSheets.WorldSheet,
-                    1),
-            };
+                rankingMapAddress);
+            avatar2State.worldInformation = new WorldInformation(
+                0,
+                tableSheets.WorldSheet,
+                1);
+
             agent2State.avatarAddresses[0] = _avatar2Address;
 #pragma warning disable CS0618
             // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319

--- a/.Lib9c.Tests/Action/JoinArena3Test.cs
+++ b/.Lib9c.Tests/Action/JoinArena3Test.cs
@@ -57,18 +57,17 @@ namespace Lib9c.Tests.Action
             var rankingMapAddress = new PrivateKey().Address;
             var agentState = new AgentState(_signer);
             var gameConfigState = new GameConfigState(_sheets[nameof(GameConfigSheet)]);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _signer,
                 0,
                 tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInRankingBoard),
-            };
+                rankingMapAddress);
+            avatarState.worldInformation = new WorldInformation(
+                0,
+                tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInRankingBoard);
+
             agentState.avatarAddresses[0] = _avatarAddress;
             avatarState.level = GameConfig.RequireClearedStageLevel.ActionsInRankingBoard;
 
@@ -76,18 +75,17 @@ namespace Lib9c.Tests.Action
             _avatar2Address = _signer2.Derive("avatar");
             var agent2State = new AgentState(_signer2);
 
-            var avatar2State = new AvatarState(
+            var avatar2State = AvatarState.Create(
                 _avatar2Address,
                 _signer2,
                 0,
                 tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    tableSheets.WorldSheet,
-                    1),
-            };
+                rankingMapAddress);
+            avatar2State.worldInformation = new WorldInformation(
+                0,
+                tableSheets.WorldSheet,
+                1);
+
             agent2State.avatarAddresses[0] = _avatar2Address;
 #pragma warning disable CS0618
             // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319

--- a/.Lib9c.Tests/Action/MigrateMonsterCollectionTest.cs
+++ b/.Lib9c.Tests/Action/MigrateMonsterCollectionTest.cs
@@ -37,7 +37,7 @@ namespace Lib9c.Tests.Action
             var tableSheets = new TableSheets(sheets);
             var rankingMapAddress = new PrivateKey().Address;
             var agentState = new AgentState(_signer);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _signer,
                 0,

--- a/.Lib9c.Tests/Action/MintAssetsTest.cs
+++ b/.Lib9c.Tests/Action/MintAssetsTest.cs
@@ -330,18 +330,17 @@ namespace Lib9c.Tests.Action
             var agentState = new AgentState(address);
             avatarAddress = address.Derive("avatar");
             var rankingMapAddress = new PrivateKey().Address;
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 address,
                 0,
                 _tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    _tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-            };
+                rankingMapAddress);
+            avatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
+
             agentState.avatarAddresses[0] = avatarAddress;
 
             state = state
@@ -355,18 +354,17 @@ namespace Lib9c.Tests.Action
         {
             var agentState = new AgentState(address);
             var rankingMapAddress = new PrivateKey().Address;
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 address,
                 0,
                 _tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    _tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-            };
+                rankingMapAddress);
+            avatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
+
             agentState.avatarAddresses[0] = avatarAddress;
 
             state = state

--- a/.Lib9c.Tests/Action/RaidTest.cs
+++ b/.Lib9c.Tests/Action/RaidTest.cs
@@ -149,7 +149,7 @@ namespace Lib9c.Tests.Action
             }
 
             var gameConfigState = new GameConfigState(_sheets[nameof(GameConfigSheet)]);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
@@ -452,7 +452,7 @@ namespace Lib9c.Tests.Action
             }
 
             var gameConfigState = new GameConfigState(_sheets[nameof(GameConfigSheet)]);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
@@ -606,7 +606,7 @@ namespace Lib9c.Tests.Action
             }
 
             var gameConfigState = new GameConfigState(_sheets[nameof(GameConfigSheet)]);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,

--- a/.Lib9c.Tests/Action/RankingBattleTest.cs
+++ b/.Lib9c.Tests/Action/RankingBattleTest.cs
@@ -116,20 +116,19 @@ namespace Lib9c.Tests.Action
             var agentState = new AgentState(agentAddress);
 
             var avatarAddress = agentAddress.Derive("avatar");
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,
                 tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    tableSheets.WorldSheet,
-                    Math.Max(
-                        tableSheets.StageSheet.First?.Id ?? 1,
-                        GameConfig.RequireClearedStageLevel.ActionsInRankingBoard)),
-            };
+                rankingMapAddress);
+            avatarState.worldInformation = new WorldInformation(
+                0,
+                tableSheets.WorldSheet,
+                Math.Max(
+                    tableSheets.StageSheet.First?.Id ?? 1,
+                    GameConfig.RequireClearedStageLevel.ActionsInRankingBoard));
+
             agentState.avatarAddresses.Add(0, avatarAddress);
 
             return (agentState, avatarState);

--- a/.Lib9c.Tests/Action/RapidCombinationTest.cs
+++ b/.Lib9c.Tests/Action/RapidCombinationTest.cs
@@ -71,7 +71,7 @@ namespace Lib9c.Tests.Action
             var agentState = new AgentState(_agentAddress);
 
             _avatarAddress = new PrivateKey().Address;
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,

--- a/.Lib9c.Tests/Action/ReRegisterProductTest.cs
+++ b/.Lib9c.Tests/Action/ReRegisterProductTest.cs
@@ -64,18 +64,17 @@ namespace Lib9c.Tests.Action
             _avatarAddress = new PrivateKey().Address;
             var rankingMapAddress = new PrivateKey().Address;
             _gameConfigState = new GameConfigState((Text)_tableSheets.GameConfigSheet.Serialize());
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    _tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-            };
+                rankingMapAddress);
+            _avatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
+
             agentState.avatarAddresses[0] = _avatarAddress;
 
             _initialState = _initialState

--- a/.Lib9c.Tests/Action/RedeemCodeTest.cs
+++ b/.Lib9c.Tests/Action/RedeemCodeTest.cs
@@ -55,7 +55,7 @@ namespace Lib9c.Tests.Action
             var gameConfigState = new GameConfigState();
             var agentState = new AgentState(_agentAddress);
             agentState.avatarAddresses[0] = _avatarAddress;
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 1,

--- a/.Lib9c.Tests/Action/RegisterProduct0Test.cs
+++ b/.Lib9c.Tests/Action/RegisterProduct0Test.cs
@@ -41,19 +41,18 @@ namespace Lib9c.Tests.Action
             var rankingMapAddress = new PrivateKey().Address;
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
             _gameConfigState = new GameConfigState((Text)_tableSheets.GameConfigSheet.Serialize());
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 AvatarAddress,
                 _agentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    _tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-                actionPoint = DailyReward.ActionPointMax,
-            };
+                rankingMapAddress);
+            _avatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
+            _avatarState.actionPoint = DailyReward.ActionPointMax;
+
             agentState.avatarAddresses[0] = AvatarAddress;
 
             _initialState = new World(MockUtil.MockModernWorldState)

--- a/.Lib9c.Tests/Action/RegisterProductTest.cs
+++ b/.Lib9c.Tests/Action/RegisterProductTest.cs
@@ -41,18 +41,17 @@ namespace Lib9c.Tests.Action
             var rankingMapAddress = new PrivateKey().Address;
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
             _gameConfigState = new GameConfigState((Text)_tableSheets.GameConfigSheet.Serialize());
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 AvatarAddress,
                 _agentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    _tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-            };
+                rankingMapAddress);
+            _avatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
+
             agentState.avatarAddresses[0] = AvatarAddress;
 
             _initialState = new World(MockUtil.MockModernWorldState)

--- a/.Lib9c.Tests/Action/RewardGoldTest.cs
+++ b/.Lib9c.Tests/Action/RewardGoldTest.cs
@@ -55,7 +55,7 @@ namespace Lib9c.Tests.Action
             var avatarAddress = agentAddress.Derive("avatar");
             _tableSheets = new TableSheets(sheets);
 
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,
@@ -63,7 +63,7 @@ namespace Lib9c.Tests.Action
                 default
             );
 
-            _avatarState2 = new AvatarState(
+            _avatarState2 = AvatarState.Create(
                 new PrivateKey().Address,
                 agentAddress,
                 0,

--- a/.Lib9c.Tests/Action/RuneEnhancementTest.cs
+++ b/.Lib9c.Tests/Action/RuneEnhancementTest.cs
@@ -62,7 +62,7 @@ namespace Lib9c.Tests.Action
             var goldCurrencyState = new GoldCurrencyState(_goldCurrency);
             var rankingMapAddress = avatarAddress.Derive("ranking_map");
             var agentState = new AgentState(agentAddress);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,
@@ -184,7 +184,7 @@ namespace Lib9c.Tests.Action
             var goldCurrencyState = new GoldCurrencyState(_goldCurrency);
             var rankingMapAddress = avatarAddress.Derive("ranking_map");
             var agentState = new AgentState(agentAddress);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,
@@ -279,7 +279,7 @@ namespace Lib9c.Tests.Action
             var goldCurrencyState = new GoldCurrencyState(_goldCurrency);
             var rankingMapAddress = avatarAddress.Derive("ranking_map");
             var agentState = new AgentState(agentAddress);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,
@@ -333,7 +333,7 @@ namespace Lib9c.Tests.Action
             var goldCurrencyState = new GoldCurrencyState(_goldCurrency);
             var rankingMapAddress = avatarAddress.Derive("ranking_map");
             var agentState = new AgentState(agentAddress);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,
@@ -402,7 +402,7 @@ namespace Lib9c.Tests.Action
             var goldCurrencyState = new GoldCurrencyState(_goldCurrency);
             var rankingMapAddress = avatarAddress.Derive("ranking_map");
             var agentState = new AgentState(agentAddress);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,
@@ -517,7 +517,7 @@ namespace Lib9c.Tests.Action
             var goldCurrencyState = new GoldCurrencyState(_goldCurrency);
             var rankingMapAddress = avatarAddress.Derive("ranking_map");
             var agentState = new AgentState(agentAddress);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,
@@ -579,7 +579,7 @@ namespace Lib9c.Tests.Action
                 state = state.SetLegacyState(Addresses.TableSheet.Derive(key), value.Serialize());
             }
 
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,
@@ -645,7 +645,7 @@ namespace Lib9c.Tests.Action
             var goldCurrencyState = new GoldCurrencyState(_goldCurrency);
             var rankingMapAddress = avatarAddress.Derive("ranking_map");
             var agentState = new AgentState(agentAddress);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,

--- a/.Lib9c.Tests/Action/Scenario/ArenaScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/ArenaScenarioTest.cs
@@ -161,18 +161,17 @@ namespace Lib9c.Tests.Action.Scenario
             var agentState = new AgentState(agentAddress);
 
             var avatarAddress = agentAddress.Derive("avatar");
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
-                _rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    _tableSheets.WorldSheet,
-                    clearStageId),
-            };
+                _rankingMapAddress);
+            avatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                clearStageId);
+
             agentState.avatarAddresses.Add(0, avatarAddress);
             _state = _state
                 .SetAgentState(agentAddress, agentState)

--- a/.Lib9c.Tests/Action/Scenario/AuraScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/AuraScenarioTest.cs
@@ -56,7 +56,7 @@ namespace Lib9c.Tests.Action.Scenario
             {
                 var avatarAddress = addresses[i];
                 agentState.avatarAddresses.Add(i, avatarAddress);
-                var avatarState = new AvatarState(
+                var avatarState = AvatarState.Create(
                     _avatarAddress,
                     _agentAddress,
                     0,

--- a/.Lib9c.Tests/Action/Scenario/CollectionScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/CollectionScenarioTest.cs
@@ -41,7 +41,7 @@ namespace Lib9c.Tests.Action.Scenario
             {
                 var avatarAddress = addresses[i];
                 agentState.avatarAddresses.Add(i, avatarAddress);
-                var avatarState = new AvatarState(
+                var avatarState = AvatarState.Create(
                     _avatarAddress,
                     _agentAddress,
                     0,

--- a/.Lib9c.Tests/Action/Scenario/GrimoireScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/GrimoireScenarioTest.cs
@@ -56,7 +56,7 @@ namespace Lib9c.Tests.Action.Scenario
             {
                 var avatarAddress = addresses[i];
                 agentState.avatarAddresses.Add(i, avatarAddress);
-                var avatarState = new AvatarState(
+                var avatarState = AvatarState.Create(
                     _avatarAddress,
                     _agentAddress,
                     0,

--- a/.Lib9c.Tests/Action/Scenario/MarketScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/MarketScenarioTest.cs
@@ -53,55 +53,52 @@ namespace Lib9c.Tests.Action.Scenario
             var rankingMapAddress = new PrivateKey().Address;
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
             _gameConfigState = new GameConfigState((Text)_tableSheets.GameConfigSheet.Serialize());
-            _sellerAvatarState = new AvatarState(
+            _sellerAvatarState = AvatarState.Create(
                 _sellerAvatarAddress,
                 _sellerAgentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    _tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-                actionPoint = DailyReward.ActionPointMax,
-            };
+                rankingMapAddress);
+            _sellerAvatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
+            _sellerAvatarState.actionPoint = DailyReward.ActionPointMax;
+
             agentState.avatarAddresses[0] = _sellerAvatarAddress;
 
             _sellerAgentAddress2 = new PrivateKey().Address;
             var agentState2 = new AgentState(_sellerAgentAddress2);
             _sellerAvatarAddress2 = new PrivateKey().Address;
-            _sellerAvatarState2 = new AvatarState(
+            _sellerAvatarState2 = AvatarState.Create(
                 _sellerAvatarAddress2,
                 _sellerAgentAddress2,
                 0,
                 _tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    _tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-                actionPoint = DailyReward.ActionPointMax,
-            };
+                rankingMapAddress);
+            _sellerAvatarState2.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
+            _sellerAvatarState2.actionPoint = DailyReward.ActionPointMax;
+
             agentState2.avatarAddresses[0] = _sellerAvatarAddress2;
 
             _buyerAgentAddress = new PrivateKey().Address;
             var agentState3 = new AgentState(_buyerAgentAddress);
             _buyerAvatarAddress = new PrivateKey().Address;
-            var buyerAvatarState = new AvatarState(
+            var buyerAvatarState = AvatarState.Create(
                 _buyerAvatarAddress,
                 _buyerAgentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    _tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-                actionPoint = DailyReward.ActionPointMax,
-            };
+                rankingMapAddress);
+            buyerAvatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
+            buyerAvatarState.actionPoint = DailyReward.ActionPointMax;
+
             agentState3.avatarAddresses[0] = _buyerAvatarAddress;
 
             _currency = Currency.Legacy("NCG", 2, minters: null);

--- a/.Lib9c.Tests/Action/Scenario/RuneScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/RuneScenarioTest.cs
@@ -31,7 +31,7 @@ namespace Lib9c.Tests.Action.Scenario
             var tableSheets = new TableSheets(sheets);
             agentState.avatarAddresses.Add(0, avatarAddress);
             var gameConfigState = new GameConfigState(sheets[nameof(GameConfigSheet)]);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,
@@ -154,7 +154,7 @@ namespace Lib9c.Tests.Action.Scenario
             var tableSheets = new TableSheets(sheets);
             agentState.avatarAddresses.Add(0, avatarAddress);
             var gameConfigState = new GameConfigState(sheets[nameof(GameConfigSheet)]);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,

--- a/.Lib9c.Tests/Action/Scenario/SellAndCancellationAndSellTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/SellAndCancellationAndSellTest.cs
@@ -46,19 +46,17 @@ namespace Lib9c.Tests.Action.Scenario
             _avatarAddress = _agentAddress.Derive("avatar");
             var agentState = new AgentState(_agentAddress);
             agentState.avatarAddresses[0] = _avatarAddress;
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 1,
                 _tableSheets.GetAvatarSheets(),
                 default
-            )
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    _tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-            };
+            );
+            avatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
 
             _initialState = new World(MockUtil.MockModernWorldState)
                 .SetLegacyState(GoldCurrencyState.Address, gold.Serialize())

--- a/.Lib9c.Tests/Action/Scenario/WorldUnlockScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/WorldUnlockScenarioTest.cs
@@ -37,16 +37,15 @@ namespace Lib9c.Tests.Action.Scenario
             _avatarAddress = _agentAddress.Derive("avatar");
             _rankingMapAddress = _avatarAddress.Derive("ranking_map");
             var gameConfigState = new GameConfigState(sheets[nameof(GameConfigSheet)]);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,
                 _tableSheets.GetAvatarSheets(),
                 _rankingMapAddress
-            )
-            {
-                level = 100,
-            };
+            );
+            avatarState.level = 100;
+
             agentState.avatarAddresses.Add(0, _avatarAddress);
 
             _weeklyArenaState = new WeeklyArenaState(0);

--- a/.Lib9c.Tests/Action/Summon/AuraSummonTest.cs
+++ b/.Lib9c.Tests/Action/Summon/AuraSummonTest.cs
@@ -38,7 +38,7 @@ namespace Lib9c.Tests.Action.Summon
             var agentState = new AgentState(_agentAddress);
 
             _avatarAddress = _agentAddress.Derive("avatar");
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,

--- a/.Lib9c.Tests/Action/Summon/RuneSummonTest.cs
+++ b/.Lib9c.Tests/Action/Summon/RuneSummonTest.cs
@@ -38,7 +38,7 @@ namespace Lib9c.Tests.Action.Summon
             var agentState = new AgentState(_agentAddress);
 
             _avatarAddress = _agentAddress.Derive("avatar");
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,

--- a/.Lib9c.Tests/Action/UnlockCombinationSlotTest.cs
+++ b/.Lib9c.Tests/Action/UnlockCombinationSlotTest.cs
@@ -48,7 +48,7 @@ public class UnlockCombinationSlotTest
             state = state.SetLegacyState(Addresses.TableSheet.Derive(key), value.Serialize());
 
         var gameConfigState = new GameConfigState(Sheets[nameof(GameConfigSheet)]);
-        var avatarState = new AvatarState(
+        var avatarState = AvatarState.Create(
             avatarAddress,
             agentAddress,
             0,

--- a/.Lib9c.Tests/Action/UnlockEquipmentRecipeTest.cs
+++ b/.Lib9c.Tests/Action/UnlockEquipmentRecipeTest.cs
@@ -42,7 +42,7 @@ namespace Lib9c.Tests.Action
             var gameConfigState = new GameConfigState(sheets[nameof(GameConfigSheet)]);
 
             var agentState = new AgentState(_agentAddress);
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,

--- a/.Lib9c.Tests/Action/UnlockWorldTest.cs
+++ b/.Lib9c.Tests/Action/UnlockWorldTest.cs
@@ -40,7 +40,7 @@ namespace Lib9c.Tests.Action
             var gameConfigState = new GameConfigState(sheets[nameof(GameConfigSheet)]);
 
             var agentState = new AgentState(_agentAddress);
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 _avatarAddress,
                 _agentAddress,
                 0,

--- a/.Lib9c.Tests/Battle/EnemyPlayerDigestTest.cs
+++ b/.Lib9c.Tests/Battle/EnemyPlayerDigestTest.cs
@@ -19,7 +19,7 @@ namespace Lib9c.Tests
         public EnemyPlayerDigestTest()
         {
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 new PrivateKey().Address,
                 new PrivateKey().Address,
                 1234,

--- a/.Lib9c.Tests/Model/AdventureBoss/AdventureBossSimulatorTest.cs
+++ b/.Lib9c.Tests/Model/AdventureBoss/AdventureBossSimulatorTest.cs
@@ -27,7 +27,7 @@ namespace Lib9c.Tests.Model.AdventureBoss
             _testOutputHelper = testOutputHelper;
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
             _random = new TestRandom();
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 default,
                 default,
                 0,

--- a/.Lib9c.Tests/Model/Arena/ArenaAvatarStateTest.cs
+++ b/.Lib9c.Tests/Model/Arena/ArenaAvatarStateTest.cs
@@ -33,7 +33,7 @@ namespace Lib9c.Tests.Model.Arena
         private AvatarState GetNewAvatarState(Address avatarAddress, Address agentAddress)
         {
             var rankingState = new RankingState1();
-            return new AvatarState(
+            return AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,

--- a/.Lib9c.Tests/Model/Arena/PlayerDigestTest.cs
+++ b/.Lib9c.Tests/Model/Arena/PlayerDigestTest.cs
@@ -22,7 +22,7 @@ namespace Lib9c.Tests.Model.Arena
         public PlayerDigestTest()
         {
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 new PrivateKey().Address,
                 new PrivateKey().Address,
                 1234,

--- a/.Lib9c.Tests/Model/ArenaSimulatorTest.cs
+++ b/.Lib9c.Tests/Model/ArenaSimulatorTest.cs
@@ -37,7 +37,7 @@ namespace Lib9c.Tests
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
             _random = new TestRandom();
 
-            _avatarState1 = new AvatarState(
+            _avatarState1 = AvatarState.Create(
                 default,
                 default,
                 0,
@@ -45,7 +45,7 @@ namespace Lib9c.Tests
                 default
             );
 
-            _avatarState2 = new AvatarState(
+            _avatarState2 = AvatarState.Create(
                 default,
                 default,
                 0,

--- a/.Lib9c.Tests/Model/BattleLogTest.cs
+++ b/.Lib9c.Tests/Model/BattleLogTest.cs
@@ -27,7 +27,7 @@ namespace Lib9c.Tests.Model
         public void IsClearBeforeSimulate()
         {
             var agentState = new AgentState(default(Address));
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 default,
                 agentState.address,
                 0,

--- a/.Lib9c.Tests/Model/Order/FungibleOrderTest.cs
+++ b/.Lib9c.Tests/Model/Order/FungibleOrderTest.cs
@@ -28,7 +28,7 @@ namespace Lib9c.Tests.Model.Order
             // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
             _currency = Currency.Legacy("NCG", 2, null);
 #pragma warning restore CS0618
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 Addresses.Blacksmith,
                 Addresses.Admin,
                 0,
@@ -636,7 +636,7 @@ namespace Lib9c.Tests.Model.Order
                 order.Sell2(_avatarState);
             }
 
-            var buyer = new AvatarState(
+            var buyer = AvatarState.Create(
                 Addresses.Blacksmith,
                 Addresses.Admin,
                 0,
@@ -684,7 +684,7 @@ namespace Lib9c.Tests.Model.Order
                 order.Sell(_avatarState);
             }
 
-            var buyer = new AvatarState(
+            var buyer = AvatarState.Create(
                 Addresses.Blacksmith,
                 Addresses.Admin,
                 0,

--- a/.Lib9c.Tests/Model/Order/NonFungibleOrderTest.cs
+++ b/.Lib9c.Tests/Model/Order/NonFungibleOrderTest.cs
@@ -30,7 +30,7 @@ namespace Lib9c.Tests.Model.Order
             // Use of obsolete method Currency.Legacy(): https://github.com/planetarium/lib9c/discussions/1319
             _currency = Currency.Legacy("NCG", 2, null);
 #pragma warning restore CS0618
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 Addresses.Blacksmith,
                 Addresses.Admin,
                 0,
@@ -649,7 +649,7 @@ namespace Lib9c.Tests.Model.Order
                 order.Sell2(_avatarState);
             }
 
-            var buyer = new AvatarState(
+            var buyer = AvatarState.Create(
                 Addresses.Blacksmith,
                 Addresses.Admin,
                 0,
@@ -697,7 +697,7 @@ namespace Lib9c.Tests.Model.Order
                 order.Sell(_avatarState);
             }
 
-            var buyer = new AvatarState(
+            var buyer = AvatarState.Create(
                 Addresses.Blacksmith,
                 Addresses.Admin,
                 0,

--- a/.Lib9c.Tests/Model/PlayerTest.cs
+++ b/.Lib9c.Tests/Model/PlayerTest.cs
@@ -30,7 +30,7 @@ namespace Lib9c.Tests.Model
         {
             _random = new TestRandom();
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 default,
                 default,
                 0,

--- a/.Lib9c.Tests/Model/RaidSimulatorV1Test.cs
+++ b/.Lib9c.Tests/Model/RaidSimulatorV1Test.cs
@@ -21,7 +21,7 @@ namespace Lib9c.Tests.Model
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
             _random = new TestRandom();
 
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 default,
                 default,
                 0,

--- a/.Lib9c.Tests/Model/RaidSimulatorV2Test.cs
+++ b/.Lib9c.Tests/Model/RaidSimulatorV2Test.cs
@@ -21,7 +21,7 @@ namespace Lib9c.Tests.Model
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
             _random = new TestRandom();
 
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 default,
                 default,
                 0,

--- a/.Lib9c.Tests/Model/RaidSimulatorV3Test.cs
+++ b/.Lib9c.Tests/Model/RaidSimulatorV3Test.cs
@@ -29,7 +29,7 @@ namespace Lib9c.Tests.Model
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
             _random = new TestRandom();
 
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 default,
                 default,
                 0,

--- a/.Lib9c.Tests/Model/RankingSimulatorTest.cs
+++ b/.Lib9c.Tests/Model/RankingSimulatorTest.cs
@@ -36,16 +36,15 @@ namespace Lib9c.Tests.Model
             var rewardSheet = new WeeklyArenaRewardSheet();
             rewardSheet.Set($"id,item_id,ratio,min,max,required_level\n1,302000,0.1,1,1,{requiredLevel}");
             _tableSheets.WeeklyArenaRewardSheet = rewardSheet;
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 default,
                 default,
                 0,
                 _tableSheets.GetAvatarSheets(),
                 default
-            )
-            {
-                level = level,
-            };
+            );
+            avatarState.level = level;
+
             avatarState.worldInformation.ClearStage(
                 1,
                 GameConfig.RequireClearedStageLevel.ActionsInRankingBoard,
@@ -88,7 +87,7 @@ namespace Lib9c.Tests.Model
         [InlineData(1900, 6)]
         public void SimulateRankingScore(int score, int expected)
         {
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 default,
                 default,
                 0,
@@ -133,7 +132,7 @@ namespace Lib9c.Tests.Model
         [Fact]
         public void ConstructorWithCostume()
         {
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 default,
                 default,
                 0,
@@ -191,19 +190,17 @@ namespace Lib9c.Tests.Model
         public void CheckToReceiveAllRewardItems(int level, int simulationCount)
         {
             _tableSheets.WeeklyArenaRewardSheet = _tableSheets.WeeklyArenaRewardSheet;
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 default,
                 default,
                 0,
                 _tableSheets.GetAvatarSheets(),
-                default)
-            {
-                level = level,
-                worldInformation = new WorldInformation(
-                    0,
-                    _tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInRankingBoard),
-            };
+                default);
+            avatarState.level = level;
+            avatarState.worldInformation = new WorldInformation(
+                0,
+                _tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInRankingBoard);
 
             var arenaInfo = new ArenaInfo(avatarState, _tableSheets.CharacterSheet, false);
             var enemyInfo = new ArenaInfo(avatarState, _tableSheets.CharacterSheet, false);

--- a/.Lib9c.Tests/Model/RankingSimulatorV1Test.cs
+++ b/.Lib9c.Tests/Model/RankingSimulatorV1Test.cs
@@ -36,16 +36,15 @@ namespace Lib9c.Tests.Model
             var rewardSheet = new WeeklyArenaRewardSheet();
             rewardSheet.Set($"id,item_id,ratio,min,max,required_level\n1,302000,0.1,1,1,{requiredLevel}");
             _tableSheets.WeeklyArenaRewardSheet = rewardSheet;
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 default,
                 default,
                 0,
                 _tableSheets.GetAvatarSheets(),
                 default
-            )
-            {
-                level = level,
-            };
+            );
+            avatarState.level = level;
+
             avatarState.worldInformation.ClearStage(
                 1,
                 GameConfig.RequireClearedStageLevel.ActionsInRankingBoard,
@@ -78,7 +77,7 @@ namespace Lib9c.Tests.Model
         [InlineData(1900, 6)]
         public void SimulateRankingScore(int score, int expected)
         {
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 default,
                 default,
                 0,
@@ -115,7 +114,7 @@ namespace Lib9c.Tests.Model
         [Fact]
         public void ConstructorWithCostume()
         {
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 default,
                 default,
                 0,
@@ -175,15 +174,14 @@ namespace Lib9c.Tests.Model
         public void CheckToReceiveAllRewardItems(int level, int simulationCount)
         {
             _tableSheets.WeeklyArenaRewardSheet = _tableSheets.WeeklyArenaRewardSheet;
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 default,
                 default,
                 0,
                 _tableSheets.GetAvatarSheets(),
-                default)
-            {
-                level = level,
-            };
+                default);
+            avatarState.level = level;
+
             avatarState.worldInformation = new WorldInformation(
                 0,
                 _tableSheets.WorldSheet,

--- a/.Lib9c.Tests/Model/Skill/Adventure/CombatTest.cs
+++ b/.Lib9c.Tests/Model/Skill/Adventure/CombatTest.cs
@@ -26,7 +26,7 @@ namespace Lib9c.Tests.Model.Skill.Adventure
             _tableSheets = new TableSheets(csv);
 
             var gameConfigState = new GameConfigState(csv[nameof(GameConfigSheet)]);
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 default,
                 default,
                 0,

--- a/.Lib9c.Tests/Model/Skill/Adventure/DoubleAttackTest.cs
+++ b/.Lib9c.Tests/Model/Skill/Adventure/DoubleAttackTest.cs
@@ -65,16 +65,15 @@ namespace Lib9c.Tests.Model.Skill.Adventure
         {
             Assert.True(_tableSheets.SkillSheet.TryGetValue(skillId, out var skillRow));
             var twinAttack = new DoubleAttack(skillRow, 100, 100, default, StatType.NONE);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 new PrivateKey().Address,
                 new PrivateKey().Address,
                 0,
                 _tableSheets.GetAvatarSheets(),
                 new PrivateKey().Address
-            )
-            {
-                level = level,
-            };
+            );
+            avatarState.level = level;
+
             var worldRow = _tableSheets.WorldSheet.First;
             Assert.NotNull(worldRow);
 

--- a/.Lib9c.Tests/Model/Skill/Adventure/NormalAttackTest.cs
+++ b/.Lib9c.Tests/Model/Skill/Adventure/NormalAttackTest.cs
@@ -36,7 +36,7 @@ namespace Lib9c.Tests.Model.Skill.Adventure
             Assert.True(_tableSheets.SkillSheet.TryGetValue(100000, out var skillRow));
             var normalAttack = new NormalAttack(skillRow, 100, 100, default, StatType.NONE);
 
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 new PrivateKey().Address,
                 new PrivateKey().Address,
                 0,
@@ -103,7 +103,7 @@ namespace Lib9c.Tests.Model.Skill.Adventure
             // Set chance to 0 to minimize attack success probability
             var normalAttack = new NormalAttack(skillRow, 100, 0, default, StatType.NONE);
 
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 new PrivateKey().Address,
                 new PrivateKey().Address,
                 0,
@@ -156,7 +156,7 @@ namespace Lib9c.Tests.Model.Skill.Adventure
             Assert.Equal(0, player.AttackCount);
 
             // With Focus buff
-            avatarState = new AvatarState(
+            avatarState = AvatarState.Create(
                 new PrivateKey().Address,
                 new PrivateKey().Address,
                 0,

--- a/.Lib9c.Tests/Model/Skill/Adventure/ShatterStrikeTest.cs
+++ b/.Lib9c.Tests/Model/Skill/Adventure/ShatterStrikeTest.cs
@@ -38,7 +38,7 @@ namespace Lib9c.Tests.Model.Skill.Adventure
             ); // 700010 is ShatterStrike
             var shatterStrike = new ShatterStrike(skillRow, 0, 0, ratioBp, StatType.NONE);
 
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 new PrivateKey().Address,
                 new PrivateKey().Address,
                 0,
@@ -118,7 +118,7 @@ shatter_strike_max_damage,1";
             ); // 700010 is ShatterStrike
             var shatterStrike = new ShatterStrike(skillRow, 0, 0, ratioBp, StatType.NONE);
 
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 new PrivateKey().Address,
                 new PrivateKey().Address,
                 0,

--- a/.Lib9c.Tests/Model/Skill/Arena/ArenaCombatTest.cs
+++ b/.Lib9c.Tests/Model/Skill/Arena/ArenaCombatTest.cs
@@ -24,14 +24,14 @@ namespace Lib9c.Tests.Model.Skill.Arena
         public ArenaCombatTest()
         {
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
-            _avatar1 = new AvatarState(
+            _avatar1 = AvatarState.Create(
                 default,
                 default,
                 0,
                 _tableSheets.GetAvatarSheets(),
                 default
             );
-            _avatar2 = new AvatarState(
+            _avatar2 = AvatarState.Create(
                 default,
                 default,
                 0,

--- a/.Lib9c.Tests/Model/Skill/Arena/ArenaDoubleAttackTest.cs
+++ b/.Lib9c.Tests/Model/Skill/Arena/ArenaDoubleAttackTest.cs
@@ -22,14 +22,14 @@ namespace Lib9c.Tests.Model.Skill.Arena
         public ArenaDoubleAttackTest()
         {
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
-            _avatar1 = new AvatarState(
+            _avatar1 = AvatarState.Create(
                 default,
                 default,
                 0,
                 _tableSheets.GetAvatarSheets(),
                 default
             );
-            _avatar2 = new AvatarState(
+            _avatar2 = AvatarState.Create(
                 default,
                 default,
                 0,

--- a/.Lib9c.Tests/Model/Skill/Arena/ArenaNormalAttackTest.cs
+++ b/.Lib9c.Tests/Model/Skill/Arena/ArenaNormalAttackTest.cs
@@ -24,14 +24,14 @@ namespace Lib9c.Tests.Model.Skill.Arena
         public ArenaNormalAttackTest()
         {
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
-            _avatar1 = new AvatarState(
+            _avatar1 = AvatarState.Create(
                 default,
                 default,
                 0,
                 _tableSheets.GetAvatarSheets(),
                 default
             );
-            _avatar2 = new AvatarState(
+            _avatar2 = AvatarState.Create(
                 default,
                 default,
                 0,

--- a/.Lib9c.Tests/Model/Skill/Arena/ArenaShatterStrikeTest.cs
+++ b/.Lib9c.Tests/Model/Skill/Arena/ArenaShatterStrikeTest.cs
@@ -25,14 +25,14 @@ namespace Lib9c.Tests.Model.Skill.Arena
         public ArenaShatterStrikeTest()
         {
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
-            _avatar1 = new AvatarState(
+            _avatar1 = AvatarState.Create(
                 default,
                 default,
                 0,
                 _tableSheets.GetAvatarSheets(),
                 default
             );
-            _avatar2 = new AvatarState(
+            _avatar2 = AvatarState.Create(
                 default,
                 default,
                 0,

--- a/.Lib9c.Tests/Model/Skill/BuffFactoryTest.cs
+++ b/.Lib9c.Tests/Model/Skill/BuffFactoryTest.cs
@@ -22,7 +22,7 @@ namespace Lib9c.Tests.Model.Skill
         {
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
             var gameConfigState = new GameConfigState();
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 default,
                 default,
                 0,

--- a/.Lib9c.Tests/Model/Skill/Raid/NormalAttackTest.cs
+++ b/.Lib9c.Tests/Model/Skill/Raid/NormalAttackTest.cs
@@ -24,7 +24,7 @@ namespace Lib9c.Tests.Model.Skill.Raid
             const int seed = 10; // This seed fails to attack enemy with NormalAttack
 
             // With Focus buff
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 new PrivateKey().Address,
                 new PrivateKey().Address,
                 0,

--- a/.Lib9c.Tests/Model/StageSimulatorTest.cs
+++ b/.Lib9c.Tests/Model/StageSimulatorTest.cs
@@ -30,7 +30,7 @@ namespace Lib9c.Tests.Model
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
             _random = new TestRandom();
 
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 default,
                 default,
                 0,

--- a/.Lib9c.Tests/Model/StageSimulatorV1Test.cs
+++ b/.Lib9c.Tests/Model/StageSimulatorV1Test.cs
@@ -24,7 +24,7 @@ namespace Lib9c.Tests.Model
             _tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
             _random = new TestRandom();
 
-            _avatarState = new AvatarState(
+            _avatarState = AvatarState.Create(
                 default,
                 default,
                 0,

--- a/.Lib9c.Tests/Model/State/AvatarStateTest.cs
+++ b/.Lib9c.Tests/Model/State/AvatarStateTest.cs
@@ -70,7 +70,7 @@ namespace Lib9c.Tests.Model.State
             var rankingState = new RankingState1();
             Address avatarAddress = new PrivateKey().Address;
             Address agentAddress = new PrivateKey().Address;
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,
@@ -480,7 +480,7 @@ namespace Lib9c.Tests.Model.State
         private AvatarState GetNewAvatarState(Address avatarAddress, Address agentAddress)
         {
             var rankingState = new RankingState1();
-            return new AvatarState(
+            return AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,

--- a/.Lib9c.Tests/Model/State/RankingMapStateTest.cs
+++ b/.Lib9c.Tests/Model/State/RankingMapStateTest.cs
@@ -27,17 +27,16 @@ namespace Lib9c.Tests.Model.State
 
             for (var i = 0; i < 10; i++)
             {
-                var avatarState = new AvatarState(
+                var avatarState = AvatarState.Create(
                     _agentAddress.Derive(i.ToString()),
                     _agentAddress,
                     0,
                     _tableSheets.GetAvatarSheets(),
                     _rankingMapAddress,
                     "test"
-                )
-                {
-                    exp = 10 - i,
-                };
+                );
+                avatarState.exp = 10 - i;
+
                 state.Update(avatarState);
             }
 
@@ -54,7 +53,7 @@ namespace Lib9c.Tests.Model.State
         public void Serialize()
         {
             var avatarAddress = _agentAddress.Derive("avatar");
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 _agentAddress,
                 0,
@@ -75,7 +74,7 @@ namespace Lib9c.Tests.Model.State
         public void SerializeEquals()
         {
             var avatarAddress = _agentAddress.Derive("avatar");
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 _agentAddress,
                 0,
@@ -85,7 +84,7 @@ namespace Lib9c.Tests.Model.State
             );
 
             var avatarAddress2 = _agentAddress.Derive("avatar2");
-            var avatarState2 = new AvatarState(
+            var avatarState2 = AvatarState.Create(
                 avatarAddress2,
                 _agentAddress,
                 0,
@@ -110,7 +109,7 @@ namespace Lib9c.Tests.Model.State
         {
             var avatarAddress = _agentAddress.Derive("avatar");
             var rankingMapAddress = avatarAddress.Derive("ranking_map");
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 _agentAddress,
                 0,

--- a/.Lib9c.Tests/Model/State/ShardedShopStateV2Test.cs
+++ b/.Lib9c.Tests/Model/State/ShardedShopStateV2Test.cs
@@ -159,7 +159,7 @@ namespace Lib9c.Tests.Model.State
         public void Remove()
         {
             var tableSheets = new TableSheets(TableSheetsImporter.ImportSheets());
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 default,
                 default,
                 0,

--- a/.Lib9c.Tests/Model/State/WeeklyArenaStateTest.cs
+++ b/.Lib9c.Tests/Model/State/WeeklyArenaStateTest.cs
@@ -98,7 +98,7 @@ namespace Lib9c.Tests.Model.State
 
             for (var i = 0; i < infoCount; i++)
             {
-                var avatarState = new AvatarState(
+                var avatarState = AvatarState.Create(
                     new PrivateKey().Address,
                     new PrivateKey().Address,
                     0L,
@@ -131,7 +131,7 @@ namespace Lib9c.Tests.Model.State
 
             for (var i = 0; i < infoCount; i++)
             {
-                var avatarState = new AvatarState(
+                var avatarState = AvatarState.Create(
                     new PrivateKey().Address,
                     new PrivateKey().Address,
                     0L,
@@ -170,7 +170,7 @@ namespace Lib9c.Tests.Model.State
                     targetAddress = avatarAddress;
                 }
 
-                var avatarState = new AvatarState(
+                var avatarState = AvatarState.Create(
                     avatarAddress,
                     new PrivateKey().Address,
                     0L,

--- a/.Lib9c.Tests/TestHelper/BlockChainHelper.cs
+++ b/.Lib9c.Tests/TestHelper/BlockChainHelper.cs
@@ -123,18 +123,17 @@ namespace Lib9c.Tests.TestHelper
             var agentState = new AgentState(agentAddress);
 
             var avatarAddress = new PrivateKey().Address;
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 0,
                 tableSheets.GetAvatarSheets(),
-                rankingMapAddress)
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    tableSheets.WorldSheet,
-                    GameConfig.RequireClearedStageLevel.ActionsInShop),
-            };
+                rankingMapAddress);
+            avatarState.worldInformation = new WorldInformation(
+                0,
+                tableSheets.WorldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInShop);
+
             agentState.avatarAddresses[0] = avatarAddress;
 
             var initCurrencyGold = goldCurrencyState.Currency * 100000000000;

--- a/.Lib9c.Tests/Util/InitializeUtil.cs
+++ b/.Lib9c.Tests/Util/InitializeUtil.cs
@@ -53,7 +53,7 @@ namespace Lib9c.Tests.Util
             agentAddr ??= new PrivateKey().Address;
             var avatarAddr = Addresses.GetAvatarAddress(agentAddr.Value, avatarIndex);
             var agentState = new AgentState(agentAddr.Value);
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddr,
                 agentAddr.Value,
                 0,

--- a/Lib9c.DevExtensions/Action/CreateOrReplaceAvatar.cs
+++ b/Lib9c.DevExtensions/Action/CreateOrReplaceAvatar.cs
@@ -414,20 +414,18 @@ namespace Lib9c.DevExtensions.Action
                 });
 
             // Set AvatarState.
-            var avatar = new AvatarState(
+            var avatar = AvatarState.Create(
                 avatarAddr,
                 agentAddr,
                 blockIndex,
                 sheets.GetAvatarSheets(),
                 default,
-                Name)
-            {
-                level = Level,
-                hair = Hair,
-                lens = Lens,
-                ear = Ear,
-                tail = Tail,
-            };
+                Name);
+            avatar.level = Level;
+            avatar.hair = Hair;
+            avatar.lens = Lens;
+            avatar.ear = Ear;
+            avatar.tail = Tail;
             // ~Set AvatarState.
 
             // Set WorldInformation.

--- a/Lib9c.DevExtensions/TestbedHelper.cs
+++ b/Lib9c.DevExtensions/TestbedHelper.cs
@@ -39,20 +39,18 @@ namespace Lib9c.DevExtensions
             GameConfigState gameConfigState,
             Address rankingMapAddress)
         {
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 agentAddress,
                 blockIndex,
                 avatarSheets,
                 rankingMapAddress,
                 name != string.Empty ? name : "testId"
-            )
-            {
-                worldInformation = new WorldInformation(
-                    0,
-                    worldSheet,
-                    0),
-            };
+            );
+            avatarState.worldInformation = new WorldInformation(
+                0,
+                worldSheet,
+                0);
 
             return avatarState;
         }

--- a/Lib9c/Action/CreateAvatar.cs
+++ b/Lib9c/Action/CreateAvatar.cs
@@ -297,7 +297,7 @@ namespace Nekoyume.Action
         {
             var state = ctx.PreviousState;
             var random = ctx.GetRandom();
-            var avatarState = new AvatarState(
+            var avatarState = AvatarState.Create(
                 avatarAddress,
                 ctx.Signer,
                 ctx.BlockIndex,

--- a/Lib9c/Model/State/AvatarState.cs
+++ b/Lib9c/Model/State/AvatarState.cs
@@ -68,10 +68,31 @@ namespace Nekoyume.Model.State
             return key.PublicKey.Address;
         }
 
-        public AvatarState(Address address,
+        public static AvatarState Create(Address address,
             Address agentAddress,
             long blockIndex,
             AvatarSheets avatarSheets,
+            Address rankingMapAddress,
+            string name = null)
+        {
+            var worldInformationVar = new WorldInformation(blockIndex, avatarSheets.WorldSheet,
+                GameConfig.IsEditor, name);
+            var questListVar = new QuestList(
+                avatarSheets.QuestSheet,
+                avatarSheets.QuestRewardSheet,
+                avatarSheets.QuestItemRewardSheet,
+                avatarSheets.EquipmentItemRecipeSheet,
+                avatarSheets.EquipmentItemSubRecipeSheet
+            );
+            return new AvatarState(
+                address, agentAddress, blockIndex, questListVar, worldInformationVar, rankingMapAddress, name);
+        }
+
+        public AvatarState(Address address,
+            Address agentAddress,
+            long blockIndex,
+            QuestList questList,
+            WorldInformation worldInformation,
             Address rankingMapAddress,
             string name = null) : base(address)
         {
@@ -81,16 +102,10 @@ namespace Nekoyume.Model.State
             level = 1;
             exp = 0;
             inventory = new Inventory();
-            worldInformation = new WorldInformation(blockIndex, avatarSheets.WorldSheet, GameConfig.IsEditor, name);
+            this.worldInformation = worldInformation;
             updatedAt = blockIndex;
             this.agentAddress = agentAddress;
-            questList = new QuestList(
-                avatarSheets.QuestSheet,
-                avatarSheets.QuestRewardSheet,
-                avatarSheets.QuestItemRewardSheet,
-                avatarSheets.EquipmentItemRecipeSheet,
-                avatarSheets.EquipmentItemSubRecipeSheet
-            );
+            this.questList = questList;
             mailBox = new MailBox();
             this.blockIndex = blockIndex;
             stageMap = new CollectionMap();


### PR DESCRIPTION
## Description

This pull request only adjusts the constructor of `AvatarState` and introduces a new static factory method, `AvatarState.Create`. With some huge changes (almost from test code) by replacing the `AvatarState` constructor with the factory method.

Before this pull request, it was hard to create an `AvatarState` instance because its constructor was heavily dependent on `AvatarSheets`. Even if I want to create a simple custom `AvatarState` instance, it requires `AvatarSheets` (CSV data).

So it will become to provide a simple constructor (just setting properties and fields) and handle something more with the factory method.

## Reviewers

I requested reviews for @ipdae, @sonohoshi, @eugene-doobu who are actively working on Lib9c. If you know someone else who would be good for this pull request, please nominate them.

## Future work plan

If this pull request is accepted, I'll refactor `WorldInformation` and `QuestList` too if I need. These works will be helpful for #2685 and https://github.com/planetarium/NineChronicles.Headless/pull/2540.