### PR TITLE
Revive migration action for delegation

### DIFF
--- a/.Lib9c.Tests/Action/Guild/Migration/MigrateStakeAndJoinGuildTest.cs
+++ b/.Lib9c.Tests/Action/Guild/Migration/MigrateStakeAndJoinGuildTest.cs
@@ -1,0 +1,94 @@
+namespace Lib9c.Tests.Action.Guild.Migration
+{
+    using System;
+    using System.Linq;
+    using System.Numerics;
+    using Bencodex.Types;
+    using Lib9c.Tests.Util;
+    using Libplanet.Action.State;
+    using Libplanet.Crypto;
+    using Nekoyume;
+    using Nekoyume.Action;
+    using Nekoyume.Action.Guild;
+    using Nekoyume.Action.Guild.Migration;
+    using Nekoyume.Action.Guild.Migration.LegacyModels;
+    using Nekoyume.Extensions;
+    using Nekoyume.Model.Guild;
+    using Nekoyume.Model.State;
+    using Nekoyume.Module;
+    using Nekoyume.Module.Guild;
+    using Nekoyume.TypedAddress;
+    using Xunit;
+
+    public class MigrateStakeAndJoinGuildTest : GuildTestBase
+    {
+        [Fact]
+        public void Execute()
+        {
+            var guildAddress = AddressUtil.CreateGuildAddress();
+            var validatorKey = new PrivateKey();
+            var adminAddress = new PrivateKey().Address;
+            var height = 100L;
+            var world = World.SetLegacyState(Addresses.Admin, new AdminState(adminAddress, 100L).Serialize());
+            world = EnsureToInitializeValidator(world, validatorKey, NCG * 100, height++);
+            world = EnsureToMakeGuild(world, guildAddress, GuildConfig.PlanetariumGuildOwner, validatorKey, height++);
+            var guildMemberCount = 10;
+            var migratedGuildMemberCount = 5;
+            var guildMemberAddresses = Enumerable.Range(0, guildMemberCount).Select(
+                _ => AddressUtil.CreateAgentAddress()).ToList();
+            for (var i = 0; i < guildMemberCount; i++)
+            {
+                world = EnsureJoinLegacyPlanetariumGuild(world, guildMemberAddresses[i]);
+            }
+
+            for (var i = 0; i < migratedGuildMemberCount; i++)
+            {
+                var action = new MigrateStakeAndJoinGuild(guildMemberAddresses[i]);
+                var actionContext = new ActionContext
+                {
+                    PreviousState = world,
+                    Signer = adminAddress,
+                    BlockIndex = height++,
+                };
+
+                world = action.Execute(actionContext);
+            }
+
+            var repo = new GuildRepository(world, new ActionContext());
+            var guild = repo.GetGuild(guildAddress);
+
+            for (var i = 0; i < migratedGuildMemberCount; i++)
+            {
+                repo.GetGuildParticipant(guildMemberAddresses[i]);
+            }
+
+            for (var i = migratedGuildMemberCount; i < guildMemberCount; i++)
+            {
+                Assert.Throws<FailedLoadStateException>(() => repo.GetGuildParticipant(guildMemberAddresses[i]));
+            }
+        }
+
+        private static IWorld EnsureJoinLegacyPlanetariumGuild(IWorld world, AgentAddress guildParticipantAddress)
+        {
+            var planetariumGuildAddress = new GuildRepository(world, new ActionContext { })
+                .GetJoinedGuild(GuildConfig.PlanetariumGuildOwner);
+            var legacyParticipant = new LegacyGuildParticipant(planetariumGuildAddress.Value);
+
+            return world
+                .MutateAccount(Addresses.GuildParticipant, account => account.SetState(guildParticipantAddress, legacyParticipant.Bencoded))
+                .MutateAccount(
+                    Addresses.GuildMemberCounter,
+                    account =>
+                    {
+                        BigInteger count = account.GetState(planetariumGuildAddress.Value) switch
+                        {
+                            Integer i => i.Value,
+                            null => 0,
+                            _ => throw new InvalidCastException(),
+                        };
+
+                        return account.SetState(planetariumGuildAddress.Value, (Integer)(count + 1));
+                    });
+        }
+    }
+}

--- a/Lib9c/Action/Guild/Migration/LegacyModels/LegacyGuildParticipant.cs
+++ b/Lib9c/Action/Guild/Migration/LegacyModels/LegacyGuildParticipant.cs
@@ -11,16 +11,44 @@ namespace Nekoyume.Action.Guild.Migration.LegacyModels
     /// </summary>
     public class LegacyGuildParticipant : IBencodable, IEquatable<LegacyGuildParticipant>
     {
+        /// <summary>
+        /// The type name of the state.
+        /// </summary>
         private const string StateTypeName = "guild_participant";
+
+        /// <summary>
+        /// The version of the state.
+        /// </summary>
         private const long StateVersion = 1;
 
+        /// <summary>
+        /// The guild address.
+        /// </summary>
         public readonly GuildAddress GuildAddress;
 
+        /// <summary>
+        /// Constructor of LegacyGuildParticipant.
+        /// </summary>
+        /// <param name="guildAddress">
+        /// The guild address.
+        /// </param>
         public LegacyGuildParticipant(GuildAddress guildAddress)
         {
             GuildAddress = guildAddress;
         }
 
+        /// <summary>
+        /// Constructor of LegacyGuildParticipant.
+        /// </summary>
+        /// <param name="list">
+        /// The serialized data.
+        /// </param>
+        /// <exception cref="InvalidCastException">
+        /// Throws when the deserialization failed.
+        /// </exception>
+        /// <exception cref="FailedLoadStateException">
+        /// Throws when the state is un-deserializable.
+        /// </exception>
         public LegacyGuildParticipant(List list) : this(new GuildAddress(list[2]))
         {
             if (list[0] is not Text text || text != StateTypeName || list[1] is not Integer integer)
@@ -34,13 +62,18 @@ namespace Nekoyume.Action.Guild.Migration.LegacyModels
             }
         }
 
+        /// <summary>
+        /// Serialize the state.
+        /// </summary>
         public List Bencoded => List.Empty
             .Add(StateTypeName)
             .Add(StateVersion)
             .Add(GuildAddress.Bencoded);
 
+        /// <inheritdoc/>
         IValue IBencodable.Bencoded => Bencoded;
 
+        /// <inheritdoc/>
         public bool Equals(LegacyGuildParticipant other)
         {
             if (ReferenceEquals(null, other)) return false;
@@ -48,6 +81,7 @@ namespace Nekoyume.Action.Guild.Migration.LegacyModels
             return GuildAddress.Equals(other.GuildAddress);
         }
 
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj)) return false;
@@ -56,6 +90,7 @@ namespace Nekoyume.Action.Guild.Migration.LegacyModels
             return Equals((LegacyGuildParticipant)obj);
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return GuildAddress.GetHashCode();

--- a/Lib9c/Action/Guild/Migration/LegacyModels/LegacyGuildParticipant.cs
+++ b/Lib9c/Action/Guild/Migration/LegacyModels/LegacyGuildParticipant.cs
@@ -1,0 +1,64 @@
+using System;
+using Bencodex;
+using Bencodex.Types;
+using Nekoyume.TypedAddress;
+
+namespace Nekoyume.Action.Guild.Migration.LegacyModels
+{
+    // TODO: [GuildMigration] Remove this class when the migration is done.
+    /// <summary>
+    /// The legacy model for GuildParticipant.
+    /// </summary>
+    public class LegacyGuildParticipant : IBencodable, IEquatable<LegacyGuildParticipant>
+    {
+        private const string StateTypeName = "guild_participant";
+        private const long StateVersion = 1;
+
+        public readonly GuildAddress GuildAddress;
+
+        public LegacyGuildParticipant(GuildAddress guildAddress)
+        {
+            GuildAddress = guildAddress;
+        }
+
+        public LegacyGuildParticipant(List list) : this(new GuildAddress(list[2]))
+        {
+            if (list[0] is not Text text || text != StateTypeName || list[1] is not Integer integer)
+            {
+                throw new InvalidCastException();
+            }
+
+            if (integer > StateVersion)
+            {
+                throw new FailedLoadStateException("Un-deserializable state.");
+            }
+        }
+
+        public List Bencoded => List.Empty
+            .Add(StateTypeName)
+            .Add(StateVersion)
+            .Add(GuildAddress.Bencoded);
+
+        IValue IBencodable.Bencoded => Bencoded;
+
+        public bool Equals(LegacyGuildParticipant other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return GuildAddress.Equals(other.GuildAddress);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((LegacyGuildParticipant)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return GuildAddress.GetHashCode();
+        }
+    }
+}

--- a/Lib9c/Action/Guild/Migration/MigrateStakeAndJoinGuild.cs
+++ b/Lib9c/Action/Guild/Migration/MigrateStakeAndJoinGuild.cs
@@ -1,0 +1,160 @@
+using System;
+using Bencodex.Types;
+using Lib9c;
+using Libplanet.Action.State;
+using Libplanet.Action;
+using Nekoyume.Model.Guild;
+using Nekoyume.TypedAddress;
+using Nekoyume.Action.Guild.Migration.LegacyModels;
+using Nekoyume.Module.Guild;
+using Nekoyume.Model.Stake;
+using Nekoyume.Model.State;
+using Nekoyume.Module;
+using Libplanet.Crypto;
+
+namespace Nekoyume.Action.Guild.Migration
+{
+    /// <summary>
+    /// An action to migrate guild delegation and join guild.
+    /// After migration is done, guild participant now have delegation with
+    /// validator.
+    /// </summary>
+    [ActionType(TypeIdentifier)]
+    public class MigrateStakeAndJoinGuild : ActionBase
+    {
+        public const string TypeIdentifier = "migrate_stake_and_join_guild";
+
+        private const string TargetKey = "t";
+
+        public AgentAddress Target { get; private set; }
+
+        public MigrateStakeAndJoinGuild()
+        {
+        }
+
+        public MigrateStakeAndJoinGuild(AgentAddress target)
+        {
+            Target = target;
+        }
+
+        public override IValue PlainValue => Dictionary.Empty
+            .Add("type_id", TypeIdentifier)
+            .Add("values", Dictionary.Empty
+                .Add(TargetKey, Target.Bencoded));
+
+        public override void LoadPlainValue(IValue plainValue)
+        {
+            if (plainValue is not Dictionary root ||
+                !root.TryGetValue((Text)"values", out var rawValues) ||
+                rawValues is not Dictionary values ||
+                !values.TryGetValue((Text)TargetKey, out var rawTarget) ||
+                rawTarget is not Binary target)
+            {
+                throw new InvalidCastException();
+            }
+
+            Target = new AgentAddress(target);
+        }
+
+        public override IWorld Execute(IActionContext context)
+        {
+            GasTracer.UseGas(1);
+
+            var world = context.PreviousState;
+
+            if (!TryGetAdminState(context, out AdminState adminState))
+            {
+                throw new InvalidOperationException("Couldn't find admin state");
+            }
+
+            if (context.Signer != adminState.AdminAddress)
+            {
+                throw new PermissionDeniedException(adminState, context.Signer);
+            }
+
+            // Migrate stake state from v2 to v3 (Mint guild gold for staking)
+            var stakeStateAddr = StakeState.DeriveAddress(Target);
+            if (world.TryGetStakeState(Target, out var stakeState)
+                && stakeState.StateVersion == 2)
+            {
+                if (!StakeStateUtils.TryMigrateV2ToV3(
+                    context,
+                    world,
+                    StakeState.DeriveAddress(Target),
+                    stakeState, out var result))
+                {
+                    throw new InvalidOperationException(
+                        "Failed to migrate stake state. Unexpected situation.");
+                }
+
+                world = result.Value.world;
+            }
+
+            // Migrate guild participant state from legacy to new
+            var repository = new GuildRepository(world, context);
+            if (repository.GetJoinedGuild(GuildConfig.PlanetariumGuildOwner) is not { } planetariumGuildAddress)
+            {
+                throw new NullReferenceException("Planetarium guild is not found.");
+            }
+
+            if (!repository.TryGetGuild(planetariumGuildAddress, out var planetariumGuild))
+            {
+                throw new InvalidOperationException("Planetarium guild is not found.");
+            }
+
+            if (planetariumGuild.GuildMasterAddress != GuildConfig.PlanetariumGuildOwner)
+            {
+                throw new InvalidOperationException("Unexpected guild master.");
+            }
+
+            try
+            {
+                if (world.GetAccountState(Addresses.GuildParticipant).GetState(Target) is not List value)
+                {
+                    throw new FailedLoadStateException(
+                        $"Failed to load guild participant state. Target: {Target}");
+                };
+
+                var legacyGuildParticipant = new LegacyGuildParticipant(value);
+                var guildParticipant = new GuildParticipant(
+                    Target,
+                    legacyGuildParticipant.GuildAddress,
+                    repository);
+                repository.SetGuildParticipant(guildParticipant);
+
+                // Migrate delegation
+                var guild = repository.GetGuild(guildParticipant.GuildAddress);
+                var guildGold = repository.GetBalance(guildParticipant.DelegationPoolAddress, Currencies.GuildGold);
+                if (guildGold.RawValue > 0)
+                {
+                    guildParticipant.Delegate(guild, guildGold, context.BlockIndex);
+                }
+
+                return repository.World;
+            }
+            catch (Exception e)
+            {
+                if (e is FailedLoadStateException || e is NullReferenceException)
+                {
+                    var pledgeAddress = ((Address)Target).GetPledgeAddress();
+
+                    // Patron contract structure:
+                    // [0] = PatronAddress
+                    // [1] = IsApproved
+                    // [2] = Mead amount to refill.
+                    if (!world.TryGetLegacyState(pledgeAddress, out List list) || list.Count < 3 ||
+                        list[0] is not Binary || list[0].ToAddress() != MeadConfig.PatronAddress ||
+                        list[1] is not Bencodex.Types.Boolean approved || !approved)
+                    {
+                        throw new InvalidOperationException("Unexpected pledge structure.");
+                    }
+
+                    repository.JoinGuild(planetariumGuildAddress, Target);
+                    return repository.World;
+                }
+
+                throw;
+            }
+        }
+    }
+}

--- a/Lib9c/Action/Guild/Migration/MigrateStakeAndJoinGuild.cs
+++ b/Lib9c/Action/Guild/Migration/MigrateStakeAndJoinGuild.cs
@@ -22,26 +22,44 @@ namespace Nekoyume.Action.Guild.Migration
     [ActionType(TypeIdentifier)]
     public class MigrateStakeAndJoinGuild : ActionBase
     {
+        /// <summary>
+        /// The type identifier for this action.
+        /// </summary>
         public const string TypeIdentifier = "migrate_stake_and_join_guild";
 
+        /// <summary>
+        /// The key of the target address.
+        /// </summary>
         private const string TargetKey = "t";
 
+        /// <summary>
+        /// The target address to migrate.
+        /// </summary>
         public AgentAddress Target { get; private set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MigrateStakeAndJoinGuild"/> class.
+        /// </summary>
         public MigrateStakeAndJoinGuild()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MigrateStakeAndJoinGuild"/> class.
+        /// </summary>
+        /// <param name="target"></param>
         public MigrateStakeAndJoinGuild(AgentAddress target)
         {
             Target = target;
         }
 
+        /// <inheritdoc/>
         public override IValue PlainValue => Dictionary.Empty
             .Add("type_id", TypeIdentifier)
             .Add("values", Dictionary.Empty
                 .Add(TargetKey, Target.Bencoded));
 
+        /// <inheritdoc/>
         public override void LoadPlainValue(IValue plainValue)
         {
             if (plainValue is not Dictionary root ||
@@ -56,6 +74,7 @@ namespace Nekoyume.Action.Guild.Migration
             Target = new AgentAddress(target);
         }
 
+        /// <inheritdoc/>
         public override IWorld Execute(IActionContext context)
         {
             GasTracer.UseGas(1);


### PR DESCRIPTION
마이그레이션용 어드민 액션을 이슈 해결을 위해 다시 살립니다. 해당 액션은
- StakeState가 마이그레이션되지 않은 경우 V2에서 V3으로 마이그레이션합니다.
- GuildParticipant가 마이그레이션되지 않은 경우 V1에서 V2로 마이그레이션합니다. (위임 포함)
- 길드에 가입되어있지 않은 경우, 길드에 가입합니다. (위임 포함)