### PR TITLE
Introduce `IWorld.RemoveLegacyState` extension method

### DIFF
--- a/Lib9c/Action/Stake.cs
+++ b/Lib9c/Action/Stake.cs
@@ -153,7 +153,7 @@ namespace Nekoyume.Action
             if (Amount == 0)
             {
                 return states
-                    .SetLegacyState(stakeStateAddress, Null.Value)
+                    .RemoveLegacyState(stakeStateAddress)
                     .TransferAsset(context, stakeStateAddress, context.Signer, stakedBalance);
             }
 

--- a/Lib9c/Module/LegacyModule.cs
+++ b/Lib9c/Module/LegacyModule.cs
@@ -15,6 +15,7 @@ using Libplanet.Crypto;
 using Libplanet.Types.Assets;
 using LruCacheNet;
 using Nekoyume.Action;
+using Nekoyume.Extensions;
 using Nekoyume.Helper;
 using Nekoyume.Model.Arena;
 using Nekoyume.Model.Coupons;
@@ -45,6 +46,11 @@ namespace Nekoyume.Module
             world.SetAccount(
                 ReservedAddresses.LegacyAccount,
                 world.GetAccount(ReservedAddresses.LegacyAccount).SetState(address, state));
+
+        public static IWorld RemoveLegacyState(this IWorld world, Address address) =>
+            world.MutateAccount(
+                ReservedAddresses.LegacyAccount,
+                account => account.RemoveState(address));
 
         // Methods from AccountExtensions
         public static IWorld MarkBalanceChanged(


### PR DESCRIPTION
This pull request introduces the `public static IWorld LegacyModule.RemoveLegacyState(this IWorld world, Address address)` method, which removes states instead of setting them to `Null`.

I replace `SetLegacyState(_, Null)` in `Stake`, with `RemoveLegacyState` as an example.