### PR TITLE
Add product info in mails

### DIFF
--- a/Lib9c/Action/BuyProduct.cs
+++ b/Lib9c/Action/BuyProduct.cs
@@ -156,14 +156,13 @@ namespace Nekoyume.Action
             }
 
             var sellerMail = new ProductSellerMail(context.BlockIndex, productId,
-                context.BlockIndex, productId);
+                context.BlockIndex, productId, product);
             sellerAvatarState.Update(sellerMail);
             sellerAvatarState.questList.UpdateTradeQuest(TradeType.Sell, product.Price);
             sellerAvatarState.UpdateQuestRewards(materialSheet);
 
             var buyerMail = new ProductBuyerMail(context.BlockIndex, productId,
-                context.BlockIndex, productId
-            );
+                context.BlockIndex, productId, product);
             buyerAvatarState.Update(buyerMail);
             buyerAvatarState.questList.UpdateTradeQuest(TradeType.Buy, product.Price);
             buyerAvatarState.UpdateQuestRewards(materialSheet);

--- a/Lib9c/Model/Mail/ProductBuyerMail.cs
+++ b/Lib9c/Model/Mail/ProductBuyerMail.cs
@@ -1,5 +1,6 @@
 using System;
 using Bencodex.Types;
+using Nekoyume.Model.Market;
 using Nekoyume.Model.State;
 using static Lib9c.SerializeKeys;
 
@@ -9,15 +10,22 @@ namespace Nekoyume.Model.Mail
     [Serializable]
     public class ProductBuyerMail : Mail
     {
+        public const string ProductKey = "p";
         public readonly Guid ProductId;
-        public ProductBuyerMail(long blockIndex, Guid id, long requiredBlockIndex, Guid productId) : base(blockIndex, id, requiredBlockIndex)
+        public readonly Product Product;
+        public ProductBuyerMail(long blockIndex, Guid id, long requiredBlockIndex, Guid productId, Product product) : base(blockIndex, id, requiredBlockIndex)
         {
             ProductId = productId;
+            Product = product;
         }
 
         public ProductBuyerMail(Dictionary serialized) : base(serialized)
         {
             ProductId = serialized[ProductIdKey].ToGuid();
+            if (serialized.ContainsKey(ProductKey))
+            {
+                Product = ProductFactory.DeserializeProduct((List) serialized[ProductKey]);
+            }
         }
 
         public override void Read(IMail mail)
@@ -30,6 +38,7 @@ namespace Nekoyume.Model.Mail
         protected override string TypeId => nameof(ProductBuyerMail);
 
         public override IValue Serialize() => ((Dictionary)base.Serialize())
-            .Add(ProductIdKey, ProductId.Serialize());
+            .Add(ProductIdKey, ProductId.Serialize())
+            .Add(ProductKey, Product.Serialize());
     }
 }

--- a/Lib9c/Model/Mail/ProductSellerMail.cs
+++ b/Lib9c/Model/Mail/ProductSellerMail.cs
@@ -1,5 +1,6 @@
 using System;
 using Bencodex.Types;
+using Nekoyume.Model.Market;
 using Nekoyume.Model.State;
 using static Lib9c.SerializeKeys;
 
@@ -8,15 +9,22 @@ namespace Nekoyume.Model.Mail
     [Serializable]
     public class ProductSellerMail : Mail
     {
+        public const string ProductKey = "p";
         public readonly Guid ProductId;
-        public ProductSellerMail(long blockIndex, Guid id, long requiredBlockIndex, Guid productId) : base(blockIndex, id, requiredBlockIndex)
+        public readonly Product Product;
+        public ProductSellerMail(long blockIndex, Guid id, long requiredBlockIndex, Guid productId, Product product) : base(blockIndex, id, requiredBlockIndex)
         {
             ProductId = productId;
+            Product = product;
         }
 
         public ProductSellerMail(Dictionary serialized) : base(serialized)
         {
             ProductId = serialized[ProductIdKey].ToGuid();
+            if (serialized.ContainsKey(ProductKey))
+            {
+                Product = ProductFactory.DeserializeProduct((List) serialized[ProductKey]);
+            }
         }
 
         public override void Read(IMail mail)
@@ -29,6 +37,7 @@ namespace Nekoyume.Model.Mail
         protected override string TypeId => nameof(ProductSellerMail);
 
         public override IValue Serialize() => ((Dictionary)base.Serialize())
-            .Add(ProductIdKey, ProductId.Serialize());
+            .Add(ProductIdKey, ProductId.Serialize())
+            .Add(ProductKey, Product.Serialize());
     }
 }


### PR DESCRIPTION
마켓서비스가 체인에서 삭제된 아이템을 db에서 제거하게 되면서 메일 정보를 보여주지 못하는 문제가 발생했습니다. 이 문제를 해결하기 위해 구매자, 판매자 메일에 Product 정보를 남깁니다.

---
- resolve https://github.com/planetarium/NineChronicles/issues/6001