### PR TITLE
Add Tradable flag to StakeRegularFixedRewardSheet.RewardInfo

### DIFF
--- a/.Lib9c.Tests/Fixtures/TableCSV/Stake/StakeRegularFixedRewardSheetFixtures.cs
+++ b/.Lib9c.Tests/Fixtures/TableCSV/Stake/StakeRegularFixedRewardSheetFixtures.cs
@@ -28,5 +28,17 @@ namespace Lib9c.Tests.Fixtures.TableCSV.Stake
 6,1000000,500000,2
 7,5000000,500000,2
 8,10000000,500000,2";
+
+        /// <summary>
+        /// Fixture with the optional <c>tradable</c> column present.
+        /// Level 1 uses <c>tradable=true</c> (explicit) and level 2 uses <c>tradable=false</c>,
+        /// so that both explicit values can be tested.
+        /// </summary>
+        public const string V1WithTradable = @"level,required_gold,item_id,count,tradable
+1,50,500000,1,true
+2,500,500000,2,false
+3,5000,500000,2,true
+4,50000,500000,2,true
+5,500000,500000,2,true";
     }
 }

--- a/.Lib9c.Tests/TableData/StakeRegularFixedRewardSheetTest.cs
+++ b/.Lib9c.Tests/TableData/StakeRegularFixedRewardSheetTest.cs
@@ -22,6 +22,10 @@ namespace Lib9c.Tests.TableData
 #pragma warning restore CS0618
         }
 
+        /// <summary>
+        /// Verifies that the sheet is parsed correctly from the V1 fixture,
+        /// including default <c>Tradable = true</c> for rows without the tradable column.
+        /// </summary>
         [Fact]
         public void SetToSheet()
         {
@@ -32,30 +36,58 @@ namespace Lib9c.Tests.TableData
             Assert.Single(_sheet[1].Rewards);
             Assert.Equal(500000, _sheet[1].Rewards[0].ItemId);
             Assert.Equal(1, _sheet[1].Rewards[0].Count);
+            // tradable column absent → defaults to true
+            Assert.True(_sheet[1].Rewards[0].Tradable);
 
             Assert.Equal(2, _sheet[2].Level);
             Assert.Equal(500, _sheet[2].RequiredGold);
             Assert.Single(_sheet[2].Rewards);
             Assert.Equal(500000, _sheet[2].Rewards[0].ItemId);
             Assert.Equal(2, _sheet[2].Rewards[0].Count);
+            Assert.True(_sheet[2].Rewards[0].Tradable);
 
             Assert.Equal(3, _sheet[3].Level);
             Assert.Equal(5000, _sheet[3].RequiredGold);
             Assert.Single(_sheet[3].Rewards);
             Assert.Equal(500000, _sheet[3].Rewards[0].ItemId);
             Assert.Equal(2, _sheet[3].Rewards[0].Count);
+            Assert.True(_sheet[3].Rewards[0].Tradable);
 
             Assert.Equal(4, _sheet[4].Level);
             Assert.Equal(50000, _sheet[4].RequiredGold);
             Assert.Single(_sheet[4].Rewards);
             Assert.Equal(500000, _sheet[4].Rewards[0].ItemId);
             Assert.Equal(2, _sheet[4].Rewards[0].Count);
+            Assert.True(_sheet[4].Rewards[0].Tradable);
 
             Assert.Equal(5, _sheet[5].Level);
             Assert.Equal(500000, _sheet[5].RequiredGold);
             Assert.Single(_sheet[3].Rewards);
             Assert.Equal(500000, _sheet[5].Rewards[0].ItemId);
             Assert.Equal(2, _sheet[5].Rewards[0].Count);
+            Assert.True(_sheet[5].Rewards[0].Tradable);
+        }
+
+        /// <summary>
+        /// Verifies that explicit <c>tradable</c> column values (true/false) are parsed correctly,
+        /// and that rows without the column still default to <c>true</c>.
+        /// </summary>
+        [Fact]
+        public void SetToSheet_WithTradableColumn()
+        {
+            var sheet = new StakeRegularFixedRewardSheet();
+            sheet.Set(StakeRegularFixedRewardSheetFixtures.V1WithTradable);
+
+            Assert.Equal(5, sheet.Count);
+
+            // Level 1: tradable=true (explicit)
+            Assert.True(sheet[1].Rewards[0].Tradable);
+            // Level 2: tradable=false (explicit)
+            Assert.False(sheet[2].Rewards[0].Tradable);
+            // Level 3~5: tradable=true (explicit)
+            Assert.True(sheet[3].Rewards[0].Tradable);
+            Assert.True(sheet[4].Rewards[0].Tradable);
+            Assert.True(sheet[5].Rewards[0].Tradable);
         }
 
         [Theory]

--- a/Lib9c/Model/State/StakeRewardCalculator.cs
+++ b/Lib9c/Model/State/StakeRewardCalculator.cs
@@ -10,17 +10,49 @@ using Nekoyume.TableData;
 
 namespace Nekoyume.Model.State
 {
+    /// <summary>
+    /// Provides methods for calculating staking rewards from reward sheets.
+    /// </summary>
     public static class StakeRewardCalculator
     {
+        /// <summary>
+        /// Calculates fixed item rewards for a given stake level.
+        /// Fixed rewards have a predetermined item count (unlike rate-based rewards in
+        /// <see cref="CalculateRewards"/>), and the <c>tradable</c> flag on each
+        /// <see cref="StakeRegularFixedRewardSheet.RewardInfo"/> controls whether
+        /// material items are created as tradable or non-tradable.
+        /// </summary>
+        /// <param name="stakeLevel">The current stake level used to look up the reward row.</param>
+        /// <param name="random">Random source used for non-material item creation.</param>
+        /// <param name="stakeRegularFixedRewardSheet">Sheet containing fixed reward definitions.</param>
+        /// <param name="itemSheet">Sheet used to look up item metadata by ID.</param>
+        /// <param name="rewardSteps">
+        /// The number of reward steps accumulated since the last claim.
+        /// Each reward's count is multiplied by this value.
+        /// </param>
+        /// <returns>
+        /// A dictionary mapping each rewarded <see cref="ItemBase"/> to its total count.
+        /// </returns>
         public static Dictionary<ItemBase, int> CalculateFixedRewards(int stakeLevel, IRandom random, StakeRegularFixedRewardSheet stakeRegularFixedRewardSheet, ItemSheet itemSheet, int rewardSteps)
         {
             var result = new Dictionary<ItemBase, int>();
             foreach (var reward in stakeRegularFixedRewardSheet[stakeLevel].Rewards)
             {
                 var itemRow = itemSheet[reward.ItemId];
-                var item = itemRow is MaterialItemSheet.Row materialRow
-                    ? ItemFactory.CreateTradableMaterial(materialRow)
-                    : ItemFactory.CreateItem(itemRow, random);
+                // Use reward.Tradable to determine whether to create a tradable or
+                // non-tradable material, consistent with StakeRegularRewardSheet behavior.
+                ItemBase item;
+                if (itemRow is MaterialItemSheet.Row materialRow)
+                {
+                    item = reward.Tradable
+                        ? ItemFactory.CreateTradableMaterial(materialRow)
+                        : ItemFactory.CreateMaterial(materialRow);
+                }
+                else
+                {
+                    item = ItemFactory.CreateItem(itemRow, random);
+                }
+
                 var count = reward.Count * rewardSteps;
                 result.TryAdd(item, 0);
                 result[item] += count;
@@ -29,6 +61,36 @@ namespace Nekoyume.Model.State
             return result;
         }
 
+        /// <summary>
+        /// Calculates rate-based item and currency rewards for a given staking level.
+        /// Unlike <see cref="CalculateFixedRewards"/>, reward quantities are derived from
+        /// the ratio of the staked NCG amount to each reward's
+        /// <see cref="StakeRegularRewardSheet.RewardInfo.DecimalRate"/>.
+        /// Rewards whose computed quantity is zero or negative are skipped.
+        /// </summary>
+        /// <param name="ncg">The NCG currency definition.</param>
+        /// <param name="stakedNcg">The total amount of staked NCG.</param>
+        /// <param name="stakingLevel">The current staking level used to look up the reward row.</param>
+        /// <param name="rewardSteps">
+        /// The number of reward steps accumulated since the last claim.
+        /// Each reward quantity is multiplied by this value.
+        /// </param>
+        /// <param name="stakeRegularRewardSheet">Sheet containing rate-based reward definitions.</param>
+        /// <param name="itemSheet">Sheet used to look up item metadata by ID.</param>
+        /// <param name="random">Random source used for non-material item creation.</param>
+        /// <returns>
+        /// A tuple of:
+        /// <list type="bullet">
+        ///   <item><description>
+        ///     <c>itemResult</c>: a dictionary mapping each rewarded <see cref="ItemBase"/>
+        ///     to its total count.
+        ///   </description></item>
+        ///   <item><description>
+        ///     <c>favResult</c>: a list of <see cref="FungibleAssetValue"/> for rune and
+        ///     currency rewards.
+        ///   </description></item>
+        /// </list>
+        /// </returns>
         public static (Dictionary<ItemBase, int> itemResult, List<FungibleAssetValue> favResult) CalculateRewards(Currency ncg, FungibleAssetValue stakedNcg, int stakingLevel, int rewardSteps, StakeRegularRewardSheet stakeRegularRewardSheet, ItemSheet itemSheet, IRandom random)
         {
             var stakedNcgDecimal = TableExtensions.ParseDecimal(stakedNcg.GetQuantityString());
@@ -95,16 +157,16 @@ namespace Nekoyume.Model.State
                             rewardCurrency =
                                 Currencies.GetMinterlessCurrency(reward.CurrencyTicker);
                         }
-                        // NOTE: throw exception if reward.CurrencyTicker is null or empty.
+                        // NOTE: throw exception if CurrencyTicker is null or empty.
                         catch (ArgumentNullException)
                         {
                             throw;
                         }
-                        // NOTE: handle the case that reward.CurrencyTicker isn't covered by
+                        // NOTE: handle the case that CurrencyTicker isn't covered by
                         //       Currencies.GetMinterlessCurrency().
                         catch (ArgumentException)
                         {
-                            // NOTE: throw exception if reward.CurrencyDecimalPlaces is null.
+                            // NOTE: throw exception if CurrencyDecimalPlaces is null.
                             if (reward.CurrencyDecimalPlaces is null)
                             {
                                 throw new ArgumentNullException(

--- a/Lib9c/TableData/StakeRegularFixedRewardSheet.cs
+++ b/Lib9c/TableData/StakeRegularFixedRewardSheet.cs
@@ -10,6 +10,13 @@ namespace Nekoyume.TableData
     /// This sheet is used for setting the regular rewards for staking.
     /// The difference between this sheet and <see cref="StakeRegularRewardSheet"/> is that
     /// the <see cref="RewardInfo"/> of this sheet has a fixed count of reward.
+    /// <para>CSV column order: level, required_gold, item_id, count[, tradable]</para>
+    /// <para>
+    /// The optional <c>tradable</c> column controls whether material items are created
+    /// as tradable (<see cref="Nekoyume.Model.Item.TradableMaterial"/>) or non-tradable
+    /// (<see cref="Nekoyume.Model.Item.Material"/>). Omitting the column defaults to
+    /// <c>true</c>, preserving backward compatibility with existing CSV data.
+    /// </para>
     /// </summary>
     [Serializable]
     public class StakeRegularFixedRewardSheet :
@@ -19,9 +26,50 @@ namespace Nekoyume.TableData
         [Serializable]
         public class RewardInfo
         {
+            public readonly int ItemId;
+            public readonly int Count;
+
+            /// <summary>
+            /// Whether the rewarded item is tradable.
+            /// If <c>true</c>, materials are created as
+            /// <see cref="Nekoyume.Model.Item.TradableMaterial"/>;
+            /// otherwise they are created as non-tradable
+            /// <see cref="Nekoyume.Model.Item.Material"/>.
+            /// Defaults to <c>true</c> when the column is omitted in the CSV.
+            /// </summary>
+            public readonly bool Tradable;
+
+            /// <summary>
+            /// Initializes a <see cref="RewardInfo"/> from CSV field tokens.
+            /// Expected order: item_id, count[, tradable].
+            /// </summary>
+            public RewardInfo(params string[] fields)
+            {
+                ItemId = ParseInt(fields[0]);
+                Count = ParseInt(fields[1]);
+                Tradable = fields.Length >= 3
+                    ? ParseBool(fields[2], true)
+                    : true;
+            }
+
+            /// <param name="itemId">The item ID to reward.</param>
+            /// <param name="count">The fixed count of items to reward.</param>
+            /// <param name="tradable">
+            /// Whether the rewarded material item should be tradable.
+            /// Defaults to <c>true</c>.
+            /// </param>
+            public RewardInfo(int itemId, int count, bool tradable = true)
+            {
+                ItemId = itemId;
+                Count = count;
+                Tradable = tradable;
+            }
+
             protected bool Equals(RewardInfo other)
             {
-                return ItemId == other.ItemId && Count == other.Count;
+                return ItemId == other.ItemId &&
+                       Count == other.Count &&
+                       Tradable == other.Tradable;
             }
 
             public override bool Equals(object obj)
@@ -36,23 +84,8 @@ namespace Nekoyume.TableData
             {
                 unchecked
                 {
-                    return (ItemId * 397) ^ Count;
+                    return ((ItemId * 397) ^ Count) ^ Tradable.GetHashCode();
                 }
-            }
-
-            public readonly int ItemId;
-            public readonly int Count;
-
-            public RewardInfo(params string[] fields)
-            {
-                ItemId = ParseInt(fields[0]);
-                Count = ParseInt(fields[1]);
-            }
-
-            public RewardInfo(int itemId, int count)
-            {
-                ItemId = itemId;
-                Count = count;
             }
         }
 


### PR DESCRIPTION
## Summary

- `StakeRegularFixedRewardSheet.RewardInfo`에 `Tradable` 필드를 추가하여 고정 스테이킹 보상의 아이템 거래 가능 여부를 CSV로 제어할 수 있도록 개선
- 기존 `StakeRegularRewardSheet`의 `Tradable` 동작과 일관성을 맞춤
- `tradable` 컬럼을 생략하면 `true`로 기본값 처리되어 기존 온체인 데이터와 하위 호환 유지

## Changes

- **`StakeRegularFixedRewardSheet.cs`**: `RewardInfo`에 `Tradable` 필드 추가 (XML doc 포함), optional CSV 컬럼 파싱, `Equals`/`GetHashCode` 반영
- **`StakeRewardCalculator.cs`**: `CalculateFixedRewards`에서 `reward.Tradable` 기반 분기 처리; 클래스 및 메서드 XML doc 추가
- **`StakeRegularFixedRewardSheetFixtures.cs`**: `tradable` 컬럼이 있는 `V1WithTradable` fixture 추가
- **`StakeRegularFixedRewardSheetTest.cs`**: 기본값(`true`) 및 명시적 `false` 파싱 검증 테스트 추가

## Test plan

- [ ] `StakeRegularFixedRewardSheetTest` — 11개 테스트 전체 통과 확인
- [ ] 기존 `ClaimStakeRewardTest`, `StakeAndClaimScenarioTest` 회귀 없음 확인
- [ ] CSV에 `tradable` 컬럼 없는 기존 시트 파싱 시 `Tradable == true` 기본값 적용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)