### PR TITLE
Fix an issue where a validator cannot stake

### DIFF
--- a/.Lib9c.Tests/Action/ClaimStakeRewardTest.cs
+++ b/.Lib9c.Tests/Action/ClaimStakeRewardTest.cs
@@ -706,6 +706,35 @@ namespace Lib9c.Tests.Action
             }
         }
 
+        [Fact]
+        public void Execute_Throw_When_Validator_Tries_To_Claim()
+        {
+            // When
+            var world = _initialState;
+            var validatorKey = new PrivateKey().PublicKey;
+            var validatorAddress = validatorKey.Address;
+            var height = 0L;
+            world = DelegationUtil.EnsureValidatorPromotionReady(world, validatorKey, height);
+            var stakeAddr = StakeState.DeriveAddress(AgentAddr);
+            var stakeStateV2 = PrepareStakeStateV2(
+                _stakePolicySheet,
+                0,
+                LegacyStakeState.RewardInterval);
+            var action = new ClaimStakeReward(validatorAddress);
+            var actionContext = new ActionContext
+            {
+                PreviousState = world,
+                Signer = validatorAddress,
+                BlockIndex = height,
+            };
+
+            // When
+            var e = Assert.Throws<InvalidOperationException>(() => action.Execute(actionContext));
+
+            // Then
+            Assert.Equal("The validator cannot claim the stake reward.", e.Message);
+        }
+
         private static StakeState PrepareStakeStateV2(
             StakePolicySheet stakePolicySheet,
             long startedBlockIndex,

--- a/.Lib9c.Tests/Action/StakeTest.cs
+++ b/.Lib9c.Tests/Action/StakeTest.cs
@@ -28,6 +28,7 @@ namespace Lib9c.Tests.Action
     {
         private readonly IWorld _initialState;
         private readonly Currency _ncg;
+        private readonly PublicKey _agentPublicKey = new PrivateKey().PublicKey;
         private readonly Address _agentAddr;
         private readonly StakePolicySheet _stakePolicySheet;
 
@@ -66,7 +67,9 @@ namespace Lib9c.Tests.Action
                 _agentAddr,
                 _,
                 _initialState
-            ) = InitializeUtil.InitializeStates(sheetsOverride: sheetsOverride);
+            ) = InitializeUtil.InitializeStates(
+                sheetsOverride: sheetsOverride,
+                agentAddr: _agentPublicKey.Address);
             _ncg = _initialState.GetGoldCurrency();
             _stakePolicySheet = _initialState.GetSheet<StakePolicySheet>();
         }
@@ -447,6 +450,80 @@ namespace Lib9c.Tests.Action
 
             var nextState = Execute(
                 height + interval,
+                world,
+                new TestRandom(),
+                _agentAddr,
+                amount);
+
+            if (amount > 0)
+            {
+                Assert.True(nextState.TryGetStakeState(_agentAddr, out StakeState nextStakeState));
+                Assert.Equal(3, nextStakeState.StateVersion);
+            }
+
+            world = DelegationUtil.EnsureStakeReleased(
+                nextState, height + LegacyStakeState.LockupInterval);
+
+            var expectedBalance = _ncg * Math.Max(0, previousAmount - amount);
+            var actualBalance = world.GetBalance(_agentAddr, _ncg);
+            var nonValidatorDelegateeBalance = world.GetBalance(
+                Addresses.NonValidatorDelegatee, Currencies.GuildGold);
+            var stakeBalance = world.GetBalance(stakeStateAddr, Currencies.GuildGold);
+            Assert.Equal(expectedBalance, actualBalance);
+            Assert.Equal(Currencies.GuildGold * 0, nonValidatorDelegateeBalance);
+            Assert.Equal(Currencies.GuildGold * amount, stakeBalance);
+        }
+
+        [Theory]
+        // NOTE: non
+        [InlineData(50, 50)]
+        [InlineData(long.MaxValue, long.MaxValue)]
+        // NOTE: delegate
+        [InlineData(0, 500)]
+        [InlineData(50, 100)]
+        [InlineData(0, long.MaxValue)]
+        // NOTE: undelegate
+        [InlineData(50, 0)]
+        [InlineData(75, 50)]
+        [InlineData(long.MaxValue, 0)]
+        [InlineData(long.MaxValue, 500)]
+        public void Execute_Success_When_Exist_StakeStateV3_Validator_Without_Interval(
+            long previousAmount,
+            long amount)
+        {
+            var interval = previousAmount < amount
+                ? LegacyStakeState.RewardInterval : LegacyStakeState.LockupInterval;
+            var stakeStateAddr = StakeState.DeriveAddress(_agentAddr);
+            var stakeState = new StakeState(
+                contract: new Contract(_stakePolicySheet),
+                startedBlockIndex: 0L,
+                receivedBlockIndex: interval,
+                stateVersion: 3);
+            var world = _initialState;
+            var height = 0L;
+
+            world = DelegationUtil.EnsureValidatorPromotionReady(world, _agentPublicKey, height++);
+
+            if (previousAmount > 0)
+            {
+                var ncgToStake = _ncg * previousAmount;
+                var gg = FungibleAssetValue.Parse(Currencies.GuildGold, ncgToStake.GetQuantityString(true));
+                world = DelegationUtil.MintGuildGold(world, _agentAddr, gg, height);
+                world = world.MintAsset(new ActionContext(), _agentAddr, ncgToStake);
+                world = world.TransferAsset(
+                    new ActionContext(), _agentAddr, stakeStateAddr, ncgToStake);
+            }
+
+            world = world.SetLegacyState(stakeStateAddr, stakeState.Serialize());
+
+            if (amount - previousAmount > 0)
+            {
+                var ncgToStake = _ncg * (amount - previousAmount);
+                world = world.MintAsset(new ActionContext(), _agentAddr, ncgToStake);
+            }
+
+            var nextState = Execute(
+                height + 1,
                 world,
                 new TestRandom(),
                 _agentAddr,

--- a/.Lib9c.Tests/Action/StakeTest.cs
+++ b/.Lib9c.Tests/Action/StakeTest.cs
@@ -475,24 +475,24 @@ namespace Lib9c.Tests.Action
         }
 
         [Theory]
-        // NOTE: non
-        [InlineData(50, 50)]
-        [InlineData(long.MaxValue, long.MaxValue)]
-        // NOTE: delegate
-        [InlineData(0, 500)]
-        [InlineData(50, 100)]
-        [InlineData(0, long.MaxValue)]
-        // NOTE: undelegate
-        [InlineData(50, 0)]
-        [InlineData(75, 50)]
-        [InlineData(long.MaxValue, 0)]
-        [InlineData(long.MaxValue, 500)]
-        public void Execute_Success_When_Exist_StakeStateV3_Validator_Without_Interval(
+        [InlineData(0, 500, false)]
+        [InlineData(50, 100, false)]
+        [InlineData(0, long.MaxValue, false)]
+        [InlineData(0, 500, true)]
+        [InlineData(50, 100, true)]
+        [InlineData(0, long.MaxValue, true)]
+        public void Execute_Success_When_Validator_Tries_To_Increase_Amount_Without_Claim(
             long previousAmount,
-            long amount)
+            long amount,
+            bool withoutInterval)
         {
-            var interval = previousAmount < amount
-                ? LegacyStakeState.RewardInterval : LegacyStakeState.LockupInterval;
+            if (previousAmount >= amount)
+            {
+                throw new ArgumentException(
+                    "previousAmount should be less than amount.", nameof(previousAmount));
+            }
+
+            var interval = LegacyStakeState.RewardInterval;
             var stakeStateAddr = StakeState.DeriveAddress(_agentAddr);
             var stakeState = new StakeState(
                 contract: new Contract(_stakePolicySheet),
@@ -523,7 +523,7 @@ namespace Lib9c.Tests.Action
             }
 
             var nextState = Execute(
-                height + 1,
+                height + (withoutInterval ? 1 : interval),
                 world,
                 new TestRandom(),
                 _agentAddr,

--- a/Lib9c/Action/ClaimStakeReward.cs
+++ b/Lib9c/Action/ClaimStakeReward.cs
@@ -16,7 +16,9 @@ using Nekoyume.Model.Item;
 using Nekoyume.Model.Stake;
 using Nekoyume.Model.State;
 using Nekoyume.Module;
+using Nekoyume.Module.ValidatorDelegation;
 using Nekoyume.TableData;
+using Nekoyume.ValidatorDelegation;
 using static Lib9c.SerializeKeys;
 
 namespace Nekoyume.Action
@@ -58,6 +60,16 @@ namespace Nekoyume.Action
             var states = context.PreviousState;
             var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
             var stakeStateAddr = LegacyStakeState.DeriveAddress(context.Signer);
+
+            var validatorRepository = new ValidatorRepository(states, context);
+            var isValidator = validatorRepository.TryGetValidatorDelegatee(
+                context.Signer, out var _);
+            if (isValidator)
+            {
+                throw new InvalidOperationException(
+                    "The validator cannot claim the stake reward.");
+            }
+
             if (!states.TryGetStakeState(context.Signer, out var stakeStateV2))
             {
                 throw new FailedLoadStateException(

--- a/Lib9c/Action/Stake.cs
+++ b/Lib9c/Action/Stake.cs
@@ -16,6 +16,7 @@ using Nekoyume.Model.Stake;
 using Nekoyume.Model.State;
 using Nekoyume.Module;
 using Nekoyume.Module.Guild;
+using Nekoyume.Module.ValidatorDelegation;
 using Nekoyume.TableData;
 using Nekoyume.TableData.Stake;
 using Nekoyume.TypedAddress;
@@ -142,7 +143,13 @@ namespace Nekoyume.Action
             // NOTE: Cannot anything if staking state is claimable.
             if (stakeStateV2.ClaimableBlockIndex <= context.BlockIndex)
             {
-                throw new StakeExistingClaimableException();
+                var validatorRepository = new ValidatorRepository(states, context);
+                var isValidator = validatorRepository.TryGetValidatorDelegatee(
+                    context.Signer, out var validatorDelegatee);
+                if (!isValidator)
+                {
+                    throw new StakeExistingClaimableException();
+                }
             }
 
             // NOTE: When the staking state is locked up.


### PR DESCRIPTION
### Fixes

* A validator can execute the `Stake` action without claiming rewards. Actions that decrease the amount still need to go through the lockup period.
* A validator cannot execute the `ClaimStakeReward` action. If a validator tries to execute this action, it throws an `InvalidOperationException`.