### PR TITLE
Prevent usage of unimplemented serialization method

### DIFF
--- a/.Lib9c.Tests/Action/MigrateMonsterCollectionTest.cs
+++ b/.Lib9c.Tests/Action/MigrateMonsterCollectionTest.cs
@@ -72,7 +72,7 @@ namespace Lib9c.Tests.Action
             Address stakeStateAddress = StakeState.DeriveAddress(_signer);
             var states = _state.SetLegacyState(
                     stakeStateAddress, new StakeState(stakeStateAddress, 0).SerializeV2())
-                .SetLegacyState(monsterCollectionAddress, monsterCollectionState.SerializeV2());
+                .SetLegacyState(monsterCollectionAddress, monsterCollectionState.Serialize());
             MigrateMonsterCollection action = new MigrateMonsterCollection(_avatarAddress);
             Assert.Throws<InvalidOperationException>(() => action.Execute(new ActionContext
             {

--- a/.Lib9c.Tests/Action/Stake0Test.cs
+++ b/.Lib9c.Tests/Action/Stake0Test.cs
@@ -78,7 +78,7 @@ namespace Lib9c.Tests.Action
                 .SetAgentState(_signerAddress, agentState)
                 .SetLegacyState(
                     monsterCollectionAddress,
-                    new MonsterCollectionState(monsterCollectionAddress, 1, 0).SerializeV2());
+                    new MonsterCollectionState(monsterCollectionAddress, 1, 0).Serialize());
             var action = new Stake0(200);
             Assert.Throws<MonsterCollectionExistingException>(() =>
                 action.Execute(new ActionContext

--- a/.Lib9c.Tests/Action/Stake2Test.cs
+++ b/.Lib9c.Tests/Action/Stake2Test.cs
@@ -80,7 +80,7 @@ namespace Lib9c.Tests.Action
                 .SetAgentState(_signerAddress, agentState)
                 .SetLegacyState(
                     monsterCollectionAddress,
-                    new MonsterCollectionState(monsterCollectionAddress, 1, 0).SerializeV2());
+                    new MonsterCollectionState(monsterCollectionAddress, 1, 0).Serialize());
             var action = new Stake2(200);
             Assert.Throws<MonsterCollectionExistingException>(() =>
                 action.Execute(new ActionContext

--- a/.Lib9c.Tests/Action/StakeTest.cs
+++ b/.Lib9c.Tests/Action/StakeTest.cs
@@ -122,7 +122,7 @@ namespace Lib9c.Tests.Action
                 1,
                 0);
             previousState = previousState
-                .SetLegacyState(monsterCollectionAddr, monsterCollectionState.SerializeV2());
+                .SetLegacyState(monsterCollectionAddr, monsterCollectionState.Serialize());
             Assert.Throws<MonsterCollectionExistingException>(() =>
                 Execute(
                     0,

--- a/.Lib9c.Tests/Model/State/LazyStateTest.cs
+++ b/.Lib9c.Tests/Model/State/LazyStateTest.cs
@@ -120,7 +120,7 @@ namespace Lib9c.Tests.Model.State
 
             public string Bar { get; set; }
 
-            public override IValue Serialize() => ((Dictionary)base.Serialize())
+            public override IValue Serialize() => ((Dictionary)base.SerializeBase())
                 .Add("foo", Foo)
                 .Add("bar", Bar);
         }

--- a/.Lib9c.Tests/Model/State/LazyStateTest.cs
+++ b/.Lib9c.Tests/Model/State/LazyStateTest.cs
@@ -120,7 +120,7 @@ namespace Lib9c.Tests.Model.State
 
             public string Bar { get; set; }
 
-            public override IValue Serialize() => ((Dictionary)base.SerializeBase())
+            public override IValue Serialize() => ((Dictionary)SerializeBase())
                 .Add("foo", Foo)
                 .Add("bar", Bar);
         }

--- a/Lib9c/Model/State/ActivatedAccountsState.cs
+++ b/Lib9c/Model/State/ActivatedAccountsState.cs
@@ -49,7 +49,7 @@ namespace Nekoyume.Model.State
             Accounts = Accounts.Remove(account);
         }
 
-        public override IValue Serialize() =>
+        public new IValue Serialize() =>
             ((Dictionary)base.Serialize()).SetItem(
                 "accounts",
                 Accounts.Select(a => a.Serialize()).Serialize()

--- a/Lib9c/Model/State/ActivatedAccountsState.cs
+++ b/Lib9c/Model/State/ActivatedAccountsState.cs
@@ -49,7 +49,7 @@ namespace Nekoyume.Model.State
             Accounts = Accounts.Remove(account);
         }
 
-        public new IValue Serialize() =>
+        public override IValue Serialize() =>
             ((Dictionary)base.SerializeBase()).SetItem(
                 "accounts",
                 Accounts.Select(a => a.Serialize()).Serialize()

--- a/Lib9c/Model/State/ActivatedAccountsState.cs
+++ b/Lib9c/Model/State/ActivatedAccountsState.cs
@@ -50,7 +50,7 @@ namespace Nekoyume.Model.State
         }
 
         public new IValue Serialize() =>
-            ((Dictionary)base.Serialize()).SetItem(
+            ((Dictionary)base.SerializeBase()).SetItem(
                 "accounts",
                 Accounts.Select(a => a.Serialize()).Serialize()
             );

--- a/Lib9c/Model/State/AdminState.cs
+++ b/Lib9c/Model/State/AdminState.cs
@@ -27,7 +27,7 @@ namespace Nekoyume.Model.State
             ValidUntil = serialized["valid_until"].ToLong();
         }
 
-        public new IValue Serialize()
+        public override IValue Serialize()
         {
             var values = new Dictionary<IKey, IValue>
             {

--- a/Lib9c/Model/State/AdminState.cs
+++ b/Lib9c/Model/State/AdminState.cs
@@ -27,7 +27,7 @@ namespace Nekoyume.Model.State
             ValidUntil = serialized["valid_until"].ToLong();
         }
 
-        public override IValue Serialize()
+        public new IValue Serialize()
         {
             var values = new Dictionary<IKey, IValue>
             {

--- a/Lib9c/Model/State/AdminState.cs
+++ b/Lib9c/Model/State/AdminState.cs
@@ -35,7 +35,7 @@ namespace Nekoyume.Model.State
                 [(Text) "valid_until"] = ValidUntil.Serialize(),
             };
 #pragma warning disable LAA1002
-            return new Dictionary(values.Union((Dictionary)base.Serialize()));
+            return new Dictionary(values.Union((Dictionary)base.SerializeBase()));
 #pragma warning restore LAA1002
         }
 

--- a/Lib9c/Model/State/AgentState.cs
+++ b/Lib9c/Model/State/AgentState.cs
@@ -70,6 +70,12 @@ namespace Nekoyume.Model.State
             MonsterCollectionRound++;
         }
 
+        /// <inheritdoc cref="IState.Serialize" />
+        public override IValue Serialize()
+        {
+            return SerializeList();
+        }
+
         public IValue SerializeList()
         {
             return new List(

--- a/Lib9c/Model/State/AgentState.cs
+++ b/Lib9c/Model/State/AgentState.cs
@@ -70,17 +70,7 @@ namespace Nekoyume.Model.State
             MonsterCollectionRound++;
         }
 
-        public override IValue Serialize()
-        {
-            throw new NotSupportedException();
-        }
-
-        public override IValue SerializeV2()
-        {
-            throw new NotSupportedException();
-        }
-
-        public override IValue SerializeList()
+        public new IValue SerializeList()
         {
             return new List(
                 base.SerializeList(),

--- a/Lib9c/Model/State/AgentState.cs
+++ b/Lib9c/Model/State/AgentState.cs
@@ -70,10 +70,10 @@ namespace Nekoyume.Model.State
             MonsterCollectionRound++;
         }
 
-        public new IValue SerializeList()
+        public IValue SerializeList()
         {
             return new List(
-                base.SerializeList(),
+                base.SerializeListBase(),
                 (Integer)CurrentVersion,
 #pragma warning disable LAA1002
                 new Dictionary(

--- a/Lib9c/Model/State/AuthorizedMinersState.cs
+++ b/Lib9c/Model/State/AuthorizedMinersState.cs
@@ -45,7 +45,7 @@ namespace Nekoyume.Model.State
                 [(Text)nameof(Interval)] = Interval.Serialize(),
                 [(Text)nameof(ValidUntil)] = ValidUntil.Serialize(),
             };
-            return new Dictionary(values.Union((Dictionary)base.Serialize()));
+            return new Dictionary(values.Union((Dictionary)base.SerializeBase()));
 #pragma warning restore LAA1002
         }
     }

--- a/Lib9c/Model/State/AuthorizedMinersState.cs
+++ b/Lib9c/Model/State/AuthorizedMinersState.cs
@@ -36,7 +36,7 @@ namespace Nekoyume.Model.State
             ValidUntil = serialized[nameof(ValidUntil)].ToLong();
         }
 
-        public new IValue Serialize()
+        public override IValue Serialize()
         {
 #pragma warning disable LAA1002
             var values = new Dictionary<IKey, IValue>

--- a/Lib9c/Model/State/AuthorizedMinersState.cs
+++ b/Lib9c/Model/State/AuthorizedMinersState.cs
@@ -36,7 +36,7 @@ namespace Nekoyume.Model.State
             ValidUntil = serialized[nameof(ValidUntil)].ToLong();
         }
 
-        public override IValue Serialize()
+        public new IValue Serialize()
         {
 #pragma warning disable LAA1002
             var values = new Dictionary<IKey, IValue>

--- a/Lib9c/Model/State/AvatarState.cs
+++ b/Lib9c/Model/State/AvatarState.cs
@@ -1254,17 +1254,7 @@ namespace Nekoyume.Model.State
             return items;
         }
 
-        public override IValue Serialize()
-        {
-            throw new NotSupportedException();
-        }
-
-        public override IValue SerializeV2()
-        {
-            throw new NotSupportedException();
-        }
-
-        public override IValue SerializeList()
+        public new IValue SerializeList()
         {
             // Migrated when serialized
             Version = CurrentVersion;

--- a/Lib9c/Model/State/AvatarState.cs
+++ b/Lib9c/Model/State/AvatarState.cs
@@ -1254,6 +1254,12 @@ namespace Nekoyume.Model.State
             return items;
         }
 
+        /// <inheritdoc cref="IState.Serialize" />
+        public override IValue Serialize()
+        {
+            return SerializeList();
+        }
+
         public IValue SerializeList()
         {
             // Migrated when serialized

--- a/Lib9c/Model/State/AvatarState.cs
+++ b/Lib9c/Model/State/AvatarState.cs
@@ -1254,12 +1254,12 @@ namespace Nekoyume.Model.State
             return items;
         }
 
-        public new IValue SerializeList()
+        public IValue SerializeList()
         {
             // Migrated when serialized
             Version = CurrentVersion;
             return new List(
-                base.SerializeList(),
+                base.SerializeListBase(),
                 (Integer)Version,
                 (Text)name,
                 (Integer)characterId,

--- a/Lib9c/Model/State/CombinationSlotState.cs
+++ b/Lib9c/Model/State/CombinationSlotState.cs
@@ -166,7 +166,7 @@ namespace Nekoyume.Model.State
             return true;
         }
 
-        public new IValue Serialize()
+        public override IValue Serialize()
         {
             var values = new Dictionary<IKey, IValue>
             {

--- a/Lib9c/Model/State/CombinationSlotState.cs
+++ b/Lib9c/Model/State/CombinationSlotState.cs
@@ -187,7 +187,7 @@ namespace Nekoyume.Model.State
             }
 
 #pragma warning disable LAA1002
-            return new Dictionary(values.Union((Dictionary) base.Serialize()));
+            return new Dictionary(values.Union((Dictionary) base.SerializeBase()));
 #pragma warning restore LAA1002
         }
     }

--- a/Lib9c/Model/State/CombinationSlotState.cs
+++ b/Lib9c/Model/State/CombinationSlotState.cs
@@ -34,7 +34,7 @@ namespace Nekoyume.Model.State
             get => Index < AvatarState.DefaultCombinationSlotCount || _isUnlocked;
             private set => _isUnlocked = value;
         }
-        
+
         private bool _isUnlocked;
 
         /// <summary>
@@ -166,7 +166,7 @@ namespace Nekoyume.Model.State
             return true;
         }
 
-        public override IValue Serialize()
+        public new IValue Serialize()
         {
             var values = new Dictionary<IKey, IValue>
             {

--- a/Lib9c/Model/State/CreditsState.cs
+++ b/Lib9c/Model/State/CreditsState.cs
@@ -11,7 +11,7 @@ namespace Nekoyume.Model.State
     public class CreditsState : State
     {
         public static readonly Address Address = Addresses.Credits;
-        
+
         public CreditsState(IEnumerable<string> names)
             : base(Addresses.Credits)
         {
@@ -26,7 +26,7 @@ namespace Nekoyume.Model.State
 
         public IImmutableList<string> Names { get; }
 
-        public override IValue Serialize()
+        public new IValue Serialize()
         {
             var values = new Dictionary<IKey, IValue>
             {

--- a/Lib9c/Model/State/CreditsState.cs
+++ b/Lib9c/Model/State/CreditsState.cs
@@ -33,7 +33,7 @@ namespace Nekoyume.Model.State
                 [(Text)nameof(Names)] = new List(Names.Select(n => (Text) n).Cast<IValue>()),
             };
 #pragma warning disable LAA1002
-            return new Dictionary(values.Union((Dictionary)base.Serialize()));
+            return new Dictionary(values.Union((Dictionary)base.SerializeBase()));
 #pragma warning restore LAA1002
         }
     }

--- a/Lib9c/Model/State/CreditsState.cs
+++ b/Lib9c/Model/State/CreditsState.cs
@@ -26,7 +26,7 @@ namespace Nekoyume.Model.State
 
         public IImmutableList<string> Names { get; }
 
-        public new IValue Serialize()
+        public override IValue Serialize()
         {
             var values = new Dictionary<IKey, IValue>
             {

--- a/Lib9c/Model/State/GameConfigState.cs
+++ b/Lib9c/Model/State/GameConfigState.cs
@@ -612,7 +612,7 @@ namespace Nekoyume.Model.State
             #endregion
 
 #pragma warning disable LAA1002
-            return new Dictionary(values.Union((Dictionary) base.Serialize()));
+            return new Dictionary(values.Union((Dictionary) base.SerializeBase()));
 #pragma warning restore LAA1002
         }
 

--- a/Lib9c/Model/State/GameConfigState.cs
+++ b/Lib9c/Model/State/GameConfigState.cs
@@ -330,7 +330,7 @@ namespace Nekoyume.Model.State
             }
         }
 
-        public override IValue Serialize()
+        public new IValue Serialize()
         {
             var values = new Dictionary<IKey, IValue>
             {

--- a/Lib9c/Model/State/GameConfigState.cs
+++ b/Lib9c/Model/State/GameConfigState.cs
@@ -330,7 +330,7 @@ namespace Nekoyume.Model.State
             }
         }
 
-        public new IValue Serialize()
+        public override IValue Serialize()
         {
             var values = new Dictionary<IKey, IValue>
             {

--- a/Lib9c/Model/State/GoldBalanceState.cs
+++ b/Lib9c/Model/State/GoldBalanceState.cs
@@ -27,7 +27,7 @@ namespace Nekoyume.Model.State
         public object Clone() =>
             MemberwiseClone();
 
-        public new IValue Serialize()
+        public override IValue Serialize()
         {
             // Add("gold", (Bencodex.Types.Integer) gold)처럼 호출하면 Bencodex.Types.Integer에 int/long으로의
             // implicit 연산자가 구현되어 있어서 아래 오버로드 중에 어느 쪽을 호출하는 것인지 모호하다고 컴파일 오류가 나버림.

--- a/Lib9c/Model/State/GoldBalanceState.cs
+++ b/Lib9c/Model/State/GoldBalanceState.cs
@@ -36,7 +36,7 @@ namespace Nekoyume.Model.State
             // - Add(string, IValue)
             // 그래서 아래처럼 온몸비틀기. 그냥 Bencodex.Types.Dictionary에 Add(string, BigInteger) 하나 넣는 게 좋을 듯...
             // -> https://github.com/planetarium/bencodex.net/issues/21
-            var @base = (Bencodex.Types.Dictionary) base.Serialize();
+            var @base = (Bencodex.Types.Dictionary) base.SerializeBase();
             var serialized = ((IImmutableDictionary<IKey, IValue>) @base)
                 .SetItem((Text) nameof(Gold), Gold.Serialize());
             return (Bencodex.Types.Dictionary) serialized;

--- a/Lib9c/Model/State/GoldBalanceState.cs
+++ b/Lib9c/Model/State/GoldBalanceState.cs
@@ -27,7 +27,7 @@ namespace Nekoyume.Model.State
         public object Clone() =>
             MemberwiseClone();
 
-        public override IValue Serialize()
+        public new IValue Serialize()
         {
             // Add("gold", (Bencodex.Types.Integer) gold)처럼 호출하면 Bencodex.Types.Integer에 int/long으로의
             // implicit 연산자가 구현되어 있어서 아래 오버로드 중에 어느 쪽을 호출하는 것인지 모호하다고 컴파일 오류가 나버림.

--- a/Lib9c/Model/State/GoldCurrencyState.cs
+++ b/Lib9c/Model/State/GoldCurrencyState.cs
@@ -51,7 +51,7 @@ namespace Nekoyume.Model.State
         {
         }
 
-        public override IValue Serialize()
+        public new IValue Serialize()
         {
             var values = new Dictionary<IKey, IValue>
             {

--- a/Lib9c/Model/State/GoldCurrencyState.cs
+++ b/Lib9c/Model/State/GoldCurrencyState.cs
@@ -63,7 +63,7 @@ namespace Nekoyume.Model.State
                 values.Add((Text)"initialSupply", (Integer)InitialSupply);
             }
 #pragma warning disable LAA1002
-            return new Dictionary(values.Union((Dictionary)base.Serialize()));
+            return new Dictionary(values.Union((Dictionary)base.SerializeBase()));
 #pragma warning restore LAA1002
         }
 

--- a/Lib9c/Model/State/GoldCurrencyState.cs
+++ b/Lib9c/Model/State/GoldCurrencyState.cs
@@ -51,7 +51,7 @@ namespace Nekoyume.Model.State
         {
         }
 
-        public new IValue Serialize()
+        public override IValue Serialize()
         {
             var values = new Dictionary<IKey, IValue>
             {

--- a/Lib9c/Model/State/MonsterCollectionState.cs
+++ b/Lib9c/Model/State/MonsterCollectionState.cs
@@ -126,7 +126,7 @@ namespace Nekoyume.Model.State
                 [(Text) LevelKey] = Level.Serialize(),
                 [(Text) StartedBlockIndexKey] = StartedBlockIndex.Serialize(),
                 [(Text) ReceivedBlockIndexKey] = ReceivedBlockIndex.Serialize(),
-            }.Union((Dictionary) base.SerializeV2()));
+            }.Union((Dictionary) base.SerializeV2Base()));
 #pragma warning restore LAA1002
         }
 

--- a/Lib9c/Model/State/MonsterCollectionState.cs
+++ b/Lib9c/Model/State/MonsterCollectionState.cs
@@ -118,7 +118,7 @@ namespace Nekoyume.Model.State
             }
         }
 
-        public new IValue Serialize()
+        public override IValue Serialize()
         {
 #pragma warning disable LAA1002
             return new Dictionary(new Dictionary<IKey, IValue>

--- a/Lib9c/Model/State/MonsterCollectionState.cs
+++ b/Lib9c/Model/State/MonsterCollectionState.cs
@@ -118,7 +118,7 @@ namespace Nekoyume.Model.State
             }
         }
 
-        public override IValue Serialize()
+        public new IValue Serialize()
         {
 #pragma warning disable LAA1002
             return new Dictionary(new Dictionary<IKey, IValue>

--- a/Lib9c/Model/State/MonsterCollectionState0.cs
+++ b/Lib9c/Model/State/MonsterCollectionState0.cs
@@ -183,11 +183,11 @@ namespace Nekoyume.Model.State
                         )
                     )
                 ),
-            }.Union((Dictionary) base.Serialize()));
+            }.Union((Dictionary) base.SerializeBase()));
 #pragma warning restore LAA1002
         }
 
-        public new IValue SerializeV2()
+        public IValue SerializeV2()
         {
 #pragma warning disable LAA1002
             return new Dictionary(new Dictionary<IKey, IValue>
@@ -195,7 +195,7 @@ namespace Nekoyume.Model.State
                 [(Text) LevelKey] = Level.Serialize(),
                 [(Text) StartedBlockIndexKey] = StartedBlockIndex.Serialize(),
                 [(Text) ReceivedBlockIndexKey] = ReceivedBlockIndex.Serialize(),
-            }.Union((Dictionary) base.SerializeV2()));
+            }.Union((Dictionary) base.SerializeV2Base()));
 #pragma warning restore LAA1002
         }
 

--- a/Lib9c/Model/State/MonsterCollectionState0.cs
+++ b/Lib9c/Model/State/MonsterCollectionState0.cs
@@ -156,7 +156,7 @@ namespace Nekoyume.Model.State
             ReceivedBlockIndex = blockIndex;
         }
 
-        public override IValue Serialize()
+        public new IValue Serialize()
         {
 #pragma warning disable LAA1002
             return new Dictionary(new Dictionary<IKey, IValue>
@@ -187,7 +187,7 @@ namespace Nekoyume.Model.State
 #pragma warning restore LAA1002
         }
 
-        public override IValue SerializeV2()
+        public new IValue SerializeV2()
         {
 #pragma warning disable LAA1002
             return new Dictionary(new Dictionary<IKey, IValue>

--- a/Lib9c/Model/State/MonsterCollectionState0.cs
+++ b/Lib9c/Model/State/MonsterCollectionState0.cs
@@ -156,7 +156,7 @@ namespace Nekoyume.Model.State
             ReceivedBlockIndex = blockIndex;
         }
 
-        public new IValue Serialize()
+        public override IValue Serialize()
         {
 #pragma warning disable LAA1002
             return new Dictionary(new Dictionary<IKey, IValue>

--- a/Lib9c/Model/State/PendingActivationState.cs
+++ b/Lib9c/Model/State/PendingActivationState.cs
@@ -42,7 +42,7 @@ namespace Nekoyume.Model.State
         {
         }
 
-        public new IValue Serialize()
+        public override IValue Serialize()
         {
             var values = new Dictionary<IKey, IValue>
             {

--- a/Lib9c/Model/State/PendingActivationState.cs
+++ b/Lib9c/Model/State/PendingActivationState.cs
@@ -51,7 +51,7 @@ namespace Nekoyume.Model.State
             };
 
 #pragma warning disable LAA1002
-            return new Dictionary(values.Union((Dictionary)base.Serialize()));
+            return new Dictionary(values.Union((Dictionary)base.SerializeBase()));
 #pragma warning restore LAA1002
         }
 

--- a/Lib9c/Model/State/PendingActivationState.cs
+++ b/Lib9c/Model/State/PendingActivationState.cs
@@ -42,7 +42,7 @@ namespace Nekoyume.Model.State
         {
         }
 
-        public override IValue Serialize()
+        public new IValue Serialize()
         {
             var values = new Dictionary<IKey, IValue>
             {

--- a/Lib9c/Model/State/RankingMapState.cs
+++ b/Lib9c/Model/State/RankingMapState.cs
@@ -53,7 +53,7 @@ namespace Nekoyume.Model.State
                 : list;
         }
 
-        public override IValue Serialize()
+        public new IValue Serialize()
         {
 #pragma warning disable LAA1002
             return new Dictionary(new Dictionary<IKey, IValue>

--- a/Lib9c/Model/State/RankingMapState.cs
+++ b/Lib9c/Model/State/RankingMapState.cs
@@ -53,7 +53,7 @@ namespace Nekoyume.Model.State
                 : list;
         }
 
-        public new IValue Serialize()
+        public override IValue Serialize()
         {
 #pragma warning disable LAA1002
             return new Dictionary(new Dictionary<IKey, IValue>

--- a/Lib9c/Model/State/RankingMapState.cs
+++ b/Lib9c/Model/State/RankingMapState.cs
@@ -64,7 +64,7 @@ namespace Nekoyume.Model.State
                         kv.Value.Serialize()
                     )
                 ))
-            }.Union((Dictionary) base.Serialize()));
+            }.Union((Dictionary) base.SerializeBase()));
 #pragma warning restore LAA1002
         }
     }

--- a/Lib9c/Model/State/RankingState.cs
+++ b/Lib9c/Model/State/RankingState.cs
@@ -83,7 +83,7 @@ namespace Nekoyume.Model.State
             throw new RankingExceededException();
         }
 
-        public override IValue Serialize() => _serialized ??
+        public new IValue Serialize() => _serialized ??
             ((Dictionary)base.Serialize()).Add(
                 "ranking_map",
 #pragma warning disable LAA1002

--- a/Lib9c/Model/State/RankingState.cs
+++ b/Lib9c/Model/State/RankingState.cs
@@ -83,7 +83,7 @@ namespace Nekoyume.Model.State
             throw new RankingExceededException();
         }
 
-        public new IValue Serialize() => _serialized ??
+        public override IValue Serialize() => _serialized ??
             ((Dictionary)base.SerializeBase()).Add(
                 "ranking_map",
 #pragma warning disable LAA1002

--- a/Lib9c/Model/State/RankingState.cs
+++ b/Lib9c/Model/State/RankingState.cs
@@ -84,7 +84,7 @@ namespace Nekoyume.Model.State
         }
 
         public new IValue Serialize() => _serialized ??
-            ((Dictionary)base.Serialize()).Add(
+            ((Dictionary)base.SerializeBase()).Add(
                 "ranking_map",
 #pragma warning disable LAA1002
                 new Dictionary(RankingMap.Select(kv =>

--- a/Lib9c/Model/State/RankingState0.cs
+++ b/Lib9c/Model/State/RankingState0.cs
@@ -79,7 +79,7 @@ namespace Nekoyume.Model.State
         }
 
         public new IValue Serialize() => _serialized ??
-            ((Dictionary)base.Serialize()).Add(
+            ((Dictionary)base.SerializeBase()).Add(
                 "ranking_map",
 #pragma warning disable LAA1002
                 new Dictionary(RankingMap.Select(kv =>

--- a/Lib9c/Model/State/RankingState0.cs
+++ b/Lib9c/Model/State/RankingState0.cs
@@ -78,7 +78,7 @@ namespace Nekoyume.Model.State
             throw new RankingExceededException();
         }
 
-        public new IValue Serialize() => _serialized ??
+        public override IValue Serialize() => _serialized ??
             ((Dictionary)base.SerializeBase()).Add(
                 "ranking_map",
 #pragma warning disable LAA1002

--- a/Lib9c/Model/State/RankingState0.cs
+++ b/Lib9c/Model/State/RankingState0.cs
@@ -78,7 +78,7 @@ namespace Nekoyume.Model.State
             throw new RankingExceededException();
         }
 
-        public override IValue Serialize() => _serialized ??
+        public new IValue Serialize() => _serialized ??
             ((Dictionary)base.Serialize()).Add(
                 "ranking_map",
 #pragma warning disable LAA1002

--- a/Lib9c/Model/State/RankingState1.cs
+++ b/Lib9c/Model/State/RankingState1.cs
@@ -79,7 +79,7 @@ namespace Nekoyume.Model.State
         }
 
         public new IValue Serialize() => _serialized ??
-            ((Dictionary)base.Serialize()).Add(
+            ((Dictionary)base.SerializeBase()).Add(
                 "ranking_map",
 #pragma warning disable LAA1002
                 new Dictionary(RankingMap.Select(kv =>

--- a/Lib9c/Model/State/RankingState1.cs
+++ b/Lib9c/Model/State/RankingState1.cs
@@ -78,7 +78,7 @@ namespace Nekoyume.Model.State
             throw new RankingExceededException();
         }
 
-        public new IValue Serialize() => _serialized ??
+        public override IValue Serialize() => _serialized ??
             ((Dictionary)base.SerializeBase()).Add(
                 "ranking_map",
 #pragma warning disable LAA1002

--- a/Lib9c/Model/State/RankingState1.cs
+++ b/Lib9c/Model/State/RankingState1.cs
@@ -78,7 +78,7 @@ namespace Nekoyume.Model.State
             throw new RankingExceededException();
         }
 
-        public override IValue Serialize() => _serialized ??
+        public new IValue Serialize() => _serialized ??
             ((Dictionary)base.Serialize()).Add(
                 "ranking_map",
 #pragma warning disable LAA1002

--- a/Lib9c/Model/State/RedeemCodeState.cs
+++ b/Lib9c/Model/State/RedeemCodeState.cs
@@ -78,7 +78,7 @@ namespace Nekoyume.Model.State
             _map = rewardMap.ToDictionary(kv => (Binary)kv.Key.Format(true), kv => kv.Value);
         }
 
-        public override IValue Serialize() =>
+        public new IValue Serialize() =>
             ((Dictionary) base.Serialize())
 #pragma warning disable LAA1002
             .Add("map", new Dictionary(_map.Select(kv => new KeyValuePair<IKey, IValue>(

--- a/Lib9c/Model/State/RedeemCodeState.cs
+++ b/Lib9c/Model/State/RedeemCodeState.cs
@@ -79,7 +79,7 @@ namespace Nekoyume.Model.State
         }
 
         public new IValue Serialize() =>
-            ((Dictionary) base.Serialize())
+            ((Dictionary) base.SerializeBase())
 #pragma warning disable LAA1002
             .Add("map", new Dictionary(_map.Select(kv => new KeyValuePair<IKey, IValue>(
                 kv.Key,

--- a/Lib9c/Model/State/RedeemCodeState.cs
+++ b/Lib9c/Model/State/RedeemCodeState.cs
@@ -78,7 +78,7 @@ namespace Nekoyume.Model.State
             _map = rewardMap.ToDictionary(kv => (Binary)kv.Key.Format(true), kv => kv.Value);
         }
 
-        public new IValue Serialize() =>
+        public override IValue Serialize() =>
             ((Dictionary) base.SerializeBase())
 #pragma warning disable LAA1002
             .Add("map", new Dictionary(_map.Select(kv => new KeyValuePair<IKey, IValue>(

--- a/Lib9c/Model/State/ShardedShopState.cs
+++ b/Lib9c/Model/State/ShardedShopState.cs
@@ -100,7 +100,7 @@ namespace Nekoyume.Model.State
             Products[shopItem.ProductId] = shopItem;
         }
 
-        public new IValue Serialize() =>
+        public override IValue Serialize() =>
 #pragma warning disable LAA1002
             new Dictionary(new Dictionary<IKey, IValue>
             {

--- a/Lib9c/Model/State/ShardedShopState.cs
+++ b/Lib9c/Model/State/ShardedShopState.cs
@@ -105,7 +105,7 @@ namespace Nekoyume.Model.State
             new Dictionary(new Dictionary<IKey, IValue>
             {
                 [(Text) ProductsKey] = new List(Products.Select(kv => kv.Value.Serialize()))
-            }.Union((Dictionary) base.Serialize()));
+            }.Union((Dictionary) base.SerializeBase()));
 #pragma warning restore LAA1002
     }
 }

--- a/Lib9c/Model/State/ShardedShopState.cs
+++ b/Lib9c/Model/State/ShardedShopState.cs
@@ -100,7 +100,7 @@ namespace Nekoyume.Model.State
             Products[shopItem.ProductId] = shopItem;
         }
 
-        public override IValue Serialize() =>
+        public new IValue Serialize() =>
 #pragma warning disable LAA1002
             new Dictionary(new Dictionary<IKey, IValue>
             {

--- a/Lib9c/Model/State/ShardedShopStateV2.cs
+++ b/Lib9c/Model/State/ShardedShopStateV2.cs
@@ -90,7 +90,7 @@ namespace Nekoyume.Model.State
                 .OrderBy(o => o.StartedBlockIndex).ToList();
         }
 
-        public new IValue Serialize() =>
+        public override IValue Serialize() =>
 #pragma warning disable LAA1002
             new Dictionary(new Dictionary<IKey, IValue>
             {

--- a/Lib9c/Model/State/ShardedShopStateV2.cs
+++ b/Lib9c/Model/State/ShardedShopStateV2.cs
@@ -90,7 +90,7 @@ namespace Nekoyume.Model.State
                 .OrderBy(o => o.StartedBlockIndex).ToList();
         }
 
-        public override IValue Serialize() =>
+        public new IValue Serialize() =>
 #pragma warning disable LAA1002
             new Dictionary(new Dictionary<IKey, IValue>
             {

--- a/Lib9c/Model/State/ShardedShopStateV2.cs
+++ b/Lib9c/Model/State/ShardedShopStateV2.cs
@@ -95,7 +95,7 @@ namespace Nekoyume.Model.State
             new Dictionary(new Dictionary<IKey, IValue>
             {
                 [(Text) OrderDigestListKey] = new List(OrderDigestList.Select(o => o.Serialize()))
-            }.Union((Dictionary) base.Serialize()));
+            }.Union((Dictionary) base.SerializeBase()));
 #pragma warning restore LAA1002
     }
 }

--- a/Lib9c/Model/State/ShopState.cs
+++ b/Lib9c/Model/State/ShopState.cs
@@ -30,7 +30,7 @@ namespace Nekoyume.Model.State
                 kv => new ShopItem((Dictionary) kv.Value));
         }
 
-        public new IValue Serialize() =>
+        public override IValue Serialize() =>
 #pragma warning disable LAA1002
             new Dictionary(new Dictionary<IKey, IValue>
             {

--- a/Lib9c/Model/State/ShopState.cs
+++ b/Lib9c/Model/State/ShopState.cs
@@ -30,7 +30,7 @@ namespace Nekoyume.Model.State
                 kv => new ShopItem((Dictionary) kv.Value));
         }
 
-        public override IValue Serialize() =>
+        public new IValue Serialize() =>
 #pragma warning disable LAA1002
             new Dictionary(new Dictionary<IKey, IValue>
             {

--- a/Lib9c/Model/State/ShopState.cs
+++ b/Lib9c/Model/State/ShopState.cs
@@ -39,7 +39,7 @@ namespace Nekoyume.Model.State
                         new KeyValuePair<IKey, IValue>(
                             (Binary) kv.Key.Serialize(),
                             kv.Value.Serialize()))),
-            }.Union((Dictionary) base.Serialize()));
+            }.Union((Dictionary) base.SerializeBase()));
 #pragma warning restore LAA1002
 
         #region Register

--- a/Lib9c/Model/State/StakeState.cs
+++ b/Lib9c/Model/State/StakeState.cs
@@ -106,10 +106,10 @@ namespace Nekoyume.Model.State
         }
 
         public new IValue Serialize() =>
-            new Dictionary(SerializeImpl().Union((Dictionary)base.Serialize()));
+            new Dictionary(SerializeImpl().Union((Dictionary)base.SerializeBase()));
 
-        public new IValue SerializeV2() =>
-            new Dictionary(SerializeImpl().Union((Dictionary)base.SerializeV2()));
+        public IValue SerializeV2() =>
+            new Dictionary(SerializeImpl().Union((Dictionary)base.SerializeV2Base()));
 
         public bool IsCancellable(long blockIndex) => blockIndex >= CancellableBlockIndex;
 

--- a/Lib9c/Model/State/StakeState.cs
+++ b/Lib9c/Model/State/StakeState.cs
@@ -105,7 +105,7 @@ namespace Nekoyume.Model.State
                 .Add(AchievementsKey, Achievements.Serialize());
         }
 
-        public new IValue Serialize() =>
+        public override IValue Serialize() =>
             new Dictionary(SerializeImpl().Union((Dictionary)base.SerializeBase()));
 
         public IValue SerializeV2() =>

--- a/Lib9c/Model/State/StakeState.cs
+++ b/Lib9c/Model/State/StakeState.cs
@@ -105,10 +105,10 @@ namespace Nekoyume.Model.State
                 .Add(AchievementsKey, Achievements.Serialize());
         }
 
-        public override IValue Serialize() =>
+        public new IValue Serialize() =>
             new Dictionary(SerializeImpl().Union((Dictionary)base.Serialize()));
 
-        public override IValue SerializeV2() =>
+        public new IValue SerializeV2() =>
             new Dictionary(SerializeImpl().Union((Dictionary)base.SerializeV2()));
 
         public bool IsCancellable(long blockIndex) => blockIndex >= CancellableBlockIndex;

--- a/Lib9c/Model/State/State.cs
+++ b/Lib9c/Model/State/State.cs
@@ -28,6 +28,8 @@ namespace Nekoyume.Model.State
         {
         }
 
+        public abstract IValue Serialize();
+
         protected IValue SerializeBase() =>
             new Dictionary(new Dictionary<IKey, IValue>
             {

--- a/Lib9c/Model/State/State.cs
+++ b/Lib9c/Model/State/State.cs
@@ -28,18 +28,18 @@ namespace Nekoyume.Model.State
         {
         }
 
-        public virtual IValue Serialize() =>
+        protected IValue Serialize() =>
             new Dictionary(new Dictionary<IKey, IValue>
             {
                 [(Text)LegacyAddressKey] = address.Serialize(),
             });
-        public virtual IValue SerializeV2() =>
+        protected IValue SerializeV2() =>
             new Dictionary(new Dictionary<IKey, IValue>
             {
                 [(Text)AddressKey] = address.Serialize(),
             });
 
-        public virtual IValue SerializeList() =>
+        protected IValue SerializeList() =>
             new List(address.Serialize());
     }
 }

--- a/Lib9c/Model/State/State.cs
+++ b/Lib9c/Model/State/State.cs
@@ -28,18 +28,18 @@ namespace Nekoyume.Model.State
         {
         }
 
-        protected IValue Serialize() =>
+        protected IValue SerializeBase() =>
             new Dictionary(new Dictionary<IKey, IValue>
             {
                 [(Text)LegacyAddressKey] = address.Serialize(),
             });
-        protected IValue SerializeV2() =>
+        protected IValue SerializeV2Base() =>
             new Dictionary(new Dictionary<IKey, IValue>
             {
                 [(Text)AddressKey] = address.Serialize(),
             });
 
-        protected IValue SerializeList() =>
+        protected IValue SerializeListBase() =>
             new List(address.Serialize());
     }
 }

--- a/Lib9c/Model/State/WeeklyArenaState.cs
+++ b/Lib9c/Model/State/WeeklyArenaState.cs
@@ -70,7 +70,7 @@ namespace Nekoyume.Model.State
         {
         }
 
-        public override IValue Serialize() => ((Dictionary)base.Serialize())
+        public new IValue Serialize() => ((Dictionary)base.Serialize())
             .Add("resetIndex", ResetIndex.Serialize())
             .Add("ended", Ended.Serialize())
 #pragma warning disable LAA1002

--- a/Lib9c/Model/State/WeeklyArenaState.cs
+++ b/Lib9c/Model/State/WeeklyArenaState.cs
@@ -70,7 +70,7 @@ namespace Nekoyume.Model.State
         {
         }
 
-        public new IValue Serialize() => ((Dictionary)base.SerializeBase())
+        public override IValue Serialize() => ((Dictionary)base.SerializeBase())
             .Add("resetIndex", ResetIndex.Serialize())
             .Add("ended", Ended.Serialize())
 #pragma warning disable LAA1002

--- a/Lib9c/Model/State/WeeklyArenaState.cs
+++ b/Lib9c/Model/State/WeeklyArenaState.cs
@@ -70,7 +70,7 @@ namespace Nekoyume.Model.State
         {
         }
 
-        public new IValue Serialize() => ((Dictionary)base.Serialize())
+        public new IValue Serialize() => ((Dictionary)base.SerializeBase())
             .Add("resetIndex", ResetIndex.Serialize())
             .Add("ended", Ended.Serialize())
 #pragma warning disable LAA1002


### PR DESCRIPTION
## Overview

This pull request resolves #2812. About details, please see #2812.

Since this pull request, `GoldCurrencyState.SerializeList` cannot be compiled.
![image](https://github.com/user-attachments/assets/62a419d5-f10b-40b8-a1f4-6bbf48d2661b)

Also it caught invalid usage of serialize method in tests. ([db46ae9](https://github.com/planetarium/lib9c/pull/2814/commits/db46ae97243d7aae79b23ad344e835e7f36c420f))

## Breaking changes in code

 - `State.Serialize` is renamed to `State.SerializeBase`.
 - `State.SerailizeV2` is renamed to `State.SerializeV2Base`
 - `State.SerializeList` is renamed to `State.SerializeListBase`

Serialization methods of classes inherited `State` class aren't renamed. 

 - `State.SerializeBase` (prior `Serialize`) method's access modifier becomes `protected`
 - `State.SerializeV2Base` (prior `SerializeV2`) method's access modifier becomes `protected`
 - `State.SerializeListBase` (prior `SerializeList`) method's access modifier becomes `protected`

Now the default serialization implementations cannot be accessed from public code (not class inner code).

## Reviewers

I have requested reviews for engineers working on lib9c. If other engineers also need to review this pull request, feel free to request reviews for them.

For reviewers, please look [9b0ce3a](https://github.com/planetarium/lib9c/pull/2814/commits/9b0ce3af6130e3ed432cdd7b72878f60abf08b42) commit carefully and leave feedback. I am not sure that it is okay to provide `SerializeList` as `IState.Serialize` because I didn't understand `IState.Serialize` method's purpose well.