### PR TITLE
Allow empty string when parse rune options

### DIFF
--- a/.Lib9c.Tests/TableData/Rune/RuneOptionSheetTest.cs
+++ b/.Lib9c.Tests/TableData/Rune/RuneOptionSheetTest.cs
@@ -1,0 +1,32 @@
+namespace Lib9c.Tests.TableData.Rune
+{
+    using System.Linq;
+    using Nekoyume.TableData;
+    using Xunit;
+
+    public class RuneOptionSheetTest
+    {
+        [Fact]
+        public void StatNoneTest()
+        {
+            const string csvData = @"rune_id,level,total_cp,stat_type_1,value_1,value_type_1,stat_type_2,value_2,value_type_2,stat_type_3,value_3,value_type3,skillId,cooldown,chance,skill_value,skill_stat_ratio,skill_value_type,stat_reference_type,buff_duration
+10043,1,364,HP,520,Add,NONE,0,Add,NONE,0,Add,,,,,,,,";
+            const string csvData2 = @"rune_id,level,total_cp,stat_type_1,value_1,value_type_1,stat_type_2,value_2,value_type_2,stat_type_3,value_3,value_type3,skillId,cooldown,chance,skill_value,skill_stat_ratio,skill_value_type,stat_reference_type,buff_duration
+10043,1,364,HP,520,Add,,,,,,,,,,,,,,";
+            var sheet = new RuneOptionSheet();
+            sheet.Set(csvData);
+            var row = sheet.Values.First();
+            var sheetWithoutNone = new RuneOptionSheet();
+            sheetWithoutNone.Set(csvData2);
+            var rowWithoutNone = sheetWithoutNone.Values.First();
+            Assert.Equal(row.RuneId, rowWithoutNone.RuneId);
+            var expected = row.LevelOptionMap[1];
+            var actual = rowWithoutNone.LevelOptionMap[1];
+            Assert.Equal(expected.Cp, actual.Cp);
+            var (expectedStat, expectedType) = Assert.Single(expected.Stats);
+            var (actualStat, actualType) = Assert.Single(actual.Stats);
+            Assert.Equal(expectedStat, actualStat);
+            Assert.Equal(expectedType, actualType);
+        }
+    }
+}

--- a/Lib9c/TableData/Rune/RuneOptionSheet.cs
+++ b/Lib9c/TableData/Rune/RuneOptionSheet.cs
@@ -73,34 +73,43 @@ namespace Nekoyume.TableData
                 var level = ParseInt(fields[1]);
                 var cp = ParseInt(fields[2]);
 
-                var statType1 = (StatType)Enum.Parse(typeof(StatType), fields[3]);
-                var value1 = ParseDecimal(fields[4]);
-                var valueType1 = (StatModifier.OperationType)
-                    Enum.Parse(typeof(StatModifier.OperationType), fields[5]);
-                if (statType1 != StatType.NONE)
+                if (!string.IsNullOrEmpty(fields[3]))
                 {
-                    var statMap = new DecimalStat(statType1, value1);
-                    stats.Add((statMap, valueType1));
+                    var statType1 = (StatType)Enum.Parse(typeof(StatType), fields[3]);
+                    var value1 = ParseDecimal(fields[4]);
+                    var valueType1 = (StatModifier.OperationType)
+                        Enum.Parse(typeof(StatModifier.OperationType), fields[5]);
+                    if (statType1 != StatType.NONE)
+                    {
+                        var statMap = new DecimalStat(statType1, value1);
+                        stats.Add((statMap, valueType1));
+                    }
                 }
 
-                var statType2 = (StatType)Enum.Parse(typeof(StatType), fields[6]);
-                var value2 = ParseDecimal(fields[7]);
-                var valueType2 = (StatModifier.OperationType)
-                    Enum.Parse(typeof(StatModifier.OperationType), fields[8]);
-                if (statType2 != StatType.NONE)
+                if (!string.IsNullOrEmpty(fields[6]))
                 {
-                    var statMap = new DecimalStat(statType2, value2);
-                    stats.Add((statMap, valueType2));
+                    var statType2 = (StatType)Enum.Parse(typeof(StatType), fields[6]);
+                    var value2 = ParseDecimal(fields[7]);
+                    var valueType2 = (StatModifier.OperationType)
+                        Enum.Parse(typeof(StatModifier.OperationType), fields[8]);
+                    if (statType2 != StatType.NONE)
+                    {
+                        var statMap = new DecimalStat(statType2, value2);
+                        stats.Add((statMap, valueType2));
+                    }
                 }
 
-                var statType3 = (StatType)Enum.Parse(typeof(StatType), fields[9]);
-                var value3 = ParseDecimal(fields[10]);
-                var valueType3 = (StatModifier.OperationType)
-                    Enum.Parse(typeof(StatModifier.OperationType), fields[11]);
-                if (statType3 != StatType.NONE)
+                if (!string.IsNullOrEmpty(fields[9]))
                 {
-                    var statMap = new DecimalStat(statType3, value3);
-                    stats.Add((statMap, valueType3));
+                    var statType3 = (StatType)Enum.Parse(typeof(StatType), fields[9]);
+                    var value3 = ParseDecimal(fields[10]);
+                    var valueType3 = (StatModifier.OperationType)
+                        Enum.Parse(typeof(StatModifier.OperationType), fields[11]);
+                    if (statType3 != StatType.NONE)
+                    {
+                        var statMap = new DecimalStat(statType3, value3);
+                        stats.Add((statMap, valueType3));
+                    }
                 }
 
                 if (TryParseInt(fields[12], out var skillId))


### PR DESCRIPTION
- allow empty string instead of NONE enum type