### PR TITLE
ci: exclude test projects from the no-docs count

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
             - id: count-no-docs
               run: |
                 set -ev
-                count=$(dotnet build -p GenerateDocumentationFile=true -p 'DocumentationFile=docs.xml' -p TreatWarningsAsErrors=false -consoleloggerparameters:WarningsOnly | grep -c -E "CS(1573|1591)" || true)
+                count=$(dotnet build -p GenerateDocumentationFile=true -p 'DocumentationFile=docs.xml' -p TreatWarningsAsErrors=false -consoleloggerparameters:WarningsOnly | grep -E "CS(1573|1591)" | grep -vc "Tests.csproj" || true)
                 echo "count=$count" >> "$GITHUB_OUTPUT"
     count-no-docs-on-headref:
         runs-on: ubuntu-latest
@@ -59,7 +59,7 @@ jobs:
             - id: count-no-docs
               run: |
                 set -ev
-                count=$(dotnet build -p GenerateDocumentationFile=true -p 'DocumentationFile=docs.xml' -p TreatWarningsAsErrors=false -consoleloggerparameters:WarningsOnly | grep -c -E "CS(1573|1591)" || true)
+                count=$(dotnet build -p GenerateDocumentationFile=true -p 'DocumentationFile=docs.xml' -p TreatWarningsAsErrors=false -consoleloggerparameters:WarningsOnly | grep -E "CS(1573|1591)" | grep -vc "Tests.csproj" || true)
                 echo "count=$count" >> "$GITHUB_OUTPUT"
     check-items-without-docs-increased:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Follow-up to #3294. The `count-no-docs` gate counts `CS1591`/`CS1573` across the **whole solution**, including test projects (~2,900 warnings come from `.Lib9c.Tests` alone). Because `check-items-without-docs-increased` compares base vs head counts, this forces **every PR that adds a public test class / constructor / `[Fact]` method** to also add XML doc comments to them — pure noise, since test methods are not shippable API.

## Change

Filter out warnings attributed to a `*.Tests.csproj` before counting, so the gate only tracks documentation coverage of the shippable projects:

```diff
- | grep -c -E "CS(1573|1591)" || true)
+ | grep -E "CS(1573|1591)" | grep -vc "Tests.csproj" || true)
```

Applied to both `count-no-docs-on-baseref` and `count-no-docs-on-headref`.

## Verification (local)

- Full doc-warning count: **11,153**
- After excluding `*.Tests.csproj`: **8,206** (the 2,947 excluded are all attributed to test projects)
- Zero-match case still yields `0` safely (guarded by `|| true`).

CI only — no application code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)