### PR TITLE
Fix Refund admin action

### DIFF
--- a/.Lib9c.Tests/Action/Guild/Migration/FixToRefundFromNonValidatorTest.cs
+++ b/.Lib9c.Tests/Action/Guild/Migration/FixToRefundFromNonValidatorTest.cs
@@ -1,132 +1,104 @@
 namespace Lib9c.Tests.Action.Guild.Migration
 {
     using System;
-    using System.Collections.Generic;
-    using Lib9c.Tests.Fixtures.TableCSV.Stake;
-    using Lib9c.Tests.Util;
+    using System.Linq;
     using Libplanet.Action.State;
     using Libplanet.Crypto;
-    using Libplanet.Types.Assets;
     using Nekoyume;
     using Nekoyume.Action;
     using Nekoyume.Action.Guild.Migration;
-    using Nekoyume.Extensions;
     using Nekoyume.Model.Stake;
     using Nekoyume.Model.State;
     using Nekoyume.Module;
-    using Nekoyume.TableData.Stake;
     using Xunit;
 
     // TODO: Remove this test class after the migration is completed.
     public class FixToRefundFromNonValidatorTest : GuildTestBase
     {
         private IWorld _world;
-        private Currency _ncg;
-        private Currency _gg;
-        private Address _agentAddress;
-        private Address _stakeAddress;
         private Address _adminAddress;
 
         public FixToRefundFromNonValidatorTest()
         {
-            _agentAddress = new PrivateKey().Address;
             _adminAddress = new PrivateKey().Address;
-            _stakeAddress = StakeState.DeriveAddress(_agentAddress);
-            _ncg = World.GetGoldCurrency();
-            _gg = Currencies.GuildGold;
-            var sheetsOverride = new Dictionary<string, string>
-            {
-                {
-                    "StakeRegularFixedRewardSheet_V1",
-                    StakeRegularFixedRewardSheetFixtures.V1
-                },
-                {
-                    "StakeRegularFixedRewardSheet_V2",
-                    StakeRegularFixedRewardSheetFixtures.V2
-                },
-                {
-                    "StakeRegularRewardSheet_V1",
-                    StakeRegularRewardSheetFixtures.V1
-                },
-                {
-                    "StakeRegularRewardSheet_V2",
-                    StakeRegularRewardSheetFixtures.V2
-                },
-                {
-                    nameof(StakePolicySheet),
-                    StakePolicySheetFixtures.V2
-                },
-            };
-            (_, _, _, _world) = InitializeUtil.InitializeStates(
-                agentAddr: _agentAddress,
-                sheetsOverride: sheetsOverride);
-            var stakePolicySheet = _world.GetSheet<StakePolicySheet>();
-            var contract = new Contract(stakePolicySheet);
             var adminState = new AdminState(_adminAddress, 100L);
-            var stakeState = new StakeState(new Contract(stakePolicySheet), 1L);
-
             _world = World
                 .SetLegacyState(Addresses.Admin, adminState.Serialize())
-                .SetLegacyState(_stakeAddress, stakeState.Serialize())
-                .MintAsset(new ActionContext { }, Addresses.NonValidatorDelegatee, _gg * 10000)
-                .MintAsset(new ActionContext { }, _stakeAddress, _ncg * 10)
-                .MintAsset(new ActionContext { }, _stakeAddress, _gg * 5);
+                .MintAsset(new ActionContext { }, Addresses.NonValidatorDelegatee, Currencies.GuildGold * 500);
+        }
+
+        [Fact]
+        public void PlainValue()
+        {
+            var addresses = Enumerable.Range(0, 5).Select(_ => new PrivateKey().Address).ToList();
+            var amounts = Enumerable.Range(0, 5).Select(i => (i + 1) * 10).ToList();
+
+            var plainValue = new FixToRefundFromNonValidator(
+                addresses,
+                amounts
+            ).PlainValue;
+
+            var recon = new FixToRefundFromNonValidator();
+            recon.LoadPlainValue(plainValue);
+            Assert.Equal(addresses, recon.Targets);
+            Assert.Equal(amounts, recon.Amounts);
         }
 
         [Fact]
         public void Execute()
         {
-            var world = new FixToRefundFromNonValidator(new Address[] { _agentAddress }).Execute(new ActionContext
+            var addresses = Enumerable.Range(0, 5).Select(_ => new PrivateKey().Address).ToList();
+            var amounts = Enumerable.Range(0, 5).Select(i => (i + 1) * 10).ToList();
+
+            var world = new FixToRefundFromNonValidator(
+                addresses,
+                amounts
+            ).Execute(new ActionContext
             {
                 PreviousState = _world,
                 Signer = _adminAddress,
+                BlockIndex = 2L,
             });
 
-            Assert.Equal(_gg * 10, world.GetBalance(_stakeAddress, _gg));
-            Assert.Equal(_gg * (10000 - 5), world.GetBalance(Addresses.NonValidatorDelegatee, _gg));
+            foreach (var item in addresses.Select((a, i) => (a, i)))
+            {
+                Assert.Equal(
+                    Currencies.GuildGold * ((item.i + 1) * 10),
+                    world.GetBalance(StakeState.DeriveAddress(item.a), Currencies.GuildGold));
+            }
+
+            Assert.Equal(
+                Currencies.GuildGold * (500 - amounts.Sum()),
+                world.GetBalance(Addresses.NonValidatorDelegatee, Currencies.GuildGold));
+        }
+
+        [Fact]
+        public void AssertWhenDifferentLengthArgument()
+        {
+            var addresses = Enumerable.Range(0, 5).Select(_ => new PrivateKey().Address).ToList();
+            var amounts = Enumerable.Range(0, 4).Select(i => (i + 1) * 10).ToList();
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                new FixToRefundFromNonValidator(addresses, amounts);
+            });
         }
 
         [Fact]
         public void AssertWhenExecutedByNonAdmin()
         {
+            var addresses = Enumerable.Range(0, 5).Select(_ => new PrivateKey().Address).ToList();
+            var amounts = Enumerable.Range(0, 5).Select(i => (i + 1) * 10);
+
             Assert.Throws<PermissionDeniedException>(() =>
             {
-                new FixToRefundFromNonValidator(new Address[] { _agentAddress }).Execute(new ActionContext
+                new FixToRefundFromNonValidator(
+                    addresses,
+                    amounts
+                ).Execute(new ActionContext
                 {
                     PreviousState = _world,
                     Signer = new PrivateKey().Address,
-                    BlockIndex = 2L,
-                });
-            });
-        }
-
-        [Fact]
-        public void AssertWhenHasSufficientGG()
-        {
-            var world = _world
-                .MintAsset(new ActionContext { }, _stakeAddress, _gg * 5);
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                new FixToRefundFromNonValidator(new Address[] { _agentAddress }).Execute(new ActionContext
-                {
-                    PreviousState = world,
-                    Signer = _adminAddress,
-                    BlockIndex = 2L,
-                });
-            });
-        }
-
-        [Fact]
-        public void AssertWhenLegacyStakeState()
-        {
-            var stakeState = new LegacyStakeState(_stakeAddress, 0L);
-            var world = _world.SetLegacyState(_stakeAddress, stakeState.Serialize());
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                new FixToRefundFromNonValidator(new Address[] { _agentAddress }).Execute(new ActionContext
-                {
-                    PreviousState = World,
-                    Signer = _adminAddress,
                     BlockIndex = 2L,
                 });
             });

--- a/Lib9c/Action/Guild/Migration/FixToRefundFromNonValidator.cs
+++ b/Lib9c/Action/Guild/Migration/FixToRefundFromNonValidator.cs
@@ -1,15 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Bencodex.Types;
 using Lib9c;
-using Libplanet.Action.State;
 using Libplanet.Action;
-using Libplanet.Types.Assets;
+using Libplanet.Action.State;
+using Libplanet.Crypto;
 using Nekoyume.Model.Stake;
 using Nekoyume.Model.State;
-using Nekoyume.Module;
-using Libplanet.Crypto;
-using System.Linq;
 
 namespace Nekoyume.Action.Guild.Migration
 {
@@ -24,21 +22,34 @@ namespace Nekoyume.Action.Guild.Migration
 
         private const string TargetsKey = "t";
 
+        private const string AmountsKey = "a";
+
         public List<Address> Targets { get; private set; }
+
+        public List<int> Amounts { get; private set; }
 
         public FixToRefundFromNonValidator()
         {
         }
 
-        public FixToRefundFromNonValidator(IEnumerable<Address> targets)
+        public FixToRefundFromNonValidator(
+            IEnumerable<Address> targets,
+            IEnumerable<int> amounts)
         {
             Targets = targets.ToList();
+            Amounts = amounts.ToList();
+
+            if (Targets.Count != Amounts.Count)
+            {
+                throw new ArgumentException("The number of targets and amounts must be the same.");
+            }
         }
 
         public override IValue PlainValue => Dictionary.Empty
             .Add("type_id", TypeIdentifier)
             .Add("values", Dictionary.Empty
-                .Add(TargetsKey, new List(Targets.Select(t => t.Bencoded))));
+                .Add(TargetsKey, new List(Targets.Select(t => t.Bencoded)))
+                .Add(AmountsKey, new List(Amounts)));
 
         public override void LoadPlainValue(IValue plainValue)
         {
@@ -46,12 +57,20 @@ namespace Nekoyume.Action.Guild.Migration
                 !root.TryGetValue((Text)"values", out var rawValues) ||
                 rawValues is not Dictionary values ||
                 !values.TryGetValue((Text)TargetsKey, out var rawTarget) ||
-                rawTarget is not List targets)
+                rawTarget is not List targets ||
+                !values.TryGetValue((Text)AmountsKey, out var rawAmounts) ||
+                rawAmounts is not List amounts)
             {
                 throw new InvalidCastException();
             }
 
             Targets = targets.Select(t => new Address(t)).ToList();
+            Amounts = amounts.Select(a => (int)(Integer)a).ToList();
+
+            if (Targets.Count != Amounts.Count)
+            {
+                throw new ArgumentException("The number of targets and amounts must be the same.");
+            }
         }
 
         public override IWorld Execute(IActionContext context)
@@ -70,43 +89,24 @@ namespace Nekoyume.Action.Guild.Migration
                 throw new PermissionDeniedException(adminState, context.Signer);
             }
 
-            foreach (var target in Targets)
+            foreach (var ta in Targets.Zip(Amounts, (f, s) => (f, s)))
             {
-                world = RefundFromNonValidator(context, world, target);
+                world = RefundFromNonValidator(context, world, ta);
             }
 
             return world;
         }
 
-        private IWorld RefundFromNonValidator(IActionContext context, IWorld world, Address target)
+        private IWorld RefundFromNonValidator(IActionContext context, IWorld world, (Address, int) ta)
         {
+            var (target, amount) = ta;
             var stakeStateAddress = StakeState.DeriveAddress(target);
 
-            if (!world.TryGetStakeState(target, out var stakeState)
-                || stakeState.StateVersion != 3)
-            {
-                throw new InvalidOperationException(
-                    "Target is not valid for refunding from non-validator.");
-            }
-
-            var ncgStaked = world.GetBalance(stakeStateAddress, world.GetGoldCurrency());
-            var ggStaked = world.GetBalance(stakeStateAddress, Currencies.GuildGold);
-
-            var requiredGG = GetGuildCoinFromNCG(ncgStaked) - ggStaked;
-
-            if (requiredGG.Sign != 1)
-            {
-                throw new InvalidOperationException(
-                    "Target has sufficient amount of guild gold.");
-            }
-
-            return world.TransferAsset(context, Addresses.NonValidatorDelegatee, stakeStateAddress, requiredGG);
-        }
-
-        private static FungibleAssetValue GetGuildCoinFromNCG(FungibleAssetValue balance)
-        {
-            return FungibleAssetValue.Parse(Currencies.GuildGold,
-                balance.GetQuantityString(true));
+            return world.TransferAsset(
+                context,
+                Addresses.NonValidatorDelegatee,
+                stakeStateAddress,
+                Currencies.GuildGold * amount);
         }
     }
 }


### PR DESCRIPTION
Fix `FixToRefundFromNonValidator` action to directly use amount of guild gold.
- After 1.19.2, it's impossible to track amount of guild gold to transfer.
- Since so, added `Amounts` property.