### PR TITLE
Select adventure boss avoiding latest 2 seasons

### DIFF
--- a/.Lib9c.Tests/Action/AdventureBoss/ClaimAdventureBossRewardTest.cs
+++ b/.Lib9c.Tests/Action/AdventureBoss/ClaimAdventureBossRewardTest.cs
@@ -169,7 +169,7 @@ namespace Lib9c.Tests.Action.AdventureBoss
                         {
                             600201, 140
                         }, // (300*1.2) * 0.7 / 0.5 * (100/360)
-                        { 600202, 15 },  // (300*1.2) * 0.3 / 2 * (100/360)
+                        { 600202, 15 }, // (300*1.2) * 0.3 / 2 * (100/360)
                         { 600203, 0 },
                     },
                     FavReward = new Dictionary<int, int>
@@ -442,12 +442,13 @@ namespace Lib9c.Tests.Action.AdventureBoss
                 NcgReward = 0 * NCG, // No Raffle Reward
                 FavReward = new Dictionary<int, int>
                 {
-                    { 20001, 0 },
-                    { 30001, 0 },
+                    { 10035, 84 },  // 100NCG * 1.2 * 0.7 Fixed / 1 NCG Ratio * 100% contribution for season 3
                 },
                 ItemReward = new Dictionary<int, int>
                 {
-                    { 600201, 336 },
+                    { 600201, 168 }, // 100NCG * 1.2 * 0.7 Fixed / 0.5 Ratio for season 1
+                    // 100NCG * 1.2 * 0.3 Random / 2 Ratio for season 1
+                    // 100NCG * 1.3 * 0.3 Random / 2 Ratio for season 3
                     { 600202, 36 },
                     { 600203, 0 },
                 },
@@ -707,14 +708,13 @@ namespace Lib9c.Tests.Action.AdventureBoss
                 NcgReward = 40 * NCG,
                 FavReward = new Dictionary<int, int>
                 {
-                    { 20001, 0 },
-                    { 30001, 0 },
+                    { 10035, 40 }, // (100 AP * 0.4 Exchange / 1 Ratio * 100% contribution) for season 3
                 },
                 ItemReward = new Dictionary<int, int>
                 {
                     {
-                        600201, 160
-                    }, // (100 AP * 0.4 Exchange / 0.5 Ratio * 100% contribution) for season 1 and 3
+                        600201, 80
+                    }, // (100 AP * 0.4 Exchange / 0.5 Ratio * 100% contribution) for season 1
                     { 600202, 0 },
                     { 600203, 0 },
                 },

--- a/Lib9c/Action/AdventureBoss/Wanted.cs
+++ b/Lib9c/Action/AdventureBoss/Wanted.cs
@@ -55,6 +55,7 @@ namespace Nekoyume.Action.AdventureBoss
             var latestSeason = states.GetLatestAdventureBossSeason();
 
             // Validation
+            // Only NCG allowed
             if (!Bounty.Currency.Equals(currency))
             {
                 throw new InvalidCurrencyException("");
@@ -72,6 +73,7 @@ namespace Nekoyume.Action.AdventureBoss
                 throw new InsufficientBalanceException($"{Bounty}", context.Signer, balance);
             }
 
+            // Ignore invalid seasons including duplication and too future
             if (Season <= 0 ||
                 Season > latestSeason.Season + 1 || Season < latestSeason.Season ||
                 (Season == latestSeason.Season &&
@@ -90,6 +92,7 @@ namespace Nekoyume.Action.AdventureBoss
                 throw new InvalidAddressException();
             }
 
+            // Min. required staking level exists to add bounty
             var requiredStakingLevel =
                 states.GetGameConfigState().AdventureBossWantedRequiredStakingLevel;
             var currentStakeRegularRewardSheetAddr = Addresses.GetSheetAddress(
@@ -114,8 +117,7 @@ namespace Nekoyume.Action.AdventureBoss
 
             BountyBoard bountyBoard;
             // Create new season if required
-            if (latestSeason.Season == 0 ||
-                latestSeason.NextStartBlockIndex <= context.BlockIndex)
+            if (latestSeason.Season == 0 || latestSeason.NextStartBlockIndex <= context.BlockIndex)
             {
                 var seasonInfo = new SeasonInfo(Season, context.BlockIndex,
                     gameConfig.AdventureBossActiveInterval,

--- a/Lib9c/Action/AdventureBoss/Wanted.cs
+++ b/Lib9c/Action/AdventureBoss/Wanted.cs
@@ -126,10 +126,19 @@ namespace Nekoyume.Action.AdventureBoss
 
                 // Set season info: boss and reward
                 var random = context.GetRandom();
+
+                // latestSeason is last season. Check latest-1 season to get second last season
+                var prevSeason = new SeasonInfo(0, 0, 0, 0) { BossId = 0 };
+                if (latestSeason.Season > 1)
+                {
+                    prevSeason = states.GetSeasonInfo(latestSeason.Season - 1);
+                }
+
                 var adventureBossSheet = states.GetSheet<AdventureBossSheet>();
-                var boss = adventureBossSheet.OrderedList[
-                    random.Next(0, adventureBossSheet.Values.Count)
-                ];
+                var candidate = adventureBossSheet.OrderedList.Where(
+                    row => row.BossId != latestSeason.BossId && row.BossId != prevSeason.BossId
+                ).ToList();
+                var boss = candidate[random.Next(candidate.Count)];
                 seasonInfo.BossId = boss.BossId;
 
                 var wantedReward = states.GetSheet<AdventureBossWantedRewardSheet>()


### PR DESCRIPTION
To pick adventure bosses evenly, see latest 2 seasons and avoid them to pick new boss.