### PR TITLE
Add SweepAdventureBoss action with play count validation and tests

### DIFF
--- a/.Lib9c.Tests/Action/ActionEvaluationTest.cs
+++ b/.Lib9c.Tests/Action/ActionEvaluationTest.cs
@@ -12,6 +12,7 @@ namespace Lib9c.Tests.Action
     using MessagePack;
     using MessagePack.Resolvers;
     using Nekoyume.Action;
+    using Nekoyume.Action.AdventureBoss;
     using Nekoyume.Helper;
     using Nekoyume.Model.Collection;
     using Nekoyume.Model.Item;
@@ -91,6 +92,7 @@ namespace Lib9c.Tests.Action
         [InlineData(typeof(TransferAssets))]
         [InlineData(typeof(RuneSummon))]
         [InlineData(typeof(EventDungeonBattleSweep))]
+        [InlineData(typeof(SweepAdventureBoss))]
         [InlineData(typeof(ActivateCollection))]
         [InlineData(typeof(RetrieveAvatarAssets))]
         [InlineData(typeof(MigrateFee))]
@@ -523,6 +525,15 @@ namespace Lib9c.Tests.Action
                     Costumes = new List<Guid>(),
                     Foods = new List<Guid>(),
                     RuneInfos = new List<RuneSlotInfo>(),
+                },
+                SweepAdventureBoss _ => new SweepAdventureBoss
+                {
+                    Season = 1,
+                    AvatarAddress = default,
+                    Costumes = new List<Guid>(),
+                    Equipments = new List<Guid>(),
+                    RuneInfos = new List<RuneSlotInfo>(),
+                    PlayCount = 1,
                 },
                 SetAddressStateCompressed _ => new SetAddressStateCompressed(new List<(Address accountAddress, Address targetAddress, byte[] compressedState)>
                 {

--- a/.Lib9c.Tests/Action/AdventureBoss/SweepAdventureBossTest.cs
+++ b/.Lib9c.Tests/Action/AdventureBoss/SweepAdventureBossTest.cs
@@ -14,6 +14,7 @@ namespace Lib9c.Tests.Action.AdventureBoss
     using Nekoyume.Action.AdventureBoss;
     using Nekoyume.Extensions;
     using Nekoyume.Model.AdventureBoss;
+    using Nekoyume.Model.Arena;
     using Nekoyume.Model.EnumType;
     using Nekoyume.Model.Item;
     using Nekoyume.Model.State;
@@ -184,6 +185,7 @@ namespace Lib9c.Tests.Action.AdventureBoss
                 Costumes = new List<Guid>(),
                 Equipments = new List<Guid>(),
                 RuneInfos = new List<RuneSlotInfo>(),
+                PlayCount = 1,
             };
 
             if (exc is not null)
@@ -258,6 +260,167 @@ namespace Lib9c.Tests.Action.AdventureBoss
 
                 Assert.True(nextCpState.Cp > 0);
             }
+        }
+
+        [Theory]
+        [InlineData(0, typeof(PlayCountIsZeroException))]
+        [InlineData(101, typeof(ExceedPlayCountException))]
+        public void Execute_PlayCountExceptions(int playCount, Type expectedExceptionType)
+        {
+            var state = _initialState;
+            var gameConfigState = new GameConfigState(Sheets[nameof(GameConfigSheet)]);
+            state = state.SetLegacyState(gameConfigState.address, gameConfigState.Serialize());
+            foreach (var (key, value) in Sheets)
+            {
+                state = state.SetLegacyState(Addresses.TableSheet.Derive(key), value.Serialize());
+            }
+
+            var validatorKey = new PrivateKey().PublicKey;
+            state = DelegationUtil.EnsureValidatorPromotionReady(state, validatorKey, 0L);
+            state = DelegationUtil.MakeGuild(state, WantedAddress, validatorKey.Address, 0L);
+
+            state = Stake(state, WantedAddress);
+
+            // Open season
+            state = new Wanted
+            {
+                Season = 1,
+                AvatarAddress = WantedAvatarAddress,
+                Bounty = gameConfigState.AdventureBossMinBounty * NCG,
+            }.Execute(
+                new ActionContext
+                {
+                    PreviousState = state,
+                    Signer = WantedAddress,
+                    BlockIndex = 0L,
+                    RandomSeed = 1,
+                });
+
+            var exp = new Explorer(TesterAvatarAddress, TesterAvatarState.name)
+            {
+                MaxFloor = 5,
+                Floor = 1,
+            };
+            state = state.SetExplorer(1, exp);
+
+            var action = new SweepAdventureBoss
+            {
+                Season = 1,
+                AvatarAddress = TesterAvatarAddress,
+                Costumes = new List<Guid>(),
+                Equipments = new List<Guid>(),
+                RuneInfos = new List<RuneSlotInfo>(),
+                PlayCount = playCount,
+            };
+
+            Assert.Throws(
+                expectedExceptionType,
+                () => action.Execute(
+                    new ActionContext
+                    {
+                        PreviousState = state,
+                        Signer = TesterAddress,
+                        BlockIndex = 1L,
+                    }
+                ));
+        }
+
+        [Fact]
+        public void Execute_WithMultiplePlayCount()
+        {
+            var state = _initialState;
+            var gameConfigState = new GameConfigState(Sheets[nameof(GameConfigSheet)]);
+            state = state.SetLegacyState(gameConfigState.address, gameConfigState.Serialize());
+            foreach (var (key, value) in Sheets)
+            {
+                state = state.SetLegacyState(Addresses.TableSheet.Derive(key), value.Serialize());
+            }
+
+            var validatorKey = new PrivateKey().PublicKey;
+            state = DelegationUtil.EnsureValidatorPromotionReady(state, validatorKey, 0L);
+            state = DelegationUtil.MakeGuild(state, WantedAddress, validatorKey.Address, 0L);
+
+            state = Stake(state, WantedAddress);
+
+            var sheets = state.GetSheets(
+                new[]
+                {
+                    typeof(MaterialItemSheet),
+                });
+            var materialSheet = sheets.GetSheet<MaterialItemSheet>();
+            var materialRow =
+                materialSheet.OrderedList.First(row => row.ItemSubType == ItemSubType.ApStone);
+            var apPotion = ItemFactory.CreateMaterial(materialRow);
+
+            var inventory = state.GetInventoryV2(TesterAvatarAddress);
+            inventory.AddItem(apPotion, 1000); // Enough potions for multiple plays
+            state = state.SetInventory(TesterAvatarAddress, inventory);
+
+            // Open season
+            state = new Wanted
+            {
+                Season = 1,
+                AvatarAddress = WantedAvatarAddress,
+                Bounty = gameConfigState.AdventureBossMinBounty * NCG,
+            }.Execute(
+                new ActionContext
+                {
+                    PreviousState = state,
+                    Signer = WantedAddress,
+                    BlockIndex = 0L,
+                    RandomSeed = 1,
+                });
+
+            const int floor = 5;
+            var exp = new Explorer(TesterAvatarAddress, TesterAvatarState.name)
+            {
+                MaxFloor = 5 * Math.Max(floor / 5, 1),
+                Floor = floor,
+            };
+            state = state.SetExplorer(1, exp);
+
+            const int playCount = 3;
+            var action = new SweepAdventureBoss
+            {
+                Season = 1,
+                AvatarAddress = TesterAvatarAddress,
+                Costumes = new List<Guid>(),
+                Equipments = new List<Guid>(),
+                RuneInfos = new List<RuneSlotInfo>(),
+                PlayCount = playCount,
+            };
+
+            var previousExploreBoard = state.GetExploreBoard(1);
+            var previousExplorer = state.GetExplorer(1, TesterAvatarAddress);
+            var previousScore = previousExplorer.Score;
+            var previousTotalPoint = previousExploreBoard.TotalPoint;
+
+            state = action.Execute(
+                new ActionContext
+                {
+                    PreviousState = state,
+                    Signer = TesterAddress,
+                    BlockIndex = 1L,
+                });
+
+            var unitSweepAp = state.GetSheet<AdventureBossSheet>().OrderedList
+                .First(row => row.BossId == state.GetLatestAdventureBossSeason().BossId)
+                .SweepAp;
+            var exploreBoard = state.GetExploreBoard(1);
+            var explorer = state.GetExplorer(1, TesterAvatarAddress);
+
+            // Verify AP potion consumption
+            var expectedApPotion = playCount * floor * unitSweepAp;
+            Assert.Equal(expectedApPotion, exploreBoard.UsedApPotion - previousExploreBoard.UsedApPotion);
+            Assert.Equal(explorer.UsedApPotion - previousExplorer.UsedApPotion, exploreBoard.UsedApPotion - previousExploreBoard.UsedApPotion);
+
+            // Verify points are accumulated
+            Assert.True(explorer.Score > previousScore);
+            Assert.True(exploreBoard.TotalPoint > previousTotalPoint);
+            Assert.Equal(explorer.Score - previousScore, exploreBoard.TotalPoint - previousTotalPoint);
+
+            // Verify floor remains the same
+            Assert.Equal(floor, explorer.Floor);
         }
 
         private IWorld Stake(IWorld world, Address agentAddress)

--- a/Lib9c/Action/AdventureBoss/SweepAdventureBoss.cs
+++ b/Lib9c/Action/AdventureBoss/SweepAdventureBoss.cs
@@ -15,6 +15,7 @@ using Nekoyume.Helper;
 using Nekoyume.Model.AdventureBoss;
 using Nekoyume.Model.Arena;
 using Nekoyume.Model.EnumType;
+using Serilog;
 using Nekoyume.Model.Item;
 using Nekoyume.Model.Stat;
 using Nekoyume.Model.State;
@@ -43,11 +44,21 @@ namespace Nekoyume.Action.AdventureBoss
     {
         public const string TypeIdentifier = "sweep_adventure_boss";
 
+        /// <summary>
+        /// Maximum allowed play count per sweep action to prevent abuse and excessive resource consumption.
+        /// </summary>
+        private const int MaxPlayCount = 100;
+
         public int Season;
         public Address AvatarAddress;
         public List<Guid> Costumes;
         public List<Guid> Equipments;
         public List<RuneSlotInfo> RuneInfos;
+
+        /// <summary>
+        /// The number of times to perform the sweep (must be between 1 and MaxPlayCount).
+        /// </summary>
+        public int PlayCount;
 
         protected override IImmutableDictionary<string, IValue> PlainValueInternal =>
             new Dictionary<string, IValue>
@@ -59,6 +70,7 @@ namespace Nekoyume.Action.AdventureBoss
                     new List(Equipments.OrderBy(i => i).Select(e => e.Serialize())),
                 ["r"] = RuneInfos.OrderBy(x => x.SlotIndex).Select(x => x.Serialize())
                     .Serialize(),
+                ["p"] = (Integer)PlayCount,
             }.ToImmutableDictionary();
 
         protected override void LoadPlainValueInternal(
@@ -69,6 +81,9 @@ namespace Nekoyume.Action.AdventureBoss
             Costumes = ((List)plainValue["c"]).Select(e => e.ToGuid()).ToList();
             Equipments = ((List)plainValue["e"]).Select(e => e.ToGuid()).ToList();
             RuneInfos = plainValue["r"].ToList(x => new RuneSlotInfo((List)x));
+            PlayCount = plainValue.TryGetValue("p", out var playCountValue)
+                ? (Integer)playCountValue
+                : 1; // Default to 1 for backward compatibility
         }
 
         public override IWorld Execute(IActionContext context)
@@ -76,15 +91,31 @@ namespace Nekoyume.Action.AdventureBoss
             GasTracer.UseGas(1);
             var addressesHex = GetSignerAndOtherAddressesHex(context, AvatarAddress);
             var states = context.PreviousState;
+            var started = DateTimeOffset.UtcNow;
+            Log.Debug("{AddressesHex}SweepAdventureBoss exec started", addressesHex);
+
+            // Validate play count - must be greater than 0 and within maximum limit
+            if (PlayCount <= 0)
+            {
+                throw new PlayCountIsZeroException(
+                    $"{addressesHex}playCount must be greater than 0. " +
+                    $"current playCount : {PlayCount}");
+            }
+
+            if (PlayCount > MaxPlayCount)
+            {
+                throw new ExceedPlayCountException(
+                    $"{addressesHex}playCount exceeds maximum allowed value. " +
+                    $"Requested: {PlayCount}, Maximum: {MaxPlayCount}");
+            }
 
             // Validation
-            var addresses = GetSignerAndOtherAddressesHex(context, AvatarAddress);
             // NOTE: The `AvatarAddress` must contained in `Signer`'s `AgentState.avatarAddresses`.
             if (!Addresses.CheckAvatarAddrIsContainedInAgent(context.Signer, AvatarAddress))
             {
                 throw new InvalidActionFieldException(
                     TypeIdentifier,
-                    addresses,
+                    addressesHex,
                     nameof(AvatarAddress),
                     $"Signer({context.Signer}) is not contained in" +
                     $" AvatarAddress({AvatarAddress}).");
@@ -124,7 +155,7 @@ namespace Nekoyume.Action.AdventureBoss
             // Use AP Potions
             var unitSweepAp = states.GetSheet<AdventureBossSheet>().OrderedList
                 .First(row => row.BossId == latestSeason.BossId).SweepAp;
-            var requiredPotion = explorer.Floor * unitSweepAp;
+            var requiredPotion = PlayCount * explorer.Floor * unitSweepAp;
             var sheets = states.GetSheets(
                 containSimulatorSheets: true,
                 sheetTypes: new[]
@@ -219,37 +250,43 @@ namespace Nekoyume.Action.AdventureBoss
             simulator.AddBreakthrough(floorIdList, sheets.GetSheet<AdventureBossFloorWaveSheet>());
 
             // Add point, reward
-            var point = 0;
+            var totalPoint = 0;
             var rewardList = new List<AdventureBossSheet.RewardAmountData>();
             var random = context.GetRandom();
             var selector = new WeightedSelector<AdventureBossFloorSheet.RewardData>(random);
-            var bossId = states.GetSheet<AdventureBossSheet>().Values
-                .First(row => row.BossId == latestSeason.BossId).Id;
             var floorPointSheet = states.GetSheet<AdventureBossFloorPointSheet>();
             var floorSheet = states.GetSheet<AdventureBossFloorSheet>();
-            for (var fl = 1; fl <= explorer.Floor; fl++)
-            {
-                var floorRow = floorSheet.Values.Where(row => row.AdventureBossId == bossId)
-                    .First(row => row.Floor == fl);
-                var pointRow = floorPointSheet[floorRow.Id];
-                point += random.Next(pointRow.MinPoint, pointRow.MaxPoint + 1);
 
-                selector.Clear();
-                foreach (var reward in floorRow.Rewards)
+            // Repeat reward calculation for PlayCount times
+            for (var play = 0; play < PlayCount; play++)
+            {
+                var point = 0;
+                for (var fl = 1; fl <= explorer.Floor; fl++)
                 {
-                    selector.Add(reward, reward.Ratio);
+                    var floorRow = floorSheet.Values.Where(row => row.AdventureBossId == adventureBossId)
+                        .First(row => row.Floor == fl);
+                    var pointRow = floorPointSheet[floorRow.Id];
+                    point += random.Next(pointRow.MinPoint, pointRow.MaxPoint + 1);
+
+                    selector.Clear();
+                    foreach (var reward in floorRow.Rewards)
+                    {
+                        selector.Add(reward, reward.Ratio);
+                    }
+
+                    var selected = selector.Select(1).First();
+                    rewardList.Add(new AdventureBossSheet.RewardAmountData(
+                        selected.ItemType,
+                        selected.ItemId,
+                        random.Next(selected.Min, selected.Max + 1)
+                    ));
                 }
 
-                var selected = selector.Select(1).First();
-                rewardList.Add(new AdventureBossSheet.RewardAmountData(
-                    selected.ItemType,
-                    selected.ItemId,
-                    random.Next(selected.Min, selected.Max + 1)
-                ));
+                totalPoint += point;
             }
 
-            exploreBoard.TotalPoint += point;
-            explorer.Score += point;
+            exploreBoard.TotalPoint += totalPoint;
+            explorer.Score += totalPoint;
             states = AdventureBossHelper.AddExploreRewards(
                 context, states, AvatarAddress, inventory, rewardList
             );
@@ -303,6 +340,12 @@ namespace Nekoyume.Action.AdventureBoss
                 costumeStatSheet,
                 collectionModifiers,
                 runeLevelBonus
+            );
+
+            var ended = DateTimeOffset.UtcNow;
+            Log.Debug(
+                "{AddressesHex}SweepAdventureBoss Total Executed Time: {Elapsed}",
+                addressesHex, ended - started
             );
 
             return states


### PR DESCRIPTION
- Implemented the SweepAdventureBoss action allowing multiple sweeps with a specified play count.
- Added validation to ensure play count is within acceptable limits (1 to 100).
- Updated tests to cover play count exceptions and multiple play scenarios.
- Enhanced logging for execution time tracking.