### PR TITLE
Exclude BTAI from docs

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/dotnet/docfx/main/schemas/docfx.schema.json",
   "metadata": [
     {
       "src": [
@@ -11,7 +12,8 @@
       ],
       "dest": "api",
       "disableGitFeatures": false,
-      "disableDefaultFilter": false
+      "disableDefaultFilter": false,
+      "filter": "filter.yml"
     }
   ],
   "build": {
@@ -53,7 +55,7 @@
       }
     ],
     "dest": "_site",
-    
+
     "template": [
       "default",
       "modern"

--- a/docs/filter.yml
+++ b/docs/filter.yml
@@ -1,0 +1,4 @@
+apiRules:
+- exclude:
+    uidRegex: ^BTAI$
+    type: Namespace


### PR DESCRIPTION
It excludes elements under `BTAI` namespace from DocFX docs. See https://dotnet.github.io/docfx/docs/dotnet-api-docs.html#filter-by-type for DocFX configuration.