### PR TITLE
Soft migration via Stake action for skipped agents

### DIFF
--- a/.Lib9c.Tests/Action/Guild/ClaimUnbonded_ValidatorTest.cs
+++ b/.Lib9c.Tests/Action/Guild/ClaimUnbonded_ValidatorTest.cs
@@ -85,6 +85,7 @@ public class ClaimUnbonded_ValidatorTest : GuildTestBase
     [InlineData(793705868)]
     [InlineData(559431555)]
     [InlineData(1133637517)]
+    [InlineData(52169708)]
     public void Execute_Fact_WithStaticSeed(int randomSeed)
     {
         var fixture = new RandomFixture(randomSeed);
@@ -162,12 +163,12 @@ public class ClaimUnbonded_ValidatorTest : GuildTestBase
 
         // Check ncg after unstaking
         var amountGG = validatorSlashedGG - expectedStakedGG;
-        const long minimumStakeAmount = 50;
-        if (amountGG.MajorUnit >= minimumStakeAmount)
+        var minimumStakeAmount = NCG * 50;
+        var ncg = GGToNCG(amountGG);
+        var majorUnit = ncg.MinorUnit > 0 ? ncg.MajorUnit + 1 : ncg.MajorUnit;
+        var amount = new FungibleAssetValue(NCG, majorUnit, 0);
+        if (amount >= minimumStakeAmount && amount <= validatorSlashedNCG)
         {
-            var ncg = GGToNCG(amountGG);
-            var majorUnit = ncg.MinorUnit > 0 ? ncg.MajorUnit + 1 : ncg.MajorUnit;
-            var amount = new FungibleAssetValue(NCG, majorUnit, 0);
             var expectedNCG1 = NCG * 0;
             var expectedNCG2 = validatorSlashedNCG - amount;
             var actualNCG1 = world.GetBalance(validatorKey.Address, NCG);

--- a/.Lib9c.Tests/Action/StakeTest.cs
+++ b/.Lib9c.Tests/Action/StakeTest.cs
@@ -592,6 +592,100 @@ namespace Lib9c.Tests.Action
             Assert.Equal(_ncg * 90, actualNCG);
         }
 
+        [Fact]
+        public void Execute_Success_Exceptional_Unmigrated()
+        {
+            var world = _initialState;
+            var height = 0L;
+            var promoteAmount = 50;
+            var validatorKey = new PrivateKey();
+            var validatorAddress = validatorKey.PublicKey.Address;
+            var guildMasterKey = new PrivateKey();
+            var guildMasterAddress = new GuildAddress(guildMasterKey.Address);
+            world = DelegationUtil.EnsureValidatorPromotionReady(
+                world, validatorKey.PublicKey, promoteAmount, height++);
+            world = DelegationUtil.MakeGuild(
+                world, guildMasterAddress, validatorAddress, height++, out var guildAddress);
+            world = DelegationUtil.JoinGuild(world, _agentAddr, guildAddress, height++);
+            world = DelegationUtil.MintNCG(world, _agentAddr, 100, height++);
+            var stakeStateAddr = LegacyStakeState.DeriveAddress(_agentAddr);
+            var stakeState = new LegacyStakeState(
+                address: stakeStateAddr,
+                startedBlockIndex: height++);
+            world = world.TransferAsset(
+                new ActionContext { },
+                _agentAddr,
+                stakeStateAddr,
+                world.GetGoldCurrency() * 100);
+            world = world.SetLegacyState(stakeStateAddr, stakeState.Serialize());
+
+            Assert.True(world.TryGetStakeState(_agentAddr, out var stakeStateV2));
+            Assert.Equal(2, stakeStateV2.StateVersion);
+            Assert.Equal(Currencies.GuildGold * 0, world.GetBalance(stakeStateAddr, Currencies.GuildGold));
+            var repo = new GuildRepository(world, new ActionContext { });
+            var share = repo.GetBond(repo.GetDelegatee(validatorAddress), _agentAddr).Share;
+            Assert.Equal((Currencies.GuildGold * 0).RawValue, share);
+
+            if (!StakeStateUtils.TryMigrateV2ToV3(
+                new ActionContext { },
+                world,
+                stakeStateAddr,
+                stakeStateV2,
+                out var result))
+            {
+                throw new InvalidOperationException("Failed to migration. Unexpected situation.");
+            }
+
+            world = result.Value.world;
+            Assert.True(world.TryGetStakeState(_agentAddr, out var stakeStateV3));
+            Assert.Equal(3, stakeStateV3.StateVersion);
+            Assert.Equal(Currencies.GuildGold * 100, world.GetBalance(stakeStateAddr, Currencies.GuildGold));
+            repo.UpdateWorld(world);
+            share = repo.GetBond(repo.GetDelegatee(validatorAddress), _agentAddr).Share;
+            Assert.Equal((Currencies.GuildGold * 0).RawValue, share);
+
+            world = DelegationUtil.Stake(world, _agentAddr, _avatarAddr, 100, height++);
+            Assert.Equal(Currencies.GuildGold * 0, world.GetBalance(stakeStateAddr, Currencies.GuildGold));
+            repo.UpdateWorld(world);
+            share = repo.GetBond(repo.GetDelegatee(validatorAddress), _agentAddr).Share;
+            Assert.Equal((Currencies.GuildGold * 100).RawValue, share);
+        }
+
+        [Fact]
+        public void Execute_Success_Unmigrated()
+        {
+            var world = _initialState;
+            var height = 0L;
+            var promoteAmount = 50;
+            var validatorKey = new PrivateKey();
+            var validatorAddress = validatorKey.PublicKey.Address;
+            var guildMasterKey = new PrivateKey();
+            var guildMasterAddress = new GuildAddress(guildMasterKey.Address);
+            world = DelegationUtil.EnsureValidatorPromotionReady(
+                world, validatorKey.PublicKey, promoteAmount, height++);
+            world = DelegationUtil.MakeGuild(
+                world, guildMasterAddress, validatorAddress, height++, out var guildAddress);
+            world = DelegationUtil.JoinGuild(world, _agentAddr, guildAddress, height++);
+            world = DelegationUtil.MintNCG(world, _agentAddr, 100, height++);
+            var stakeStateAddr = LegacyStakeState.DeriveAddress(_agentAddr);
+            var stakeState = new LegacyStakeState(
+                address: stakeStateAddr,
+                startedBlockIndex: height++);
+            world = world.TransferAsset(
+                new ActionContext { },
+                _agentAddr,
+                stakeStateAddr,
+                world.GetGoldCurrency() * 100);
+            world = world.SetLegacyState(stakeStateAddr, stakeState.Serialize());
+            var repo = new GuildRepository(world, new ActionContext { });
+            var share = repo.GetBond(repo.GetDelegatee(validatorAddress), _agentAddr).Share;
+            Assert.Equal((Currencies.GuildGold * 0).RawValue, share);
+            world = DelegationUtil.Stake(world, _agentAddr, _avatarAddr, 100, height++);
+            repo.UpdateWorld(world);
+            share = repo.GetBond(repo.GetDelegatee(validatorAddress), _agentAddr).Share;
+            Assert.Equal((Currencies.GuildGold * 100).RawValue, share);
+        }
+
         private IWorld Execute(
             long blockIndex,
             IWorld previousState,

--- a/.Lib9c.Tests/Delegation/DelegateeTest.cs
+++ b/.Lib9c.Tests/Delegation/DelegateeTest.cs
@@ -2,17 +2,14 @@ namespace Lib9c.Tests.Delegation
 {
     using System;
     using System.Numerics;
-    using Bencodex;
     using Libplanet.Crypto;
     using Libplanet.Types.Assets;
-    using Nekoyume;
     using Nekoyume.Delegation;
     using Xunit;
 
     public class DelegateeTest
     {
         private readonly DelegationFixture _fixture;
-        private readonly Codec _codec = new Codec();
 
         public DelegateeTest()
         {


### PR DESCRIPTION
Stake 액션을 통해서 마이그레이션에서 누락된 에이전트들에 위임을 진행합니다.
아래의 두 케이스를 커버합니다.

1. Pledge가 없어 기존 마이그레이션이 실패한 경우
  - LegacyStakeState로 스테이킹 상태를 가지고 있음
  - GuildGold도 존재하지 않고, 위임도 존재하지 않음

2. 기존 마이그레이션 이후, Stake액션을 통해 StakeStateV3으로 이행하여 GuildGold를 획득하였지만, 위임은 누락된 경우
  - StakeStateV3으로 스테이킹 상태를 가지고 있음
  - GuildGold는 존재하나, 위임이 존재하지 않음

추가: Validator 대상으로 하는 ClaimUnbonded 테스트 코드 검증방법에 오류가 있어 테스트 코드 수정 커밋을 추가하였습니다.