### PR TITLE
ci(gh-actions): fix `concurrency.group` in `publish-docs` workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #3051

There is already `concurrency.group` field in `publish-docs` but it uses `<workflow-name>-<ref-name>` as lock key. So it didn't work well and this pull request fixed it as `<workflow-name>`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/planetarium/lib9c/pull/3052?shareId=708632cf-f87d-4546-a117-4f6a4165e57f).