### PR TITLE
Fix arena rune skill cooldown using SkillSheet instead of RuneOptionSheet

### DIFF
--- a/.Lib9c.Tests/Model/Character/ArenaRuneSkillCooldownTest.cs
+++ b/.Lib9c.Tests/Model/Character/ArenaRuneSkillCooldownTest.cs
@@ -1,0 +1,133 @@
+namespace Lib9c.Tests.Model.Character
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Lib9c.Tests.Action;
+    using Nekoyume.Action;
+    using Nekoyume.Arena;
+    using Nekoyume.Model;
+    using Nekoyume.Model.EnumType;
+    using Nekoyume.Model.Rune;
+    using Nekoyume.Model.Stat;
+    using Nekoyume.Model.State;
+    using Nekoyume.TableData;
+    using Xunit;
+
+    public class ArenaRuneSkillCooldownTest
+    {
+        private readonly TableSheets _tableSheets;
+        private readonly AvatarState _avatar1;
+        private readonly AvatarState _avatar2;
+
+        public ArenaRuneSkillCooldownTest()
+        {
+            _tableSheets = new TableSheets(
+                TableSheetsImporter.ImportSheets());
+            _avatar1 = AvatarState.Create(
+                default,
+                default,
+                0,
+                _tableSheets.GetAvatarSheets(),
+                default);
+            _avatar2 = AvatarState.Create(
+                default,
+                default,
+                0,
+                _tableSheets.GetAvatarSheets(),
+                default);
+        }
+
+        [Fact]
+        public void RuneSkillCooldownMap_Uses_RuneOptionSheet_Value()
+        {
+            // Arrange: rune 10051 level 1 has cooldown 20 in
+            // RuneOptionSheet, while SkillSheet has cooldown 15
+            const int runeId = 10051;
+            const int runeLevel = 1;
+            const int expectedCooldown = 20;
+
+            var runeStates =
+                new List<RuneState> { new RuneState(runeId, runeLevel) };
+            var allRuneState = new AllRuneState();
+            allRuneState.AddRuneState(runeStates[0]);
+
+            var runeSlotState = new RuneSlotState(BattleType.Arena);
+            runeSlotState.UpdateSlot(
+                new List<RuneSlotInfo>
+                {
+                    new RuneSlotInfo(3, runeId),
+                },
+                _tableSheets.RuneListSheet);
+
+            var digest = new ArenaPlayerDigest(
+                _avatar1,
+                new List<Nekoyume.Model.Item.Costume>(),
+                new List<Nekoyume.Model.Item.Equipment>(),
+                allRuneState,
+                runeSlotState);
+
+            var simulator = new ArenaSimulator(new TestRandom());
+            var arenaSheets =
+                _tableSheets.GetArenaSimulatorSheets();
+
+            var character = new Nekoyume.Model.ArenaCharacter(
+                simulator,
+                digest,
+                arenaSheets,
+                simulator.HpModifier,
+                new List<StatModifier>());
+
+            // Assert: RuneSkillCooldownMap should have the
+            // RuneOptionSheet value (20), not SkillSheet value (15)
+            Assert.True(
+                character.RuneSkillCooldownMap.ContainsKey(700015));
+            Assert.Equal(
+                expectedCooldown,
+                character.RuneSkillCooldownMap[700015]);
+        }
+
+        [Theory]
+        [InlineData(1, 20)]
+        [InlineData(2, 19)]
+        [InlineData(3, 18)]
+        public void RuneSkillCooldownMap_Varies_By_RuneLevel(
+            int runeLevel,
+            int expectedCooldown)
+        {
+            // Arrange: rune 10051 at different levels
+            const int runeId = 10051;
+
+            var allRuneState = new AllRuneState();
+            allRuneState.AddRuneState(
+                new RuneState(runeId, runeLevel));
+
+            var runeSlotState = new RuneSlotState(BattleType.Arena);
+            runeSlotState.UpdateSlot(
+                new List<RuneSlotInfo>
+                {
+                    new RuneSlotInfo(3, runeId),
+                },
+                _tableSheets.RuneListSheet);
+
+            var digest = new ArenaPlayerDigest(
+                _avatar1,
+                new List<Nekoyume.Model.Item.Costume>(),
+                new List<Nekoyume.Model.Item.Equipment>(),
+                allRuneState,
+                runeSlotState);
+
+            var simulator = new ArenaSimulator(new TestRandom());
+            var character = new Nekoyume.Model.ArenaCharacter(
+                simulator,
+                digest,
+                _tableSheets.GetArenaSimulatorSheets(),
+                simulator.HpModifier,
+                new List<StatModifier>());
+
+            // Assert
+            Assert.Equal(
+                expectedCooldown,
+                character.RuneSkillCooldownMap[700015]);
+        }
+    }
+}

--- a/Lib9c/Model/Character/ArenaCharacter.cs
+++ b/Lib9c/Model/Character/ArenaCharacter.cs
@@ -726,7 +726,8 @@ namespace Nekoyume.Model
             }
             else
             {
-                _runeSkills.SetCooldown(selectedSkill.SkillRow.Id, row.Cooldown);
+                var cooldown = RuneSkillCooldownMap[selectedSkill.SkillRow.Id];
+                _runeSkills.SetCooldown(selectedSkill.SkillRow.Id, cooldown);
             }
 
             Simulator.Log.Add(usedSkill);


### PR DESCRIPTION
## Summary
- 아레나에서 룬 스킬 쿨다운이 `SkillSheet.Cooldown` 값을 사용하여 의도보다 짧게 적용되던 버그 수정
- `RuneSkillCooldownMap`에서 룬 레벨별 정확한 쿨다운을 가져오도록 변경

## Root Cause
`ArenaCharacter.UseSkill()`에서 룬 스킬 쿨다운 설정 시:
```csharp
// Before (bug): SkillSheet의 고정 쿨다운 사용
_runeSkills.SetCooldown(selectedSkill.SkillRow.Id, row.Cooldown);

// After (fix): RuneOptionSheet의 룬 레벨별 쿨다운 사용
var cooldown = RuneSkillCooldownMap[selectedSkill.SkillRow.Id];
_runeSkills.SetCooldown(selectedSkill.SkillRow.Id, cooldown);
```

`Player.cs`(일반 전투)에서는 이미 `RuneSkillCooldownMap`을 올바르게 사용하고 있었음.

Fixes #3281

## Test plan
- [x] 빌드 성공
- [x] Arena 관련 테스트 249개 전체 통과

🤖 Generated with [Claude Code](https://claude.ai/code)