### PR TITLE
Release 1.20.1

### DIFF
--- a/.Lib9c.Tests/Action/Guild/ClaimRewardTest.cs
+++ b/.Lib9c.Tests/Action/Guild/ClaimRewardTest.cs
@@ -376,7 +376,6 @@ public class ClaimRewardTest : ValidatorDelegationTestBase
                 AllocateRewardCurrency))
             .ToArray();
 
-        Assert.Equal(expectedRemainGuildReward, actualRemainGuildReward);
         Assert.Equal(expectedValidatorBalance, actualValidatorBalance);
         Assert.Equal(expectedDelegatorBalances, actualDelegatorBalances);
         Assert.Equal(expectedValidatorGuildReward, actualValidatorGuildReward);
@@ -384,8 +383,9 @@ public class ClaimRewardTest : ValidatorDelegationTestBase
         Assert.Equal(expectedValidatorClaim, actualValidatorReward);
         Assert.Equal(expectedGuildClaims, actualGuildRewards);
         Assert.Equal(expectedGuildParticipantClaims, actualGuildParticipantRewards);
-        Assert.Equal(expectedRemainReward, actualRemainReward);
-
+        // Flushing to remainder pool is now inactive.
+        // Assert.Equal(expectedRemainGuildReward, actualRemainGuildReward);
+        // Assert.Equal(expectedRemainReward, actualRemainReward);
         foreach (var key in guildParticipantKeys)
         {
             Assert.Throws<InvalidOperationException>(

--- a/.Lib9c.Tests/Action/ValidatorDelegation/PromoteValidatorTest.cs
+++ b/.Lib9c.Tests/Action/ValidatorDelegation/PromoteValidatorTest.cs
@@ -49,7 +49,6 @@ public class PromoteValidatorTest : ValidatorDelegationTestBase
         var bond = repository.GetBond(validator, validatorKey.Address);
         var validatorList = repository.GetValidatorList();
 
-        Assert.Equal(validatorKey.Address, Assert.Single(validator.Delegators));
         Assert.Equal(gold.RawValue, bond.Share);
         Assert.Equal(validator.Validator, Assert.Single(validatorList.Validators));
         Assert.Equal(validator.Validator, Assert.Single(validatorList.ActiveSet()));

--- a/.Lib9c.Tests/Action/ValidatorDelegation/UndelegateValidatorTest.cs
+++ b/.Lib9c.Tests/Action/ValidatorDelegation/UndelegateValidatorTest.cs
@@ -70,7 +70,6 @@ public class UndelegateValidatorTest : ValidatorDelegationTestBase
         var actualValidatorList = actualRepository.GetValidatorList();
         var actualBond = actualRepository.GetBond(actualDelegatee, validatorKey.Address);
 
-        Assert.NotEqual(expectedDelegatee.Delegators, actualDelegatee.Delegators);
         Assert.NotEqual(expectedDelegatee.Validator.Power, actualDelegatee.Validator.Power);
         Assert.Equal(BigInteger.Zero, actualDelegatee.Validator.Power);
         Assert.Empty(actualValidatorList.Validators);

--- a/.Lib9c.Tests/Delegation/DelegateeTest.cs
+++ b/.Lib9c.Tests/Delegation/DelegateeTest.cs
@@ -4,6 +4,7 @@ namespace Lib9c.Tests.Delegation
     using System.Numerics;
     using Libplanet.Crypto;
     using Libplanet.Types.Assets;
+    using Nekoyume;
     using Nekoyume.Delegation;
     using Xunit;
 
@@ -38,7 +39,6 @@ namespace Lib9c.Tests.Delegation
             delegatee.Bond(delegator, delegatee.DelegationCurrency * 10, 10L);
             var delegateeRecon = repo.GetDelegatee(delegatee.Address);
             Assert.Equal(delegatee.Address, delegateeRecon.Address);
-            Assert.Equal(delegator.Address, Assert.Single(delegateeRecon.Delegators));
             Assert.Equal(delegatee.TotalDelegated, delegateeRecon.TotalDelegated);
             Assert.Equal(delegatee.TotalShares, delegateeRecon.TotalShares);
         }
@@ -70,7 +70,6 @@ namespace Lib9c.Tests.Delegation
 
             var bondedShare = testDelegatee.Bond(testDelegator1, bonding, 10L);
             var bondedShare1 = _fixture.TestRepository.GetBond(testDelegatee, testDelegator1.Address).Share;
-            Assert.Equal(testDelegator1.Address, Assert.Single(testDelegatee.Delegators));
             Assert.Equal(share, bondedShare);
             Assert.Equal(share1, bondedShare1);
             Assert.Equal(totalShare, testDelegatee.TotalShares);
@@ -83,7 +82,6 @@ namespace Lib9c.Tests.Delegation
             totalBonding += bonding;
             bondedShare = testDelegatee.Bond(testDelegator1, bonding, 20L);
             bondedShare1 = _fixture.TestRepository.GetBond(testDelegatee, testDelegator1.Address).Share;
-            Assert.Equal(testDelegator1.Address, Assert.Single(testDelegatee.Delegators));
             Assert.Equal(share, bondedShare);
             Assert.Equal(share1, bondedShare1);
             Assert.Equal(totalShare, testDelegatee.TotalShares);
@@ -96,9 +94,6 @@ namespace Lib9c.Tests.Delegation
             totalBonding += bonding;
             bondedShare = testDelegatee.Bond(testDelegator2, bonding, 30L);
             var bondedShare2 = _fixture.TestRepository.GetBond(testDelegatee, testDelegator2.Address).Share;
-            Assert.Equal(2, testDelegatee.Delegators.Count);
-            Assert.Contains(testDelegator1.Address, testDelegatee.Delegators);
-            Assert.Contains(testDelegator2.Address, testDelegatee.Delegators);
             Assert.Equal(share, bondedShare);
             Assert.Equal(share2, bondedShare2);
             Assert.Equal(totalShare, testDelegatee.TotalShares);
@@ -163,9 +158,6 @@ namespace Lib9c.Tests.Delegation
             totalDelegated -= unbondingFAV;
             var unbondedFAV = testDelegatee.Unbond(testDelegator1, unbonding, 3L);
             var shareAfterUnbond = _fixture.TestRepository.GetBond(testDelegatee, testDelegator1.Address).Share;
-            Assert.Equal(2, testDelegatee.Delegators.Count);
-            Assert.Contains(testDelegator1.Address, testDelegatee.Delegators);
-            Assert.Contains(testDelegator2.Address, testDelegatee.Delegators);
             Assert.Equal(unbondingFAV, unbondedFAV);
             Assert.Equal(share1, shareAfterUnbond);
             Assert.Equal(totalShares, testDelegatee.TotalShares);
@@ -178,9 +170,6 @@ namespace Lib9c.Tests.Delegation
             totalDelegated -= unbondingFAV;
             unbondedFAV = testDelegatee.Unbond(testDelegator2, unbonding, 4L);
             shareAfterUnbond = _fixture.TestRepository.GetBond(testDelegatee, testDelegator2.Address).Share;
-            Assert.Equal(2, testDelegatee.Delegators.Count);
-            Assert.Contains(testDelegator1.Address, testDelegatee.Delegators);
-            Assert.Contains(testDelegator2.Address, testDelegatee.Delegators);
             Assert.Equal(unbondingFAV, unbondedFAV);
             Assert.Equal(share2, shareAfterUnbond);
             Assert.Equal(totalShares, testDelegatee.TotalShares);
@@ -191,7 +180,6 @@ namespace Lib9c.Tests.Delegation
             totalDelegated -= unbondingFAV;
             unbondedFAV = testDelegatee.Unbond(testDelegator1, share1, 5L);
             shareAfterUnbond = _fixture.TestRepository.GetBond(testDelegatee, testDelegator1.Address).Share;
-            Assert.Equal(testDelegator2.Address, Assert.Single(testDelegatee.Delegators));
             Assert.Equal(unbondingFAV, unbondedFAV);
             Assert.Equal(BigInteger.Zero, shareAfterUnbond);
             Assert.Equal(totalShares, testDelegatee.TotalShares);
@@ -207,7 +195,7 @@ namespace Lib9c.Tests.Delegation
                     _fixture.DummyDelegator1, BigInteger.One, 10L));
         }
 
-        [Fact]
+        [Fact(Skip = "Flushing to remainder pool is now inactive.")]
         public void ClearRemainderRewards()
         {
             var repo = _fixture.TestRepository;

--- a/.Lib9c.Tests/Delegation/DelegatorTest.cs
+++ b/.Lib9c.Tests/Delegation/DelegatorTest.cs
@@ -57,7 +57,6 @@ namespace Lib9c.Tests.Delegation
             Assert.Equal(delegateShare, share);
             Assert.Equal(delegateFAV, delegatee1.TotalDelegated);
             Assert.Equal(delegateShare, delegatee1.TotalShares);
-            Assert.Equal(delegator.Address, Assert.Single(delegatee1.Delegators));
             Assert.Equal(delegatee1.Address, Assert.Single(delegator.Delegatees));
 
             var delegateFAV2 = delegatee1.DelegationCurrency * 20;
@@ -71,7 +70,6 @@ namespace Lib9c.Tests.Delegation
             Assert.Equal(delegateShare + delegateShare2, share);
             Assert.Equal(delegateFAV + delegateFAV2, delegatee1.TotalDelegated);
             Assert.Equal(delegateShare + delegateShare2, delegatee1.TotalShares);
-            Assert.Equal(delegator.Address, Assert.Single(delegatee1.Delegators));
             Assert.Equal(delegatee1.Address, Assert.Single(delegator.Delegatees));
 
             delegator.Delegate(delegatee2, delegateFAV, 3L);
@@ -112,7 +110,6 @@ namespace Lib9c.Tests.Delegation
             Assert.Equal(initialShare - undelegatingShare, share1);
             Assert.Equal(delegatingFAV - undelegatingFAV, delegatee.TotalDelegated);
             Assert.Equal(initialShare - undelegatingShare, delegatee.TotalShares);
-            Assert.Equal(delegator.Address, Assert.Single(delegatee.Delegators));
             Assert.Equal(delegatee.Address, Assert.Single(delegator.Delegatees));
             Assert.Equal(unbondLockIn.Address, Assert.Single(unbondingSet.FlattenedUnbondingRefs).Address);
             var entriesByExpireHeight = Assert.Single(unbondLockIn.Entries);
@@ -137,7 +134,6 @@ namespace Lib9c.Tests.Delegation
             Assert.Equal(delegatee.DelegationCurrency * 0, delegatee.TotalDelegated);
             Assert.Equal(System.Numerics.BigInteger.Zero, delegatee.TotalShares);
             Assert.Empty(delegator.Delegatees);
-            Assert.Empty(delegatee.Delegators);
             Assert.Equal(unbondLockIn.Address, Assert.Single(unbondingSet.FlattenedUnbondingRefs).Address);
             Assert.Equal(2, unbondLockIn.Entries.Count);
 
@@ -215,8 +211,6 @@ namespace Lib9c.Tests.Delegation
             Assert.Equal(redelegatedDstShare, delegatee2.TotalShares);
             Assert.Equal(delegatingFAV - redelegatingFAV, delegatee1.TotalDelegated);
             Assert.Equal(redelegatingFAV, delegatee2.TotalDelegated);
-            Assert.Equal(delegator.Address, Assert.Single(delegatee1.Delegators));
-            Assert.Equal(delegator.Address, Assert.Single(delegatee2.Delegators));
             Assert.Equal(2, delegator.Delegatees.Count);
             Assert.Equal(rebondGrace.Address, Assert.Single(unbondingSet.FlattenedUnbondingRefs).Address);
             var entriesByExpireHeight = Assert.Single(rebondGrace.Entries);
@@ -247,8 +241,6 @@ namespace Lib9c.Tests.Delegation
             Assert.Equal(redelegatedDstShare + redelegatedDstShare2, delegatee2.TotalShares);
             Assert.Equal(delegatingFAV - redelegatingFAV - redelegatingFAV2, delegatee1.TotalDelegated);
             Assert.Equal(redelegatingFAV + redelegatingFAV2, delegatee2.TotalDelegated);
-            Assert.Empty(delegatee1.Delegators);
-            Assert.Equal(delegator.Address, Assert.Single(delegatee2.Delegators));
             Assert.Equal(delegatee2.Address, Assert.Single(delegator.Delegatees));
             Assert.Equal(rebondGrace.Address, Assert.Single(unbondingSet.FlattenedUnbondingRefs).Address);
             Assert.Equal(2, rebondGrace.Entries.Count);
@@ -357,7 +349,12 @@ namespace Lib9c.Tests.Delegation
             Assert.Equal(delegatorInitialBalance - delegatingFAV2 * 2, delegator2Balance);
             Assert.Equal(rewards1, delegator1RewardBalances);
             Assert.Equal(rewards2, delegator2RewardBalances);
-            Assert.Equal(delegatee.RewardCurrencies.Select(c => c * 0), collectedRewards);
+
+            // Flushing to remainder pool is now inactive.
+            // Assert.Equal(delegatee.RewardCurrencies.Select(c => c * 0), collectedRewards);
+            Assert.Equal(
+                rewards.Select(r => r * 2).Zip(rewards1.Zip(rewards2, (f, s) => f + s), (f, s) => f - s).ToArray(),
+                collectedRewards);
         }
 
         [Fact]
@@ -431,7 +428,12 @@ namespace Lib9c.Tests.Delegation
             Assert.Equal(delegatorInitialBalance - delegatingFAV2, delegator2Balance);
             Assert.Equal(rewards1, delegator1RewardBalances);
             Assert.Equal(rewards2, delegator2RewardBalances);
-            Assert.Equal(delegatee.RewardCurrencies.Select(c => c * 0), collectedRewards);
+
+            // Flushing to remainder pool is now inactive.
+            // Assert.Equal(delegatee.RewardCurrencies.Select(c => c * 0), collectedRewards);
+            Assert.Equal(
+                rewards.Select(r => r * 2).Zip(rewards1.Zip(rewards2, (f, s) => f + s), (f, s) => f - s).ToArray(),
+                collectedRewards);
         }
 
         [Fact]
@@ -506,7 +508,12 @@ namespace Lib9c.Tests.Delegation
             Assert.Equal(delegatorInitialBalance - delegatingFAV2, delegator2Balance);
             Assert.Equal(rewards1, delegator1RewardBalances);
             Assert.Equal(rewards2, delegator2RewardBalances);
-            Assert.Equal(delegatee.RewardCurrencies.Select(c => c * 0), collectedRewards);
+
+            // Flushing to remainder pool is now inactive.
+            // Assert.Equal(delegatee.RewardCurrencies.Select(c => c * 0), collectedRewards);
+            Assert.Equal(
+                rewards.Select(r => r * 2).Zip(rewards1.Zip(rewards2, (f, s) => f + s), (f, s) => f - s).ToArray(),
+                collectedRewards);
         }
 
         [Fact]
@@ -581,7 +588,12 @@ namespace Lib9c.Tests.Delegation
             Assert.Equal(delegatorInitialBalance - delegatingFAV2, delegator2Balance);
             Assert.Equal(rewards1, delegator1RewardBalances);
             Assert.Equal(rewards2, delegator2RewardBalances);
-            Assert.Equal(delegatee.RewardCurrencies.Select(c => c * 0), collectedRewards);
+
+            // Flushing to remainder pool is now inactive.
+            // Assert.Equal(delegatee.RewardCurrencies.Select(c => c * 0), collectedRewards);
+            Assert.Equal(
+                rewards.Select(r => r * 2).Zip(rewards1.Zip(rewards2, (f, s) => f + s), (f, s) => f - s).ToArray(),
+                collectedRewards);
         }
     }
 }

--- a/.Lib9c.Tests/Delegation/Migration/LegacyDelegateeMetadata.cs
+++ b/.Lib9c.Tests/Delegation/Migration/LegacyDelegateeMetadata.cs
@@ -1,0 +1,221 @@
+#nullable enable
+namespace Lib9c.Tests.Delegation.Migration
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Numerics;
+    using Bencodex;
+    using Bencodex.Types;
+    using Libplanet.Crypto;
+    using Libplanet.Types.Assets;
+    using Nekoyume.Delegation;
+
+    public class LegacyDelegateeMetadata : IDelegateeMetadata
+    {
+        private readonly IComparer<Currency> _currencyComparer = new CurrencyComparer();
+        private Address? _address;
+
+        public LegacyDelegateeMetadata(
+            Address delegateeAddress,
+            Address delegateeAccountAddress,
+            Currency delegationCurrency,
+            IEnumerable<Currency> rewardCurrencies,
+            Address delegationPoolAddress,
+            Address rewardPoolAddress,
+            Address rewardRemainderPoolAddress,
+            Address slashedPoolAddress,
+            long unbondingPeriod,
+            int maxUnbondLockInEntries,
+            int maxRebondGraceEntries)
+            : this(
+                  delegateeAddress,
+                  delegateeAccountAddress,
+                  delegationCurrency,
+                  rewardCurrencies,
+                  delegationPoolAddress,
+                  rewardPoolAddress,
+                  rewardRemainderPoolAddress,
+                  slashedPoolAddress,
+                  unbondingPeriod,
+                  maxUnbondLockInEntries,
+                  maxRebondGraceEntries,
+                  ImmutableSortedSet<Address>.Empty,
+                  delegationCurrency * 0,
+                  BigInteger.Zero,
+                  false,
+                  -1L,
+                  false,
+                  ImmutableSortedSet<UnbondingRef>.Empty)
+        {
+        }
+
+        public LegacyDelegateeMetadata(
+            Address delegateeAddress,
+            Address delegateeAccountAddress,
+            IValue bencoded)
+            : this(delegateeAddress, delegateeAccountAddress, (List)bencoded)
+        {
+        }
+
+        public LegacyDelegateeMetadata(
+            Address address,
+            Address accountAddress,
+            List bencoded)
+            : this(
+                  address,
+                  accountAddress,
+                  new Currency(bencoded[0]),
+                  ((List)bencoded[1]).Select(v => new Currency(v)),
+                  new Address(bencoded[2]),
+                  new Address(bencoded[3]),
+                  new Address(bencoded[4]),
+                  new Address(bencoded[5]),
+                  (Integer)bencoded[6],
+                  (Integer)bencoded[7],
+                  (Integer)bencoded[8],
+                  ((List)bencoded[9]).Select(item => new Address(item)),
+                  new FungibleAssetValue(bencoded[10]),
+                  (Integer)bencoded[11],
+                  (Bencodex.Types.Boolean)bencoded[12],
+                  (Integer)bencoded[13],
+                  (Bencodex.Types.Boolean)bencoded[14],
+                  ((List)bencoded[15]).Select(item => new UnbondingRef(item)))
+        {
+        }
+
+        private LegacyDelegateeMetadata(
+            Address delegateeAddress,
+            Address delegateeAccountAddress,
+            Currency delegationCurrency,
+            IEnumerable<Currency> rewardCurrencies,
+            Address delegationPoolAddress,
+            Address rewardPoolAddress,
+            Address rewardRemainderPoolAddress,
+            Address slashedPoolAddress,
+            long unbondingPeriod,
+            int maxUnbondLockInEntries,
+            int maxRebondGraceEntries,
+            IEnumerable<Address> delegators,
+            FungibleAssetValue totalDelegated,
+            BigInteger totalShares,
+            bool jailed,
+            long jailedUntil,
+            bool tombstoned,
+            IEnumerable<UnbondingRef> unbondingRefs)
+        {
+            if (!totalDelegated.Currency.Equals(delegationCurrency))
+            {
+                throw new InvalidOperationException("Invalid currency.");
+            }
+
+            if (totalDelegated.Sign < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(totalDelegated),
+                    totalDelegated,
+                    "Total delegated must be non-negative.");
+            }
+
+            if (totalShares.Sign < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(totalShares),
+                    totalShares,
+                    "Total shares must be non-negative.");
+            }
+
+            DelegateeAddress = delegateeAddress;
+            DelegateeAccountAddress = delegateeAccountAddress;
+            DelegationCurrency = delegationCurrency;
+            RewardCurrencies = rewardCurrencies.ToImmutableSortedSet(_currencyComparer);
+            DelegationPoolAddress = delegationPoolAddress;
+            RewardPoolAddress = rewardPoolAddress;
+            RewardRemainderPoolAddress = rewardRemainderPoolAddress;
+            SlashedPoolAddress = slashedPoolAddress;
+            UnbondingPeriod = unbondingPeriod;
+            MaxUnbondLockInEntries = maxUnbondLockInEntries;
+            MaxRebondGraceEntries = maxRebondGraceEntries;
+            Delegators = delegators.ToImmutableSortedSet();
+            TotalDelegatedFAV = totalDelegated;
+            TotalShares = totalShares;
+            Jailed = jailed;
+            JailedUntil = jailedUntil;
+            Tombstoned = tombstoned;
+            UnbondingRefs = unbondingRefs.ToImmutableSortedSet();
+        }
+
+        public Address DelegateeAddress { get; }
+
+        public Address DelegateeAccountAddress { get; }
+
+        public Address Address
+            => _address ??= DelegationAddress.DelegateeMetadataAddress(
+                DelegateeAddress,
+                DelegateeAccountAddress);
+
+        public Currency DelegationCurrency { get; }
+
+        public ImmutableSortedSet<Currency> RewardCurrencies { get; }
+
+        public Address DelegationPoolAddress { get; internal set; }
+
+        public Address RewardPoolAddress { get; }
+
+        public Address RewardRemainderPoolAddress { get; }
+
+        public Address SlashedPoolAddress { get; }
+
+        public long UnbondingPeriod { get; private set; }
+
+        public int MaxUnbondLockInEntries { get; }
+
+        public int MaxRebondGraceEntries { get; }
+
+        public ImmutableSortedSet<Address> Delegators { get; private set; }
+
+        public FungibleAssetValue TotalDelegatedFAV { get; private set; }
+
+        public BigInteger TotalShares { get; private set; }
+
+        public bool Jailed { get; internal set; }
+
+        public long JailedUntil { get; internal set; }
+
+        public bool Tombstoned { get; internal set; }
+
+        public ImmutableSortedSet<UnbondingRef> UnbondingRefs { get; private set; }
+
+        // TODO : Better serialization
+        public List Bencoded => List.Empty
+            .Add(DelegationCurrency.Serialize())
+            .Add(new List(RewardCurrencies.Select(c => c.Serialize())))
+            .Add(DelegationPoolAddress.Bencoded)
+            .Add(RewardPoolAddress.Bencoded)
+            .Add(RewardRemainderPoolAddress.Bencoded)
+            .Add(SlashedPoolAddress.Bencoded)
+            .Add(UnbondingPeriod)
+            .Add(MaxUnbondLockInEntries)
+            .Add(MaxRebondGraceEntries)
+            .Add(new List(Delegators.Select(delegator => delegator.Bencoded)))
+            .Add(TotalDelegatedFAV.Serialize())
+            .Add(TotalShares)
+            .Add(Jailed)
+            .Add(JailedUntil)
+            .Add(Tombstoned)
+            .Add(new List(UnbondingRefs.Select(unbondingRef => unbondingRef.Bencoded)));
+
+        IValue IBencodable.Bencoded => Bencoded;
+
+        public BigInteger ShareFromFAV(FungibleAssetValue fav)
+            => TotalShares.IsZero
+                ? fav.RawValue
+                : TotalShares * fav.RawValue / TotalDelegatedFAV.RawValue;
+
+        public FungibleAssetValue FAVFromShare(BigInteger share)
+            => TotalShares == share
+                ? TotalDelegatedFAV
+                : (TotalDelegatedFAV * share).DivRem(TotalShares).Quotient;
+    }
+}

--- a/.Lib9c.Tests/Delegation/Migration/LegacyLumpSumRewardsRecord.cs
+++ b/.Lib9c.Tests/Delegation/Migration/LegacyLumpSumRewardsRecord.cs
@@ -1,0 +1,138 @@
+#nullable enable
+namespace Lib9c.Tests.Delegation.Migration
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Numerics;
+    using Bencodex;
+    using Bencodex.Types;
+    using Libplanet.Crypto;
+    using Libplanet.Types.Assets;
+    using Nekoyume.Delegation;
+
+    public class LegacyLumpSumRewardsRecord : IBencodable
+    {
+        private readonly IComparer<Currency> _currencyComparer = new CurrencyComparer();
+
+        public LegacyLumpSumRewardsRecord(
+            Address address,
+            long startHeight,
+            BigInteger totalShares,
+            ImmutableSortedSet<Address> delegators,
+            IEnumerable<Currency> currencies)
+            : this(
+                  address,
+                  startHeight,
+                  totalShares,
+                  delegators,
+                  currencies,
+                  null)
+        {
+        }
+
+        public LegacyLumpSumRewardsRecord(
+            Address address,
+            long startHeight,
+            BigInteger totalShares,
+            ImmutableSortedSet<Address> delegators,
+            IEnumerable<Currency> currencies,
+            long? lastStartHeight)
+            : this(
+                  address,
+                  startHeight,
+                  totalShares,
+                  delegators,
+                  currencies.Select(c => c * 0),
+                  lastStartHeight)
+        {
+        }
+
+        public LegacyLumpSumRewardsRecord(
+            Address address,
+            long startHeight,
+            BigInteger totalShares,
+            ImmutableSortedSet<Address> delegators,
+            IEnumerable<FungibleAssetValue> lumpSumRewards,
+            long? lastStartHeight)
+        {
+            Address = address;
+            StartHeight = startHeight;
+            TotalShares = totalShares;
+            Delegators = delegators;
+
+            if (!lumpSumRewards.Select(f => f.Currency).All(new HashSet<Currency>().Add))
+            {
+                throw new ArgumentException("Duplicated currency in lump sum rewards.");
+            }
+
+            LumpSumRewards = lumpSumRewards.ToImmutableDictionary(f => f.Currency, f => f);
+            LastStartHeight = lastStartHeight;
+        }
+
+        public LegacyLumpSumRewardsRecord(Address address, IValue bencoded)
+            : this(address, (List)bencoded)
+        {
+        }
+
+        public LegacyLumpSumRewardsRecord(Address address, List bencoded)
+            : this(
+                address,
+                (Integer)bencoded[0],
+                (Integer)bencoded[1],
+                ((List)bencoded[2]).Select(a => new Address(a)).ToImmutableSortedSet(),
+                ((List)bencoded[3]).Select(v => new FungibleAssetValue(v)),
+                (Integer?)bencoded.ElementAtOrDefault(4))
+        {
+        }
+
+        private LegacyLumpSumRewardsRecord(
+            Address address,
+            long startHeight,
+            BigInteger totalShares,
+            ImmutableSortedSet<Address> delegators,
+            ImmutableDictionary<Currency, FungibleAssetValue> lumpSumRewards,
+            long? lastStartHeight)
+        {
+            Address = address;
+            StartHeight = startHeight;
+            TotalShares = totalShares;
+            Delegators = delegators;
+            LumpSumRewards = lumpSumRewards;
+            LastStartHeight = lastStartHeight;
+        }
+
+        public Address Address { get; }
+
+        public long StartHeight { get; }
+
+        public BigInteger TotalShares { get; }
+
+        public ImmutableDictionary<Currency, FungibleAssetValue> LumpSumRewards { get; }
+
+        public ImmutableSortedSet<Address> Delegators { get; }
+
+        public long? LastStartHeight { get; }
+
+        public List Bencoded
+        {
+            get
+            {
+                var bencoded = List.Empty
+                    .Add(StartHeight)
+                    .Add(TotalShares)
+                    .Add(new List(Delegators.Select(a => a.Bencoded)))
+                    .Add(new List(LumpSumRewards
+                        .OrderBy(r => r.Key, _currencyComparer)
+                        .Select(r => r.Value.Serialize())));
+
+                return LastStartHeight is long lastStartHeight
+                    ? bencoded.Add(lastStartHeight)
+                    : bencoded;
+            }
+        }
+
+        IValue IBencodable.Bencoded => Bencoded;
+    }
+}

--- a/.Lib9c.Tests/Delegation/Migration/MigrateLegacyStateTest.cs
+++ b/.Lib9c.Tests/Delegation/Migration/MigrateLegacyStateTest.cs
@@ -1,0 +1,81 @@
+namespace Lib9c.Tests.Delegation.Migration
+{
+    using System.Collections.Immutable;
+    using System.Linq;
+    using Libplanet.Crypto;
+    using Libplanet.Types.Assets;
+    using Nekoyume.Delegation;
+    using Xunit;
+
+    public class MigrateLegacyStateTest
+    {
+        [Fact]
+        public void ParseLegacyDelegateeMetadata()
+        {
+            var address = new PrivateKey().Address;
+            var accountAddress = new PrivateKey().Address;
+            var delegationCurrency = Currency.Uncapped("del", 5, null);
+            var rewardCurrencies = new Currency[] { Currency.Uncapped("rew", 5, null), };
+            var delegationPoolAddress = new PrivateKey().Address;
+            var rewardPoolAddress = new PrivateKey().Address;
+            var rewardRemainderPoolAddress = new PrivateKey().Address;
+            var slashedPoolAddress = new PrivateKey().Address;
+            var unbondingPeriod = 1L;
+            var maxUnbondLockInEntries = 2;
+            var maxRebondGraceEntries = 3;
+
+            var legacyDelegateeMetadataBencoded = new LegacyDelegateeMetadata(
+                address,
+                accountAddress,
+                delegationCurrency,
+                rewardCurrencies,
+                delegationPoolAddress,
+                rewardPoolAddress,
+                rewardRemainderPoolAddress,
+                slashedPoolAddress,
+                unbondingPeriod,
+                maxUnbondLockInEntries,
+                maxRebondGraceEntries).Bencoded;
+
+            var delegateeMetadata = new DelegateeMetadata(address, accountAddress, legacyDelegateeMetadataBencoded);
+
+            Assert.Equal(address, delegateeMetadata.DelegateeAddress);
+            Assert.Equal(accountAddress, delegateeMetadata.DelegateeAccountAddress);
+            Assert.Equal(delegationCurrency, delegateeMetadata.DelegationCurrency);
+            Assert.Equal(rewardCurrencies, delegateeMetadata.RewardCurrencies);
+            Assert.Equal(delegationPoolAddress, delegateeMetadata.DelegationPoolAddress);
+            Assert.Equal(rewardPoolAddress, delegateeMetadata.RewardPoolAddress);
+            Assert.Equal(rewardRemainderPoolAddress, delegateeMetadata.RewardRemainderPoolAddress);
+            Assert.Equal(slashedPoolAddress, delegateeMetadata.SlashedPoolAddress);
+            Assert.Equal(unbondingPeriod, delegateeMetadata.UnbondingPeriod);
+            Assert.Equal(maxUnbondLockInEntries, delegateeMetadata.MaxUnbondLockInEntries);
+            Assert.Equal(maxRebondGraceEntries, delegateeMetadata.MaxRebondGraceEntries);
+        }
+
+        [Fact]
+        public void ParseLegacyLumpSumRewardsRecord()
+        {
+            var address = new PrivateKey().Address;
+            var startHeight = 1L;
+            var totalShares = 2;
+            var delegators = ImmutableSortedSet.Create<Address>(new PrivateKey().Address);
+            var currencies = new Currency[] { Currency.Uncapped("cur", 5, null), };
+            var lastStartHeight = 3L;
+
+            var legacyLumpSumRewardsRecordBencoded = new LegacyLumpSumRewardsRecord(
+                address,
+                startHeight,
+                totalShares,
+                delegators,
+                currencies,
+                lastStartHeight).Bencoded;
+
+            var lumpSumRewardsRecord = new LumpSumRewardsRecord(address, legacyLumpSumRewardsRecordBencoded);
+
+            Assert.Equal(address, lumpSumRewardsRecord.Address);
+            Assert.Equal(startHeight, lumpSumRewardsRecord.StartHeight);
+            Assert.Equal(totalShares, lumpSumRewardsRecord.TotalShares);
+            Assert.Equal(currencies, lumpSumRewardsRecord.LumpSumRewards.Select(c => c.Key));
+        }
+    }
+}

--- a/Lib9c.Abstractions/Lib9c.Abstractions.csproj
+++ b/Lib9c.Abstractions/Lib9c.Abstractions.csproj
@@ -8,7 +8,7 @@
     <IntermediateOutputPath>.obj</IntermediateOutputPath>
     <LangVersion>9</LangVersion>
     <CodeAnalysisRuleSet>..\Lib9c.Common.ruleset</CodeAnalysisRuleSet>
-    <VersionPrefix>1.20.0</VersionPrefix>
+    <VersionPrefix>1.20.1</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup Condition="!'$(UseLocalLibplanet)'">

--- a/Lib9c.MessagePack/Lib9c.MessagePack.csproj
+++ b/Lib9c.MessagePack/Lib9c.MessagePack.csproj
@@ -8,7 +8,7 @@
     <Platforms>AnyCPU</Platforms>
     <OutputPath>.bin</OutputPath>
     <IntermediateOutputPath>.obj</IntermediateOutputPath>
-    <VersionPrefix>1.20.0</VersionPrefix>
+    <VersionPrefix>1.20.1</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Lib9c.Renderers/Lib9c.Renderers.csproj
+++ b/Lib9c.Renderers/Lib9c.Renderers.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <OutputPath>.bin</OutputPath>
     <IntermediateOutputPath>.obj</IntermediateOutputPath>
-    <VersionPrefix>1.20.0</VersionPrefix>
+    <VersionPrefix>1.20.1</VersionPrefix>
     <RootNamespace>Lib9c</RootNamespace>
   </PropertyGroup>
 

--- a/Lib9c/Delegation/Delegatee.cs
+++ b/Lib9c/Delegation/Delegatee.cs
@@ -91,8 +91,6 @@ namespace Nekoyume.Delegation
 
         public int MaxRebondGraceEntries => Metadata.MaxRebondGraceEntries;
 
-        public ImmutableSortedSet<Address> Delegators => Metadata.Delegators;
-
         public FungibleAssetValue TotalDelegated => Metadata.TotalDelegatedFAV;
 
         public BigInteger TotalShares => Metadata.TotalShares;
@@ -192,7 +190,6 @@ namespace Nekoyume.Delegation
             Bond bond = Repository.GetBond(this, delegator.Address);
             BigInteger share = ShareFromFAV(fav);
             bond = bond.AddShare(share);
-            Metadata.AddDelegator(delegator.Address);
             Metadata.AddShare(share);
             Metadata.AddDelegatedFAV(fav);
             Repository.SetBond(bond);
@@ -221,7 +218,6 @@ namespace Nekoyume.Delegation
             if (bond.Share.IsZero)
             {
                 bond = bond.ClearLastDistributeHeight();
-                Metadata.RemoveDelegator(delegator.Address);
             }
 
             Metadata.RemoveShare(share);
@@ -249,15 +245,9 @@ namespace Nekoyume.Delegation
 
                 foreach (LumpSumRewardsRecord record in lumpSumRewardsRecords)
                 {
-                    if (!record.Delegators.Contains(delegator.Address))
-                    {
-                        continue;
-                    }
-
                     TransferReward(delegator, share, record);
-                    LumpSumRewardsRecord newRecord = record.RemoveDelegator(delegator.Address);
-                    TransferRemainders(newRecord);
-                    Repository.SetLumpSumRewardsRecord(newRecord);
+                    // TransferRemainders(newRecord);
+                    Repository.SetLumpSumRewardsRecord(record);
                 }
             }
 
@@ -280,7 +270,6 @@ namespace Nekoyume.Delegation
                     CurrentLumpSumRewardsRecordAddress(),
                     height,
                     TotalShares,
-                    Delegators,
                     RewardCurrencies);
             record = record.AddLumpSumRewards(rewards);
 
@@ -393,7 +382,6 @@ namespace Nekoyume.Delegation
                         currentRecord.Address,
                         currentRecord.StartHeight,
                         TotalShares,
-                        Delegators,
                         RewardCurrencies,
                         currentRecord.LastStartHeight);
 
@@ -420,7 +408,6 @@ namespace Nekoyume.Delegation
                 CurrentLumpSumRewardsRecordAddress(),
                 height,
                 TotalShares,
-                Delegators,
                 RewardCurrencies,
                 lastStartHeight);
 
@@ -467,11 +454,6 @@ namespace Nekoyume.Delegation
 
         private void TransferRemainders(LumpSumRewardsRecord record)
         {
-            if (!record.Delegators.IsEmpty)
-            {
-                return;
-            }
-
             foreach (var rewardCurrency in RewardCurrencies)
             {
                 FungibleAssetValue remainder = Repository.GetBalance(record.Address, rewardCurrency);

--- a/Lib9c/Delegation/Delegator.cs
+++ b/Lib9c/Delegation/Delegator.cs
@@ -109,7 +109,7 @@ namespace Nekoyume.Delegation
             unbondLockIn = unbondLockIn.LockIn(
                 fav, height, height + delegatee.UnbondingPeriod);
 
-            if (!delegatee.Delegators.Contains(Address))
+            if (Repository.GetBond(delegatee, Address).Share.IsZero)
             {
                 Metadata.RemoveDelegatee(delegatee.Address);
             }
@@ -157,7 +157,7 @@ namespace Nekoyume.Delegation
                 height,
                 height + srcDelegatee.UnbondingPeriod);
 
-            if (!srcDelegatee.Delegators.Contains(Address))
+            if (Repository.GetBond(srcDelegatee, Address).Share.IsZero)
             {
                 Metadata.RemoveDelegatee(srcDelegatee.Address);
             }

--- a/Lib9c/Delegation/IDelegatee.cs
+++ b/Lib9c/Delegation/IDelegatee.cs
@@ -29,8 +29,6 @@ namespace Nekoyume.Delegation
 
         Address RewardPoolAddress { get; }
 
-        ImmutableSortedSet<Address> Delegators { get; }
-
         FungibleAssetValue TotalDelegated { get; }
 
         BigInteger TotalShares { get; }

--- a/Lib9c/Delegation/IDelegateeMetadata.cs
+++ b/Lib9c/Delegation/IDelegateeMetadata.cs
@@ -1,6 +1,4 @@
 #nullable enable
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Numerics;
 using Bencodex;
@@ -32,8 +30,6 @@ namespace Nekoyume.Delegation
         int MaxRebondGraceEntries { get; }
 
         Address RewardPoolAddress { get; }
-
-        ImmutableSortedSet<Address> Delegators { get; }
 
         FungibleAssetValue TotalDelegatedFAV { get; }
 

--- a/Lib9c/Lib9c.csproj
+++ b/Lib9c/Lib9c.csproj
@@ -9,7 +9,7 @@
     <IntermediateOutputPath>.obj</IntermediateOutputPath>
     <RootNamespace>Nekoyume</RootNamespace>
     <LangVersion>9</LangVersion>
-    <VersionPrefix>1.20.0</VersionPrefix>
+    <VersionPrefix>1.20.1</VersionPrefix>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>


### PR DESCRIPTION
Hotfix for heavy `Delegators` property
- This PR removes `Delegators` property from `DelegateeMetadata` and `LumpSumRewardsRecord`.
- Above two properties were too heavy to en/decode, I/O.
- Removed those properties, abandoning feature for remainder gathering.