### PR TITLE
자동생성된 코드스타일 파일 커밋

### DIFF
--- a/Lib9c.sln.DotSettings
+++ b/Lib9c.sln.DotSettings
@@ -52,6 +52,10 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PACKAGE/@EntryIndexedValue">PACKAGE</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SINGLE/@EntryIndexedValue">SINGLE</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=VFX/@EntryIndexedValue">VFX</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Addr/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Addressables/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Alfheim/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
https://rider-support.jetbrains.com/hc/en-us/community/posts/4583761682066-Have-some-default-C-code-styles-changed-in-Rider-2021

Rider 버전이 올라가며 기존 셋팅이 바뀐 부분이 있는데 해당 이유로 이러한 마이그레이션 관련 옵션이 자동 생성되는 것으로 보인다. 자동 생성되는 옵션이 기존에 진행했던 StyleCop 코드 검사 규칙에 맞게 코드 룰 추가하는거랑 방향성이 일치하는 것으로 보여 자동생성된 내용 그대로 커밋하였다.

Within single-line expression braces (checked)
```
int[] x = new int[] { 0, 1, 2 };
```

After type cast parentheses (unchecked)
```
int a = (int)b;
```

https://github.com/planetarium/lib9c/pull/2912