### PR TITLE
Fix version prefix

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
     <PropertyGroup>
         <LibplanetVersion>5.5.0</LibplanetVersion>
+        <Lib9cVersion>1.23.0</Lib9cVersion>
 
         <!-- Fill with Libplanet's absolute path to debug with local Libplanet.
              Example: $(MSBuildThisFileDirectory).Libplanet -->

--- a/Lib9c.Abstractions/Lib9c.Abstractions.csproj
+++ b/Lib9c.Abstractions/Lib9c.Abstractions.csproj
@@ -8,7 +8,7 @@
     <IntermediateOutputPath>.obj</IntermediateOutputPath>
     <LangVersion>9</LangVersion>
     <CodeAnalysisRuleSet>..\Lib9c.Common.ruleset</CodeAnalysisRuleSet>
-    <VersionPrefix>1.20.1</VersionPrefix>
+    <VersionPrefix>$(Lib9cVersion)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup Condition="!'$(UseLocalLibplanet)'">

--- a/Lib9c.MessagePack/Lib9c.MessagePack.csproj
+++ b/Lib9c.MessagePack/Lib9c.MessagePack.csproj
@@ -8,7 +8,7 @@
     <Platforms>AnyCPU</Platforms>
     <OutputPath>.bin</OutputPath>
     <IntermediateOutputPath>.obj</IntermediateOutputPath>
-    <VersionPrefix>1.20.1</VersionPrefix>
+    <VersionPrefix>$(Lib9cVersion)</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Lib9c.Renderers/Lib9c.Renderers.csproj
+++ b/Lib9c.Renderers/Lib9c.Renderers.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <OutputPath>.bin</OutputPath>
     <IntermediateOutputPath>.obj</IntermediateOutputPath>
-    <VersionPrefix>1.20.1</VersionPrefix>
+    <VersionPrefix>$(Lib9cVersion)</VersionPrefix>
     <RootNamespace>Lib9c</RootNamespace>
   </PropertyGroup>
 

--- a/Lib9c/Lib9c.csproj
+++ b/Lib9c/Lib9c.csproj
@@ -9,7 +9,7 @@
     <IntermediateOutputPath>.obj</IntermediateOutputPath>
     <RootNamespace>Nekoyume</RootNamespace>
     <LangVersion>9</LangVersion>
-    <VersionPrefix>1.21.0</VersionPrefix>
+    <VersionPrefix>$(Lib9cVersion)</VersionPrefix>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>


### PR DESCRIPTION
- resolve #3149 

```yang@yangcheon-ung-ui-MacBookPro lib9c % dotnet pack
MSBuild version 17.3.2+561848881 for .NET
  복원할 프로젝트를 확인하는 중...
  복원할 모든 프로젝트가 최신 상태입니다.
  Libplanet.Crypto.Secp256k1 -> /Users/yang/projects/lib9c/Libplanet.Crypto.Secp256k1/.bin/net6.0/Libplanet.Crypto.Secp256k1.dll
  Lib9c.Abstractions -> /Users/yang/projects/lib9c/Lib9c.Abstractions/.bin/net6.0/Lib9c.Abstractions.dll
  Lib9c.ActionEvaluatorCommonComponents -> /Users/yang/projects/lib9c/.Lib9c.ActionEvaluatorCommonComponents/.bin/net6.0/Lib9c.ActionEvaluatorCommonComponents.dll
  Lib9c.Plugin.Shared -> /Users/yang/projects/lib9c/.Lib9c.Plugin.Shared/.bin/net6.0/Lib9c.Plugin.Shared.dll
  '/Users/yang/projects/lib9c/Lib9c.Abstractions/.bin/Lib9c.Abstractions.1.23.0.nupkg' 패키지를 만들었습니다.
  '/Users/yang/projects/lib9c/.Lib9c.ActionEvaluatorCommonComponents/.bin/Lib9c.ActionEvaluatorCommonComponents.1.0.0.nupkg' 패키지를 만들었습니다.
/usr/local/share/dotnet/sdk/6.0.418/Sdks/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets(221,5): warning NU5104: 안정판 패키지에는 시험판 종속성이 없어야 합니다. 종속성 "Secp256k1.Native [0.1.24-alpha, )"의 버전 사양을 수정하거나 nuspec의 버전 필드를 업데이트하세요. [/Users/yang/projects/lib9c/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj]
/usr/local/share/dotnet/sdk/6.0.418/Sdks/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets(221,5): warning NU5104: 안정판 패키지에는 시험판 종속성이 없어야 합니다. 종속성 "Secp256k1.Net [1.0.0-alpha, )"의 버전 사양을 수정하거나 nuspec의 버전 필드를 업데이트하세요. [/Users/yang/projects/lib9c/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj]
  '/Users/yang/projects/lib9c/Libplanet.Crypto.Secp256k1/.bin/Libplanet.Crypto.Secp256k1.1.0.0.nupkg' 패키지를 만들었습니다.
  Lib9c -> /Users/yang/projects/lib9c/Lib9c/.bin/net6.0/Lib9c.dll
  '/Users/yang/projects/lib9c/.Lib9c.Plugin.Shared/.bin/Lib9c.Plugin.Shared.1.0.0.nupkg' 패키지를 만들었습니다.
  Lib9c.Proposer -> /Users/yang/projects/lib9c/Lib9c.Proposer/.bin/net6.0/Lib9c.Proposer.dll
  Lib9c.Renderers -> /Users/yang/projects/lib9c/Lib9c.Renderers/.bin/net6.0/Lib9c.Renderers.dll
  Lib9c.Plugin -> /Users/yang/projects/lib9c/.Lib9c.Plugin/bin/Debug/net6.0/Lib9c.Plugin.dll
  '/Users/yang/projects/lib9c/Lib9c/.bin/Lib9c.1.23.0.nupkg' 패키지를 만들었습니다.
  '/Users/yang/projects/lib9c/Lib9c.Proposer/.bin/Lib9c.Proposer.1.0.0.nupkg' 패키지를 만들었습니다.
  '/Users/yang/projects/lib9c/Lib9c.Renderers/.bin/Lib9c.Renderers.1.23.0.nupkg' 패키지를 만들었습니다.
  Lib9c.MessagePack -> /Users/yang/projects/lib9c/Lib9c.MessagePack/.bin/net6.0/Lib9c.MessagePack.dll
  Lib9c.Policy -> /Users/yang/projects/lib9c/Lib9c.Policy/.bin/net6.0/Lib9c.Policy.dll
/usr/local/share/dotnet/sdk/6.0.418/Sdks/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets(221,5): warning NU5104: 안정판 패키지에는 시험판 종속성이 없어야 합니다. 종속성 "Serilog [4.1.0-dev-02238, )"의 버전 사양을 수정하거나 nuspec의 버전 필드를 업데이트하세요. [/Users/yang/projects/lib9c/.Lib9c.Plugin/Lib9c.Plugin.csproj]
  '/Users/yang/projects/lib9c/.Lib9c.Plugin/bin/Debug/Lib9c.Plugin.1.0.0.nupkg' 패키지를 만들었습니다.
  '/Users/yang/projects/lib9c/Lib9c.MessagePack/.bin/Lib9c.MessagePack.1.23.0.nupkg' 패키지를 만들었습니다.
  '/Users/yang/projects/lib9c/Lib9c.Policy/.bin/Lib9c.Policy.1.0.0.nupkg' 패키지를 만들었습니다.
  Lib9c.DevExtensions -> /Users/yang/projects/lib9c/Lib9c.DevExtensions/.bin/net6.0/Lib9c.DevExtensions.dll
  Lib9c.Utils -> /Users/yang/projects/lib9c/Lib9c.Utils/.bin/net6.0/Lib9c.Utils.dll
  '/Users/yang/projects/lib9c/Lib9c.DevExtensions/.bin/Lib9c.DevExtensions.1.0.0.nupkg' 패키지를 만들었습니다.
  '/Users/yang/projects/lib9c/Lib9c.Utils/.bin/Lib9c.Utils.1.0.0.nupkg' 패키지를 만들었습니다.
  Lib9c.Tools -> /Users/yang/projects/lib9c/.Lib9c.Tools/bin/Debug/net6.0/9c-tools.dll
  Lib9c.Tests -> /Users/yang/projects/lib9c/.Lib9c.Tests/bin/Debug/net6.0/Lib9c.Tests.dll
  Lib9c.Benchmarks -> /Users/yang/projects/lib9c/.Lib9c.Benchmarks/bin/Debug/net6.0/Lib9c.Benchmarks.dll
/usr/local/share/dotnet/sdk/6.0.418/Sdks/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets(221,5): warning NU5104: 안정판 패키지에는 시험판 종속성이 없어야 합니다. 종속성 "Planetarium.RocksDbSharp [6.2.6-planetarium, )"의 버전 사양을 수정하거나 nuspec의 버전 필드를 업데이트하세요. [/Users/yang/projects/lib9c/.Lib9c.Tools/Lib9c.Tools.csproj]
  '/Users/yang/projects/lib9c/.Lib9c.Tools/bin/Debug/9c-tools.1.0.0.nupkg' 패키지를 만들었습니다.
  '/Users/yang/projects/lib9c/.Lib9c.Benchmarks/bin/Debug/Lib9c.Benchmarks.1.0.0.nupkg' 패키지를 만들었습니다.```