### PR TITLE
Add block actions to PluginActionEvaluator

### DIFF
--- a/.Lib9c.Plugin/PluginActionEvaluator.cs
+++ b/.Lib9c.Plugin/PluginActionEvaluator.cs
@@ -7,6 +7,7 @@ using Libplanet.Extensions.ActionEvaluatorCommonComponents;
 using Libplanet.Store;
 using Nekoyume.Action;
 using Nekoyume.Action.Loader;
+using Nekoyume.Action.ValidatorDelegation;
 
 namespace Lib9c.Plugin
 {
@@ -19,10 +20,23 @@ namespace Lib9c.Plugin
             var stateStore = new TrieStateStore(new WrappedKeyValueStore(keyValueStore));
             _actionEvaluator = new ActionEvaluator(
                 new PolicyActionsRegistry(
-                    beginBlockActions: ImmutableArray<IAction>.Empty,
-                    endBlockActions: new IAction[] { new RewardGold() }.ToImmutableArray(),
-                    beginTxActions: ImmutableArray<IAction>.Empty,
-                    endTxActions: ImmutableArray<IAction>.Empty),
+                    beginBlockActions: new IAction[] {
+                        new SlashValidator(),
+                        new AllocateGuildReward(),
+                        new AllocateReward(),
+                    }.ToImmutableArray(),
+                    endBlockActions: new IAction[] {
+                        new UpdateValidators(),
+                        new RecordProposer(),
+                        new RewardGold(),
+                        new ReleaseValidatorUnbondings(),
+                    }.ToImmutableArray(),
+                    beginTxActions: new IAction[] {
+                        new Mortgage(),
+                    }.ToImmutableArray(),
+                    endTxActions: new IAction[] {
+                        new Reward(), new Refund(),
+                    }.ToImmutableArray()),
                 stateStore,
                 new NCActionLoader());
         }

--- a/Lib9c.Policy/Policy/BlockPolicySource.cs
+++ b/Lib9c.Policy/Policy/BlockPolicySource.cs
@@ -143,6 +143,8 @@ namespace Nekoyume.Blockchain.Policy
                     maxTransactionsPerSignerPerBlockPolicy);
 
             // FIXME: Slight inconsistency due to pre-existing delegate.
+            // WARNING: If the block actions in the policyActionsRegistry have been modified,
+            // the constructor of the PluginActionEvaluator must be modified as well.
             return new BlockPolicy(
                 policyActionsRegistry: new PolicyActionsRegistry(
                     beginBlockActions: new IAction[] {


### PR DESCRIPTION
Identical to #3048
Since missed to backmerge it, and already higher versions are released, handle this as a separated PR.