### PR TITLE
Avoid Exception when serialize

### DIFF
--- a/.Lib9c.Tests/Action/BuyProductTest.cs
+++ b/.Lib9c.Tests/Action/BuyProductTest.cs
@@ -328,7 +328,7 @@ namespace Lib9c.Tests.Action
         }
 
         [Fact]
-        public void Mail_BackwardComaptibility()
+        public void Mail_Serialize_BackwardCompatibility()
         {
             var favProduct = new FavProduct
             {
@@ -361,6 +361,8 @@ namespace Lib9c.Tests.Action
             buyerDeserialized = new ProductBuyerMail(buyerSerialized);
             Assert.Equal(buyerDeserialized.ProductId, ProductId);
             Assert.Null(buyerDeserialized.Product);
+            // check serialize not throw exception
+            buyerDeserialized.Serialize();
 
             var sellerMail = new ProductSellerMail(1L, ProductId, 1L, ProductId, itemProduct);
             var sellerSerialized = (Dictionary)sellerMail.Serialize();
@@ -371,6 +373,8 @@ namespace Lib9c.Tests.Action
             sellerDeserialized = new ProductSellerMail(sellerSerialized);
             Assert.Equal(sellerDeserialized.ProductId, ProductId);
             Assert.Null(sellerDeserialized.Product);
+            // check serialize not throw exception
+            sellerDeserialized.Serialize();
         }
 
         public class ExecuteMember

--- a/Lib9c/Model/Mail/ProductBuyerMail.cs
+++ b/Lib9c/Model/Mail/ProductBuyerMail.cs
@@ -37,8 +37,17 @@ namespace Nekoyume.Model.Mail
 
         protected override string TypeId => nameof(ProductBuyerMail);
 
-        public override IValue Serialize() => ((Dictionary)base.Serialize())
-            .Add(ProductIdKey, ProductId.Serialize())
-            .Add(ProductKey, Product.Serialize());
+        public override IValue Serialize()
+        {
+            var dict = ((Dictionary) base.Serialize())
+                .Add(ProductIdKey, ProductId.Serialize());
+            if (Product is not null)
+            {
+                dict = dict.Add(ProductKey, Product.Serialize());
+            }
+
+            return dict;
+
+        }
     }
 }

--- a/Lib9c/Model/Mail/ProductSellerMail.cs
+++ b/Lib9c/Model/Mail/ProductSellerMail.cs
@@ -36,8 +36,16 @@ namespace Nekoyume.Model.Mail
 
         protected override string TypeId => nameof(ProductSellerMail);
 
-        public override IValue Serialize() => ((Dictionary)base.Serialize())
-            .Add(ProductIdKey, ProductId.Serialize())
-            .Add(ProductKey, Product.Serialize());
+        public override IValue Serialize()
+        {
+            var dict = ((Dictionary) base.Serialize())
+                .Add(ProductIdKey, ProductId.Serialize());
+            if (Product is not null)
+            {
+                dict = dict.Add(ProductKey, Product.Serialize());
+            }
+
+            return dict;
+        }
     }
 }


### PR DESCRIPTION
메일에서 이전버전에 직렬화를 해둬서 Product가 비어있을 경우 발생하는 문제를 회피합니다.