### PR TITLE
add grade - mythic

### DIFF
--- a/Lib9c/Helper/SynthesizeSimulator.cs
+++ b/Lib9c/Helper/SynthesizeSimulator.cs
@@ -684,6 +684,7 @@ namespace Nekoyume.Helper
             Grade.Unique => Grade.Legendary,
             Grade.Legendary => Grade.Divinity,
             Grade.Divinity => Grade.Divinity,
+            Grade.Mythic => Grade.Mythic,
             _ => throw new ArgumentOutOfRangeException(nameof(grade), grade, null),
         };
 
@@ -704,6 +705,7 @@ namespace Nekoyume.Helper
                 4 => 5, // Grade.Unique => Grade.Legendary
                 5 => 6, // Grade.Legendary => Grade.Divinity
                 6 => 6, // Grade.Divinity => Grade.Divinity (Max)
+                7 => 7, // Grade.Mythic => Grade.Mythic (Max)
                 _ => throw new ArgumentOutOfRangeException(nameof(gradeId), gradeId, null),
             };
         }

--- a/Lib9c/Model/EnumType/Grade.cs
+++ b/Lib9c/Model/EnumType/Grade.cs
@@ -8,5 +8,6 @@ namespace Nekoyume.Model.EnumType
         Unique = 4,
         Legendary = 5,
         Divinity = 6,
+        Mythic = 7,
     }
 }

--- a/Lib9c/Model/EnumType/Grade.cs
+++ b/Lib9c/Model/EnumType/Grade.cs
@@ -1,5 +1,8 @@
 namespace Nekoyume.Model.EnumType
 {
+    /// <summary>
+    /// Enumeration of item grades.
+    /// </summary>
     public enum Grade
     {
         Normal = 1,


### PR DESCRIPTION
This pull request includes changes to the `Lib9c` project, primarily focusing on adding support for a new grade level, `Mythic`. The changes include updates to the `Grade` enumeration and relevant methods to accommodate this new grade.

Updates for new grade level support:

* [`Lib9c/Model/EnumType/Grade.cs`](diffhunk://#diff-b1630ed25f81b227df72f3b86ae0166e451b1117096355640fb7c26514d8a61dR11): Added `Mythic` as a new grade level in the `Grade` enumeration.
* [`Lib9c/Helper/SynthesizeSimulator.cs`](diffhunk://#diff-fa42125eac2e831dc44269bb4480f7be39a088187ddb283ff45e7ac1f39f8cfdR687): Updated the `GetItemGuids` method to handle the new `Mythic` grade.
* [`Lib9c/Helper/SynthesizeSimulator.cs`](diffhunk://#diff-fa42125eac2e831dc44269bb4480f7be39a088187ddb283ff45e7ac1f39f8cfdR708): Modified the `GetTargetGrade` method to include the new `Mythic` grade.