### PR TITLE
Feature/fix msgpack exception formatter

### DIFF
--- a/.Lib9c.Tests/Action/ExceptionTest.cs
+++ b/.Lib9c.Tests/Action/ExceptionTest.cs
@@ -89,7 +89,6 @@ namespace Lib9c.Tests.Action
         [InlineData(typeof(AlreadyJoinedArenaException))]
         public void Exception_Serializable(Type excType)
         {
-            // TODO: parameter로 값을 받는게 아니라 여기서 Assembly를 찾아서 생성자를 찾아서 생성하도록 수정해야 합니다
             if (Activator.CreateInstance(excType, "for testing") is Exception exc)
             {
                 AssertException(excType, exc);
@@ -109,7 +108,7 @@ namespace Lib9c.Tests.Action
         [InlineData(typeof(Libplanet.Action.State.InsufficientBalanceException))]
         public void Libplanet_Exception_Serializable(Type excType)
         {
-            // TODO: parameter로 값을 받는게 아니라 여기서 Assembly를 찾아서 생성자를 찾아서 생성하도록 수정해야 합니다
+            // TODO: 테스트 받는 방식 수정
             var customAddress = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
             var customFav = new Libplanet.Types.Assets.FungibleAssetValue(Currencies.Crystal);
             if (Activator.CreateInstance(excType, "for testing", customAddress, customFav) is Exception exc)

--- a/.Lib9c.Tests/Action/ExceptionTest.cs
+++ b/.Lib9c.Tests/Action/ExceptionTest.cs
@@ -89,7 +89,30 @@ namespace Lib9c.Tests.Action
         [InlineData(typeof(AlreadyJoinedArenaException))]
         public void Exception_Serializable(Type excType)
         {
+            // TODO: parameter로 값을 받는게 아니라 여기서 Assembly를 찾아서 생성자를 찾아서 생성하도록 수정해야 합니다
             if (Activator.CreateInstance(excType, "for testing") is Exception exc)
+            {
+                AssertException(excType, exc);
+            }
+            else
+            {
+                throw new InvalidCastException();
+            }
+        }
+
+        /// <summary>
+        /// Libplanet Exception을 수정하기 위한 임시 테스트 코드입니다
+        /// TODO: Libplanet Exception을 수정하고 테스트 코드 케이스를 추가해야 합니다
+        /// </summary>
+        /// <param name="excType">예외타입.</param>
+        [Theory]
+        [InlineData(typeof(Libplanet.Action.State.InsufficientBalanceException))]
+        public void Libplanet_Exception_Serializable(Type excType)
+        {
+            // TODO: parameter로 값을 받는게 아니라 여기서 Assembly를 찾아서 생성자를 찾아서 생성하도록 수정해야 합니다
+            var customAddress = new Address("399bddF9F7B6d902ea27037B907B2486C9910730");
+            var customFav = new Libplanet.Types.Assets.FungibleAssetValue(Currencies.Crystal);
+            if (Activator.CreateInstance(excType, "for testing", customAddress, customFav) is Exception exc)
             {
                 AssertException(excType, exc);
             }

--- a/Lib9c.MessagePack/Formatters/ExceptionFormatter.cs
+++ b/Lib9c.MessagePack/Formatters/ExceptionFormatter.cs
@@ -6,8 +6,6 @@ using MessagePack.Formatters;
 
 namespace Lib9c.Formatters
 {
-    // FIXME: This class must be removed and replaced with other way for serialization.
-    // https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md
     public class ExceptionFormatter<T> : IMessagePackFormatter<T?> where T : Exception
     {
         public void Serialize(ref MessagePackWriter writer, T? value,

--- a/Lib9c.MessagePack/Formatters/ExceptionFormatter.cs
+++ b/Lib9c.MessagePack/Formatters/ExceptionFormatter.cs
@@ -55,11 +55,11 @@ namespace Lib9c.Formatters
             for (int i = 0; i < count; i++)
             {
                 var name = reader.ReadString();
-                if (name == null)
+                if (string.IsNullOrWhiteSpace(name))
                 {
                     throw new MessagePackSerializationException("Exception Name is missing.");
                 }
-                
+
                 if (name == "ExceptionType")
                 {
                     typeName = reader.ReadString();
@@ -67,31 +67,31 @@ namespace Lib9c.Formatters
                 else
                 {
                     var readType = reader.ReadString();
-                    if (readType == null)
+                    if (string.IsNullOrWhiteSpace(readType))
                     {
                         throw new MessagePackSerializationException("Exception type information is missing.");
                     }
-                    
-                    var type  = Type.GetType(readType);
+
+                    var type = Type.GetType(readType);
                     if (type == null)
                     {
-                        throw new MessagePackSerializationException("Exception type information is missing.");
+                        throw new MessagePackSerializationException($"Exception type cannot be found for '{readType}'.");
                     }
-                    
+
                     var value = MessagePackSerializer.Deserialize(type, ref reader, options);
                     info.AddValue(name, value);
                 }
             }
 
-            if (typeName == null)
+            if (string.IsNullOrWhiteSpace(typeName))
             {
-                throw new MessagePackSerializationException("Exception type information is missing.");
+                throw new MessagePackSerializationException("Exception exception type name is missing.");
             }
 
             var exceptionType = Type.GetType(typeName);
             if (exceptionType == null)
             {
-                throw new MessagePackSerializationException($"Exception type '{typeName}' not found.");
+                throw new MessagePackSerializationException($"Exception exception type cannot be found for '{typeName}'.");
             }
 
             var ctor = exceptionType.GetConstructor(

--- a/Lib9c.MessagePack/Formatters/ExceptionFormatter.cs
+++ b/Lib9c.MessagePack/Formatters/ExceptionFormatter.cs
@@ -72,9 +72,9 @@ namespace Lib9c.Formatters
                         throw new MessagePackSerializationException("Exception type information is missing.");
                     }
 
-                    var type = Type.GetType(readType);
+                    var type = GetType(readType);
                     if (type == null)
-                    {
+                    {           
                         throw new MessagePackSerializationException($"Exception type cannot be found for '{readType}'.");
                     }
 
@@ -136,6 +136,26 @@ namespace Lib9c.Formatters
             }
 
             return exception;
+        }
+        
+        private Type? GetType(string typeName)
+        {
+            var type = Type.GetType(typeName);
+            if (type != null)
+            {
+                return type;
+            }
+
+            foreach (var assembly in NineChroniclesResolverGetFormatterHelper.GetAssemblies())
+            {
+                type = assembly.GetType(typeName);
+                if (type != null)
+                {
+                    return type;
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/Lib9c.MessagePack/Formatters/NineChroniclesResolverGetFormatterHelper.cs
+++ b/Lib9c.MessagePack/Formatters/NineChroniclesResolverGetFormatterHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using Bencodex.Types;
 using Libplanet.Crypto;
@@ -8,10 +9,11 @@ using Nekoyume.Action;
 
 namespace Lib9c.Formatters
 {
+
     public static class NineChroniclesResolverGetFormatterHelper
     {
         // If type is concrete type, use type-formatter map
-        private static readonly Dictionary<Type, object> FormatterMap = new Dictionary<Type, object>()
+        private static readonly Dictionary<Type, object> FormatterMap = new()
         {
             {typeof(Address), new AddressFormatter()},
             {typeof(Exception), new ExceptionFormatter<Exception>()},
@@ -19,7 +21,7 @@ namespace Lib9c.Formatters
             {typeof(PublicKey), new PublicKeyFormatter()},
             {typeof(Dictionary), new BencodexFormatter<Dictionary>()},
             {typeof(IValue), new BencodexFormatter<IValue>()},
-            {typeof(ActionBase), new NCActionFormatter()}
+            {typeof(ActionBase), new NCActionFormatter()},
             // add more your own custom serializers.
         };
 
@@ -39,5 +41,12 @@ namespace Lib9c.Formatters
             // If type can not get, must return null for fallback mechanism.
             return null;
         }
+        
+        public static System.Reflection.Assembly[] GetAssemblies() => _assemblies ??= FormatterMap.Keys
+            .Select(t => t.Assembly)
+            .Distinct()
+            .ToArray();
+        
+        private static System.Reflection.Assembly[]? _assemblies = null;
     }
 }

--- a/Lib9c.MessagePack/Formatters/NineChroniclesResolverGetFormatterHelper.cs
+++ b/Lib9c.MessagePack/Formatters/NineChroniclesResolverGetFormatterHelper.cs
@@ -13,7 +13,7 @@ namespace Lib9c.Formatters
     public static class NineChroniclesResolverGetFormatterHelper
     {
         // If type is concrete type, use type-formatter map
-        private static readonly Dictionary<Type, object> FormatterMap = new()
+        private static readonly Dictionary<Type, object> FormatterMap = new Dictionary<Type, object>()
         {
             {typeof(Address), new AddressFormatter()},
             {typeof(Exception), new ExceptionFormatter<Exception>()},


### PR DESCRIPTION
- 닷넷 업그레이드 대처 이후 고장난 exception formatter를 고칩니다
- Libplanet Exception에 대한 테스트 코드가 없어 임시 테스트 코드 하나(Libplanet_Exception_Serializable) 추가하였습니다. 관련해서 테스트 제대로 작성하려면 Libplaent의 Exception수정 필요해 보입니다
- Libplanet Exception을 Serialize하는 기준을 모르겠습니다 혹시 아시는 분 있음 알려주세요
- Exception Serialize시 직렬화 할 데이터 타입을 NineChroniclesResolverGetFormatterHelper의 FormatterMap에 추가해줘야 합니다.

@boscohyun 님의 커밋 c53349a5ca19a94f92d28bdf553163f0ce2e175d 체리픽하여 추가하였습니다

https://github.com/planetarium/lib9c/pull/2803
https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md