### PR TITLE
feat: set `ArenaParticipant` in `BattleArena` action

### DIFF
--- a/.Lib9c.Tests/Action/ExceptionTest.cs
+++ b/.Lib9c.Tests/Action/ExceptionTest.cs
@@ -10,6 +10,7 @@ namespace Lib9c.Tests.Action
     using Nekoyume.Action;
     using Nekoyume.Action.Exceptions;
     using Nekoyume.Action.Exceptions.AdventureBoss;
+    using Nekoyume.Action.Exceptions.Arena;
     using Nekoyume.Exceptions;
     using Nekoyume.Model.State;
     using Nekoyume.TableData;
@@ -85,6 +86,7 @@ namespace Lib9c.Tests.Action
         [InlineData(typeof(SeasonInProgressException))]
         [InlineData(typeof(EmptyRewardException))]
         [InlineData(typeof(UnsupportedStateException))]
+        [InlineData(typeof(AlreadyJoinedArenaException))]
         public void Exception_Serializable(Type excType)
         {
             if (Activator.CreateInstance(excType, "for testing") is Exception exc)

--- a/.Lib9c.Tests/Action/ExceptionTest.cs
+++ b/.Lib9c.Tests/Action/ExceptionTest.cs
@@ -84,6 +84,7 @@ namespace Lib9c.Tests.Action
         [InlineData(typeof(PreviousBountyException))]
         [InlineData(typeof(SeasonInProgressException))]
         [InlineData(typeof(EmptyRewardException))]
+        [InlineData(typeof(UnsupportedStateException))]
         public void Exception_Serializable(Type excType)
         {
             if (Activator.CreateInstance(excType, "for testing") is Exception exc)

--- a/.Lib9c.Tests/Model/Arena/ArenaParticipantTest.cs
+++ b/.Lib9c.Tests/Model/Arena/ArenaParticipantTest.cs
@@ -1,0 +1,46 @@
+namespace Lib9c.Tests.Model.Arena;
+
+using Libplanet.Crypto;
+using Nekoyume.Model.Arena;
+using Xunit;
+
+public class ArenaParticipantTest
+{
+    [Fact]
+    public void Serialize()
+    {
+        var avatarAddr = new PrivateKey().Address;
+        var state = new ArenaParticipant(avatarAddr)
+        {
+            Name = "Joy",
+            PortraitId = 1,
+            Level = 99,
+            Cp = 999_999_999,
+            Score = 999_999,
+            Ticket = 7,
+            TicketResetCount = 1,
+            PurchasedTicketCount = 1,
+            Win = 100,
+            Lose = 99,
+            LastBattleBlockIndex = long.MaxValue,
+        };
+        var serialized = state.Bencoded;
+        var deserialized = new ArenaParticipant(serialized);
+
+        Assert.Equal(state.AvatarAddr, deserialized.AvatarAddr);
+        Assert.Equal(state.Name, deserialized.Name);
+        Assert.Equal(state.PortraitId, deserialized.PortraitId);
+        Assert.Equal(state.Level, deserialized.Level);
+        Assert.Equal(state.Cp, deserialized.Cp);
+        Assert.Equal(state.Score, deserialized.Score);
+        Assert.Equal(state.Ticket, deserialized.Ticket);
+        Assert.Equal(state.TicketResetCount, deserialized.TicketResetCount);
+        Assert.Equal(state.PurchasedTicketCount, deserialized.PurchasedTicketCount);
+        Assert.Equal(state.Win, deserialized.Win);
+        Assert.Equal(state.Lose, deserialized.Lose);
+        Assert.Equal(state.LastBattleBlockIndex, deserialized.LastBattleBlockIndex);
+
+        var serialized2 = deserialized.Bencoded;
+        Assert.Equal(serialized, serialized2);
+    }
+}

--- a/Lib9c.sln.DotSettings
+++ b/Lib9c.sln.DotSettings
@@ -2,6 +2,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=AI/@EntryIndexedValue">AI</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NCG/@EntryIndexedValue">NCG</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Addr/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=bencoded/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bencodex/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Equippable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Gacha/@EntryIndexedValue">True</s:Boolean>

--- a/Lib9c/Action/Exceptions/Arena/AlreadyJoinedArenaException.cs
+++ b/Lib9c/Action/Exceptions/Arena/AlreadyJoinedArenaException.cs
@@ -1,0 +1,18 @@
+using System;
+using Libplanet.Crypto;
+
+namespace Nekoyume.Action.Exceptions.Arena
+{
+    [Serializable]
+    public class AlreadyJoinedArenaException : Exception
+    {
+        public AlreadyJoinedArenaException(
+            int championshipId,
+            int round,
+            Address avatarAddress) :
+            base(
+                $"Avatar {avatarAddress} has already joined the arena for championship {championshipId}, round {round}.")
+        {
+        }
+    }
+}

--- a/Lib9c/Action/Exceptions/Arena/AlreadyJoinedArenaException.cs
+++ b/Lib9c/Action/Exceptions/Arena/AlreadyJoinedArenaException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 using Libplanet.Crypto;
 
 namespace Nekoyume.Action.Exceptions.Arena
@@ -12,6 +13,14 @@ namespace Nekoyume.Action.Exceptions.Arena
             Address avatarAddress) :
             base(
                 $"Avatar {avatarAddress} has already joined the arena for championship {championshipId}, round {round}.")
+        {
+        }
+
+        public AlreadyJoinedArenaException(string msg) : base(msg)
+        {
+        }
+
+        protected AlreadyJoinedArenaException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/Lib9c/Action/JoinArena.cs
+++ b/Lib9c/Action/JoinArena.cs
@@ -7,11 +7,14 @@ using Lib9c.Abstractions;
 using Libplanet.Action;
 using Libplanet.Action.State;
 using Libplanet.Crypto;
+using Nekoyume.Action.Exceptions.Arena;
 using Nekoyume.Arena;
+using Nekoyume.Battle;
 using Nekoyume.Extensions;
 using Nekoyume.Helper;
 using Nekoyume.Model.Arena;
 using Nekoyume.Model.EnumType;
+using Nekoyume.Model.Stat;
 using Nekoyume.Model.State;
 using Nekoyume.Module;
 using Nekoyume.TableData;
@@ -39,6 +42,7 @@ namespace Nekoyume.Action
         int IJoinArenaV1.Round => round;
         IEnumerable<Guid> IJoinArenaV1.Costumes => costumes;
         IEnumerable<Guid> IJoinArenaV1.Equipments => equipments;
+
         IEnumerable<IValue> IJoinArenaV1.RuneSlotInfos => runeInfos
             .Select(x => x.Serialize());
 
@@ -52,7 +56,7 @@ namespace Nekoyume.Action
                     .OrderBy(element => element).Select(e => e.Serialize())),
                 ["equipments"] = new List(equipments
                     .OrderBy(element => element).Select(e => e.Serialize())),
-                ["runeInfos"] = runeInfos.OrderBy(x => x.SlotIndex).Select(x=> x.Serialize()).Serialize(),
+                ["runeInfos"] = runeInfos.OrderBy(x => x.SlotIndex).Select(x => x.Serialize()).Serialize(),
             }.ToImmutableDictionary();
 
         protected override void LoadPlainValueInternal(
@@ -77,32 +81,53 @@ namespace Nekoyume.Action
             var agentState = states.GetAgentState(context.Signer);
             if (agentState is null)
             {
-                throw new FailedLoadStateException($"[{nameof(JoinArena)}] Aborted as the agent state of the signer was failed to load.");
+                throw new FailedLoadStateException(
+                    $"[{nameof(JoinArena)}] Aborted as the agent state of the signer was failed to load.");
             }
 
             if (!states.TryGetAvatarState(context.Signer, avatarAddress, out var avatarState))
             {
-                throw new FailedLoadStateException($"[{nameof(JoinArena)}] Aborted as the avatar state of the signer was failed to load.");
+                throw new FailedLoadStateException(
+                    $"[{nameof(JoinArena)}] Aborted as the avatar state of the signer was failed to load.");
             }
 
-            var sheets = states.GetSheets(
-                sheetTypes: new[]
-                {
-                    typeof(ItemRequirementSheet),
-                    typeof(EquipmentItemRecipeSheet),
-                    typeof(EquipmentItemSubRecipeSheetV2),
-                    typeof(EquipmentItemOptionSheet),
-                    typeof(ArenaSheet),
-                    typeof(RuneListSheet),
-                });
+            if (states.GetArenaParticipant(championshipId, round, avatarAddress) is not null)
+            {
+                throw new AlreadyJoinedArenaException(championshipId, round, avatarAddress);
+            }
 
+            var collectionExist =
+                states.TryGetCollectionState(avatarAddress, out var collectionState) &&
+                collectionState.Ids.Any();
+            var sheetTypes = new List<Type>
+            {
+                typeof(ArenaSheet),
+                typeof(CharacterSheet),
+                typeof(CostumeStatSheet),
+                typeof(EquipmentItemOptionSheet),
+                typeof(EquipmentItemRecipeSheet),
+                typeof(EquipmentItemSubRecipeSheetV2),
+                typeof(ItemRequirementSheet),
+                typeof(RuneLevelBonusSheet),
+                typeof(RuneListSheet),
+            };
+            if (collectionExist)
+            {
+                sheetTypes.Add(typeof(CollectionSheet));
+            }
+
+            var sheets = states.GetSheets(sheetTypes: sheetTypes);
             var gameConfigState = states.GetGameConfigState();
-            avatarState.ValidEquipmentAndCostumeV2(costumes, equipments,
+            var (equipmentItems, costumeItems) = avatarState.ValidEquipmentAndCostumeV2(
+                costumes,
+                equipments,
                 sheets.GetSheet<ItemRequirementSheet>(),
                 sheets.GetSheet<EquipmentItemRecipeSheet>(),
                 sheets.GetSheet<EquipmentItemSubRecipeSheetV2>(),
                 sheets.GetSheet<EquipmentItemOptionSheet>(),
-                context.BlockIndex, addressesHex, gameConfigState);
+                context.BlockIndex,
+                addressesHex,
+                gameConfigState);
 
             // update rune slot
             var runeSlotStateAddress = RuneSlotState.DeriveAddress(avatarAddress, BattleType.Arena);
@@ -136,7 +161,6 @@ namespace Nekoyume.Action
             }
 
             // check fee
-
             var fee = ArenaHelper.GetEntranceFee(roundData, context.BlockIndex, avatarState.level);
             if (fee > 0 * CrystalCalculator.CRYSTAL)
             {
@@ -187,14 +211,92 @@ namespace Nekoyume.Action
 
             // update ArenaParticipants
             var arenaParticipantsAdr = ArenaParticipants.DeriveAddress(roundData.ChampionshipId, roundData.Round);
-            var arenaParticipants = states.GetArenaParticipants(arenaParticipantsAdr, roundData.ChampionshipId, roundData.Round);
+            var arenaParticipants =
+                states.GetArenaParticipants(arenaParticipantsAdr, roundData.ChampionshipId, roundData.Round);
             arenaParticipants.Add(avatarAddress);
 
-            // update ArenaAvatarState
+            // update ArenaAvatarState: It seems like a good idea to consolidate this into ItemSlotState.
             var arenaAvatarStateAdr = ArenaAvatarState.DeriveAddress(avatarAddress);
             var arenaAvatarState = states.GetArenaAvatarState(arenaAvatarStateAdr, avatarState);
             arenaAvatarState.UpdateCostumes(costumes);
             arenaAvatarState.UpdateEquipment(equipments);
+
+            // start getting the total CP from here.
+            var runeStates = states.GetRuneState(avatarAddress, out var migrateRequired);
+            if (migrateRequired)
+            {
+                states = states.SetRuneState(avatarAddress, runeStates);
+            }
+
+            var equippedRune = new List<RuneState>();
+            foreach (var runeInfo in runeSlotState.GetEquippedRuneSlotInfos())
+            {
+                if (runeStates.TryGetRuneState(runeInfo.RuneId, out var runeState))
+                {
+                    equippedRune.Add(runeState);
+                }
+            }
+
+            var runeOptionSheet = sheets.GetSheet<RuneOptionSheet>();
+            var runeOptions = new List<RuneOptionSheet.Row.RuneOptionInfo>();
+            foreach (var runeState in equippedRune)
+            {
+                if (!runeOptionSheet.TryGetValue(runeState.RuneId, out var optionRow))
+                {
+                    throw new SheetRowNotFoundException("RuneOptionSheet", runeState.RuneId);
+                }
+
+                if (!optionRow.LevelOptionMap.TryGetValue(runeState.Level, out var option))
+                {
+                    throw new SheetRowNotFoundException("RuneOptionSheet", runeState.Level);
+                }
+
+                runeOptions.Add(option);
+            }
+
+            var characterSheet = sheets.GetSheet<CharacterSheet>();
+            if (!characterSheet.TryGetValue(avatarState.characterId, out var characterRow))
+            {
+                throw new SheetRowNotFoundException("CharacterSheet", avatarState.characterId);
+            }
+
+            var costumeStatSheet = sheets.GetSheet<CostumeStatSheet>();
+            var collectionModifiers = new List<StatModifier>();
+            if (collectionExist)
+            {
+                var collectionSheet = sheets.GetSheet<CollectionSheet>();
+                collectionModifiers = collectionState.GetModifiers(collectionSheet);
+            }
+
+            var runeLevelBonusSheet = sheets.GetSheet<RuneLevelBonusSheet>();
+            var runeLevelBonus =
+                RuneHelper.CalculateRuneLevelBonus(runeStates, runeListSheet, runeLevelBonusSheet);
+            var cp = CPHelper.TotalCP(
+                equipmentItems,
+                costumeItems,
+                runeOptions,
+                avatarState.level,
+                characterRow,
+                costumeStatSheet,
+                collectionModifiers,
+                runeLevelBonus);
+
+            // create ArenaParticipant: This is currently redundant, but we plan to replace all the ArenaScore and
+            // ArenaInformation states and some of the ArenaAvatarState states in the future.
+            var arenaParticipant = new ArenaParticipant(avatarAddress)
+            {
+                Name = avatarState.name,
+                PortraitId = avatarState.GetPortraitId(),
+                Level = avatarState.level,
+                Cp = cp,
+                Score = arenaScore.Score,
+                Ticket = arenaInformation.Ticket,
+                TicketResetCount = arenaInformation.TicketResetCount,
+                PurchasedTicketCount = arenaInformation.PurchasedTicketCount,
+                Win = arenaInformation.Win,
+                Lose = arenaInformation.Lose,
+                LastBattleBlockIndex = arenaAvatarState.LastBattleBlockIndex,
+            };
 
             var ended = DateTimeOffset.UtcNow;
             Log.Debug("{AddressesHex}JoinArena Total Executed Time: {Elapsed}", addressesHex, ended - started);
@@ -203,7 +305,8 @@ namespace Nekoyume.Action
                 .SetLegacyState(arenaInformationAdr, arenaInformation.Serialize())
                 .SetLegacyState(arenaParticipantsAdr, arenaParticipants.Serialize())
                 .SetLegacyState(arenaAvatarStateAdr, arenaAvatarState.Serialize())
-                .SetAgentState(context.Signer, agentState);
+                .SetAgentState(context.Signer, agentState)
+                .SetArenaParticipant(championshipId, round, avatarAddress, arenaParticipant);
         }
     }
 }

--- a/Lib9c/Action/JoinArena.cs
+++ b/Lib9c/Action/JoinArena.cs
@@ -110,6 +110,7 @@ namespace Nekoyume.Action
                 typeof(ItemRequirementSheet),
                 typeof(RuneLevelBonusSheet),
                 typeof(RuneListSheet),
+                typeof(RuneOptionSheet),
             };
             if (collectionExist)
             {

--- a/Lib9c/Addresses.cs
+++ b/Lib9c/Addresses.cs
@@ -5,7 +5,6 @@ using System.Security.Cryptography;
 using Libplanet.Common;
 using Libplanet.Crypto;
 using Nekoyume.Action;
-using Nekoyume.Model.Guild;
 using Nekoyume.Model.State;
 using Nekoyume.TableData;
 using static Lib9c.SerializeKeys;
@@ -14,77 +13,74 @@ namespace Nekoyume
 {
     public static class Addresses
     {
-        public static readonly Address Shop                  = new Address("0000000000000000000000000000000000000000");
-        public static readonly Address Ranking               = new Address("0000000000000000000000000000000000000001");
-        public static readonly Address WeeklyArena           = new Address("0000000000000000000000000000000000000002");
-        public static readonly Address TableSheet            = new Address("0000000000000000000000000000000000000003");
-        public static readonly Address GameConfig            = new Address("0000000000000000000000000000000000000004");
-        public static readonly Address RedeemCode            = new Address("0000000000000000000000000000000000000005");
-        public static readonly Address Admin                 = new Address("0000000000000000000000000000000000000006");
-        public static readonly Address PendingActivation     = new Address("0000000000000000000000000000000000000007");
-        public static readonly Address ActivatedAccount      = new Address("0000000000000000000000000000000000000008");
-        public static readonly Address Blacksmith            = new Address("0000000000000000000000000000000000000009");
-        public static readonly Address GoldCurrency          = new Address("000000000000000000000000000000000000000a");
-        public static readonly Address GoldDistribution      = new Address("000000000000000000000000000000000000000b");
-        public static readonly Address AuthorizedMiners      = new Address("000000000000000000000000000000000000000c");
-        public static readonly Address Credits               = new Address("000000000000000000000000000000000000000d");
-        public static readonly Address UnlockWorld           = new Address("000000000000000000000000000000000000000e");
-        public static readonly Address UnlockEquipmentRecipe = new Address("000000000000000000000000000000000000000f");
-        public static readonly Address MaterialCost          = new Address("0000000000000000000000000000000000000010");
-        public static readonly Address StageRandomBuff       = new Address("0000000000000000000000000000000000000011");
-        public static readonly Address Arena                 = new Address("0000000000000000000000000000000000000012");
-        public static readonly Address SuperCraft            = new Address("0000000000000000000000000000000000000013");
-        public static readonly Address EventDungeon          = new Address("0000000000000000000000000000000000000014");
-        public static readonly Address Raid                  = new Address("0000000000000000000000000000000000000015");
-        public static readonly Address Rune                  = new Address("0000000000000000000000000000000000000016");
-        public static readonly Address Market                = new Address("0000000000000000000000000000000000000017");
-        public static readonly Address GarageWallet          = new Address("0000000000000000000000000000000000000018");
-        public static readonly Address AssetMinters          = new Address("0000000000000000000000000000000000000019");
-        public static readonly Address Agent                 = new Address("000000000000000000000000000000000000001a");
-        public static readonly Address Avatar                = new Address("000000000000000000000000000000000000001b");
-        public static readonly Address Inventory             = new Address("000000000000000000000000000000000000001c");
-        public static readonly Address WorldInformation      = new Address("000000000000000000000000000000000000001d");
-        public static readonly Address QuestList             = new Address("000000000000000000000000000000000000001e");
-        public static readonly Address Collection            = new Address("000000000000000000000000000000000000001f");
-        public static readonly Address DailyReward           = new Address("0000000000000000000000000000000000000020");
-        public static readonly Address ActionPoint           = new Address("0000000000000000000000000000000000000021");
-        public static readonly Address RuneState             = new Address("0000000000000000000000000000000000000022");
-        public static readonly Address CombinationSlot       = new Address("0000000000000000000000000000000000000024");
+        public static readonly Address Shop                  = new("0000000000000000000000000000000000000000");
+        public static readonly Address Ranking               = new("0000000000000000000000000000000000000001");
+        public static readonly Address WeeklyArena           = new("0000000000000000000000000000000000000002");
+        public static readonly Address TableSheet            = new("0000000000000000000000000000000000000003");
+        public static readonly Address GameConfig            = new("0000000000000000000000000000000000000004");
+        public static readonly Address RedeemCode            = new("0000000000000000000000000000000000000005");
+        public static readonly Address Admin                 = new("0000000000000000000000000000000000000006");
+        public static readonly Address PendingActivation     = new("0000000000000000000000000000000000000007");
+        public static readonly Address ActivatedAccount      = new("0000000000000000000000000000000000000008");
+        public static readonly Address Blacksmith            = new("0000000000000000000000000000000000000009");
+        public static readonly Address GoldCurrency          = new("000000000000000000000000000000000000000a");
+        public static readonly Address GoldDistribution      = new("000000000000000000000000000000000000000b");
+        public static readonly Address AuthorizedMiners      = new("000000000000000000000000000000000000000c");
+        public static readonly Address Credits               = new("000000000000000000000000000000000000000d");
+        public static readonly Address UnlockWorld           = new("000000000000000000000000000000000000000e");
+        public static readonly Address UnlockEquipmentRecipe = new("000000000000000000000000000000000000000f");
+        public static readonly Address MaterialCost          = new("0000000000000000000000000000000000000010");
+        public static readonly Address StageRandomBuff       = new("0000000000000000000000000000000000000011");
+        public static readonly Address Arena                 = new("0000000000000000000000000000000000000012");
+        public static readonly Address SuperCraft            = new("0000000000000000000000000000000000000013");
+        public static readonly Address EventDungeon          = new("0000000000000000000000000000000000000014");
+        public static readonly Address Raid                  = new("0000000000000000000000000000000000000015");
+        public static readonly Address Rune                  = new("0000000000000000000000000000000000000016");
+        public static readonly Address Market                = new("0000000000000000000000000000000000000017");
+        public static readonly Address GarageWallet          = new("0000000000000000000000000000000000000018");
+        public static readonly Address AssetMinters          = new("0000000000000000000000000000000000000019");
+        public static readonly Address Agent                 = new("000000000000000000000000000000000000001a");
+        public static readonly Address Avatar                = new("000000000000000000000000000000000000001b");
+        public static readonly Address Inventory             = new("000000000000000000000000000000000000001c");
+        public static readonly Address WorldInformation      = new("000000000000000000000000000000000000001d");
+        public static readonly Address QuestList             = new("000000000000000000000000000000000000001e");
+        public static readonly Address Collection            = new("000000000000000000000000000000000000001f");
+        public static readonly Address DailyReward           = new("0000000000000000000000000000000000000020");
+        public static readonly Address ActionPoint           = new("0000000000000000000000000000000000000021");
+        public static readonly Address RuneState             = new("0000000000000000000000000000000000000022");
 
         // Custom Equipment Craft
-        public static readonly Address Relationship           = new ("0000000000000000000000000000000000000023");
+        public static readonly Address Relationship          = new("0000000000000000000000000000000000000023");
+
+        public static readonly Address CombinationSlot       = new("0000000000000000000000000000000000000024");
 
         // Adventure Boss
-        public static readonly Address AdventureBoss         = new Address("0000000000000000000000000000000000000100");
-        public static readonly Address BountyBoard           = new Address("0000000000000000000000000000000000000101");
-        public static readonly Address ExploreBoard          = new Address("0000000000000000000000000000000000000102");
-        public static readonly Address ExplorerList          = new Address("0000000000000000000000000000000000000103");
+        public static readonly Address AdventureBoss         = new("0000000000000000000000000000000000000100");
+        public static readonly Address BountyBoard           = new("0000000000000000000000000000000000000101");
+        public static readonly Address ExploreBoard          = new("0000000000000000000000000000000000000102");
+        public static readonly Address ExplorerList          = new("0000000000000000000000000000000000000103");
 
         #region Guild
 
         /// <summary>
         /// An address of an account having <see cref="Nekoyume.Model.Guild.Guild"/>.
         /// </summary>
-        public static readonly Address Guild =
-            new Address("0000000000000000000000000000000000000200");
+        public static readonly Address Guild = new("0000000000000000000000000000000000000200");
 
         /// <summary>
         /// An address of an account having <see cref="Bencodex.Types.Integer"/> which means the number of the guild.
         /// </summary>
-        public static readonly Address GuildMemberCounter =
-            new Address("0000000000000000000000000000000000000201");
+        public static readonly Address GuildMemberCounter = new("0000000000000000000000000000000000000201");
 
         /// <summary>
         /// An address of an account having <see cref="Nekoyume.Model.Guild.GuildApplication"/>.
         /// </summary>
-        public static readonly Address GuildApplication =
-            new Address("0000000000000000000000000000000000000202");
+        public static readonly Address GuildApplication = new("0000000000000000000000000000000000000202");
 
         /// <summary>
         /// An address of an account having <see cref="Nekoyume.Model.Guild.GuildParticipant"/>
         /// </summary>
-        public static readonly Address GuildParticipant =
-            new Address("0000000000000000000000000000000000000203");
+        public static readonly Address GuildParticipant = new("0000000000000000000000000000000000000203");
 
         /// <summary>
         /// Build an <see cref="Address"/> of an <see cref="Libplanet.Action.State.Account"/>,
@@ -96,8 +92,7 @@ namespace Nekoyume
         public static Address GetGuildBanAccountAddress(Address guildAddress) =>
             guildAddress.Derive("guild.banned");
 
-        public static readonly Address EmptyAccountAddress =
-            new Address("ffffffffffffffffffffffffffffffffffffffff");
+        public static readonly Address EmptyAccountAddress = new("ffffffffffffffffffffffffffffffffffffffff");
 
         #endregion
 
@@ -198,6 +193,7 @@ namespace Nekoyume
                 .Select(index => GetAvatarAddress(agentAddr, index))
                 .Contains(inventoryAddr);
 
-        public static Address AdventureSeasonAddress(long season) => AdventureBoss.Derive(season.ToString(CultureInfo.InvariantCulture));
+        public static Address AdventureSeasonAddress(long season) =>
+            AdventureBoss.Derive(season.ToString(CultureInfo.InvariantCulture));
     }
 }

--- a/Lib9c/Addresses.cs
+++ b/Lib9c/Addresses.cs
@@ -54,6 +54,15 @@ namespace Nekoyume
 
         public static readonly Address CombinationSlot       = new("0000000000000000000000000000000000000024");
 
+        /// <summary>
+        /// This address is used to get an account in IWorld. The account obtained at this address stores the status of
+        /// individual participants in a particular ChampionshipID-round.
+        /// Derive the state address like this:
+        ///     Addresses.ArenaParticipant.Derive($"{championshipId}_{round}_{avatarAddress}");
+        /// And it returns the <see cref="Nekoyume.Model.Arena.ArenaParticipant"/> type value.
+        /// </summary>
+        public static readonly Address ArenaParticipant      = new("0000000000000000000000000000000000000025");
+
         // Adventure Boss
         public static readonly Address AdventureBoss         = new("0000000000000000000000000000000000000100");
         public static readonly Address BountyBoard           = new("0000000000000000000000000000000000000101");

--- a/Lib9c/Exceptions/UnsupportedStateException.cs
+++ b/Lib9c/Exceptions/UnsupportedStateException.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Nekoyume.Exceptions
+{
+    [Serializable]
+    public class UnsupportedStateException : Exception
+    {
+        public UnsupportedStateException(
+            string expectedName,
+            int expectedVersion,
+            string actualName,
+            int actualVersion,
+            Exception innerException = null) :
+            base(
+                "Unsupported state." +
+                $" Expected: {expectedName}({expectedVersion}), Actual: {actualName}({actualVersion}).",
+                innerException)
+        {
+        }
+
+        protected UnsupportedStateException(
+            SerializationInfo info,
+            StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/Lib9c/Exceptions/UnsupportedStateException.cs
+++ b/Lib9c/Exceptions/UnsupportedStateException.cs
@@ -19,10 +19,11 @@ namespace Nekoyume.Exceptions
         {
         }
 
-        protected UnsupportedStateException(
-            SerializationInfo info,
-            StreamingContext context)
-            : base(info, context)
+        public UnsupportedStateException(string msg) : base(msg)
+        {
+        }
+
+        protected UnsupportedStateException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/Lib9c/Model/Arena/ArenaParticipant.cs
+++ b/Lib9c/Model/Arena/ArenaParticipant.cs
@@ -1,0 +1,157 @@
+using System;
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Crypto;
+using Nekoyume.Action;
+using Nekoyume.Exceptions;
+using Nekoyume.Model.State;
+
+namespace Nekoyume.Model.Arena
+{
+    /// <summary>
+    /// This class combines the information from <see cref="Nekoyume.Model.Arena.ArenaScore"/> and
+    /// <see cref="Nekoyume.Model.Arena.ArenaInformation"/>, and brings together information about the arena
+    /// participant, including additional information.
+    /// </summary>
+    public class ArenaParticipant : IBencodable, IState
+    {
+        private const string StateTypeName = "arena_participant";
+        private const int StateVersion = 1;
+
+        public const int DefaultScore = 1000;
+        public const int MaxTicketCount = 8;
+
+        public static Address DeriveAddress(int championshipId, int round, Address avatarAddress) =>
+            Addresses.ArenaParticipant.Derive($"{championshipId}_{round}_{avatarAddress.ToHex()}");
+
+        public readonly Address AvatarAddr;
+
+        /// <summary>
+        /// If you need to know <see cref="Nekoyume.Model.State.AvatarState.NameWithHash"/>, check
+        /// <see cref="Nekoyume.Model.State.AvatarState.PostConstructor"/> method of the
+        /// <see cref="Nekoyume.Model.State.AvatarState"/> class and you can find the relevant information there. It
+        /// provides a formatted string that includes the avatar's <see cref="Nekoyume.Model.State.AvatarState.name"/>
+        /// and a shortened version of their address.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// $"{name} &lt;size=80%&gt;&lt;color=#A68F7E&gt;#{address.ToHex().Substring(0, 4)}&lt;/color&gt;&lt;/size&gt;";
+        /// </code>
+        /// </example>
+        public string Name;
+
+        public int PortraitId;
+        public int Level;
+        public int Cp;
+
+        public int Score;
+
+        public int Ticket;
+        public int TicketResetCount;
+        public int PurchasedTicketCount;
+
+        public int Win;
+        public int Lose;
+
+        public long LastBattleBlockIndex;
+
+        public IValue Bencoded => List.Empty
+            .Add(StateTypeName)
+            .Add(StateVersion)
+            .Add(AvatarAddr.Serialize())
+            .Add(Name)
+            .Add(PortraitId)
+            .Add(Level)
+            .Add(Cp)
+            .Add(Score)
+            .Add(Ticket)
+            .Add(TicketResetCount)
+            .Add(PurchasedTicketCount)
+            .Add(Win)
+            .Add(Lose)
+            .Add(LastBattleBlockIndex);
+
+        public ArenaParticipant(Address avatarAddr)
+        {
+            AvatarAddr = avatarAddr;
+            Score = DefaultScore;
+            Ticket = MaxTicketCount;
+        }
+
+        public ArenaParticipant(IValue bencoded)
+        {
+            if (bencoded is not List l)
+            {
+                throw new ArgumentException($"Invalid bencoded value: {bencoded.Inspect()}", nameof(bencoded));
+            }
+
+            try
+            {
+                var stateTypeName = (Text)l[0];
+                var stateVersion = (Integer)l[1];
+                if (stateTypeName != StateTypeName || stateVersion != StateVersion)
+                {
+                    throw new UnsupportedStateException(StateTypeName, StateVersion, stateTypeName, stateVersion);
+                }
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentException("Invalid state type name or version", e);
+            }
+
+            AvatarAddr = l[2].ToAddress();
+            Name = (Text)l[3];
+            PortraitId = (Integer)l[4];
+            Level = (Integer)l[5];
+            Cp = (Integer)l[6];
+            Score = (Integer)l[7];
+            Ticket = (Integer)l[8];
+            TicketResetCount = (Integer)l[9];
+            PurchasedTicketCount = (Integer)l[10];
+            Win = (Integer)l[11];
+            Lose = (Integer)l[12];
+            LastBattleBlockIndex = (Integer)l[13];
+        }
+
+        public IValue Serialize() => Bencoded;
+
+        public void AddScore(int score)
+        {
+            Score = Math.Max(Score + score, DefaultScore);
+        }
+
+        public void UseTicket(int ticketCount)
+        {
+            if (Ticket < ticketCount)
+            {
+                throw new NotEnoughTicketException(
+                    $"[{nameof(ArenaParticipant)}] have({Ticket}) < use({ticketCount})");
+            }
+
+            Ticket -= ticketCount;
+        }
+
+        public void BuyTicket(long maxCount)
+        {
+            if (PurchasedTicketCount >= maxCount)
+            {
+                throw new ExceedTicketPurchaseLimitException(
+                    $"[{nameof(ArenaParticipant)}] PurchasedTicketCount({PurchasedTicketCount}) >= MAX({maxCount})");
+            }
+
+            PurchasedTicketCount++;
+        }
+
+        public void UpdateRecord(int win, int lose)
+        {
+            Win += win;
+            Lose += lose;
+        }
+
+        public void ResetTicket(int resetCount)
+        {
+            Ticket = MaxTicketCount;
+            TicketResetCount = resetCount;
+        }
+    }
+}

--- a/Lib9c/Model/State/AvatarState.cs
+++ b/Lib9c/Model/State/AvatarState.cs
@@ -609,6 +609,12 @@ namespace Nekoyume.Model.State
             return armor?.Id ?? GameConfig.DefaultAvatarArmorId;
         }
 
+        public int GetPortraitId()
+        {
+            var fc = inventory.Costumes.FirstOrDefault(e => e.ItemSubType == ItemSubType.FullCostume);
+            return fc?.Id ?? GetArmorId();
+        }
+
         public void ValidateEquipments(List<Guid> equipmentIds, long blockIndex)
         {
             var ringCount = 0;

--- a/Lib9c/Module/ArenaModule.cs
+++ b/Lib9c/Module/ArenaModule.cs
@@ -1,0 +1,54 @@
+using Bencodex.Types;
+using Libplanet.Action.State;
+using Libplanet.Crypto;
+using Nekoyume.Model.Arena;
+
+namespace Nekoyume.Module
+{
+    public static class ArenaModule
+    {
+        public static IWorld SetArenaParticipant(
+            this IWorld world,
+            int championshipId,
+            int round,
+            Address avatarAddress,
+            ArenaParticipant arenaParticipant)
+        {
+            var stateAddress = ArenaParticipant.DeriveAddress(championshipId, round, avatarAddress);
+            return world.SetArenaParticipant(stateAddress, arenaParticipant.Bencoded);
+        }
+
+        public static IWorld SetArenaParticipant(
+            this IWorld world,
+            Address stateAddress,
+            IValue arenaParticipant)
+        {
+            var account = world
+                .GetAccount(Addresses.ArenaParticipant)
+                .SetState(stateAddress, arenaParticipant);
+            return world.SetAccount(Addresses.ArenaParticipant, account);
+        }
+
+        public static ArenaParticipant GetArenaParticipant(
+            this IWorldState worldState,
+            int championshipId,
+            int round,
+            Address avatarAddress)
+        {
+            var stateAddress = ArenaParticipant.DeriveAddress(championshipId, round, avatarAddress);
+            var state = worldState.GetArenaParticipant(stateAddress);
+            return state is null
+                ? null
+                : new ArenaParticipant(state);
+        }
+
+        public static IValue GetArenaParticipant(
+            this IWorldState worldState,
+            Address stateAddress)
+        {
+            return worldState
+                .GetAccountState(Addresses.ArenaParticipant)
+                .GetState(stateAddress);
+        }
+    }
+}


### PR DESCRIPTION
This pull request based on #2823.

Since the `ArenaParticipant` state is currently not canonical, or to put it another way, avatars that have already joined an ongoing round do not have their `ArenaParticipant` state created first via the `JoinArena` action, the changes this pull request includes may seem a bit awkward. This is solved with a simple fix once the Arena Round has started anew.