### PR TITLE
Disable punishment

### DIFF
--- a/Lib9c.Policy/Policy/BlockPolicySource.cs
+++ b/Lib9c.Policy/Policy/BlockPolicySource.cs
@@ -148,7 +148,7 @@ namespace Nekoyume.Blockchain.Policy
             return new BlockPolicy(
                 policyActionsRegistry: new PolicyActionsRegistry(
                     beginBlockActions: new IAction[] {
-                        new SlashValidator(),
+                        // new SlashValidator(),
                         new AllocateGuildReward(),
                         new AllocateReward(),
                     }.ToImmutableArray(),


### PR DESCRIPTION
Disables Slashing
- 슬래싱 및 툼스톤 기능을 임시로 끕니다.
- 이후 컨센서스 커밋에서 투표를 하지 못하거나, 이중투표가 발생하는 경우에도 증거만 수집할 뿐, 처벌이 이루어지지 않습니다.