### PR TITLE
Remove libplanet submodule

### DIFF
--- a/.Lib9c.Benchmarks/Lib9c.Benchmarks.csproj
+++ b/.Lib9c.Benchmarks/Lib9c.Benchmarks.csproj
@@ -13,10 +13,10 @@
 
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-      <PackageReference Include="Libplanet" Version="5.3.2-alpha.1" />
-      <PackageReference Include="Libplanet.RocksDBStore" Version="5.3.2-alpha.1" />
-      <PackageReference Include="Libplanet.Crypto.Secp256k1" Version="5.3.2-alpha.1" />
-      <PackageReference Include="Libplanet.Mocks" Version="5.3.2-alpha.1" />
+      <PackageReference Include="Libplanet" Version="$(LibplanetVersion)" />
+      <PackageReference Include="Libplanet.RocksDBStore" Version="$(LibplanetVersion)" />
+      <PackageReference Include="Libplanet.Crypto.Secp256k1" Version="$(LibplanetVersion)" />
+      <PackageReference Include="Libplanet.Mocks" Version="$(LibplanetVersion)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/.Lib9c.Benchmarks/Lib9c.Benchmarks.csproj
+++ b/.Lib9c.Benchmarks/Lib9c.Benchmarks.csproj
@@ -13,10 +13,20 @@
 
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    </ItemGroup>
+
+    <ItemGroup Condition="!'$(UseLocalLibplanet)'">
       <PackageReference Include="Libplanet" Version="$(LibplanetVersion)" />
       <PackageReference Include="Libplanet.RocksDBStore" Version="$(LibplanetVersion)" />
       <PackageReference Include="Libplanet.Crypto.Secp256k1" Version="$(LibplanetVersion)" />
       <PackageReference Include="Libplanet.Mocks" Version="$(LibplanetVersion)" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(UseLocalLibplanet)'">
+      <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet\Libplanet.csproj" Version="$(LibplanetVersion)" />
+      <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet.RocksDBStore\Libplanet.csproj" Version="$(LibplanetVersion)" />
+      <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet.Crypto.Secp256k1\Libplanet.Crypto.Secp256k1.csproj" Version="$(LibplanetVersion)" />
+      <ProjectReference Include="$(LibplanetDirectory)\test\Libplanet.Mocks\Libplanet.Mocks.csproj" Version="$(LibplanetVersion)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/.Lib9c.Benchmarks/Lib9c.Benchmarks.csproj
+++ b/.Lib9c.Benchmarks/Lib9c.Benchmarks.csproj
@@ -23,10 +23,10 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(UseLocalLibplanet)'">
-      <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet\Libplanet.csproj" Version="$(LibplanetVersion)" />
-      <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet.RocksDBStore\Libplanet.csproj" Version="$(LibplanetVersion)" />
-      <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet.Crypto.Secp256k1\Libplanet.Crypto.Secp256k1.csproj" Version="$(LibplanetVersion)" />
-      <ProjectReference Include="$(LibplanetDirectory)\test\Libplanet.Mocks\Libplanet.Mocks.csproj" Version="$(LibplanetVersion)" />
+      <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet\Libplanet.csproj" />
+      <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
+      <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet.Crypto.Secp256k1\Libplanet.Crypto.Secp256k1.csproj" />
+      <ProjectReference Include="$(LibplanetDirectory)\test\Libplanet.Mocks\Libplanet.Mocks.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/.Lib9c.Benchmarks/Lib9c.Benchmarks.csproj
+++ b/.Lib9c.Benchmarks/Lib9c.Benchmarks.csproj
@@ -13,16 +13,16 @@
 
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+      <PackageReference Include="Libplanet" Version="5.3.2-alpha.1" />
+      <PackageReference Include="Libplanet.RocksDBStore" Version="5.3.2-alpha.1" />
+      <PackageReference Include="Libplanet.Crypto.Secp256k1" Version="5.3.2-alpha.1" />
+      <PackageReference Include="Libplanet.Mocks" Version="5.3.2-alpha.1" />
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\.Lib9c.Tests\Lib9c.Tests.csproj" />
-      <ProjectReference Include="..\.Libplanet\src\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
-      <ProjectReference Include="..\.Libplanet\src\Libplanet\Libplanet.csproj" />
       <ProjectReference Include="..\Lib9c\Lib9c.csproj" />
       <ProjectReference Include="..\Lib9c.Policy\Lib9c.Policy.csproj" />
-      <ProjectReference Include="..\Libplanet.Crypto.Secp256k1\Libplanet.Crypto.Secp256k1.csproj" />
-      <ProjectReference Include="..\.Libplanet\test\Libplanet.Mocks\Libplanet.Mocks.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/.Lib9c.Tests/Lib9c.Tests.csproj
+++ b/.Lib9c.Tests/Lib9c.Tests.csproj
@@ -50,7 +50,14 @@
     <ProjectReference Include="..\Lib9c\Lib9c.csproj" />
     <ProjectReference Include="..\Lib9c.Utils\Lib9c.Utils.csproj" />
     <ProjectReference Include="..\Lib9c.MessagePack\Lib9c.MessagePack.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!'$(UseLocalLibplanet)'">
     <PackageReference Include="Libplanet.Mocks" Version="$(LibplanetVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseLocalLibplanet)'">
+    <ProjectReference Include="$(LibplanetDirectory)\test\Libplanet.Mocks\Libplanet.Mocks.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(Configuration)' != 'DevEx' ">

--- a/.Lib9c.Tests/Lib9c.Tests.csproj
+++ b/.Lib9c.Tests/Lib9c.Tests.csproj
@@ -50,7 +50,7 @@
     <ProjectReference Include="..\Lib9c\Lib9c.csproj" />
     <ProjectReference Include="..\Lib9c.Utils\Lib9c.Utils.csproj" />
     <ProjectReference Include="..\Lib9c.MessagePack\Lib9c.MessagePack.csproj" />
-    <PackageReference Include="Libplanet.Mocks" Version="5.3.2-alpha.1" />
+    <PackageReference Include="Libplanet.Mocks" Version="$(LibplanetVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(Configuration)' != 'DevEx' ">

--- a/.Lib9c.Tests/Lib9c.Tests.csproj
+++ b/.Lib9c.Tests/Lib9c.Tests.csproj
@@ -50,7 +50,7 @@
     <ProjectReference Include="..\Lib9c\Lib9c.csproj" />
     <ProjectReference Include="..\Lib9c.Utils\Lib9c.Utils.csproj" />
     <ProjectReference Include="..\Lib9c.MessagePack\Lib9c.MessagePack.csproj" />
-    <ProjectReference Include="..\.Libplanet\test\Libplanet.Mocks\Libplanet.Mocks.csproj" />
+    <PackageReference Include="Libplanet.Mocks" Version="5.3.2-alpha.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(Configuration)' != 'DevEx' ">

--- a/.Lib9c.Tools/Lib9c.Tools.csproj
+++ b/.Lib9c.Tools/Lib9c.Tools.csproj
@@ -13,9 +13,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Libplanet.RocksDBStore" Version="$(LibplanetVersion)" />
       <ProjectReference Include="..\Lib9c\Lib9c.csproj" />
       <ProjectReference Include="..\Lib9c.DevExtensions\Lib9c.DevExtensions.csproj" />
+    </ItemGroup>
+
+    <ItemGroup Condition="!'$(UseLocalLibplanet)'">
+      <PackageReference Include="Libplanet.RocksDBStore" Version="$(LibplanetVersion)" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(UseLocalLibplanet)'">
+      <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/.Lib9c.Tools/Lib9c.Tools.csproj
+++ b/.Lib9c.Tools/Lib9c.Tools.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\.Libplanet\src\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
+      <PackageReference Include="Libplanet.RocksDBStore" Version="5.3.2-alpha.1" />
       <ProjectReference Include="..\Lib9c\Lib9c.csproj" />
       <ProjectReference Include="..\Lib9c.DevExtensions\Lib9c.DevExtensions.csproj" />
     </ItemGroup>

--- a/.Lib9c.Tools/Lib9c.Tools.csproj
+++ b/.Lib9c.Tools/Lib9c.Tools.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Libplanet.RocksDBStore" Version="5.3.2-alpha.1" />
+      <PackageReference Include="Libplanet.RocksDBStore" Version="$(LibplanetVersion)" />
       <ProjectReference Include="..\Lib9c\Lib9c.csproj" />
       <ProjectReference Include="..\Lib9c.DevExtensions\Lib9c.DevExtensions.csproj" />
     </ItemGroup>

--- a/.Libplanet.Extensions.ActionEvaluatorCommonComponents/Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj
+++ b/.Libplanet.Extensions.ActionEvaluatorCommonComponents/Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Libplanet" Version="5.3.2-alpha.1" />
+    <PackageReference Include="Libplanet" Version="$(LibplanetVersion)" />
   </ItemGroup>
 
 </Project>

--- a/.Libplanet.Extensions.ActionEvaluatorCommonComponents/Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj
+++ b/.Libplanet.Extensions.ActionEvaluatorCommonComponents/Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj
@@ -6,8 +6,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="!'$(UseLocalLibplanet)'">
     <PackageReference Include="Libplanet" Version="$(LibplanetVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseLocalLibplanet)'">
+    <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet\Libplanet.csproj" />
   </ItemGroup>
 
 </Project>

--- a/.Libplanet.Extensions.ActionEvaluatorCommonComponents/Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj
+++ b/.Libplanet.Extensions.ActionEvaluatorCommonComponents/Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\.Libplanet\src\Libplanet\Libplanet.csproj" />
+    <PackageReference Include="Libplanet" Version="5.3.2-alpha.1" />
   </ItemGroup>
 
 </Project>

--- a/.github/workflows/lib9c_plugin_build_and_push_s3.yaml
+++ b/.github/workflows/lib9c_plugin_build_and_push_s3.yaml
@@ -16,8 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.400

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,3 +9,10 @@ jobs:
             - uses: actions/checkout@v4
             - name: Check typos
               uses: crate-ci/typos@v1.15.5
+
+    local-libplanet:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Check LibplanetDirectory is empty
+              run: grep -q '<LibplanetDirectory></LibplanetDirectory>' Directory.Build.props

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,3 +16,15 @@ jobs:
             - uses: actions/checkout@v4
             - name: Check LibplanetDirectory is empty
               run: grep -q '<LibplanetDirectory></LibplanetDirectory>' Directory.Build.props
+
+    no-submodules:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Check if there is submodule
+              run: |
+                set -ev
+                count=$(git submodule status | wc -l)
+                if [ "$count" -gt 0 ]; then
+                  exit 1
+                fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,6 @@ jobs:
           set -e
 
           sed -i -E 's|<TargetFramework>.*</TargetFramework>|<TargetFramework>netstandard2.1</TargetFramework>|' Lib9c*/*.csproj
-          sed -i -E 's|(<TargetFramework.+>).*(</TargetFramework>)|\1netstandard2.1\2|' .Libplanet/Directory.Build.props
           sed -i -E 's|<ImplicitUsings>.*</ImplicitUsings>|<ImplicitUsings>disable</ImplicitUsings>|' Lib9c*/*.csproj Libplanet*/*.csproj
           sed -i -E 's|\[MaybeNullWhen\(false\)] out TValue value|out TValue value|' Lib9c/TableData/Sheet.cs
           sed -i -E 's|public bool TryGetValue\(TKey key, out TValue value, bool throwException\)|public bool TryGetValue\(TKey key, out TValue? value, bool throwException\)|' Lib9c/TableData/Sheet.cs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: true
     - name: Check if .Libplanet refers to a tagged commit
       if: |
         github.event_name == 'push' && (
@@ -58,8 +56,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.400
@@ -79,8 +75,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: 'recursive'
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:
@@ -105,8 +99,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: true
     - name: Check if a new tag refers a merge commit
       if: github.ref_type == 'tag'
       run: |

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: recursive
           fetch-tags: true
       - name: Dotnet Setup
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: true
     - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.400

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,10 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - name: Git Sumbodule Update
-      run: git submodule update --init --recursive
     - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".Libplanet"]
-	path = .Libplanet
-	url = https://github.com/planetarium/libplanet.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,3 +111,9 @@ This branch naming rule is not forced but highly recommended to recognize which 
 - date (e.g., YYYYMMDD)
 - revision (e.g., some digits)
 - related base version (e.g., v200210)
+
+### Work with your local [Libplanet]
+
+If you want to work with your local [Libplanet], you can fill `LibplanetDirectory` property in `Directory.Build.props` file.
+
+When making a pull request, please do not include the `LibplanetDirectory` change.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,13 @@
+<Project>
+    <PropertyGroup>
+        <LibplanetVersion>5.3.2-alpha.1</LibplanetVersion>
+
+        <!-- Fill with Libplanet's absolute path to debug with local Libplanet. -->
+        <LibplanetDirectory></LibplanetDirectory>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <UseLocalLibplanet Condition="Exists('$(LibplanetDirectory)')">true</UseLocalLibplanet>
+        <UseLocalLibplanet Condition=" '$(UseLocalLibplanet)' == '' ">false</UseLocalLibplanet>
+    </PropertyGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,8 @@
     <PropertyGroup>
         <LibplanetVersion>5.3.2-alpha.1</LibplanetVersion>
 
-        <!-- Fill with Libplanet's absolute path to debug with local Libplanet. -->
+        <!-- Fill with Libplanet's absolute path to debug with local Libplanet.
+             Example: $(MSBuildThisFileDirectory).Libplanet -->
         <LibplanetDirectory></LibplanetDirectory>
     </PropertyGroup>
 
@@ -10,4 +11,8 @@
         <UseLocalLibplanet Condition="Exists('$(LibplanetDirectory)')">true</UseLocalLibplanet>
         <UseLocalLibplanet Condition=" '$(UseLocalLibplanet)' == '' ">false</UseLocalLibplanet>
     </PropertyGroup>
+
+    <Target Name="NoticeBuildingWithLocalLibplanet" BeforeTargets="BeforeBuild;BeforeRebuild">
+        <Message Importance="high" Text="Libplanet is being used as the local repository." Condition="$(UseLocalLibplanet)" />
+    </Target>
 </Project>

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <LibplanetVersion>5.3.2-alpha.1</LibplanetVersion>
+    </PropertyGroup>
+</Project>

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,5 +1,0 @@
-<Project>
-    <PropertyGroup>
-        <LibplanetVersion>5.3.2-alpha.1</LibplanetVersion>
-    </PropertyGroup>
-</Project>

--- a/Lib9c.Abstractions/Lib9c.Abstractions.csproj
+++ b/Lib9c.Abstractions/Lib9c.Abstractions.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Libplanet" Version="5.3.2-alpha.1" />
+    <PackageReference Include="Libplanet" Version="$(LibplanetVersion)" />
   </ItemGroup>
 
 </Project>

--- a/Lib9c.Abstractions/Lib9c.Abstractions.csproj
+++ b/Lib9c.Abstractions/Lib9c.Abstractions.csproj
@@ -9,8 +9,12 @@
     <VersionPrefix>1.19.0</VersionPrefix>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="!'$(UseLocalLibplanet)'">
     <PackageReference Include="Libplanet" Version="$(LibplanetVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseLocalLibplanet)'">
+    <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet\Libplanet.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Lib9c.Abstractions/Lib9c.Abstractions.csproj
+++ b/Lib9c.Abstractions/Lib9c.Abstractions.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\.Libplanet\src\Libplanet\Libplanet.csproj" />
+    <PackageReference Include="Libplanet" Version="5.3.2-alpha.1" />
   </ItemGroup>
 
 </Project>

--- a/Lib9c.DevExtensions/Lib9c.DevExtensions.csproj
+++ b/Lib9c.DevExtensions/Lib9c.DevExtensions.csproj
@@ -10,11 +10,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Libplanet" Version="$(LibplanetVersion)" />
-    <PackageReference Include="Libplanet.RocksDBStore" Version="$(LibplanetVersion)" />
-    <PackageReference Include="Libplanet.Stun" Version="$(LibplanetVersion)" />
     <ProjectReference Include="..\Lib9c\Lib9c.csproj" />
     <ProjectReference Include="..\Lib9c.Policy\Lib9c.Policy.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!'$(UseLocalLibplanet)'">
+    <PackageReference Include="Libplanet" Version="$(LibplanetVersion)" />
+    <PackageReference Include="Libplanet.Stun" Version="$(LibplanetVersion)" />
+    <PackageReference Include="Libplanet.RocksDBStore" Version="$(LibplanetVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseLocalLibplanet)'">
+    <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet\Libplanet.csproj" />
+    <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet.Stun\Libplanet.Stun.csproj" />
+    <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lib9c.DevExtensions/Lib9c.DevExtensions.csproj
+++ b/Lib9c.DevExtensions/Lib9c.DevExtensions.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Libplanet" Version="5.3.2-alpha.1" />
-    <PackageReference Include="Libplanet.RocksDBStore" Version="5.3.2-alpha.1" />
-    <PackageReference Include="Libplanet.Stun" Version="5.3.2-alpha.1" />
+    <PackageReference Include="Libplanet" Version="$(LibplanetVersion)" />
+    <PackageReference Include="Libplanet.RocksDBStore" Version="$(LibplanetVersion)" />
+    <PackageReference Include="Libplanet.Stun" Version="$(LibplanetVersion)" />
     <ProjectReference Include="..\Lib9c\Lib9c.csproj" />
     <ProjectReference Include="..\Lib9c.Policy\Lib9c.Policy.csproj" />
   </ItemGroup>

--- a/Lib9c.DevExtensions/Lib9c.DevExtensions.csproj
+++ b/Lib9c.DevExtensions/Lib9c.DevExtensions.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\.Libplanet\src\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
-    <ProjectReference Include="..\.Libplanet\src\Libplanet.Stun\Libplanet.Stun.csproj" />
-    <ProjectReference Include="..\.Libplanet\src\Libplanet\Libplanet.csproj" />
+    <PackageReference Include="Libplanet" Version="5.3.2-alpha.1" />
+    <PackageReference Include="Libplanet.RocksDBStore" Version="5.3.2-alpha.1" />
+    <PackageReference Include="Libplanet.Stun" Version="5.3.2-alpha.1" />
     <ProjectReference Include="..\Lib9c\Lib9c.csproj" />
     <ProjectReference Include="..\Lib9c.Policy\Lib9c.Policy.csproj" />
   </ItemGroup>

--- a/Lib9c.Proposer/Lib9c.Proposer.csproj
+++ b/Lib9c.Proposer/Lib9c.Proposer.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Lib9c\Lib9c.csproj" />
-    <PackageReference Include="Libplanet.Net" Version="5.3.2-alpha.1" />
+    <PackageReference Include="Libplanet.Net" Version="$(LibplanetVersion)" />
   </ItemGroup>
 
 </Project>

--- a/Lib9c.Proposer/Lib9c.Proposer.csproj
+++ b/Lib9c.Proposer/Lib9c.Proposer.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Lib9c\Lib9c.csproj" />
-    <ProjectReference Include="..\.Libplanet\src\Libplanet.Net\Libplanet.Net.csproj" />
+    <PackageReference Include="Libplanet.Net" Version="5.3.2-alpha.1" />
   </ItemGroup>
 
 </Project>

--- a/Lib9c.Proposer/Lib9c.Proposer.csproj
+++ b/Lib9c.Proposer/Lib9c.Proposer.csproj
@@ -17,6 +17,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalLibplanet)'">
-    <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet.Net\Libplane.Net.csproj" />
+    <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet.Net\Libplanet.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/Lib9c.Proposer/Lib9c.Proposer.csproj
+++ b/Lib9c.Proposer/Lib9c.Proposer.csproj
@@ -10,7 +10,13 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Lib9c\Lib9c.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!'$(UseLocalLibplanet)'">
     <PackageReference Include="Libplanet.Net" Version="$(LibplanetVersion)" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(UseLocalLibplanet)'">
+    <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet.Net\Libplane.Net.csproj" />
+  </ItemGroup>
 </Project>

--- a/Lib9c.sln
+++ b/Lib9c.sln
@@ -11,17 +11,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lib9c.Tools", ".Lib9c.Tools
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lib9c.Tools.Tests", ".Lib9c.Tools.Tests\Lib9c.Tools.Tests.csproj", "{451E155A-BD5F-4035-9DB0-7C561B1B7197}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libplanet", "Libplanet", "{AFA609F0-8CAE-4494-A4E2-EABD9E95D678}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Stun", ".Libplanet\src\Libplanet.Stun\Libplanet.Stun.csproj", "{6126D57A-F079-4B07-B1E4-531630DCCDBF}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet", ".Libplanet\src\Libplanet\Libplanet.csproj", "{5C9F5F97-367E-4F8B-A123-D9AADE786CA1}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Analyzers", ".Libplanet\tools\Libplanet.Analyzers\Libplanet.Analyzers.csproj", "{659722A9-132F-4B41-87BC-1B56A97A98FA}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lib9c.Benchmarks", ".Lib9c.Benchmarks\Lib9c.Benchmarks.csproj", "{9EB7458F-FD90-4719-A3B6-FBC678BC43D8}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.RocksDBStore", ".Libplanet\src\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj", "{17AAB5B1-695B-4597-8B36-1DF5012EE686}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6BFB8C34-37DB-4FA1-9565-DA1B8BF8CF6C}"
 	ProjectSection(SolutionItems) = preProject
@@ -31,8 +21,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lib9c.DevExtensions", "Lib9c.DevExtensions\Lib9c.DevExtensions.csproj", "{90723E02-D1AD-462F-B285-DA62E030AB3B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lib9c.DevExtensions.Tests", ".Lib9c.DevExtensions.Tests\Lib9c.DevExtensions.Tests.csproj", "{805D6BE8-E2CC-46CB-B503-2A114064432C}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Net", ".Libplanet\src\Libplanet.Net\Libplanet.Net.csproj", "{E879E951-62DF-4682-B78D-7E8A7165B58B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Crypto.Secp256k1", "Libplanet.Crypto.Secp256k1\Libplanet.Crypto.Secp256k1.csproj", "{964DB502-1A12-4979-9A22-E6633AFEA5E8}"
 EndProject
@@ -50,16 +38,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lib9c.Utils", "Lib9c.Utils\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lib9c.Proposer", "Lib9c.Proposer\Lib9c.Proposer.csproj", "{7DC1D595-095D-462A-864D-0CE57915901A}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Action", ".Libplanet\src\Libplanet.Action\Libplanet.Action.csproj", "{566832F1-47C7-47AD-8F48-E0EFC40BAF1A}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Common", ".Libplanet\src\Libplanet.Common\Libplanet.Common.csproj", "{55DA19A9-F793-496B-9F53-D0788107BB4C}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Crypto", ".Libplanet\src\Libplanet.Crypto\Libplanet.Crypto.csproj", "{E29043C5-43C9-4EBB-9632-8A80F9F35EE6}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Types", ".Libplanet\src\Libplanet.Types\Libplanet.Types.csproj", "{BB4464CB-B9DD-45E5-9450-38A2922FB178}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Store", ".Libplanet\src\Libplanet.Store\Libplanet.Store.csproj", "{82BCD815-0AB6-4EEF-A12B-CDB9CD98EEA1}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Extensions.ActionEvaluatorCommonComponents", ".Libplanet.Extensions.ActionEvaluatorCommonComponents\Libplanet.Extensions.ActionEvaluatorCommonComponents.csproj", "{64C44AFB-1E14-44D3-B236-A4A37DF2C27A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests", ".Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests\Libplanet.Extensions.ActionEvaluatorCommonComponents.Tests.csproj", "{EACB2E8D-9A13-491C-BACD-5D79C6C13783}"
@@ -67,8 +45,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lib9c.Plugin", ".Lib9c.Plugin\Lib9c.Plugin.csproj", "{484A5A5B-D610-42D4-9CAC-B19EA1A71281}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lib9c.Plugin.Shared", ".Lib9c.Plugin.Shared\Lib9c.Plugin.Shared.csproj", "{76F6C25E-94D2-4EA9-B88D-0249F44D1D16}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Mocks", ".Libplanet\test\Libplanet.Mocks\Libplanet.Mocks.csproj", "{8BC561CB-91EF-4290-893F-025E9E6A0CF7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -92,26 +68,10 @@ Global
 		{451E155A-BD5F-4035-9DB0-7C561B1B7197}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{451E155A-BD5F-4035-9DB0-7C561B1B7197}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{451E155A-BD5F-4035-9DB0-7C561B1B7197}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6126D57A-F079-4B07-B1E4-531630DCCDBF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6126D57A-F079-4B07-B1E4-531630DCCDBF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6126D57A-F079-4B07-B1E4-531630DCCDBF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6126D57A-F079-4B07-B1E4-531630DCCDBF}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5C9F5F97-367E-4F8B-A123-D9AADE786CA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5C9F5F97-367E-4F8B-A123-D9AADE786CA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5C9F5F97-367E-4F8B-A123-D9AADE786CA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5C9F5F97-367E-4F8B-A123-D9AADE786CA1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{659722A9-132F-4B41-87BC-1B56A97A98FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{659722A9-132F-4B41-87BC-1B56A97A98FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{659722A9-132F-4B41-87BC-1B56A97A98FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{659722A9-132F-4B41-87BC-1B56A97A98FA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9EB7458F-FD90-4719-A3B6-FBC678BC43D8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9EB7458F-FD90-4719-A3B6-FBC678BC43D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9EB7458F-FD90-4719-A3B6-FBC678BC43D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9EB7458F-FD90-4719-A3B6-FBC678BC43D8}.Release|Any CPU.Build.0 = Release|Any CPU
-		{17AAB5B1-695B-4597-8B36-1DF5012EE686}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{17AAB5B1-695B-4597-8B36-1DF5012EE686}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{17AAB5B1-695B-4597-8B36-1DF5012EE686}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{17AAB5B1-695B-4597-8B36-1DF5012EE686}.Release|Any CPU.Build.0 = Release|Any CPU
 		{90723E02-D1AD-462F-B285-DA62E030AB3B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{90723E02-D1AD-462F-B285-DA62E030AB3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{90723E02-D1AD-462F-B285-DA62E030AB3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -120,10 +80,6 @@ Global
 		{805D6BE8-E2CC-46CB-B503-2A114064432C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{805D6BE8-E2CC-46CB-B503-2A114064432C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{805D6BE8-E2CC-46CB-B503-2A114064432C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E879E951-62DF-4682-B78D-7E8A7165B58B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E879E951-62DF-4682-B78D-7E8A7165B58B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E879E951-62DF-4682-B78D-7E8A7165B58B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E879E951-62DF-4682-B78D-7E8A7165B58B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{964DB502-1A12-4979-9A22-E6633AFEA5E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{964DB502-1A12-4979-9A22-E6633AFEA5E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{964DB502-1A12-4979-9A22-E6633AFEA5E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -156,26 +112,6 @@ Global
 		{7DC1D595-095D-462A-864D-0CE57915901A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7DC1D595-095D-462A-864D-0CE57915901A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7DC1D595-095D-462A-864D-0CE57915901A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{566832F1-47C7-47AD-8F48-E0EFC40BAF1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{566832F1-47C7-47AD-8F48-E0EFC40BAF1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{566832F1-47C7-47AD-8F48-E0EFC40BAF1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{566832F1-47C7-47AD-8F48-E0EFC40BAF1A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{55DA19A9-F793-496B-9F53-D0788107BB4C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{55DA19A9-F793-496B-9F53-D0788107BB4C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{55DA19A9-F793-496B-9F53-D0788107BB4C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{55DA19A9-F793-496B-9F53-D0788107BB4C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E29043C5-43C9-4EBB-9632-8A80F9F35EE6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E29043C5-43C9-4EBB-9632-8A80F9F35EE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E29043C5-43C9-4EBB-9632-8A80F9F35EE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E29043C5-43C9-4EBB-9632-8A80F9F35EE6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BB4464CB-B9DD-45E5-9450-38A2922FB178}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BB4464CB-B9DD-45E5-9450-38A2922FB178}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BB4464CB-B9DD-45E5-9450-38A2922FB178}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BB4464CB-B9DD-45E5-9450-38A2922FB178}.Release|Any CPU.Build.0 = Release|Any CPU
-		{82BCD815-0AB6-4EEF-A12B-CDB9CD98EEA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{82BCD815-0AB6-4EEF-A12B-CDB9CD98EEA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{82BCD815-0AB6-4EEF-A12B-CDB9CD98EEA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{82BCD815-0AB6-4EEF-A12B-CDB9CD98EEA1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{64C44AFB-1E14-44D3-B236-A4A37DF2C27A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{64C44AFB-1E14-44D3-B236-A4A37DF2C27A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{64C44AFB-1E14-44D3-B236-A4A37DF2C27A}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -192,26 +128,9 @@ Global
 		{76F6C25E-94D2-4EA9-B88D-0249F44D1D16}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{76F6C25E-94D2-4EA9-B88D-0249F44D1D16}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{76F6C25E-94D2-4EA9-B88D-0249F44D1D16}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8BC561CB-91EF-4290-893F-025E9E6A0CF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8BC561CB-91EF-4290-893F-025E9E6A0CF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8BC561CB-91EF-4290-893F-025E9E6A0CF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8BC561CB-91EF-4290-893F-025E9E6A0CF7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{6126D57A-F079-4B07-B1E4-531630DCCDBF} = {AFA609F0-8CAE-4494-A4E2-EABD9E95D678}
-		{5C9F5F97-367E-4F8B-A123-D9AADE786CA1} = {AFA609F0-8CAE-4494-A4E2-EABD9E95D678}
-		{659722A9-132F-4B41-87BC-1B56A97A98FA} = {AFA609F0-8CAE-4494-A4E2-EABD9E95D678}
-		{17AAB5B1-695B-4597-8B36-1DF5012EE686} = {AFA609F0-8CAE-4494-A4E2-EABD9E95D678}
-		{E879E951-62DF-4682-B78D-7E8A7165B58B} = {AFA609F0-8CAE-4494-A4E2-EABD9E95D678}
-		{566832F1-47C7-47AD-8F48-E0EFC40BAF1A} = {AFA609F0-8CAE-4494-A4E2-EABD9E95D678}
-		{55DA19A9-F793-496B-9F53-D0788107BB4C} = {AFA609F0-8CAE-4494-A4E2-EABD9E95D678}
-		{E29043C5-43C9-4EBB-9632-8A80F9F35EE6} = {AFA609F0-8CAE-4494-A4E2-EABD9E95D678}
-		{BB4464CB-B9DD-45E5-9450-38A2922FB178} = {AFA609F0-8CAE-4494-A4E2-EABD9E95D678}
-		{82BCD815-0AB6-4EEF-A12B-CDB9CD98EEA1} = {AFA609F0-8CAE-4494-A4E2-EABD9E95D678}
-		{8BC561CB-91EF-4290-893F-025E9E6A0CF7} = {AFA609F0-8CAE-4494-A4E2-EABD9E95D678}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {547C7D6E-6301-4BB4-AEF7-979CD504D913}

--- a/Lib9c/Lib9c.csproj
+++ b/Lib9c/Lib9c.csproj
@@ -36,15 +36,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\.Libplanet\src\Libplanet\Libplanet.csproj">
+    <PackageReference Include="Libplanet" Version="5.3.2-alpha.1">
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>
-    </ProjectReference>
-    <ProjectReference Include="..\.Libplanet\tools\Libplanet.Analyzers\Libplanet.Analyzers.csproj">
+    </PackageReference>
+    <PackageReference Include="Libplanet.Analyzers" Version="5.3.2-alpha.1">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Analyzer</OutputItemType>
       <!-- https://github.com/dotnet/roslyn/issues/18093#issuecomment-405702631 -->
-    </ProjectReference>
+    </PackageReference>
     <ProjectReference Include="..\Lib9c.Abstractions\Lib9c.Abstractions.csproj" />
   </ItemGroup>
 

--- a/Lib9c/Lib9c.csproj
+++ b/Lib9c/Lib9c.csproj
@@ -36,6 +36,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Lib9c.Abstractions\Lib9c.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!$(UseLocalLibplanet)">
     <PackageReference Include="Libplanet" Version="$(LibplanetVersion)">
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>
@@ -45,7 +49,18 @@
       <OutputItemType>Analyzer</OutputItemType>
       <!-- https://github.com/dotnet/roslyn/issues/18093#issuecomment-405702631 -->
     </PackageReference>
-    <ProjectReference Include="..\Lib9c.Abstractions\Lib9c.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(UseLocalLibplanet)">
+    <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet\Libplanet.csporj">
+      <Private>false</Private>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
+    <ProjectReference Include="$(LibplanetDirectory)\tools\Libplanet.Analyzers\Libplanet.Analyzers.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Analyzer</OutputItemType>
+      <!-- https://github.com/dotnet/roslyn/issues/18093#issuecomment-405702631 -->
+    </ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/Lib9c/Lib9c.csproj
+++ b/Lib9c/Lib9c.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(UseLocalLibplanet)">
-    <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet\Libplanet.csporj">
+    <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet\Libplanet.csproj">
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>
     </ProjectReference>

--- a/Lib9c/Lib9c.csproj
+++ b/Lib9c/Lib9c.csproj
@@ -36,11 +36,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Libplanet" Version="5.3.2-alpha.1">
+    <PackageReference Include="Libplanet" Version="$(LibplanetVersion)">
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="Libplanet.Analyzers" Version="5.3.2-alpha.1">
+    <PackageReference Include="Libplanet.Analyzers" Version="$(LibplanetVersion)">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Analyzer</OutputItemType>
       <!-- https://github.com/dotnet/roslyn/issues/18093#issuecomment-405702631 -->

--- a/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
+++ b/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\.Libplanet\src\Libplanet\Libplanet.csproj" />
+    <PackageReference Include="Libplanet" Version="5.3.2-alpha.1" />
 
     <PackageReference Include="Secp256k1.Net" Version="1.0.0-alpha" />
     <PackageReference Include="Secp256k1.Native" Version="0.1.24-alpha" />

--- a/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
+++ b/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Libplanet" Version="5.3.2-alpha.1" />
+    <PackageReference Include="Libplanet" Version="$(LibplanetVersion)" />
 
     <PackageReference Include="Secp256k1.Net" Version="1.0.0-alpha" />
     <PackageReference Include="Secp256k1.Native" Version="0.1.24-alpha" />

--- a/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
+++ b/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
@@ -9,10 +9,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Libplanet" Version="$(LibplanetVersion)" />
-
     <PackageReference Include="Secp256k1.Net" Version="1.0.0-alpha" />
     <PackageReference Include="Secp256k1.Native" Version="0.1.24-alpha" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!'$(UseLocalLibplanet)'">
+    <PackageReference Include="Libplanet" Version="$(LibplanetVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UseLocalLibplanet)'">
+    <ProjectReference Include="$(LibplanetDirectory)\src\Libplanet\Libplanet.csproj" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ and [Lib9c/TableCSV](Lib9c/TableCSV).
 ## Dependencies
 
 - .Net >= 6.0
-- [Libplanet](https://github.com/planetarium/libplanet.git) as a submodule
 
 ## Contribution
 

--- a/integrations/javascript/@planetarium/lib9c/CONTRIBUTING.md
+++ b/integrations/javascript/@planetarium/lib9c/CONTRIBUTING.md
@@ -22,13 +22,6 @@ pnpm build
 
 `@planetarium/lib9c` uses `Lib9c.Tools action analyze` command to check whether implemented actions make valid bencodex value. You should build the .NET project first. **If the .NET Lib9c project is changed, you must build `Lib9c.Tools` project again.**
 
-if you haven't pulled submodules, run this command first.
-
-```
-git submodule update --init --recursive
-```
-after
-
 ```
 dotnet build ../../.Lib9c.Tools/Lib9c.Tools.csproj
 ```


### PR DESCRIPTION
It resolves https://github.com/planetarium/lib9c/issues/2955

------

This pull request did:
  - Remove `.Libplanet` submodule.
    - Remove items related with submodule. (docs, ci)
  - Make controllable Libplanet-related dependencies' version by `LibplanetVersion` property in `Directory.Build.props`
  - Make testable with local Libplanet by `LibplanetDirectory` property in `Directory.Build.props`
    - Guide by `CONTRIBUTING.md`
    - Check `LibplanetDirectory` is empty well by `lint.yaml#jobs.local-libplanet` workflow.

----

I requested reviews to @planetarium/libplanet  and @planetarium/9c-dev but if there is someone I missed, please add them too.