### PR TITLE
Release 1.36.1

### DIFF
--- a/.Lib9c.Tests/Action/InfiniteTowerBattleTest.cs
+++ b/.Lib9c.Tests/Action/InfiniteTowerBattleTest.cs
@@ -350,7 +350,7 @@ namespace Lib9c.Tests.Action
         }
 
         [Fact]
-        public void Execute_SecondClear_ShouldNotGiveRewards()
+        public void Execute_SecondClear_ShouldThrowFloorAlreadyCleared()
         {
             // Arrange
             var agentAddress = new PrivateKey().Address;
@@ -359,7 +359,6 @@ namespace Lib9c.Tests.Action
             var infiniteTowerId = 1;
             var floorId = 1;
 
-            // Create initial state
             var initialState = new World(MockUtil.MockModernWorldState);
             var agentState = new AgentState(agentAddress);
             var avatarState = AvatarState.Create(
@@ -369,31 +368,35 @@ namespace Lib9c.Tests.Action
                 _tableSheets.GetAvatarSheets(),
                 default
             );
-
-            // Set avatar level to ensure success
             avatarState.level = 100;
 
-            // Set up sheets with default CSV data
             foreach (var (key, value) in _sheets)
             {
-                initialState = (World)initialState.SetLegacyState(Addresses.TableSheet.Derive(key), value.Serialize());
+                initialState = (World)initialState
+                    .SetLegacyState(
+                        Addresses.TableSheet.Derive(key),
+                        value.Serialize());
             }
 
-            // Set up game config
-            var gameConfigState = new GameConfigState(_sheets[nameof(GameConfigSheet)]);
-            initialState = (World)initialState.SetLegacyState(gameConfigState.address, gameConfigState.Serialize());
+            var gameConfigState =
+                new GameConfigState(_sheets[nameof(GameConfigSheet)]);
+            initialState = (World)initialState
+                .SetLegacyState(
+                    gameConfigState.address,
+                    gameConfigState.Serialize());
 
             // Pre-clear the floor to simulate second attempt
-            var infiniteTowerInfo = CreateInfiniteTowerInfo(avatarAddress, infiniteTowerId);
-            infiniteTowerInfo.AddTickets(5); // Give some tickets
+            var infiniteTowerInfo =
+                CreateInfiniteTowerInfo(avatarAddress, infiniteTowerId);
+            infiniteTowerInfo.AddTickets(5);
             infiniteTowerInfo.ClearFloor(floorId);
 
             initialState = (World)initialState
                 .SetAgentState(agentAddress, agentState)
                 .SetAvatarState(avatarAddress, avatarState)
-                .SetInfiniteTowerInfo(avatarAddress, infiniteTowerInfo);
+                .SetInfiniteTowerInfo(
+                    avatarAddress, infiniteTowerInfo);
 
-            // Create action for second clear
             var action = new InfiniteTowerBattle
             {
                 AvatarAddress = avatarAddress,
@@ -406,7 +409,6 @@ namespace Lib9c.Tests.Action
                 BuyTicketIfNeeded = false,
             };
 
-            // Act - Second clear
             var context = new ActionContext
             {
                 Signer = agentAddress,
@@ -415,21 +417,9 @@ namespace Lib9c.Tests.Action
                 RandomSeed = 0,
             };
 
-            var nextState = action.Execute(context);
-
-            // Assert - Should not have additional rewards for second clear
-            var finalAvatarState = nextState.GetAvatarState(avatarAddress);
-            var finalInfiniteTowerInfo = nextState.GetInfiniteTowerInfo(avatarAddress, infiniteTowerId);
-
-            // Check if floor is still cleared
-            Assert.True(finalInfiniteTowerInfo.IsCleared(floorId));
-
-            // Check that no additional rewards were given
-            var initialInventoryCount = avatarState.inventory.Items.Count;
-            var finalInventoryCount = finalAvatarState.inventory.Items.Count;
-
-            // For second clear, should not have received additional rewards
-            Assert.Equal(initialInventoryCount, finalInventoryCount);
+            // Act & Assert: re-entering cleared floor now throws
+            Assert.Throws<FloorAlreadyClearedException>(
+                () => action.Execute(context));
         }
 
         [Fact]
@@ -665,7 +655,7 @@ namespace Lib9c.Tests.Action
         }
 
         [Fact]
-        public void Execute_With_AlreadyClearedFloor_ShouldNotUpdateBoardState()
+        public void Execute_With_AlreadyClearedFloor_ShouldThrowException()
         {
             // Arrange
             var agentAddress = new PrivateKey().Address;
@@ -686,39 +676,39 @@ namespace Lib9c.Tests.Action
             );
             avatarState.level = 10;
 
-            // Set up sheets with default CSV data
             foreach (var (key, value) in _sheets)
             {
-                initialState = (World)initialState.SetLegacyState(Addresses.TableSheet.Derive(key), value.Serialize());
+                initialState = (World)initialState
+                    .SetLegacyState(
+                        Addresses.TableSheet.Derive(key),
+                        value.Serialize());
             }
 
-            // Set up game config
-            var gameConfigState = new GameConfigState(_sheets[nameof(GameConfigSheet)]);
-            initialState = (World)initialState.SetLegacyState(gameConfigState.address, gameConfigState.Serialize());
+            var gameConfigState =
+                new GameConfigState(_sheets[nameof(GameConfigSheet)]);
+            initialState = (World)initialState
+                .SetLegacyState(
+                    gameConfigState.address,
+                    gameConfigState.Serialize());
 
-            // Set up states
             initialState = (World)initialState
                 .SetAgentState(agentAddress, agentState)
                 .SetAvatarState(avatarAddress, avatarState);
 
-            // Create infinite tower info with tickets and floor already cleared
-            var infiniteTowerInfo = CreateInfiniteTowerInfo(avatarAddress, infiniteTowerId);
+            // Create info with floor already cleared and tickets
+            var infiniteTowerInfo =
+                CreateInfiniteTowerInfo(avatarAddress, infiniteTowerId);
             infiniteTowerInfo.AddTickets(5);
-            infiniteTowerInfo.ClearFloor(floorId); // Floor already cleared
-            // Set LastResetBlockIndex to prevent season reset (StartBlockIndex is 0, so use blockIndex + 1)
-            infiniteTowerInfo.GetType().GetProperty("LastResetBlockIndex")?.SetValue(infiniteTowerInfo, blockIndex + 1);
-            initialState = (World)initialState.SetInfiniteTowerInfo(avatarAddress, infiniteTowerInfo);
+            infiniteTowerInfo.ClearFloor(floorId);
+            infiniteTowerInfo.GetType()
+                .GetProperty("LastResetBlockIndex")
+                ?.SetValue(infiniteTowerInfo, blockIndex + 1);
+            initialState = (World)initialState
+                .SetInfiniteTowerInfo(
+                    avatarAddress, infiniteTowerInfo);
 
-            // Create initial board state with floor already cleared
-            var initialBoardState = new InfiniteTowerBoardState(infiniteTowerId);
-            initialBoardState.RecordFloorClear(floorId, blockIndex - 1); // Record previous clear
-            initialState = (World)initialState.SetInfiniteTowerBoardState(initialBoardState);
+            var ticketsBefore = infiniteTowerInfo.RemainingTickets;
 
-            // Verify initial board state has one clear
-            var boardStateBefore = initialState.GetInfiniteTowerBoardState(infiniteTowerId);
-            Assert.Equal(1, boardStateBefore.GetFloorClearCount(floorId));
-
-            // Create action
             var action = new InfiniteTowerBattle
             {
                 AvatarAddress = avatarAddress,
@@ -731,7 +721,6 @@ namespace Lib9c.Tests.Action
                 BuyTicketIfNeeded = false,
             };
 
-            // Act
             var context = new ActionContext
             {
                 BlockIndex = blockIndex,
@@ -740,16 +729,14 @@ namespace Lib9c.Tests.Action
                 Signer = agentAddress,
             };
 
-            var nextState = action.Execute(context);
+            // Act & Assert: should throw and not consume tickets
+            Assert.Throws<FloorAlreadyClearedException>(
+                () => action.Execute(context));
 
-            // Assert
-            Assert.NotNull(nextState);
-
-            // Verify board state was NOT updated for already cleared floor
-            var boardStateAfter = nextState.GetInfiniteTowerBoardState(infiniteTowerId);
-            Assert.NotNull(boardStateAfter);
-            Assert.Equal(1, boardStateAfter.GetFloorClearCount(floorId)); // Should remain 1, not increase
-            Assert.Equal(blockIndex - 1, boardStateAfter.LastUpdatedBlockIndex); // Should remain previous block index
+            // Tickets should remain unchanged (exception before consume)
+            var infoAfter = initialState.GetInfiniteTowerInfo(
+                avatarAddress, infiniteTowerId);
+            Assert.Equal(ticketsBefore, infoAfter.RemainingTickets);
         }
 
         [Fact]
@@ -1287,12 +1274,14 @@ namespace Lib9c.Tests.Action
                 .SetAgentState(agentAddress, agentState)
                 .SetAvatarState(avatarAddress, avatarState);
 
-            // Create infinite tower info with LastResetBlockIndex = 0 and some progress
-            // This simulates a new season where previous progress should be reset
+            // Create infinite tower info with previous progress
+            // Set LastResetBlockIndex to -1 so isNewSeason = (-1 < 0) = true
             var infiniteTowerInfo = CreateInfiniteTowerInfo(avatarAddress, infiniteTowerId);
-            infiniteTowerInfo.ClearFloor(5); // Set some previous progress
-            // LastResetBlockIndex is already 0 from constructor, which will trigger season reset
-            Assert.Equal(0, infiniteTowerInfo.LastResetBlockIndex);
+            infiniteTowerInfo.ClearFloor(5);
+            infiniteTowerInfo.GetType()
+                .GetProperty("LastResetBlockIndex")
+                ?.SetValue(infiniteTowerInfo, -1L);
+            Assert.Equal(-1, infiniteTowerInfo.LastResetBlockIndex);
             Assert.Equal(5, infiniteTowerInfo.ClearedFloor);
             Assert.True(infiniteTowerInfo.RemainingTickets > 0);
             initialState = (World)initialState.SetInfiniteTowerInfo(avatarAddress, infiniteTowerInfo);

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <LibplanetVersion>5.5.2</LibplanetVersion>
-        <Lib9cVersion>1.36.0</Lib9cVersion>
+        <Lib9cVersion>1.36.1</Lib9cVersion>
 
         <!-- Fill with Libplanet's absolute path to debug with local Libplanet.
              Example: $(MSBuildThisFileDirectory).Libplanet -->

--- a/Lib9c/Action/Exceptions/InfiniteTower/FloorAlreadyClearedException.cs
+++ b/Lib9c/Action/Exceptions/InfiniteTower/FloorAlreadyClearedException.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Nekoyume.Action.Exceptions
+{
+    /// <summary>
+    /// Exception thrown when trying to re-enter a floor that has
+    /// already been cleared in the current season.
+    /// </summary>
+    public class FloorAlreadyClearedException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the
+        /// FloorAlreadyClearedException class.
+        /// </summary>
+        /// <param name="actionType">The type of action that failed.</param>
+        /// <param name="addressesHex">The hex representation of
+        /// addresses involved.</param>
+        /// <param name="floorId">The floor that was attempted.</param>
+        /// <param name="clearedFloor">The highest cleared floor.</param>
+        public FloorAlreadyClearedException(
+            string actionType,
+            string addressesHex,
+            int floorId,
+            int clearedFloor)
+            : base(
+                $"{actionType} {addressesHex} Floor {floorId}" +
+                $" already cleared. Cleared floor: {clearedFloor}")
+        {
+        }
+    }
+}

--- a/Lib9c/Action/InfiniteTowerBattle.cs
+++ b/Lib9c/Action/InfiniteTowerBattle.cs
@@ -344,6 +344,16 @@ FloorId - 1,
                     infiniteTowerInfo.ClearedFloor);
             }
 
+            // Prevent re-entering already cleared floors in the same season
+            if (infiniteTowerInfo.IsCleared(FloorId))
+            {
+                throw new FloorAlreadyClearedException(
+                    "InfiniteTowerBattle",
+                    addressesHex,
+                    FloorId,
+                    infiniteTowerInfo.ClearedFloor);
+            }
+
             // Check tickets
             if (!infiniteTowerInfo.TryUseTickets(PlayCount))
             {


### PR DESCRIPTION
## Release 1.36.1

### Changes
- 무한의탑에서 이미 클리어한 층 재진입 시 `FloorAlreadyClearedException` 발생하여 티켓 소모 차단

### Details
- 기존: 클리어한 층 재진입 시 보상만 미지급, 티켓은 소모됨 (유저 손해)
- 변경: 티켓 소모 전에 `IsCleared(FloorId)` 검증 → 예외 발생으로 진입 자체 차단
- 시즌 리셋 후에는 `ClearedFloor=0`으로 초기화되므로 정상 재도전 가능

### Version
- Lib9c: 1.36.0 → **1.36.1**

## Test plan
- [x] 클리어한 층 재진입 시 `FloorAlreadyClearedException` 발생 확인
- [x] 예외 발생 시 티켓 미소모 확인
- [x] 시즌 리셋 후 같은 층 재진입 가능 확인
- [x] 기존 InfiniteTowerBattle 테스트 58개 전체 통과

🤖 Generated with [Claude Code](https://claude.ai/code)