### PR TITLE
feat: introduce `ArenaParticipant` and apply to `JoinArena` first

### DIFF
--- a/.Lib9c.Tests/Action/BattleArenaTest.cs
+++ b/.Lib9c.Tests/Action/BattleArenaTest.cs
@@ -954,7 +954,8 @@ namespace Lib9c.Tests.Action
 
             if (roundData.ArenaType != ArenaType.OffSeason)
             {
-                throw new InvalidSeasonException($"[{nameof(BattleArena)}] This test is only for OffSeason. ArenaType : {roundData.ArenaType}");
+                throw new InvalidSeasonException(
+                    $"[{nameof(BattleArena)}] This test is only for OffSeason. ArenaType : {roundData.ArenaType}");
             }
 
             var random = new TestRandom();
@@ -1193,17 +1194,17 @@ namespace Lib9c.Tests.Action
                 BlockIndex = blockIndex,
             });
 
-            if (!nextStates.TryGetArenaScore(myScoreAdr, out var myAfterScore))
+            if (!nextStates.TryGetArenaScore(myScoreAdr, out var myScoreNext))
             {
                 throw new ArenaScoreNotFoundException($"myScoreAdr : {myScoreAdr}");
             }
 
-            if (!nextStates.TryGetArenaScore(enemyScoreAdr, out var enemyAfterScore))
+            if (!nextStates.TryGetArenaScore(enemyScoreAdr, out var enemyScoreNext))
             {
                 throw new ArenaScoreNotFoundException($"enemyScoreAdr : {enemyScoreAdr}");
             }
 
-            if (!nextStates.TryGetArenaInformation(arenaInfoAdr, out var afterInfo))
+            if (!nextStates.TryGetArenaInformation(arenaInfoAdr, out var myAfterInfoNext))
             {
                 throw new ArenaInformationNotFoundException($"arenaInfoAdr : {arenaInfoAdr}");
             }
@@ -1211,8 +1212,8 @@ namespace Lib9c.Tests.Action
             var (myWinScore, myDefeatScore, enemyDefeatScore) =
                 ArenaHelper.GetScores(beforeMyScore.Score, beforeEnemyScore.Score);
 
-            var addMyScore = afterInfo.Win * myWinScore + afterInfo.Lose * myDefeatScore;
-            var addEnemyScore = afterInfo.Win * enemyDefeatScore;
+            var addMyScore = myAfterInfoNext.Win * myWinScore + myAfterInfoNext.Lose * myDefeatScore;
+            var addEnemyScore = myAfterInfoNext.Win * enemyDefeatScore;
             var expectedMyScore = Math.Max(
                 beforeMyScore.Score + addMyScore,
                 ArenaScore.ArenaScoreDefault);
@@ -1220,8 +1221,8 @@ namespace Lib9c.Tests.Action
                 beforeEnemyScore.Score + addEnemyScore,
                 ArenaScore.ArenaScoreDefault);
 
-            Assert.Equal(expectedMyScore, myAfterScore.Score);
-            Assert.Equal(expectedEnemyScore, enemyAfterScore.Score);
+            Assert.Equal(expectedMyScore, myScoreNext.Score);
+            Assert.Equal(expectedEnemyScore, enemyScoreNext.Score);
             Assert.Equal(
                 isPurchased
                     ? 0
@@ -1231,28 +1232,28 @@ namespace Lib9c.Tests.Action
             Assert.Equal(0, beforeInfo.Lose);
 
             var useTicket = Math.Min(ticket, beforeInfo.Ticket);
-            Assert.Equal(beforeInfo.Ticket - useTicket, afterInfo.Ticket);
-            Assert.Equal(ticket, afterInfo.Win + afterInfo.Lose);
+            Assert.Equal(beforeInfo.Ticket - useTicket, myAfterInfoNext.Ticket);
+            Assert.Equal(ticket, myAfterInfoNext.Win + myAfterInfoNext.Lose);
 
             var balance = nextStates.GetBalance(
                 myAgentAddress,
                 nextStates.GetGoldCurrency());
             if (isPurchased)
             {
-                Assert.Equal(ticket, afterInfo.PurchasedTicketCount);
+                Assert.Equal(ticket, myAfterInfoNext.PurchasedTicketCount);
             }
 
             Assert.Equal(0, balance.RawValue);
 
-            var avatarState = nextStates.GetAvatarState(myAvatarAddress);
+            var myAvatarStateNext = nextStates.GetAvatarState(myAvatarAddress);
             var medalCount = 0;
             if (roundData.ArenaType != ArenaType.OffSeason)
             {
                 var medalId = ArenaHelper.GetMedalItemId(championshipId, round);
-                avatarState.inventory.TryGetItem(medalId, out var medal);
-                if (afterInfo.Win > 0)
+                myAvatarStateNext.inventory.TryGetItem(medalId, out var medal);
+                if (myAfterInfoNext.Win > 0)
                 {
-                    Assert.Equal(afterInfo.Win, medal.count);
+                    Assert.Equal(myAfterInfoNext.Win, medal.count);
                 }
                 else
                 {
@@ -1262,9 +1263,33 @@ namespace Lib9c.Tests.Action
                 medalCount = medal?.count ?? 0;
             }
 
-            var materialCount = avatarState.inventory.Materials.Count();
+            var materialCount = myAvatarStateNext.inventory.Materials.Count();
             var high = (ArenaHelper.GetRewardCount(beforeMyScore.Score) * ticket) + medalCount;
             Assert.InRange(materialCount, 0, high);
+
+            var myArenaAvatarStateAddr = ArenaAvatarState.DeriveAddress(myAvatarAddress);
+            Assert.True(nextStates.TryGetArenaAvatarState(myArenaAvatarStateAddr, out var myArenaAvatarStateNext));
+
+            // check my ArenaParticipant
+            var arenaParticipantNext = nextStates.GetArenaParticipant(championshipId, round, myAvatarAddress);
+            Assert.NotNull(arenaParticipantNext);
+            Assert.Equal(myAvatarAddress, arenaParticipantNext.AvatarAddr);
+            Assert.Equal(myAvatarStateNext.name, arenaParticipantNext.Name);
+            Assert.Equal(myAvatarStateNext.GetPortraitId(), arenaParticipantNext.PortraitId);
+            Assert.Equal(myAvatarStateNext.level, arenaParticipantNext.Level);
+            // Assert.Equal(cp, arenaParticipantNext.Cp);
+            Assert.Equal(myScoreNext.Score, arenaParticipantNext.Score);
+            Assert.Equal(myAfterInfoNext.Ticket, arenaParticipantNext.Ticket);
+            Assert.Equal(myAfterInfoNext.TicketResetCount, arenaParticipantNext.TicketResetCount);
+            Assert.Equal(myAfterInfoNext.PurchasedTicketCount, arenaParticipantNext.PurchasedTicketCount);
+            Assert.Equal(myAfterInfoNext.Win, arenaParticipantNext.Win);
+            Assert.Equal(myAfterInfoNext.Lose, arenaParticipantNext.Lose);
+            Assert.Equal(myArenaAvatarStateNext.LastBattleBlockIndex, arenaParticipantNext.LastBattleBlockIndex);
+
+            // check enemy's ArenaParticipant
+            var enemyArenaParticipantNext = nextStates.GetArenaParticipant(championshipId, round, enemyAvatarAddress);
+            Assert.NotNull(enemyArenaParticipantNext);
+            Assert.Equal(enemyScoreNext.Score, enemyArenaParticipantNext.Score);
         }
 
         private IWorld JoinArena(
@@ -1280,13 +1305,14 @@ namespace Lib9c.Tests.Action
             var preCurrency = 1000 * _crystal;
             states = states.MintAsset(context, signer, preCurrency);
 
-            var action = new JoinArena1
+            var action = new JoinArena
             {
+                avatarAddress = avatarAddress,
                 championshipId = championshipId,
                 round = round,
                 costumes = new List<Guid>(),
                 equipments = new List<Guid>(),
-                avatarAddress = avatarAddress,
+                runeInfos = new List<RuneSlotInfo>(),
             };
 
             states = action.Execute(new ActionContext

--- a/.Lib9c.Tests/Action/ExceptionTest.cs
+++ b/.Lib9c.Tests/Action/ExceptionTest.cs
@@ -10,6 +10,7 @@ namespace Lib9c.Tests.Action
     using Nekoyume.Action;
     using Nekoyume.Action.Exceptions;
     using Nekoyume.Action.Exceptions.AdventureBoss;
+    using Nekoyume.Action.Exceptions.Arena;
     using Nekoyume.Exceptions;
     using Nekoyume.Model.State;
     using Nekoyume.TableData;
@@ -85,6 +86,7 @@ namespace Lib9c.Tests.Action
         [InlineData(typeof(SeasonInProgressException))]
         [InlineData(typeof(EmptyRewardException))]
         [InlineData(typeof(UnsupportedStateException))]
+        [InlineData(typeof(AlreadyJoinedArenaException))]
         public void Exception_Serializable(Type excType)
         {
             if (Activator.CreateInstance(excType, "for testing") is Exception exc)

--- a/.Lib9c.Tests/Action/ExceptionTest.cs
+++ b/.Lib9c.Tests/Action/ExceptionTest.cs
@@ -84,6 +84,7 @@ namespace Lib9c.Tests.Action
         [InlineData(typeof(PreviousBountyException))]
         [InlineData(typeof(SeasonInProgressException))]
         [InlineData(typeof(EmptyRewardException))]
+        [InlineData(typeof(UnsupportedStateException))]
         public void Exception_Serializable(Type excType)
         {
             if (Activator.CreateInstance(excType, "for testing") is Exception exc)

--- a/.Lib9c.Tests/Action/Garages/BulkUnloadFromGaragesTest.cs
+++ b/.Lib9c.Tests/Action/Garages/BulkUnloadFromGaragesTest.cs
@@ -39,8 +39,8 @@ namespace Lib9c.Tests.Action.Garages
                 agentAddr: AgentAddress,
                 avatarIndex: AvatarIndex);
             _tableSheets = initializeStates.tableSheets;
-            _previousStates = initializeStates.initialStatesWithAvatarState;
-            _ncg = initializeStates.initialStatesWithAvatarState.GetGoldCurrency();
+            _previousStates = initializeStates.world;
+            _ncg = initializeStates.world.GetGoldCurrency();
         }
 
         public static IEnumerable<object[]> Get_Sample_PlainValue()

--- a/.Lib9c.Tests/Action/JoinArenaTest.cs
+++ b/.Lib9c.Tests/Action/JoinArenaTest.cs
@@ -26,8 +26,6 @@ public class JoinArenaTest
     private readonly TableSheets _tableSheets;
     private readonly AgentState _myAgentState;
     private readonly AvatarState _myAvatarState;
-    private readonly AgentState _enemyAgentState;
-    private readonly AvatarState _enemyAvatarState;
 
     public JoinArenaTest(ITestOutputHelper outputHelper)
     {
@@ -41,11 +39,6 @@ public class JoinArenaTest
             _world,
             _tableSheets.GetAvatarSheets(),
             _myAgentState.address);
-        (_world, _enemyAgentState) = InitializeUtil.AddAgent(_world);
-        (_world, _enemyAvatarState, _) = InitializeUtil.AddAvatar(
-            _world,
-            _tableSheets.GetAvatarSheets(),
-            _enemyAgentState.address);
     }
 
     [Fact]

--- a/.Lib9c.Tests/Action/JoinArenaTest.cs
+++ b/.Lib9c.Tests/Action/JoinArenaTest.cs
@@ -1,0 +1,350 @@
+namespace Lib9c.Tests.Action;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bencodex.Types;
+using Libplanet.Action.State;
+using Libplanet.Crypto;
+using Libplanet.Types.Assets;
+using Lib9c.Tests.Util;
+using Nekoyume.Action;
+using Nekoyume.Arena;
+using Nekoyume.Model.Arena;
+using Nekoyume.Model.EnumType;
+using Nekoyume.Model.Item;
+using Nekoyume.Model.State;
+using Nekoyume.Module;
+using Nekoyume.TableData;
+using Serilog;
+using Xunit;
+using Xunit.Abstractions;
+
+public class JoinArenaTest
+{
+    private readonly IWorld _world;
+    private readonly TableSheets _tableSheets;
+    private readonly AgentState _myAgentState;
+    private readonly AvatarState _myAvatarState;
+    private readonly AgentState _enemyAgentState;
+    private readonly AvatarState _enemyAvatarState;
+
+    public JoinArenaTest(ITestOutputHelper outputHelper)
+    {
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.TestOutput(outputHelper)
+            .CreateLogger();
+        (_world, _tableSheets) = InitializeUtil.Initialize();
+        (_world, _myAgentState) = InitializeUtil.AddAgent(_world);
+        (_world, _myAvatarState, _) = InitializeUtil.AddAvatar(
+            _world,
+            _tableSheets.GetAvatarSheets(),
+            _myAgentState.address);
+        (_world, _enemyAgentState) = InitializeUtil.AddAgent(_world);
+        (_world, _enemyAvatarState, _) = InitializeUtil.AddAvatar(
+            _world,
+            _tableSheets.GetAvatarSheets(),
+            _enemyAgentState.address);
+    }
+
+    [Fact]
+    public void Execute_OffSeason_Success()
+    {
+        Execute(
+            _world,
+            _myAgentState.address,
+            blockIndex: 0,
+            randomSeed: 0,
+            _myAvatarState.address,
+            championshipId: 1,
+            round: 1,
+            costumes: new List<Guid>(),
+            equipments: new List<Guid>(),
+            runeInfos: new List<RuneSlotInfo>());
+    }
+
+    [Fact]
+    public void Execute_Season_Success()
+    {
+        var row = _tableSheets.ArenaSheet.OrderedList!.First(e =>
+            e.Round.Any(e2 =>
+                e2.ArenaType == ArenaType.Season &&
+                e2.EntranceFee > 0));
+        var roundData = row.Round.First(e =>
+            e.ArenaType == ArenaType.Season &&
+            e.EntranceFee > 0);
+        var blockIndex = roundData.StartBlockIndex;
+        var fee = ArenaHelper.GetEntranceFee(
+            roundData,
+            blockIndex,
+            _myAvatarState.level);
+        var world = _world.MintAsset(new ActionContext(), _myAgentState.address, fee);
+        Execute(
+            world,
+            _myAgentState.address,
+            blockIndex: blockIndex,
+            randomSeed: 0,
+            _myAvatarState.address,
+            championshipId: row.ChampionshipId,
+            round: roundData.Round,
+            costumes: new List<Guid>(),
+            equipments: new List<Guid>(),
+            runeInfos: new List<RuneSlotInfo>());
+    }
+
+    [Fact]
+    public void Execute_Championship_Success()
+    {
+        var row = _tableSheets.ArenaSheet.OrderedList!.First(e =>
+            e.Round.Any(e2 =>
+                e2.ArenaType == ArenaType.Championship &&
+                e2.RequiredMedalCount > 0));
+        Assert.True(row.TryGetChampionshipRound(out var roundData));
+        var blockIndex = roundData.StartBlockIndex;
+        var fee = ArenaHelper.GetEntranceFee(
+            roundData,
+            blockIndex,
+            _myAvatarState.level);
+        var world = _world.MintAsset(new ActionContext(), _myAgentState.address, fee);
+        var seasonRound = row.Round.First(e => e.ArenaType == ArenaType.Season);
+        var itemSheetId = ArenaHelper.GetMedalItemId(row.ChampionshipId, seasonRound.Round);
+        Assert.True(_tableSheets.ItemSheet.TryGetValue(itemSheetId, out var itemRow));
+        var item = ItemFactory.CreateItem(itemRow, new TestRandom());
+        var inventory = _world.GetInventoryV2(_myAvatarState.address);
+        inventory.AddItem(item, roundData.RequiredMedalCount);
+        world = world.SetInventory(_myAvatarState.address, inventory);
+
+        Execute(
+            world,
+            _myAgentState.address,
+            blockIndex: blockIndex,
+            randomSeed: 0,
+            _myAvatarState.address,
+            championshipId: row.ChampionshipId,
+            round: roundData.Round,
+            costumes: new List<Guid>(),
+            equipments: new List<Guid>(),
+            runeInfos: new List<RuneSlotInfo>());
+    }
+
+    [Theory]
+    [InlineData(int.MaxValue)]
+    public void Execute_SheetRowNotFoundException(int championshipId)
+    {
+        Assert.Throws<SheetRowNotFoundException>(() => Execute(
+            _world,
+            _myAgentState.address,
+            blockIndex: 0,
+            randomSeed: 0,
+            _myAvatarState.address,
+            championshipId: championshipId,
+            round: 1,
+            costumes: new List<Guid>(),
+            equipments: new List<Guid>(),
+            runeInfos: new List<RuneSlotInfo>()));
+    }
+
+    [Theory]
+    [InlineData(10)]
+    public void Execute_RoundNotFoundByIdsException(int round)
+    {
+        Assert.Throws<RoundNotFoundException>(() => Execute(
+            _world,
+            _myAgentState.address,
+            blockIndex: 0,
+            randomSeed: 0,
+            _myAvatarState.address,
+            championshipId: 1,
+            round: round,
+            costumes: new List<Guid>(),
+            equipments: new List<Guid>(),
+            runeInfos: new List<RuneSlotInfo>()));
+    }
+
+    [Fact]
+    public void Execute_NotEnoughFungibleAssetValueException()
+    {
+        var row = _tableSheets.ArenaSheet.OrderedList!.First(e =>
+            e.Round.Any(e2 =>
+                e2.ArenaType == ArenaType.Season &&
+                e2.EntranceFee > 0));
+        var roundData = row.Round.First(e =>
+            e.ArenaType == ArenaType.Season &&
+            e.EntranceFee > 0);
+        var blockIndex = roundData.StartBlockIndex;
+
+        // with 0 assets.
+        Assert.Throws<NotEnoughFungibleAssetValueException>(() => Execute(
+            _world,
+            _myAgentState.address,
+            blockIndex: blockIndex,
+            randomSeed: 0,
+            _myAvatarState.address,
+            championshipId: row.ChampionshipId,
+            round: roundData.Round,
+            costumes: new List<Guid>(),
+            equipments: new List<Guid>(),
+            runeInfos: new List<RuneSlotInfo>()));
+
+        // get discounted fee.
+        var fee = ArenaHelper.GetEntranceFee(
+            roundData,
+            blockIndex - 1,
+            _myAvatarState.level);
+        var world = _world
+            .MintAsset(new ActionContext(), _myAgentState.address, fee)
+            .BurnAsset(new ActionContext(), _myAgentState.address, new FungibleAssetValue(fee.Currency, 0, 1));
+        // with not enough assets in discount period.
+        Assert.Throws<NotEnoughFungibleAssetValueException>(() => Execute(
+            world,
+            _myAgentState.address,
+            blockIndex: blockIndex - 1,
+            randomSeed: 0,
+            _myAvatarState.address,
+            championshipId: row.ChampionshipId,
+            round: roundData.Round,
+            costumes: new List<Guid>(),
+            equipments: new List<Guid>(),
+            runeInfos: new List<RuneSlotInfo>()));
+
+        // get original fee.
+        fee = ArenaHelper.GetEntranceFee(
+            roundData,
+            blockIndex,
+            _myAvatarState.level);
+        world = _world
+            .MintAsset(new ActionContext(), _myAgentState.address, fee)
+            .BurnAsset(new ActionContext(), _myAgentState.address, new FungibleAssetValue(fee.Currency, 0, 1));
+        // with not enough assets in discount period.
+        Assert.Throws<NotEnoughFungibleAssetValueException>(() => Execute(
+            world,
+            _myAgentState.address,
+            blockIndex: blockIndex,
+            randomSeed: 0,
+            _myAvatarState.address,
+            championshipId: row.ChampionshipId,
+            round: roundData.Round,
+            costumes: new List<Guid>(),
+            equipments: new List<Guid>(),
+            runeInfos: new List<RuneSlotInfo>()));
+    }
+
+    [Fact]
+    public void Execute_NotEnoughMedalException()
+    {
+        var row = _tableSheets.ArenaSheet.OrderedList!.First(e =>
+            e.Round.Any(e2 =>
+                e2.ArenaType == ArenaType.Championship &&
+                e2.RequiredMedalCount > 0));
+        Assert.True(row.TryGetChampionshipRound(out var roundData));
+        var blockIndex = roundData.StartBlockIndex;
+        var fee = ArenaHelper.GetEntranceFee(
+            roundData,
+            blockIndex,
+            _myAvatarState.level);
+        var world = _world.MintAsset(new ActionContext(), _myAgentState.address, fee);
+        Assert.Throws<NotEnoughMedalException>(() => Execute(
+            world,
+            _myAgentState.address,
+            blockIndex: blockIndex,
+            randomSeed: 0,
+            _myAvatarState.address,
+            championshipId: row.ChampionshipId,
+            round: roundData.Round,
+            costumes: new List<Guid>(),
+            equipments: new List<Guid>(),
+            runeInfos: new List<RuneSlotInfo>()));
+    }
+
+    private IWorld Execute(
+        IWorld world,
+        Address signer,
+        long blockIndex,
+        int randomSeed,
+        Address avatarAddr,
+        int championshipId,
+        int round,
+        List<Guid> costumes,
+        List<Guid> equipments,
+        List<RuneSlotInfo> runeInfos)
+    {
+        var action = new JoinArena
+        {
+            avatarAddress = avatarAddr,
+            championshipId = championshipId,
+            round = round,
+            costumes = costumes,
+            equipments = equipments,
+            runeInfos = runeInfos,
+        };
+        world = action.Execute(new ActionContext
+        {
+            PreviousState = world,
+            Signer = signer,
+            BlockIndex = blockIndex,
+            RandomSeed = randomSeed,
+        });
+
+        // check ItemSlotState
+        var itemSlotState = new ItemSlotState(BattleType.Arena);
+        itemSlotState.UpdateCostumes(costumes);
+        itemSlotState.UpdateEquipment(equipments);
+        var itemSlotStateAddr = ItemSlotState.DeriveAddress(avatarAddr, BattleType.Arena);
+        Assert.Equal(itemSlotState.Serialize(), world.GetLegacyState(itemSlotStateAddr));
+
+        // check RuneSlotState
+        var runeSlotState = new RuneSlotState(BattleType.Arena);
+        runeSlotState.UpdateSlot(runeInfos, _tableSheets.RuneListSheet);
+        var runeSlotStateAddr = RuneSlotState.DeriveAddress(avatarAddr, BattleType.Arena);
+        Assert.Equal(runeSlotState.Serialize(), world.GetLegacyState(runeSlotStateAddr));
+
+        // check ArenaParticipant
+        var avatarState = world.GetAvatarState(avatarAddr);
+        var arenaParticipant = world.GetArenaParticipant(championshipId, round, avatarAddr);
+        Assert.NotNull(arenaParticipant);
+        Assert.Equal(avatarAddr, arenaParticipant.AvatarAddr);
+        Assert.Equal(avatarState.name, arenaParticipant.Name);
+        Assert.Equal(avatarState.GetPortraitId(), arenaParticipant.PortraitId);
+        Assert.Equal(avatarState.level, arenaParticipant.Level);
+        // Assert.Equal(cp, arenaParticipant.Cp);
+        Assert.Equal(ArenaParticipant.DefaultScore, arenaParticipant.Score);
+        Assert.Equal(ArenaParticipant.MaxTicketCount, arenaParticipant.Ticket);
+        Assert.Equal(0, arenaParticipant.TicketResetCount);
+        Assert.Equal(0, arenaParticipant.PurchasedTicketCount);
+        Assert.Equal(0, arenaParticipant.Win);
+        Assert.Equal(0, arenaParticipant.Lose);
+        Assert.Equal(0, arenaParticipant.LastBattleBlockIndex);
+
+        // check ArenaParticipants
+        var arenaParticipantsAdr = ArenaParticipants.DeriveAddress(championshipId, round);
+        var arenaParticipants = world.GetArenaParticipants(arenaParticipantsAdr, championshipId, round);
+        Assert.Equal(arenaParticipantsAdr, arenaParticipants.Address);
+        Assert.Contains(avatarAddr, arenaParticipants.AvatarAddresses);
+
+        // check ArenaScore
+        var arenaScoreAdr = ArenaScore.DeriveAddress(avatarAddr, championshipId, round);
+        Assert.True(world.TryGetArenaScore(arenaScoreAdr, out var arenaScore));
+        Assert.Equal(ArenaScore.ArenaScoreDefault, arenaScore.Score);
+
+        // check ArenaInformation
+        var arenaInformationAdr = ArenaInformation.DeriveAddress(avatarAddr, championshipId, round);
+        Assert.True(world.TryGetArenaInformation(arenaInformationAdr, out var arenaInformation));
+        Assert.Equal(arenaInformationAdr, arenaInformation.Address);
+        Assert.Equal(0, arenaInformation.Win);
+        Assert.Equal(0, arenaInformation.Lose);
+        Assert.Equal(ArenaInformation.MaxTicketCount, arenaInformation.Ticket);
+        Assert.Equal(0, arenaInformation.TicketResetCount);
+        Assert.Equal(0, arenaInformation.PurchasedTicketCount);
+
+        // check ArenaAvatarState
+        var arenaAvatarStateAddr = ArenaAvatarState.DeriveAddress(avatarAddr);
+        var arenaAvatarState = new ArenaAvatarState(avatarState);
+        arenaAvatarState.UpdateCostumes(costumes);
+        arenaAvatarState.UpdateEquipment(equipments);
+        Assert.True(world.TryGetLegacyState(arenaAvatarStateAddr, out IValue arenaAvatarStateInWorld));
+        Assert.Equal(arenaAvatarState.Serialize(), arenaAvatarStateInWorld);
+
+        return world;
+    }
+}

--- a/.Lib9c.Tests/Action/Scenario/StakeAndClaimScenarioTest.cs
+++ b/.Lib9c.Tests/Action/Scenario/StakeAndClaimScenarioTest.cs
@@ -67,7 +67,7 @@ namespace Lib9c.Tests.Action.Scenario
                 });
             _agentAddr = tuple.agentAddr;
             _avatarAddr = tuple.avatarAddr;
-            _initialStateWithoutStakePolicySheet = tuple.initialStatesWithAvatarState;
+            _initialStateWithoutStakePolicySheet = tuple.world;
             _ncg = _initialStateWithoutStakePolicySheet.GetGoldCurrency();
         }
 

--- a/.Lib9c.Tests/AddressesTest.cs
+++ b/.Lib9c.Tests/AddressesTest.cs
@@ -53,4 +53,23 @@ public class AddressesTest
         var address = Addresses.GetArenaParticipantAccountAddress(championshipId, round);
         Assert.Equal(expectedHex, address.ToHex());
     }
+
+    [Theory]
+    [InlineData("0000000000000000000000000000000000000000", false)]
+    [InlineData("0099999999999999999999999999999999999999", false)]
+    [InlineData("0100000000000000000000000000000000000000", true)]
+    [InlineData("0199999999999999999999999999999999999999", true)]
+    [InlineData("0200000000000000000000000000000000000000", false)]
+    public void IsArenaParticipantAccountAddressTest(string addressHex, bool expected)
+    {
+        var address = new Address(addressHex);
+        if (expected)
+        {
+            Assert.True(Addresses.IsArenaParticipantAccountAddress(address));
+        }
+        else
+        {
+            Assert.False(Addresses.IsArenaParticipantAccountAddress(address));
+        }
+    }
 }

--- a/.Lib9c.Tests/AddressesTest.cs
+++ b/.Lib9c.Tests/AddressesTest.cs
@@ -11,7 +11,7 @@ using Xunit;
 public class AddressesTest
 {
     [Fact]
-    public void There_Are_No_Conflicts_In_Addresses()
+    public void There_Are_No_Address_Conflicts()
     {
         var addressesInTypes = new List<Address>();
         InsertStaticAddressFieldValues(typeof(ReservedAddresses));

--- a/.Lib9c.Tests/AddressesTest.cs
+++ b/.Lib9c.Tests/AddressesTest.cs
@@ -1,0 +1,56 @@
+namespace Lib9c.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Libplanet.Action.State;
+using Libplanet.Crypto;
+using Nekoyume;
+using Xunit;
+
+public class AddressesTest
+{
+    [Fact]
+    public void There_Are_No_Conflicts_In_Addresses()
+    {
+        var addressesInTypes = new List<Address>();
+        InsertStaticAddressFieldValues(typeof(ReservedAddresses));
+        InsertStaticAddressFieldValues(typeof(Addresses));
+
+        var addresses = new HashSet<Address>();
+        foreach (var address in addressesInTypes)
+        {
+            Assert.DoesNotContain(address, addresses);
+            Assert.False(Addresses.IsArenaParticipantAccountAddress(address));
+            addresses.Add(address);
+        }
+
+        return;
+
+        void InsertStaticAddressFieldValues(Type type)
+        {
+            var addressFields = type.GetFields(BindingFlags.Public | BindingFlags.Static);
+            foreach (var field in addressFields)
+            {
+                if (field.FieldType != typeof(Address))
+                {
+                    continue;
+                }
+
+                // GetValue(null) because the fields are static
+                var address = (Address)field.GetValue(null)!;
+                addressesInTypes.Add(address);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(0, 0, "0100000000000000000000000000000000000000")]
+    [InlineData(1, 1, "0100000000000000000000000000000000000101")]
+    [InlineData(int.MaxValue, 99, "0100000000000000000000000000214748364799")]
+    public void GetArenaParticipantAccountAddressTest(int championshipId, int round, string expectedHex)
+    {
+        var address = Addresses.GetArenaParticipantAccountAddress(championshipId, round);
+        Assert.Equal(expectedHex, address.ToHex());
+    }
+}

--- a/.Lib9c.Tests/Extensions/BencodexTypesExtensionsTest.cs
+++ b/.Lib9c.Tests/Extensions/BencodexTypesExtensionsTest.cs
@@ -12,17 +12,17 @@ public class BencodexTypesExtensionsTest
     [InlineData(1, 0, false)]
     [InlineData(2, 1, false)]
     [InlineData(2, 2, true)]
-    public void InsertTo_List(int count, int index, bool throwException)
+    public void Replace_List(int count, int index, bool throwException)
     {
         var list = new List(new int[count]);
         if (throwException)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                list.InsertTo(index, (Integer)1));
+                list.Replace(index, (Integer)1));
         }
         else
         {
-            list = list.InsertTo(index, (Integer)1);
+            list = list.Replace(index, (Integer)1);
             Assert.Equal(1, (int)(Integer)list[index]);
         }
     }

--- a/.Lib9c.Tests/Extensions/BencodexTypesExtensionsTest.cs
+++ b/.Lib9c.Tests/Extensions/BencodexTypesExtensionsTest.cs
@@ -1,0 +1,29 @@
+namespace Lib9c.Tests.Extensions;
+
+using System;
+using Bencodex.Types;
+using Nekoyume.Exceptions;
+using Xunit;
+
+public class BencodexTypesExtensionsTest
+{
+    [Theory]
+    [InlineData(0, 0, true)]
+    [InlineData(1, 0, false)]
+    [InlineData(2, 1, false)]
+    [InlineData(2, 2, true)]
+    public void InsertTo_List(int count, int index, bool throwException)
+    {
+        var list = new List(new int[count]);
+        if (throwException)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                list.InsertTo(index, (Integer)1));
+        }
+        else
+        {
+            list = list.InsertTo(index, (Integer)1);
+            Assert.Equal(1, (int)(Integer)list[index]);
+        }
+    }
+}

--- a/.Lib9c.Tests/Model/Arena/ArenaParticipantTest.cs
+++ b/.Lib9c.Tests/Model/Arena/ArenaParticipantTest.cs
@@ -1,0 +1,46 @@
+namespace Lib9c.Tests.Model.Arena;
+
+using Libplanet.Crypto;
+using Nekoyume.Model.Arena;
+using Xunit;
+
+public class ArenaParticipantTest
+{
+    [Fact]
+    public void Serialize()
+    {
+        var avatarAddr = new PrivateKey().Address;
+        var state = new ArenaParticipant(avatarAddr)
+        {
+            Name = "Joy",
+            PortraitId = 1,
+            Level = 99,
+            Cp = 999_999_999,
+            Score = 999_999,
+            Ticket = 7,
+            TicketResetCount = 1,
+            PurchasedTicketCount = 1,
+            Win = 100,
+            Lose = 99,
+            LastBattleBlockIndex = long.MaxValue,
+        };
+        var serialized = state.Bencoded;
+        var deserialized = new ArenaParticipant(serialized);
+
+        Assert.Equal(state.AvatarAddr, deserialized.AvatarAddr);
+        Assert.Equal(state.Name, deserialized.Name);
+        Assert.Equal(state.PortraitId, deserialized.PortraitId);
+        Assert.Equal(state.Level, deserialized.Level);
+        Assert.Equal(state.Cp, deserialized.Cp);
+        Assert.Equal(state.Score, deserialized.Score);
+        Assert.Equal(state.Ticket, deserialized.Ticket);
+        Assert.Equal(state.TicketResetCount, deserialized.TicketResetCount);
+        Assert.Equal(state.PurchasedTicketCount, deserialized.PurchasedTicketCount);
+        Assert.Equal(state.Win, deserialized.Win);
+        Assert.Equal(state.Lose, deserialized.Lose);
+        Assert.Equal(state.LastBattleBlockIndex, deserialized.LastBattleBlockIndex);
+
+        var serialized2 = deserialized.Bencoded;
+        Assert.Equal(serialized, serialized2);
+    }
+}

--- a/.Lib9c.Tests/Util/InitializeUtil.cs
+++ b/.Lib9c.Tests/Util/InitializeUtil.cs
@@ -190,4 +190,9 @@ public static class InitializeUtil
         agentState.avatarAddresses.Add(index.Value, avatarAddr);
         return (world.SetAvatarState(avatarAddr, avatarState), avatarState, index.Value);
     }
+
+    public static IWorld MainAsset(IWorld world, Address recipient, FungibleAssetValue asset)
+    {
+        return world.MintAsset(new ActionContext(), recipient, asset);
+    }
 }

--- a/.Lib9c.Tests/Util/InitializeUtil.cs
+++ b/.Lib9c.Tests/Util/InitializeUtil.cs
@@ -1,106 +1,193 @@
-namespace Lib9c.Tests.Util
+namespace Lib9c.Tests.Util;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Lib9c.Tests.Action;
+using Libplanet.Action.State;
+using Libplanet.Crypto;
+using Libplanet.Mocks;
+using Libplanet.Types.Assets;
+using Nekoyume;
+using Nekoyume.Action;
+using Nekoyume.Model;
+using Nekoyume.Model.State;
+using Nekoyume.Module;
+using Nekoyume.TableData;
+
+public static class InitializeUtil
 {
-    using System.Collections.Generic;
-    using System.IO;
-    using Lib9c.Tests.Action;
-    using Libplanet.Action.State;
-    using Libplanet.Crypto;
-    using Libplanet.Mocks;
-    using Libplanet.Types.Assets;
-    using Nekoyume;
-    using Nekoyume.Action;
-    using Nekoyume.Model.State;
-    using Nekoyume.Module;
-    using Nekoyume.TableData;
-
-    public static class InitializeUtil
+    public static (
+        TableSheets tableSheets,
+        Address agentAddr,
+        Address avatarAddr,
+        IWorld world) InitializeStates(
+            Address? adminAddr = null,
+            Address? agentAddr = null,
+            int avatarIndex = 0,
+            bool isDevEx = false,
+            Dictionary<string, string> sheetsOverride = null)
     {
-        public static (
-            TableSheets tableSheets,
-            Address agentAddr,
-            Address avatarAddr,
-            IWorld initialStatesWithAvatarState
-            ) InitializeStates(
-                Address? adminAddr = null,
-                Address? agentAddr = null,
-                int avatarIndex = 0,
-                bool isDevEx = false,
-                Dictionary<string, string> sheetsOverride = null)
+        adminAddr ??= new PrivateKey().Address;
+        var context = new ActionContext();
+        var world = new World(MockUtil.MockModernWorldState)
+            .SetLegacyState(
+                Addresses.Admin,
+                new AdminState(adminAddr.Value, long.MaxValue).Serialize());
+
+        var goldCurrency = Currency.Legacy(
+            "NCG",
+            2,
+            minters: default
+        );
+        var goldCurrencyState = new GoldCurrencyState(goldCurrency);
+        world = world
+            .SetLegacyState(goldCurrencyState.address, goldCurrencyState.Serialize())
+            .MintAsset(context, goldCurrencyState.address, goldCurrency * 1_000_000_000);
+
+        var tuple = InitializeTableSheets(world, isDevEx, sheetsOverride);
+        world = tuple.states;
+        var tableSheets = new TableSheets(tuple.sheets, ignoreFailedGetProperty: true);
+        var gameConfigState = new GameConfigState(tuple.sheets[nameof(GameConfigSheet)]);
+        world = world.SetLegacyState(gameConfigState.address, gameConfigState.Serialize());
+
+        (world, var agentState) = AddAgent(world, agentAddr);
+        (world, var avatarState, _) = AddAvatar(
+            world,
+            tableSheets.GetAvatarSheets(),
+            agentState.address,
+            avatarIndex);
+        return (
+            tableSheets,
+            agentState.address,
+            avatarState.address,
+            world);
+    }
+
+    public static (IWorld world, TableSheets tableSheets) Initialize(
+        Address? adminAddr = null,
+        bool isDevEx = false,
+        Dictionary<string, string> sheetsOverride = null)
+    {
+        adminAddr ??= new PrivateKey().Address;
+        var world = new World(MockUtil.MockModernWorldState)
+            .SetLegacyState(
+                Addresses.Admin,
+                new AdminState(adminAddr.Value, long.MaxValue).Serialize());
+        var goldCurrency = Currency.Legacy(
+            "NCG",
+            2,
+            minters: default
+        );
+        var goldCurrencyState = new GoldCurrencyState(goldCurrency);
+        var gold = goldCurrency * 1_000_000_000;
+        world = world
+            .SetLegacyState(goldCurrencyState.address, goldCurrencyState.Serialize())
+            .MintAsset(new ActionContext(), goldCurrencyState.address, gold);
+
+        (world, var sheets) = InitializeTableSheets(world, isDevEx, sheetsOverride);
+        var tableSheets = new TableSheets(sheets, ignoreFailedGetProperty: true);
+        var gameConfigState = new GameConfigState(sheets[nameof(GameConfigSheet)]);
+        world = world.SetLegacyState(gameConfigState.address, gameConfigState.Serialize());
+        return (world, tableSheets);
+    }
+
+    public static (IWorld states, Dictionary<string, string> sheets)
+        InitializeTableSheets(
+            IWorld states,
+            bool isDevEx = false,
+            Dictionary<string, string> sheetsOverride = null)
+    {
+        var csvPath = isDevEx
+            ? Path.GetFullPath("../../").Replace(
+                Path.Combine(".Lib9c.DevExtensions.Tests", "bin"),
+                Path.Combine("Lib9c", "TableCSV"))
+            : null;
+        var sheets = TableSheetsImporter.ImportSheets(csvPath);
+        if (sheetsOverride != null)
         {
-            adminAddr ??= new PrivateKey().Address;
-            var context = new ActionContext();
-            var states = new World(MockUtil.MockModernWorldState)
-                .SetLegacyState(
-                    Addresses.Admin,
-                    new AdminState(adminAddr.Value, long.MaxValue).Serialize());
-
-            var goldCurrency = Currency.Legacy(
-                "NCG",
-                2,
-                minters: default
-            );
-            var goldCurrencyState = new GoldCurrencyState(goldCurrency);
-            states = states
-                .SetLegacyState(goldCurrencyState.address, goldCurrencyState.Serialize())
-                .MintAsset(context, goldCurrencyState.address, goldCurrency * 1_000_000_000);
-
-            var tuple = InitializeTableSheets(states, isDevEx, sheetsOverride);
-            states = tuple.states;
-            var tableSheets = new TableSheets(tuple.sheets, ignoreFailedGetProperty: true);
-            var gameConfigState = new GameConfigState(tuple.sheets[nameof(GameConfigSheet)]);
-            states = states.SetLegacyState(gameConfigState.address, gameConfigState.Serialize());
-
-            agentAddr ??= new PrivateKey().Address;
-            var avatarAddr = Addresses.GetAvatarAddress(agentAddr.Value, avatarIndex);
-            var agentState = new AgentState(agentAddr.Value);
-            var avatarState = AvatarState.Create(
-                avatarAddr,
-                agentAddr.Value,
-                0,
-                tableSheets.GetAvatarSheets(),
-                avatarAddr.Derive("ranking_map"));
-            agentState.avatarAddresses.Add(avatarIndex, avatarAddr);
-
-            var initialStatesWithAvatarState = states
-                .SetAgentState(agentAddr.Value, agentState)
-                .SetAvatarState(avatarAddr, avatarState);
-
-            return (
-                tableSheets,
-                agentAddr.Value,
-                avatarAddr,
-                initialStatesWithAvatarState);
+            foreach (var (key, value) in sheetsOverride)
+            {
+                sheets[key] = value;
+            }
         }
 
-        public static (IWorld states, Dictionary<string, string> sheets)
-            InitializeTableSheets(
-                IWorld states,
-                bool isDevEx = false,
-                Dictionary<string, string> sheetsOverride = null)
+        foreach (var (key, value) in sheets)
         {
-            var sheets = TableSheetsImporter.ImportSheets(
-                isDevEx
-                    ? Path.GetFullPath("../../").Replace(
-                        Path.Combine(".Lib9c.DevExtensions.Tests", "bin"),
-                        Path.Combine("Lib9c", "TableCSV"))
-                    : null
-            );
-            if (sheetsOverride != null)
+            var address = Addresses.TableSheet.Derive(key);
+            states = states.SetLegacyState(address, value.Serialize());
+        }
+
+        return (states, sheets);
+    }
+
+    public static (IWorld world, AgentState agentState) AddAgent(
+        IWorld world,
+        Address? agentAddr = null)
+    {
+        agentAddr ??= new PrivateKey().Address;
+        var agentState = new AgentState(agentAddr.Value);
+        return (world.SetAgentState(agentAddr.Value, agentState), agentState);
+    }
+
+    public static (IWorld world, AvatarState avatarState, int index) AddAvatar(
+        IWorld world,
+        AvatarSheets avatarSheets,
+        Address? agentAddr = null,
+        int? index = 0,
+        string name = null,
+        int? level = 1,
+        int? clearedStageId = 0)
+    {
+        agentAddr ??= new PrivateKey().Address;
+        var agentState = world.GetAgentState(agentAddr.Value);
+        if (agentState is null)
+        {
+            (world, agentState) = AddAgent(world, agentAddr.Value);
+        }
+
+        if (index is null)
+        {
+            for (var i = 0; i < GameConfig.SlotCount; i++)
             {
-                foreach (var (key, value) in sheetsOverride)
+                if (agentState.avatarAddresses.ContainsKey(i))
                 {
-                    sheets[key] = value;
+                    continue;
                 }
+
+                index = i;
+                break;
             }
 
-            foreach (var (key, value) in sheets)
+            if (index is null)
             {
-                states = states.SetLegacyState(
-                    Addresses.TableSheet.Derive(key),
-                    value.Serialize());
+                throw new InvalidOperationException("No available avatar slot.");
             }
-
-            return (states, sheets);
         }
+        else if (agentState.avatarAddresses.ContainsKey(index.Value))
+        {
+            throw new ArgumentException($"Avatar index {index.Value} is already in use.");
+        }
+
+        var avatarAddr = Addresses.GetAvatarAddress(agentAddr.Value, index.Value);
+        var avatarState = AvatarState.Create(
+            avatarAddr,
+            agentAddr.Value,
+            0,
+            avatarSheets,
+            avatarAddr.Derive("ranking_map"),
+            name ?? $"Avatar_{index:D2}");
+        avatarState.level = level ?? 1;
+        if (clearedStageId is not null)
+        {
+            var worldSheet = world.GetSheet<WorldSheet>();
+            avatarState.worldInformation = new WorldInformation(
+                0,
+                worldSheet,
+                GameConfig.RequireClearedStageLevel.ActionsInRankingBoard);
+        }
+
+        agentState.avatarAddresses.Add(index.Value, avatarAddr);
+        return (world.SetAvatarState(avatarAddr, avatarState), avatarState, index.Value);
     }
 }

--- a/Lib9c.sln.DotSettings
+++ b/Lib9c.sln.DotSettings
@@ -2,6 +2,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=AI/@EntryIndexedValue">AI</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NCG/@EntryIndexedValue">NCG</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Addr/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=bencoded/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bencodex/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Equippable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Gacha/@EntryIndexedValue">True</s:Boolean>

--- a/Lib9c/Action/BattleArena.cs
+++ b/Lib9c/Action/BattleArena.cs
@@ -452,19 +452,15 @@ namespace Nekoyume.Action
             myArenaInformation.UpdateRecord(winCount, defeatCount);
 
             // start getting the total my CP from here.
-            var myEquippedRune = new List<RuneState>();
-            foreach (var runeInfo in myRuneSlotState.GetEquippedRuneSlotInfos())
-            {
-                if (myRuneStates.TryGetRuneState(runeInfo.RuneId, out var runeState))
-                {
-                    myEquippedRune.Add(runeState);
-                }
-            }
-
             var runeOptionSheet = sheets.GetSheet<RuneOptionSheet>();
             var myRuneOptions = new List<RuneOptionSheet.Row.RuneOptionInfo>();
-            foreach (var runeState in myEquippedRune)
+            foreach (var runeInfo in myRuneSlotState.GetEquippedRuneSlotInfos())
             {
+                if (!myRuneStates.TryGetRuneState(runeInfo.RuneId, out var runeState))
+                {
+                    continue;
+                }
+
                 if (!runeOptionSheet.TryGetValue(runeState.RuneId, out var optionRow))
                 {
                     throw new SheetRowNotFoundException("RuneOptionSheet", runeState.RuneId);

--- a/Lib9c/Action/BattleArena.cs
+++ b/Lib9c/Action/BattleArena.cs
@@ -514,15 +514,11 @@ namespace Nekoyume.Action
             states = states.SetArenaParticipant(championshipId, round, myAvatarAddress, myArenaParticipant);
 
             // update enemyArenaParticipantState.Score
-            var enemyArenaParticipantState = states.GetArenaParticipantState(championshipId, round, enemyAvatarAddress);
-            if (enemyArenaParticipantState is List enemyArenaParticipantList)
+            var enemyArenaParticipant = states.GetArenaParticipant(championshipId, round, enemyAvatarAddress);
+            if (enemyArenaParticipant is not null)
             {
-                enemyArenaParticipantList = enemyArenaParticipantList.InsertTo(6, (Integer)enemyArenaScore.Score);
-                states = states.SetArenaParticipant(
-                    championshipId,
-                    round,
-                    enemyAvatarAddress,
-                    enemyArenaParticipantList);
+                enemyArenaParticipant.Score = enemyArenaScore.Score;
+                states = states.SetArenaParticipant(championshipId, round, enemyAvatarAddress, enemyArenaParticipant);
             }
 
             var ended = DateTimeOffset.UtcNow;

--- a/Lib9c/Action/Exceptions/Arena/AlreadyJoinedArenaException.cs
+++ b/Lib9c/Action/Exceptions/Arena/AlreadyJoinedArenaException.cs
@@ -1,0 +1,18 @@
+using System;
+using Libplanet.Crypto;
+
+namespace Nekoyume.Action.Exceptions.Arena
+{
+    [Serializable]
+    public class AlreadyJoinedArenaException : Exception
+    {
+        public AlreadyJoinedArenaException(
+            int championshipId,
+            int round,
+            Address avatarAddress) :
+            base(
+                $"Avatar {avatarAddress} has already joined the arena for championship {championshipId}, round {round}.")
+        {
+        }
+    }
+}

--- a/Lib9c/Action/Exceptions/Arena/AlreadyJoinedArenaException.cs
+++ b/Lib9c/Action/Exceptions/Arena/AlreadyJoinedArenaException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 using Libplanet.Crypto;
 
 namespace Nekoyume.Action.Exceptions.Arena
@@ -12,6 +13,14 @@ namespace Nekoyume.Action.Exceptions.Arena
             Address avatarAddress) :
             base(
                 $"Avatar {avatarAddress} has already joined the arena for championship {championshipId}, round {round}.")
+        {
+        }
+
+        public AlreadyJoinedArenaException(string msg) : base(msg)
+        {
+        }
+
+        protected AlreadyJoinedArenaException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/Lib9c/Action/JoinArena.cs
+++ b/Lib9c/Action/JoinArena.cs
@@ -184,7 +184,8 @@ namespace Nekoyume.Action
                 if (medalCount < roundData.RequiredMedalCount)
                 {
                     throw new NotEnoughMedalException(
-                        $"[{nameof(JoinArena)}] have({medalCount}) < Required Medal Count({roundData.RequiredMedalCount}) ");
+                        $"[{nameof(JoinArena)}] Not enough medals to join the arena." +
+                        $" Required: {roundData.RequiredMedalCount}, but has: {medalCount}");
                 }
             }
 

--- a/Lib9c/Action/JoinArena.cs
+++ b/Lib9c/Action/JoinArena.cs
@@ -7,11 +7,14 @@ using Lib9c.Abstractions;
 using Libplanet.Action;
 using Libplanet.Action.State;
 using Libplanet.Crypto;
+using Nekoyume.Action.Exceptions.Arena;
 using Nekoyume.Arena;
+using Nekoyume.Battle;
 using Nekoyume.Extensions;
 using Nekoyume.Helper;
 using Nekoyume.Model.Arena;
 using Nekoyume.Model.EnumType;
+using Nekoyume.Model.Stat;
 using Nekoyume.Model.State;
 using Nekoyume.Module;
 using Nekoyume.TableData;
@@ -39,6 +42,7 @@ namespace Nekoyume.Action
         int IJoinArenaV1.Round => round;
         IEnumerable<Guid> IJoinArenaV1.Costumes => costumes;
         IEnumerable<Guid> IJoinArenaV1.Equipments => equipments;
+
         IEnumerable<IValue> IJoinArenaV1.RuneSlotInfos => runeInfos
             .Select(x => x.Serialize());
 
@@ -52,7 +56,7 @@ namespace Nekoyume.Action
                     .OrderBy(element => element).Select(e => e.Serialize())),
                 ["equipments"] = new List(equipments
                     .OrderBy(element => element).Select(e => e.Serialize())),
-                ["runeInfos"] = runeInfos.OrderBy(x => x.SlotIndex).Select(x=> x.Serialize()).Serialize(),
+                ["runeInfos"] = runeInfos.OrderBy(x => x.SlotIndex).Select(x => x.Serialize()).Serialize(),
             }.ToImmutableDictionary();
 
         protected override void LoadPlainValueInternal(
@@ -77,32 +81,53 @@ namespace Nekoyume.Action
             var agentState = states.GetAgentState(context.Signer);
             if (agentState is null)
             {
-                throw new FailedLoadStateException($"[{nameof(JoinArena)}] Aborted as the agent state of the signer was failed to load.");
+                throw new FailedLoadStateException(
+                    $"[{nameof(JoinArena)}] Aborted as the agent state of the signer was failed to load.");
             }
 
             if (!states.TryGetAvatarState(context.Signer, avatarAddress, out var avatarState))
             {
-                throw new FailedLoadStateException($"[{nameof(JoinArena)}] Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException(
+                    $"[{nameof(JoinArena)}] Aborted as the avatar state of the signer was failed to load.");
             }
 
-            var sheets = states.GetSheets(
-                sheetTypes: new[]
-                {
-                    typeof(ItemRequirementSheet),
-                    typeof(EquipmentItemRecipeSheet),
-                    typeof(EquipmentItemSubRecipeSheetV2),
-                    typeof(EquipmentItemOptionSheet),
-                    typeof(ArenaSheet),
-                    typeof(RuneListSheet),
-                });
+            if (states.GetArenaParticipant(championshipId, round, avatarAddress) is not null)
+            {
+                throw new AlreadyJoinedArenaException(championshipId, round, avatarAddress);
+            }
 
+            var collectionExist =
+                states.TryGetCollectionState(avatarAddress, out var collectionState) &&
+                collectionState.Ids.Any();
+            var sheetTypes = new List<Type>
+            {
+                typeof(ArenaSheet),
+                typeof(CharacterSheet),
+                typeof(CostumeStatSheet),
+                typeof(EquipmentItemOptionSheet),
+                typeof(EquipmentItemRecipeSheet),
+                typeof(EquipmentItemSubRecipeSheetV2),
+                typeof(ItemRequirementSheet),
+                typeof(RuneLevelBonusSheet),
+                typeof(RuneListSheet),
+            };
+            if (collectionExist)
+            {
+                sheetTypes.Add(typeof(CollectionSheet));
+            }
+
+            var sheets = states.GetSheets(sheetTypes: sheetTypes);
             var gameConfigState = states.GetGameConfigState();
-            avatarState.ValidEquipmentAndCostumeV2(costumes, equipments,
+            var (equipmentItems, costumeItems) = avatarState.ValidEquipmentAndCostumeV2(
+                costumes,
+                equipments,
                 sheets.GetSheet<ItemRequirementSheet>(),
                 sheets.GetSheet<EquipmentItemRecipeSheet>(),
                 sheets.GetSheet<EquipmentItemSubRecipeSheetV2>(),
                 sheets.GetSheet<EquipmentItemOptionSheet>(),
-                context.BlockIndex, addressesHex, gameConfigState);
+                context.BlockIndex,
+                addressesHex,
+                gameConfigState);
 
             // update rune slot
             var runeSlotStateAddress = RuneSlotState.DeriveAddress(avatarAddress, BattleType.Arena);
@@ -136,7 +161,6 @@ namespace Nekoyume.Action
             }
 
             // check fee
-
             var fee = ArenaHelper.GetEntranceFee(roundData, context.BlockIndex, avatarState.level);
             if (fee > 0 * CrystalCalculator.CRYSTAL)
             {
@@ -187,14 +211,92 @@ namespace Nekoyume.Action
 
             // update ArenaParticipants
             var arenaParticipantsAdr = ArenaParticipants.DeriveAddress(roundData.ChampionshipId, roundData.Round);
-            var arenaParticipants = states.GetArenaParticipants(arenaParticipantsAdr, roundData.ChampionshipId, roundData.Round);
+            var arenaParticipants =
+                states.GetArenaParticipants(arenaParticipantsAdr, roundData.ChampionshipId, roundData.Round);
             arenaParticipants.Add(avatarAddress);
 
-            // update ArenaAvatarState
+            // update ArenaAvatarState: It seems like a good idea to consolidate this into ItemSlotState.
             var arenaAvatarStateAdr = ArenaAvatarState.DeriveAddress(avatarAddress);
             var arenaAvatarState = states.GetArenaAvatarState(arenaAvatarStateAdr, avatarState);
             arenaAvatarState.UpdateCostumes(costumes);
             arenaAvatarState.UpdateEquipment(equipments);
+
+            // start getting the total CP from here.
+            var runeStates = states.GetRuneState(avatarAddress, out var migrateRequired);
+            if (migrateRequired)
+            {
+                states = states.SetRuneState(avatarAddress, runeStates);
+            }
+
+            var equippedRune = new List<RuneState>();
+            foreach (var runeInfo in runeSlotState.GetEquippedRuneSlotInfos())
+            {
+                if (runeStates.TryGetRuneState(runeInfo.RuneId, out var runeState))
+                {
+                    equippedRune.Add(runeState);
+                }
+            }
+
+            var runeOptionSheet = sheets.GetSheet<RuneOptionSheet>();
+            var runeOptions = new List<RuneOptionSheet.Row.RuneOptionInfo>();
+            foreach (var runeState in equippedRune)
+            {
+                if (!runeOptionSheet.TryGetValue(runeState.RuneId, out var optionRow))
+                {
+                    throw new SheetRowNotFoundException("RuneOptionSheet", runeState.RuneId);
+                }
+
+                if (!optionRow.LevelOptionMap.TryGetValue(runeState.Level, out var option))
+                {
+                    throw new SheetRowNotFoundException("RuneOptionSheet", runeState.Level);
+                }
+
+                runeOptions.Add(option);
+            }
+
+            var characterSheet = sheets.GetSheet<CharacterSheet>();
+            if (!characterSheet.TryGetValue(avatarState.characterId, out var characterRow))
+            {
+                throw new SheetRowNotFoundException("CharacterSheet", avatarState.characterId);
+            }
+
+            var costumeStatSheet = sheets.GetSheet<CostumeStatSheet>();
+            var collectionModifiers = new List<StatModifier>();
+            if (collectionExist)
+            {
+                var collectionSheet = sheets.GetSheet<CollectionSheet>();
+                collectionModifiers = collectionState.GetModifiers(collectionSheet);
+            }
+
+            var runeLevelBonusSheet = sheets.GetSheet<RuneLevelBonusSheet>();
+            var runeLevelBonus =
+                RuneHelper.CalculateRuneLevelBonus(runeStates, runeListSheet, runeLevelBonusSheet);
+            var cp = CPHelper.TotalCP(
+                equipmentItems,
+                costumeItems,
+                runeOptions,
+                avatarState.level,
+                characterRow,
+                costumeStatSheet,
+                collectionModifiers,
+                runeLevelBonus);
+
+            // create ArenaParticipant: This is currently redundant, but we plan to replace all the ArenaScore and
+            // ArenaInformation states and some of the ArenaAvatarState states in the future.
+            var arenaParticipant = new ArenaParticipant(avatarAddress)
+            {
+                Name = avatarState.name,
+                PortraitId = avatarState.GetPortraitId(),
+                Level = avatarState.level,
+                Cp = cp,
+                Score = arenaScore.Score,
+                Ticket = arenaInformation.Ticket,
+                TicketResetCount = arenaInformation.TicketResetCount,
+                PurchasedTicketCount = arenaInformation.PurchasedTicketCount,
+                Win = arenaInformation.Win,
+                Lose = arenaInformation.Lose,
+                LastBattleBlockIndex = arenaAvatarState.LastBattleBlockIndex,
+            };
 
             var ended = DateTimeOffset.UtcNow;
             Log.Debug("{AddressesHex}JoinArena Total Executed Time: {Elapsed}", addressesHex, ended - started);
@@ -203,7 +305,8 @@ namespace Nekoyume.Action
                 .SetLegacyState(arenaInformationAdr, arenaInformation.Serialize())
                 .SetLegacyState(arenaParticipantsAdr, arenaParticipants.Serialize())
                 .SetLegacyState(arenaAvatarStateAdr, arenaAvatarState.Serialize())
-                .SetAgentState(context.Signer, agentState);
+                .SetAgentState(context.Signer, agentState)
+                .SetArenaParticipant(championshipId, round, avatarAddress, arenaParticipant);
         }
     }
 }

--- a/Lib9c/Action/JoinArena.cs
+++ b/Lib9c/Action/JoinArena.cs
@@ -110,6 +110,7 @@ namespace Nekoyume.Action
                 typeof(ItemRequirementSheet),
                 typeof(RuneLevelBonusSheet),
                 typeof(RuneListSheet),
+                typeof(RuneOptionSheet),
             };
             if (collectionExist)
             {

--- a/Lib9c/Action/JoinArena.cs
+++ b/Lib9c/Action/JoinArena.cs
@@ -173,8 +173,8 @@ namespace Nekoyume.Action
                         $"required {fee}, but balance is {crystalBalance}");
                 }
 
-                var arenaAdr = ArenaHelper.DeriveArenaAddress(roundData.ChampionshipId, roundData.Round);
-                states = states.TransferAsset(context, context.Signer, arenaAdr, fee);
+                var arenaAddr = ArenaHelper.DeriveArenaAddress(roundData.ChampionshipId, roundData.Round);
+                states = states.TransferAsset(context, context.Signer, arenaAddr, fee);
             }
 
             // check medal
@@ -189,9 +189,9 @@ namespace Nekoyume.Action
             }
 
             // create ArenaScore
-            var arenaScoreAdr =
+            var arenaScoreAddr =
                 ArenaScore.DeriveAddress(avatarAddress, roundData.ChampionshipId, roundData.Round);
-            if (states.TryGetLegacyState(arenaScoreAdr, out List _))
+            if (states.TryGetLegacyState(arenaScoreAddr, out List _))
             {
                 throw new ArenaScoreAlreadyContainsException(
                     $"[{nameof(JoinArena)}] id({roundData.ChampionshipId}) / round({roundData.Round})");
@@ -200,9 +200,9 @@ namespace Nekoyume.Action
             var arenaScore = new ArenaScore(avatarAddress, roundData.ChampionshipId, roundData.Round);
 
             // create ArenaInformation
-            var arenaInformationAdr =
+            var arenaInformationAddr =
                 ArenaInformation.DeriveAddress(avatarAddress, roundData.ChampionshipId, roundData.Round);
-            if (states.TryGetLegacyState(arenaInformationAdr, out List _))
+            if (states.TryGetLegacyState(arenaInformationAddr, out List _))
             {
                 throw new ArenaInformationAlreadyContainsException(
                     $"[{nameof(JoinArena)}] id({roundData.ChampionshipId}) / round({roundData.Round})");
@@ -212,14 +212,14 @@ namespace Nekoyume.Action
                 new ArenaInformation(avatarAddress, roundData.ChampionshipId, roundData.Round);
 
             // update ArenaParticipants
-            var arenaParticipantsAdr = ArenaParticipants.DeriveAddress(roundData.ChampionshipId, roundData.Round);
+            var arenaParticipantsAddr = ArenaParticipants.DeriveAddress(roundData.ChampionshipId, roundData.Round);
             var arenaParticipants =
-                states.GetArenaParticipants(arenaParticipantsAdr, roundData.ChampionshipId, roundData.Round);
+                states.GetArenaParticipants(arenaParticipantsAddr, roundData.ChampionshipId, roundData.Round);
             arenaParticipants.Add(avatarAddress);
 
             // update ArenaAvatarState: It seems like a good idea to consolidate this into ItemSlotState.
-            var arenaAvatarStateAdr = ArenaAvatarState.DeriveAddress(avatarAddress);
-            var arenaAvatarState = states.GetArenaAvatarState(arenaAvatarStateAdr, avatarState);
+            var arenaAvatarStateAddr = ArenaAvatarState.DeriveAddress(avatarAddress);
+            var arenaAvatarState = states.GetArenaAvatarState(arenaAvatarStateAddr, avatarState);
             arenaAvatarState.UpdateCostumes(costumes);
             arenaAvatarState.UpdateEquipment(equipments);
 
@@ -303,10 +303,10 @@ namespace Nekoyume.Action
             var ended = DateTimeOffset.UtcNow;
             Log.Debug("{AddressesHex}JoinArena Total Executed Time: {Elapsed}", addressesHex, ended - started);
             return states
-                .SetLegacyState(arenaScoreAdr, arenaScore.Serialize())
-                .SetLegacyState(arenaInformationAdr, arenaInformation.Serialize())
-                .SetLegacyState(arenaParticipantsAdr, arenaParticipants.Serialize())
-                .SetLegacyState(arenaAvatarStateAdr, arenaAvatarState.Serialize())
+                .SetLegacyState(arenaScoreAddr, arenaScore.Serialize())
+                .SetLegacyState(arenaInformationAddr, arenaInformation.Serialize())
+                .SetLegacyState(arenaParticipantsAddr, arenaParticipants.Serialize())
+                .SetLegacyState(arenaAvatarStateAddr, arenaAvatarState.Serialize())
                 .SetAgentState(context.Signer, agentState)
                 .SetArenaParticipant(championshipId, round, avatarAddress, arenaParticipant);
         }

--- a/Lib9c/Action/JoinArena.cs
+++ b/Lib9c/Action/JoinArena.cs
@@ -91,6 +91,7 @@ namespace Nekoyume.Action
                     $"[{nameof(JoinArena)}] Aborted as the avatar state of the signer was failed to load.");
             }
 
+            // check the avatar already joined the arena. 
             if (states.GetArenaParticipant(championshipId, round, avatarAddress) is not null)
             {
                 throw new AlreadyJoinedArenaException(championshipId, round, avatarAddress);

--- a/Lib9c/Addresses.cs
+++ b/Lib9c/Addresses.cs
@@ -54,15 +54,6 @@ namespace Nekoyume
 
         public static readonly Address CombinationSlot       = new("0000000000000000000000000000000000000024");
 
-        /// <summary>
-        /// This address is used to get an account in IWorld. The account obtained at this address stores the status of
-        /// individual participants in a particular ChampionshipID-round.
-        /// Derive the state address like this:
-        ///     Addresses.ArenaParticipant.Derive($"{championshipId}_{round}_{avatarAddress}");
-        /// And it returns the <see cref="Nekoyume.Model.Arena.ArenaParticipant"/> type value.
-        /// </summary>
-        public static readonly Address ArenaParticipant      = new("0000000000000000000000000000000000000025");
-
         // Adventure Boss
         public static readonly Address AdventureBoss         = new("0000000000000000000000000000000000000100");
         public static readonly Address BountyBoard           = new("0000000000000000000000000000000000000101");
@@ -204,5 +195,21 @@ namespace Nekoyume
 
         public static Address AdventureSeasonAddress(long season) =>
             AdventureBoss.Derive(season.ToString(CultureInfo.InvariantCulture));
+
+        public static Address GetArenaParticipantAccountAddress(int championshipId, int round)
+        {
+            var hex = $"01{championshipId:D36}{round:D2}";
+            return new Address(hex);
+        }
+
+        public static bool IsArenaParticipantAccountAddress(Address address)
+        {
+            const string lowerBound = "0100000000000000000000000000000000000000";
+            const string upperBound = "0199999999999999999999999999999999999999";
+            var hex = address.ToHex();
+
+            return string.CompareOrdinal(hex, lowerBound) >= 0 &&
+                   string.CompareOrdinal(hex, upperBound) <= 0;
+        }
     }
 }

--- a/Lib9c/Addresses.cs
+++ b/Lib9c/Addresses.cs
@@ -196,12 +196,23 @@ namespace Nekoyume
         public static Address AdventureSeasonAddress(long season) =>
             AdventureBoss.Derive(season.ToString(CultureInfo.InvariantCulture));
 
+        /// <summary>
+        /// Get the account address of an arena participant.
+        /// </summary>
+        /// <returns>
+        /// The account address of an arena participant.
+        /// "0100000000000000000000000000000000000000" ~ "0199999999999999999999999999999999999999".
+        /// </returns>
         public static Address GetArenaParticipantAccountAddress(int championshipId, int round)
         {
             var hex = $"01{championshipId:D36}{round:D2}";
             return new Address(hex);
         }
 
+        /// <summary>
+        /// Check if the given address is within the range of arena participant account addresses.
+        /// "0100000000000000000000000000000000000000" ~ "0199999999999999999999999999999999999999".
+        /// </summary>
         public static bool IsArenaParticipantAccountAddress(Address address)
         {
             const string lowerBound = "0100000000000000000000000000000000000000";

--- a/Lib9c/Addresses.cs
+++ b/Lib9c/Addresses.cs
@@ -5,7 +5,6 @@ using System.Security.Cryptography;
 using Libplanet.Common;
 using Libplanet.Crypto;
 using Nekoyume.Action;
-using Nekoyume.Model.Guild;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
@@ -14,77 +13,74 @@ namespace Nekoyume
 {
     public static class Addresses
     {
-        public static readonly Address Shop                  = new Address("0000000000000000000000000000000000000000");
-        public static readonly Address Ranking               = new Address("0000000000000000000000000000000000000001");
-        public static readonly Address WeeklyArena           = new Address("0000000000000000000000000000000000000002");
-        public static readonly Address TableSheet            = new Address("0000000000000000000000000000000000000003");
-        public static readonly Address GameConfig            = new Address("0000000000000000000000000000000000000004");
-        public static readonly Address RedeemCode            = new Address("0000000000000000000000000000000000000005");
-        public static readonly Address Admin                 = new Address("0000000000000000000000000000000000000006");
-        public static readonly Address PendingActivation     = new Address("0000000000000000000000000000000000000007");
-        public static readonly Address ActivatedAccount      = new Address("0000000000000000000000000000000000000008");
-        public static readonly Address Blacksmith            = new Address("0000000000000000000000000000000000000009");
-        public static readonly Address GoldCurrency          = new Address("000000000000000000000000000000000000000a");
-        public static readonly Address GoldDistribution      = new Address("000000000000000000000000000000000000000b");
-        public static readonly Address AuthorizedMiners      = new Address("000000000000000000000000000000000000000c");
-        public static readonly Address Credits               = new Address("000000000000000000000000000000000000000d");
-        public static readonly Address UnlockWorld           = new Address("000000000000000000000000000000000000000e");
-        public static readonly Address UnlockEquipmentRecipe = new Address("000000000000000000000000000000000000000f");
-        public static readonly Address MaterialCost          = new Address("0000000000000000000000000000000000000010");
-        public static readonly Address StageRandomBuff       = new Address("0000000000000000000000000000000000000011");
-        public static readonly Address Arena                 = new Address("0000000000000000000000000000000000000012");
-        public static readonly Address SuperCraft            = new Address("0000000000000000000000000000000000000013");
-        public static readonly Address EventDungeon          = new Address("0000000000000000000000000000000000000014");
-        public static readonly Address Raid                  = new Address("0000000000000000000000000000000000000015");
-        public static readonly Address Rune                  = new Address("0000000000000000000000000000000000000016");
-        public static readonly Address Market                = new Address("0000000000000000000000000000000000000017");
-        public static readonly Address GarageWallet          = new Address("0000000000000000000000000000000000000018");
-        public static readonly Address AssetMinters          = new Address("0000000000000000000000000000000000000019");
-        public static readonly Address Agent                 = new Address("000000000000000000000000000000000000001a");
-        public static readonly Address Avatar                = new Address("000000000000000000000000000000000000001b");
-        public static readonly Address Inventory             = new Address("000000000000000000000000000000000000001c");
-        public static readonly Address WorldInformation      = new Address("000000000000000000000000000000000000001d");
-        public static readonly Address QuestList             = new Address("000000000000000000000000000000000000001e");
-        public static readonly Address Collection            = new Address("000000000000000000000000000000000000001f");
-        public static readonly Address DailyReward           = new Address("0000000000000000000000000000000000000020");
-        public static readonly Address ActionPoint           = new Address("0000000000000000000000000000000000000021");
-        public static readonly Address RuneState             = new Address("0000000000000000000000000000000000000022");
-        public static readonly Address CombinationSlot       = new Address("0000000000000000000000000000000000000024");
+        public static readonly Address Shop                  = new("0000000000000000000000000000000000000000");
+        public static readonly Address Ranking               = new("0000000000000000000000000000000000000001");
+        public static readonly Address WeeklyArena           = new("0000000000000000000000000000000000000002");
+        public static readonly Address TableSheet            = new("0000000000000000000000000000000000000003");
+        public static readonly Address GameConfig            = new("0000000000000000000000000000000000000004");
+        public static readonly Address RedeemCode            = new("0000000000000000000000000000000000000005");
+        public static readonly Address Admin                 = new("0000000000000000000000000000000000000006");
+        public static readonly Address PendingActivation     = new("0000000000000000000000000000000000000007");
+        public static readonly Address ActivatedAccount      = new("0000000000000000000000000000000000000008");
+        public static readonly Address Blacksmith            = new("0000000000000000000000000000000000000009");
+        public static readonly Address GoldCurrency          = new("000000000000000000000000000000000000000a");
+        public static readonly Address GoldDistribution      = new("000000000000000000000000000000000000000b");
+        public static readonly Address AuthorizedMiners      = new("000000000000000000000000000000000000000c");
+        public static readonly Address Credits               = new("000000000000000000000000000000000000000d");
+        public static readonly Address UnlockWorld           = new("000000000000000000000000000000000000000e");
+        public static readonly Address UnlockEquipmentRecipe = new("000000000000000000000000000000000000000f");
+        public static readonly Address MaterialCost          = new("0000000000000000000000000000000000000010");
+        public static readonly Address StageRandomBuff       = new("0000000000000000000000000000000000000011");
+        public static readonly Address Arena                 = new("0000000000000000000000000000000000000012");
+        public static readonly Address SuperCraft            = new("0000000000000000000000000000000000000013");
+        public static readonly Address EventDungeon          = new("0000000000000000000000000000000000000014");
+        public static readonly Address Raid                  = new("0000000000000000000000000000000000000015");
+        public static readonly Address Rune                  = new("0000000000000000000000000000000000000016");
+        public static readonly Address Market                = new("0000000000000000000000000000000000000017");
+        public static readonly Address GarageWallet          = new("0000000000000000000000000000000000000018");
+        public static readonly Address AssetMinters          = new("0000000000000000000000000000000000000019");
+        public static readonly Address Agent                 = new("000000000000000000000000000000000000001a");
+        public static readonly Address Avatar                = new("000000000000000000000000000000000000001b");
+        public static readonly Address Inventory             = new("000000000000000000000000000000000000001c");
+        public static readonly Address WorldInformation      = new("000000000000000000000000000000000000001d");
+        public static readonly Address QuestList             = new("000000000000000000000000000000000000001e");
+        public static readonly Address Collection            = new("000000000000000000000000000000000000001f");
+        public static readonly Address DailyReward           = new("0000000000000000000000000000000000000020");
+        public static readonly Address ActionPoint           = new("0000000000000000000000000000000000000021");
+        public static readonly Address RuneState             = new("0000000000000000000000000000000000000022");
 
         // Custom Equipment Craft
-        public static readonly Address Relationship           = new ("0000000000000000000000000000000000000023");
+        public static readonly Address Relationship          = new("0000000000000000000000000000000000000023");
+
+        public static readonly Address CombinationSlot       = new("0000000000000000000000000000000000000024");
 
         // Adventure Boss
-        public static readonly Address AdventureBoss         = new Address("0000000000000000000000000000000000000100");
-        public static readonly Address BountyBoard           = new Address("0000000000000000000000000000000000000101");
-        public static readonly Address ExploreBoard          = new Address("0000000000000000000000000000000000000102");
-        public static readonly Address ExplorerList          = new Address("0000000000000000000000000000000000000103");
+        public static readonly Address AdventureBoss         = new("0000000000000000000000000000000000000100");
+        public static readonly Address BountyBoard           = new("0000000000000000000000000000000000000101");
+        public static readonly Address ExploreBoard          = new("0000000000000000000000000000000000000102");
+        public static readonly Address ExplorerList          = new("0000000000000000000000000000000000000103");
 
         #region Guild
 
         /// <summary>
         /// An address of an account having <see cref="Nekoyume.Model.Guild.Guild"/>.
         /// </summary>
-        public static readonly Address Guild =
-            new Address("0000000000000000000000000000000000000200");
+        public static readonly Address Guild = new("0000000000000000000000000000000000000200");
 
         /// <summary>
         /// An address of an account having <see cref="Bencodex.Types.Integer"/> which means the number of the guild.
         /// </summary>
-        public static readonly Address GuildMemberCounter =
-            new Address("0000000000000000000000000000000000000201");
+        public static readonly Address GuildMemberCounter = new("0000000000000000000000000000000000000201");
 
         /// <summary>
         /// An address of an account having <see cref="Nekoyume.Model.Guild.GuildApplication"/>.
         /// </summary>
-        public static readonly Address GuildApplication =
-            new Address("0000000000000000000000000000000000000202");
+        public static readonly Address GuildApplication = new("0000000000000000000000000000000000000202");
 
         /// <summary>
         /// An address of an account having <see cref="Nekoyume.Model.Guild.GuildParticipant"/>
         /// </summary>
-        public static readonly Address GuildParticipant =
-            new Address("0000000000000000000000000000000000000203");
+        public static readonly Address GuildParticipant = new("0000000000000000000000000000000000000203");
 
         /// <summary>
         /// Build an <see cref="Address"/> of an <see cref="Libplanet.Action.State.Account"/>,
@@ -96,8 +92,7 @@ namespace Nekoyume
         public static Address GetGuildBanAccountAddress(Address guildAddress) =>
             guildAddress.Derive("guild.banned");
 
-        public static readonly Address EmptyAccountAddress =
-            new Address("ffffffffffffffffffffffffffffffffffffffff");
+        public static readonly Address EmptyAccountAddress = new("ffffffffffffffffffffffffffffffffffffffff");
 
         #endregion
 
@@ -198,6 +193,7 @@ namespace Nekoyume
                 .Select(index => GetAvatarAddress(agentAddr, index))
                 .Contains(inventoryAddr);
 
-        public static Address AdventureSeasonAddress(long season) => AdventureBoss.Derive(season.ToString(CultureInfo.InvariantCulture));
+        public static Address AdventureSeasonAddress(long season) =>
+            AdventureBoss.Derive(season.ToString(CultureInfo.InvariantCulture));
     }
 }

--- a/Lib9c/Addresses.cs
+++ b/Lib9c/Addresses.cs
@@ -54,6 +54,15 @@ namespace Nekoyume
 
         public static readonly Address CombinationSlot       = new("0000000000000000000000000000000000000024");
 
+        /// <summary>
+        /// This address is used to get an account in IWorld. The account obtained at this address stores the status of
+        /// individual participants in a particular ChampionshipID-round.
+        /// Derive the state address like this:
+        ///     Addresses.ArenaParticipant.Derive($"{championshipId}_{round}_{avatarAddress}");
+        /// And it returns the <see cref="Nekoyume.Model.Arena.ArenaParticipant"/> type value.
+        /// </summary>
+        public static readonly Address ArenaParticipant      = new("0000000000000000000000000000000000000025");
+
         // Adventure Boss
         public static readonly Address AdventureBoss         = new("0000000000000000000000000000000000000100");
         public static readonly Address BountyBoard           = new("0000000000000000000000000000000000000101");

--- a/Lib9c/Exceptions/BencodexTypesExtensions.cs
+++ b/Lib9c/Exceptions/BencodexTypesExtensions.cs
@@ -7,10 +7,10 @@ namespace Nekoyume.Exceptions
     public static class BencodexTypesExtensions
     {
         /// <summary>
-        /// Returns a new list with the value inserted at the specified index.
+        /// Returns a new list with the value replaced at the specified index.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public static List InsertTo(this List list, int index, IValue value)
+        public static List Replace(this List list, int index, IValue value)
         {
             if (list.Count <= index)
             {

--- a/Lib9c/Exceptions/BencodexTypesExtensions.cs
+++ b/Lib9c/Exceptions/BencodexTypesExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq;
+using Bencodex.Types;
+
+namespace Nekoyume.Exceptions
+{
+    public static class BencodexTypesExtensions
+    {
+        /// <summary>
+        /// Returns a new list with the value inserted at the specified index.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        public static List InsertTo(this List list, int index, IValue value)
+        {
+            if (list.Count <= index)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(index),
+                    $"Index({index}) is out of range({list.Count}).");
+            }
+
+            var newList = list.ToArray();
+            newList[index] = value;
+            return new List(newList);
+        }
+    }
+}

--- a/Lib9c/Exceptions/UnsupportedStateException.cs
+++ b/Lib9c/Exceptions/UnsupportedStateException.cs
@@ -18,6 +18,17 @@ namespace Nekoyume.Exceptions
                 innerException)
         {
         }
+        
+        public UnsupportedStateException(
+            int expectedVersion,
+            int actualVersion,
+            Exception innerException = null) :
+            base(
+                "Unsupported state version." +
+                $" Expected: {expectedVersion}, Actual: {actualVersion}.",
+                innerException)
+        {
+        }
 
         public UnsupportedStateException(string msg) : base(msg)
         {

--- a/Lib9c/Exceptions/UnsupportedStateException.cs
+++ b/Lib9c/Exceptions/UnsupportedStateException.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Nekoyume.Exceptions
+{
+    [Serializable]
+    public class UnsupportedStateException : Exception
+    {
+        public UnsupportedStateException(
+            string expectedName,
+            int expectedVersion,
+            string actualName,
+            int actualVersion,
+            Exception innerException = null) :
+            base(
+                "Unsupported state." +
+                $" Expected: {expectedName}({expectedVersion}), Actual: {actualName}({actualVersion}).",
+                innerException)
+        {
+        }
+
+        protected UnsupportedStateException(
+            SerializationInfo info,
+            StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/Lib9c/Exceptions/UnsupportedStateException.cs
+++ b/Lib9c/Exceptions/UnsupportedStateException.cs
@@ -19,10 +19,11 @@ namespace Nekoyume.Exceptions
         {
         }
 
-        protected UnsupportedStateException(
-            SerializationInfo info,
-            StreamingContext context)
-            : base(info, context)
+        public UnsupportedStateException(string msg) : base(msg)
+        {
+        }
+
+        protected UnsupportedStateException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/Lib9c/Model/Arena/ArenaParticipant.cs
+++ b/Lib9c/Model/Arena/ArenaParticipant.cs
@@ -21,9 +21,6 @@ namespace Nekoyume.Model.Arena
         public const int DefaultScore = 1000;
         public const int MaxTicketCount = 8;
 
-        public static Address DeriveAddress(int championshipId, int round, Address avatarAddress) =>
-            Addresses.ArenaParticipant.Derive($"{championshipId}_{round}_{avatarAddress.ToHex()}");
-
         public readonly Address AvatarAddr;
 
         /// <summary>

--- a/Lib9c/Model/Arena/ArenaParticipant.cs
+++ b/Lib9c/Model/Arena/ArenaParticipant.cs
@@ -1,0 +1,157 @@
+using System;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Crypto;
+using Nekoyume.Action;
+using Nekoyume.Exceptions;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Model.Arena
+{
+    /// <summary>
+    /// This class combines the information from <see cref="Nekoyume.Model.Arena.ArenaScore"/> and
+    /// <see cref="Nekoyume.Model.Arena.ArenaInformation"/>, and brings together information about the arena
+    /// participant, including additional information.
+    /// </summary>
+    public class ArenaParticipant : IBencodable, IState
+    {
+        private const string StateTypeName = "arena_participant";
+        private const int StateVersion = 1;
+
+        public const int DefaultScore = 1000;
+        public const int MaxTicketCount = 8;
+
+        public static Address DeriveAddress(int championshipId, int round, Address avatarAddress) =>
+            Addresses.ArenaParticipant.Derive($"{championshipId}_{round}_{avatarAddress.ToHex()}");
+
+        public readonly Address AvatarAddr;
+
+        /// <summary>
+        /// If you need to know <see cref="Nekoyume.Model.State.AvatarState.NameWithHash"/>, check
+        /// <see cref="Nekoyume.Model.State.AvatarState.PostConstructor"/> method of the
+        /// <see cref="Nekoyume.Model.State.AvatarState"/> class and you can find the relevant information there. It
+        /// provides a formatted string that includes the avatar's <see cref="Nekoyume.Model.State.AvatarState.name"/>
+        /// and a shortened version of their address.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// $"{name} &lt;size=80%&gt;&lt;color=#A68F7E&gt;#{address.ToHex().Substring(0, 4)}&lt;/color&gt;&lt;/size&gt;";
+        /// </code>
+        /// </example>
+        public string Name;
+
+        public int PortraitId;
+        public int Level;
+        public int Cp;
+
+        public int Score;
+
+        public int Ticket;
+        public int TicketResetCount;
+        public int PurchasedTicketCount;
+
+        public int Win;
+        public int Lose;
+
+        public long LastBattleBlockIndex;
+
+        public IValue Bencoded => List.Empty
+            .Add(StateTypeName)
+            .Add(StateVersion)
+            .Add(AvatarAddr.Serialize())
+            .Add(Name)
+            .Add(PortraitId)
+            .Add(Level)
+            .Add(Cp)
+            .Add(Score)
+            .Add(Ticket)
+            .Add(TicketResetCount)
+            .Add(PurchasedTicketCount)
+            .Add(Win)
+            .Add(Lose)
+            .Add(LastBattleBlockIndex);
+
+        public ArenaParticipant(Address avatarAddr)
+        {
+            AvatarAddr = avatarAddr;
+            Score = DefaultScore;
+            Ticket = MaxTicketCount;
+        }
+
+        public ArenaParticipant(IValue bencoded)
+        {
+            if (bencoded is not List l)
+            {
+                throw new ArgumentException($"Invalid bencoded value: {bencoded.Inspect()}", nameof(bencoded));
+            }
+
+            try
+            {
+                var stateTypeName = (Text)l[0];
+                var stateVersion = (Integer)l[1];
+                if (stateTypeName != StateTypeName || stateVersion != StateVersion)
+                {
+                    throw new UnsupportedStateException(StateTypeName, StateVersion, stateTypeName, stateVersion);
+                }
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentException("Invalid state type name or version", e);
+            }
+
+            AvatarAddr = l[2].ToAddress();
+            Name = (Text)l[3];
+            PortraitId = (Integer)l[4];
+            Level = (Integer)l[5];
+            Cp = (Integer)l[6];
+            Score = (Integer)l[7];
+            Ticket = (Integer)l[8];
+            TicketResetCount = (Integer)l[9];
+            PurchasedTicketCount = (Integer)l[10];
+            Win = (Integer)l[11];
+            Lose = (Integer)l[12];
+            LastBattleBlockIndex = (Integer)l[13];
+        }
+
+        public IValue Serialize() => Bencoded;
+
+        public void AddScore(int score)
+        {
+            Score = Math.Max(Score + score, DefaultScore);
+        }
+
+        public void UseTicket(int ticketCount)
+        {
+            if (Ticket < ticketCount)
+            {
+                throw new NotEnoughTicketException(
+                    $"[{nameof(ArenaParticipant)}] have({Ticket}) < use({ticketCount})");
+            }
+
+            Ticket -= ticketCount;
+        }
+
+        public void BuyTicket(long maxCount)
+        {
+            if (PurchasedTicketCount >= maxCount)
+            {
+                throw new ExceedTicketPurchaseLimitException(
+                    $"[{nameof(ArenaParticipant)}] PurchasedTicketCount({PurchasedTicketCount}) >= MAX({maxCount})");
+            }
+
+            PurchasedTicketCount++;
+        }
+
+        public void UpdateRecord(int win, int lose)
+        {
+            Win += win;
+            Lose += lose;
+        }
+
+        public void ResetTicket(int resetCount)
+        {
+            Ticket = MaxTicketCount;
+            TicketResetCount = resetCount;
+        }
+    }
+}

--- a/Lib9c/Model/Arena/ArenaParticipant.cs
+++ b/Lib9c/Model/Arena/ArenaParticipant.cs
@@ -15,7 +15,6 @@ namespace Nekoyume.Model.Arena
     /// </summary>
     public class ArenaParticipant : IBencodable, IState
     {
-        private const string StateTypeName = "arena_participant";
         private const int StateVersion = 1;
 
         public const int DefaultScore = 1000;
@@ -53,7 +52,6 @@ namespace Nekoyume.Model.Arena
         public long LastBattleBlockIndex;
 
         public IValue Bencoded => List.Empty
-            .Add(StateTypeName)
             .Add(StateVersion)
             .Add(AvatarAddr.Serialize())
             .Add(Name)
@@ -84,11 +82,10 @@ namespace Nekoyume.Model.Arena
 
             try
             {
-                var stateTypeName = (Text)l[0];
-                var stateVersion = (Integer)l[1];
-                if (stateTypeName != StateTypeName || stateVersion != StateVersion)
+                var stateVersion = (Integer)l[0];
+                if (stateVersion != StateVersion)
                 {
-                    throw new UnsupportedStateException(StateTypeName, StateVersion, stateTypeName, stateVersion);
+                    throw new UnsupportedStateException(StateVersion, stateVersion);
                 }
             }
             catch (Exception e)
@@ -96,18 +93,18 @@ namespace Nekoyume.Model.Arena
                 throw new ArgumentException("Invalid state type name or version", e);
             }
 
-            AvatarAddr = l[2].ToAddress();
-            Name = (Text)l[3];
-            PortraitId = (Integer)l[4];
-            Level = (Integer)l[5];
-            Cp = (Integer)l[6];
-            Score = (Integer)l[7];
-            Ticket = (Integer)l[8];
-            TicketResetCount = (Integer)l[9];
-            PurchasedTicketCount = (Integer)l[10];
-            Win = (Integer)l[11];
-            Lose = (Integer)l[12];
-            LastBattleBlockIndex = (Integer)l[13];
+            AvatarAddr = l[1].ToAddress();
+            Name = (Text)l[2];
+            PortraitId = (Integer)l[3];
+            Level = (Integer)l[4];
+            Cp = (Integer)l[5];
+            Score = (Integer)l[6];
+            Ticket = (Integer)l[7];
+            TicketResetCount = (Integer)l[8];
+            PurchasedTicketCount = (Integer)l[9];
+            Win = (Integer)l[10];
+            Lose = (Integer)l[11];
+            LastBattleBlockIndex = (Integer)l[12];
         }
 
         public IValue Serialize() => Bencoded;

--- a/Lib9c/Model/State/AvatarState.cs
+++ b/Lib9c/Model/State/AvatarState.cs
@@ -609,6 +609,12 @@ namespace Nekoyume.Model.State
             return armor?.Id ?? GameConfig.DefaultAvatarArmorId;
         }
 
+        public int GetPortraitId()
+        {
+            var fc = inventory.Costumes.FirstOrDefault(e => e.ItemSubType == ItemSubType.FullCostume);
+            return fc?.Id ?? GetArmorId();
+        }
+
         public void ValidateEquipments(List<Guid> equipmentIds, long blockIndex)
         {
             var ringCount = 0;

--- a/Lib9c/Module/ArenaModule.cs
+++ b/Lib9c/Module/ArenaModule.cs
@@ -14,19 +14,20 @@ namespace Nekoyume.Module
             Address avatarAddress,
             ArenaParticipant arenaParticipant)
         {
-            var stateAddress = ArenaParticipant.DeriveAddress(championshipId, round, avatarAddress);
-            return world.SetArenaParticipant(stateAddress, arenaParticipant.Bencoded);
+            var accountAddress = Addresses.GetArenaParticipantAccountAddress(championshipId, round);
+            return world.SetArenaParticipant(accountAddress, avatarAddress, arenaParticipant.Bencoded);
         }
 
         public static IWorld SetArenaParticipant(
             this IWorld world,
+            Address accountAddress,
             Address stateAddress,
             IValue arenaParticipant)
         {
             var account = world
-                .GetAccount(Addresses.ArenaParticipant)
+                .GetAccount(accountAddress)
                 .SetState(stateAddress, arenaParticipant);
-            return world.SetAccount(Addresses.ArenaParticipant, account);
+            return world.SetAccount(accountAddress, account);
         }
 
         public static ArenaParticipant GetArenaParticipant(
@@ -35,8 +36,8 @@ namespace Nekoyume.Module
             int round,
             Address avatarAddress)
         {
-            var stateAddress = ArenaParticipant.DeriveAddress(championshipId, round, avatarAddress);
-            var state = worldState.GetArenaParticipant(stateAddress);
+            var accountAddress = Addresses.GetArenaParticipantAccountAddress(championshipId, round);
+            var state = worldState.GetArenaParticipant(accountAddress, avatarAddress);
             return state is null
                 ? null
                 : new ArenaParticipant(state);
@@ -44,10 +45,11 @@ namespace Nekoyume.Module
 
         public static IValue GetArenaParticipant(
             this IWorldState worldState,
+            Address accountAddress,
             Address stateAddress)
         {
             return worldState
-                .GetAccountState(Addresses.ArenaParticipant)
+                .GetAccountState(accountAddress)
                 .GetState(stateAddress);
         }
     }

--- a/Lib9c/Module/ArenaModule.cs
+++ b/Lib9c/Module/ArenaModule.cs
@@ -1,0 +1,54 @@
+using Bencodex.Types;
+using Libplanet.Action.State;
+using Libplanet.Crypto;
+using Nekoyume.Model.Arena;
+
+namespace Nekoyume.Module
+{
+    public static class ArenaModule
+    {
+        public static IWorld SetArenaParticipant(
+            this IWorld world,
+            int championshipId,
+            int round,
+            Address avatarAddress,
+            ArenaParticipant arenaParticipant)
+        {
+            var stateAddress = ArenaParticipant.DeriveAddress(championshipId, round, avatarAddress);
+            return world.SetArenaParticipant(stateAddress, arenaParticipant.Bencoded);
+        }
+
+        public static IWorld SetArenaParticipant(
+            this IWorld world,
+            Address stateAddress,
+            IValue arenaParticipant)
+        {
+            var account = world
+                .GetAccount(Addresses.ArenaParticipant)
+                .SetState(stateAddress, arenaParticipant);
+            return world.SetAccount(Addresses.ArenaParticipant, account);
+        }
+
+        public static ArenaParticipant GetArenaParticipant(
+            this IWorldState worldState,
+            int championshipId,
+            int round,
+            Address avatarAddress)
+        {
+            var stateAddress = ArenaParticipant.DeriveAddress(championshipId, round, avatarAddress);
+            var state = worldState.GetArenaParticipant(stateAddress);
+            return state is null
+                ? null
+                : new ArenaParticipant(state);
+        }
+
+        public static IValue GetArenaParticipant(
+            this IWorldState worldState,
+            Address stateAddress)
+        {
+            return worldState
+                .GetAccountState(Addresses.ArenaParticipant)
+                .GetState(stateAddress);
+        }
+    }
+}

--- a/Lib9c/Module/ArenaModule.cs
+++ b/Lib9c/Module/ArenaModule.cs
@@ -20,13 +20,24 @@ namespace Nekoyume.Module
 
         public static IWorld SetArenaParticipant(
             this IWorld world,
+            int championshipId,
+            int round,
+            Address avatarAddress,
+            IValue arenaParticipantState)
+        {
+            var accountAddress = Addresses.GetArenaParticipantAccountAddress(championshipId, round);
+            return world.SetArenaParticipant(accountAddress, avatarAddress, arenaParticipantState);
+        }
+
+        public static IWorld SetArenaParticipant(
+            this IWorld world,
             Address accountAddress,
             Address stateAddress,
-            IValue arenaParticipant)
+            IValue arenaParticipantState)
         {
             var account = world
                 .GetAccount(accountAddress)
-                .SetState(stateAddress, arenaParticipant);
+                .SetState(stateAddress, arenaParticipantState);
             return world.SetAccount(accountAddress, account);
         }
 
@@ -37,13 +48,23 @@ namespace Nekoyume.Module
             Address avatarAddress)
         {
             var accountAddress = Addresses.GetArenaParticipantAccountAddress(championshipId, round);
-            var state = worldState.GetArenaParticipant(accountAddress, avatarAddress);
+            var state = worldState.GetArenaParticipantState(accountAddress, avatarAddress);
             return state is null
                 ? null
                 : new ArenaParticipant(state);
         }
 
-        public static IValue GetArenaParticipant(
+        public static IValue GetArenaParticipantState(
+            this IWorldState worldState,
+            int championshipId,
+            int round,
+            Address avatarAddress)
+        {
+            var accountAddress = Addresses.GetArenaParticipantAccountAddress(championshipId, round);
+            return worldState.GetArenaParticipantState(accountAddress, avatarAddress);
+        }
+
+        public static IValue GetArenaParticipantState(
             this IWorldState worldState,
             Address accountAddress,
             Address stateAddress)


### PR DESCRIPTION
# Background

The `ArenaParticipant` type and its corresponding account (IAccount) were created to address the issue where Arena participant information was split across multiple addresses and too many status queries were made each time, for example, to calculate the CP of an Arena participant.

# Concern

Arenas are non-stop, so we didn't change any of the states we already created and use, such as `ArenaScore`, `ArenaInformation`, and `ArenaAvatarState`, but we did configure and synchronize the `ArenaParticipant` state to replace them going forward, which will dramatically reduce a lot of the state lookups and operations we used to do to configure Arena information.

First, I'm proposing changes to the `JoinArena` action, followed by changes to the `BattleArena` action.

# Changes

- Add `Nekoyume.Addresses.ArenaParticipant` address.
- Add `Nekoyume.Model.Arena.ArenaParticipant` with tests.
- Add `AvatarState.GetPortraitId()` method.
- Add exceptions: `UnsupportedStateException`, `AlreadyJoinedArenaException`
- Add `ArenaModule`.
- Check and set `ArenaParticipant` state in `JoinArena`.
- Update `ArenaParticipant` state in `BattleArena`.
- Improve unit tests for `JoinArena` and `BattleArena`.
