### PR TITLE
Resolve Battle.cs not using ToDotnetString for the memo field.

### DIFF
--- a/Lib9c/Action/Arena/Battle.cs
+++ b/Lib9c/Action/Arena/Battle.cs
@@ -73,7 +73,7 @@ namespace Nekoyume.Action.Arena
         {
             myAvatarAddress = plainValue[MyAvatarAddressKey].ToAddress();
             enemyAvatarAddress = plainValue[EnemyAvatarAddressKey].ToAddress();
-            memo = plainValue[MemoKey].ToString();
+            memo = plainValue[MemoKey].ToDotnetString();
             arenaProvider = plainValue[ArenaProviderKey].ToEnum<ArenaProvider>();
             chargeAp = plainValue[ChargeApKey].ToBoolean();
             costumes = ((List)plainValue[CostumesKey]).Select(e => e.ToGuid()).ToList();


### PR DESCRIPTION
Fixes the issue where GQL Battle Actions get their MEMO loaded into the wrong format. Due to an invalid memo format, all GQL Battle Actions are unreadable by the Arena Endpoints.

Before the change:


![prefix](https://github.com/user-attachments/assets/f92a1a32-1872-453d-ba94-99e64d7787fc)


Post the change:
![postfix](https://github.com/user-attachments/assets/2ae87dd7-b6a4-4d1a-97fb-a196bac45ff3)

